### PR TITLE
Use classOrArrayType in typeArgument rule

### DIFF
--- a/java7/Java7.g4
+++ b/java7/Java7.g4
@@ -169,8 +169,15 @@ typeArguments
   ;
 
 typeArgument
-  : classOrInterfaceType ('[' ']')* // array types are allowed here, as an type argument
-  | '?' (('extends' | 'super') classOrInterfaceType)?
+  : classOrArrayType
+  | '?' ( ('extends' | 'super') classOrArrayType )?
+  ;
+
+classOrArrayType
+// Includes primitive arrays, which are really a kind of class.
+// Just like rule typeRef, except that a simple primative is forbidden.
+  : primitiveType '[' ']' ('[' ']')*
+  | classOrInterfaceType  ('[' ']')*
   ;
 
 interfaceMemberDecl


### PR DESCRIPTION
New classOrArrayType rule includes arrays of primitives, which are
classes, too. This rule is used only in rule typeArgument.

This completes the review of the Java7.g4 grammar in response to Bug
report 7080366 : Grammar bugs in JLS7,
http://bugs.sun.com/view_bug.do?bug_id=7080366.

I do not believe that there are any more places where Java7.g4 is too
strict. There are still a few places where it is more relaxed than the
JLS7 grammar, but I judge them to require too much reworking of the
Java7.g4 grammar to be practical. In particular, the expression rule
sometimes allows too general of a subexpression. If someone wishes to
catch these particular syntax errors, they will have to do it in a
second phase scan of the parse tree.
