### PR TITLE
Improve Lua grammar for supporting string concatenation with '\' and shebang (#!).

### DIFF
--- a/lua/Lua.g4
+++ b/lua/Lua.g4
@@ -274,15 +274,17 @@ COMMENT
     ;
     
 LINE_COMMENT
-    : '--' ('[' '='*)? (~'['|EOF) ~('\n'|'\r')* -> channel(HIDDEN)
+    : '--'
+    (                                               // --
+    | '[' '='*                                      // --[==
+    | '[' '='* ~('='|'['|'\r'|'\n') ~('\r'|'\n')*   // --[==AA
+    | ~('['|'\r'|'\n') ~('\r'|'\n')*                // --AAA
+    ) ('\r\n'|'\r'|'\n'|EOF)
+    -> channel(HIDDEN)
     ;
     
 WS  
-    : [ \t\u000C]+ -> skip
-    ;
-    
-NEWLINE
-    : '\r'? '\n' -> skip
+    : [ \t\u000C\r\n]+ -> skip
     ;
 
 SHEBANG


### PR DESCRIPTION
### Support string concatenation with '\'

```lua
s = 'br\
ah'
```

### Support shebang

```lua
#!/usr/bin/lua
```

### Support comment with long brackets

```lua
--[===[
  brah
]===]
```