### PR TITLE
Update Java.g4

### DIFF
--- a/java/Java.g4
+++ b/java/Java.g4
@@ -469,7 +469,7 @@ forInit
     ;
 
 enhancedForControl
-    :   variableModifier* type Identifier ':' expression
+    :   variableModifier* type variableDeclaratorId ':' expression
     ;
 
 forUpdate


### PR DESCRIPTION
Currently, `for(String foo[] : listOfStringArrays) {}` cannot be parsed by Java.g4 even though it is valid syntax.
