### PR TITLE
Delete gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-*.bak
-build/


### PR DESCRIPTION
Ter, this pull request is to give you the option to easily remove the .gitignore file that I accidentally included in a pull that I sent you. It's an OK .gitignore file but I think it amounts to an extra tiny bit of clutter for the grammars repository. 
