### PR TITLE
Correct array creation

### DIFF
--- a/java7/Java7.g4
+++ b/java7/Java7.g4
@@ -450,7 +450,7 @@ tryStatement
   ;
 
 catchClause
-  : 'catch' '(' variableModifier* typeRef ('|' typeRef)* Identifier ')' block
+  : 'catch' '(' variableModifier* typeName ('|' typeName)* Identifier ')' block
   ;
 
 resources


### PR DESCRIPTION
“If there are no dimension expressions, then there must be an array initializer.” - from JLS 7 Topic 15.10.1

My original code allowed array creation such as 
  new int[];
but it must have either a dimension, e.g.,
  new int[10];
or an initializer, e.g.,
  new int[] {1,2,3};
There is no problem with the Java 6 grammar (Java.g4).
