### PR TITLE
fix. array types were not accepted as a generics type parameter.

### DIFF
--- a/java7/Java7.g4
+++ b/java7/Java7.g4
@@ -169,7 +169,7 @@ typeArguments
   ;
 
 typeArgument
-  : classOrInterfaceType
+  : classOrInterfaceType ('[' ']')* // array types are allowed here, as an type argument
   | '?' (('extends' | 'super') classOrInterfaceType)?
   ;
 


### PR DESCRIPTION
Hi,

Thank you for the great parser library.

I've found a java7/Java7.g4 not accepting array types as a type parameter 
(in code such as the following), so slightly modified a definition of "typeArgument".

---

```
    import java.util.List;

    class A
    {
            List<String[]> s;
            private class B implements List<String[]>
            {
                    int col;
            }
    }
```

---

I'm not so familiar with the Java's grammar and have not checked this modification has
some unwanted side effects or not, however, this modification reduces parse errors when I run Java7.g4 at my side.

Regards,
- Toshihiro
