### PR TITLE
fix selector space issues in scss

### DIFF
--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -30,10 +30,6 @@ lexer grammar ScssLexer;
 
 NULL              : 'null';
 
-// Whitespace -- ignored
-WS
-  : (' '|'\t'|'\n'|'\r'|'\r\n')+ -> skip
-  ;
 
 IN              : 'in';
 
@@ -45,8 +41,9 @@ COMBINE_COMPARE : '&&' | '||';
 
 Ellipsis          : '...';
 
-//MathCharacter   : DIV | PLUS | MINUS | TIMES | PERC;
-
+InterpolationStart
+  : HASH BlockStart -> pushMode(IDENTIFY)
+  ;
 
 //Separators
 LPAREN          : '(';
@@ -79,6 +76,8 @@ UrlStart
   : 'url' LPAREN -> pushMode(URL_STARTED)
   ;
 
+
+
 EQEQ            : '==';
 NOTEQ           : '!=';
 
@@ -108,10 +107,10 @@ POUND_DEFAULT   : '!default';
 
 
 Identifier
-	:	('_' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' )
+	:	(('_' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' )
 		('_' | '-' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' | '0'..'9')*
 	|	'-' ('_' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' )
-		('_' | '-' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' | '0'..'9')*
+		('_' | '-' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' | '0'..'9')*) -> pushMode(IDENTIFY)
 	;
 
 
@@ -136,6 +135,12 @@ Color
 	:	'#' ('0'..'9'|'a'..'f'|'A'..'F')+
 	;
 
+
+// Whitespace -- ignored
+WS
+  : (' '|'\t'|'\n'|'\r'|'\r\n')+ -> skip
+  ;
+
 // Single-line comments
 SL_COMMENT
 	:	'//'
@@ -151,6 +156,27 @@ COMMENT
 mode URL_STARTED;
 UrlEnd                 : RPAREN -> popMode;
 Url                    :	STRING | (~(')' | '\n' | '\r' | ';'))+;
+
+mode IDENTIFY;
+SPACE                  : WS -> popMode, skip;
+DOLLAR_ID              : DOLLAR -> type(DOLLAR);
+
+
+InterpolationStartAfter  : InterpolationStart;
+InterpolationEnd_ID    : BlockEnd -> type(BlockEnd);
+
+IdentifierAfter        : Identifier;
+Ellipsis_ID            : Ellipsis -> popMode, type(Ellipsis);
+DOT_ID                 : DOT -> popMode, type(DOT);
+
+LPAREN_ID                 : LPAREN -> popMode, type(LPAREN);
+RPAREN_ID                 : RPAREN -> popMode, type(RPAREN);
+
+COLON_ID                  : COLON -> popMode, type(COLON);
+COMMA_ID                  : COMMA -> popMode, type(COMMA);
+SEMI_ID                  : SEMI -> popMode, type(SEMI);
+
+
 
 
 

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -232,19 +232,19 @@ selectors
 	;
 
 selector
-	: element+ (selectorPrefix? element)* attrib* pseudo?
+	: element+ (selectorPrefix element)* attrib* pseudo?
 	;
 
 selectorPrefix
-  : (GT | PLUS | TIL | SPACE)
+  : (GT | PLUS | TIL)
   ;
 
 element
 	: identifier
   | '#' identifier
   | '.' identifier
-  | AND
-  | TIMES
+  | '&'
+  | '*'
 	;
 
 pseudo
@@ -263,7 +263,16 @@ attribRelate
 	;
 
 identifier
-  : (Identifier | interpolation)+
+  : Identifier identifierPart*
+  | InterpolationStart identifierVariableName BlockEnd identifierPart*
+  ;
+
+identifierPart
+  : InterpolationStartAfter identifierVariableName BlockEnd
+  | IdentifierAfter
+  ;
+identifierVariableName
+  : DOLLAR (Identifier | IdentifierAfter)
   ;
 
 property
@@ -282,9 +291,6 @@ measurement
   : Number Unit?
   ;
 
-interpolation
-  : HASH BlockStart variableName BlockEnd
-  ;
 
 functionCall
 	: Identifier LPAREN values? RPAREN

--- a/scss/src/test/java/TestBase.java
+++ b/scss/src/test/java/TestBase.java
@@ -39,6 +39,7 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.misc.Nullable;
@@ -69,7 +70,9 @@ public class TestBase
       ScssLexer lexer = new ScssLexer(source);
       TokenStream stream = new BufferedTokenStream(lexer);
       ScssParser par = new ScssParser(stream);
-      //par.addErrorListener(new FailOnErrorListener());
+      par.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
+
+      par.addErrorListener(new FailOnErrorListener());
       return par.stylesheet();
     }
     catch (IOException e)

--- a/scss/src/test/java/TestBasicCss.java
+++ b/scss/src/test/java/TestBasicCss.java
@@ -322,9 +322,22 @@ public class TestBasicCss extends TestBase
     ScssParser.StylesheetContext context = parse(lines);
     Assert.assertEquals(context.statement(0).ruleset().selectors().selector(0).element(0).identifier().getText(), "p");
     Assert.assertEquals(context.statement(0).ruleset().selectors().selector(0).element(1)
-                            .identifier().interpolation(0).variableName().getText(), "$name");
+                            .identifier().identifierVariableName().getText(), "$name");
 
     Assert.assertEquals(context.statement(0).ruleset().selectors().selector(0).element(2).getText(), "select2");
+  }
+
+  @Test
+  public void testInterpolationSpace()
+  {
+    String [] lines = {
+        "p #{$name} {}"
+    };
+    ScssParser.StylesheetContext context = parse(lines);
+    Assert.assertEquals(context.statement(0).ruleset().selectors().selector(0).element(0).identifier().getText(), "p");
+    Assert.assertEquals(context.statement(0).ruleset().selectors().selector(0).element(1)
+                            .identifier().identifierVariableName().getText(), "$name");
+
   }
 
   private ScssParser.SelectorsContext getSelector( String ... lines)

--- a/scss/src/test/java/TestInclude.java
+++ b/scss/src/test/java/TestInclude.java
@@ -130,9 +130,9 @@ public class TestInclude extends TestBase
     };
     ScssParser.IncludeDeclarationContext context = parse(lines).statement(0).includeDeclaration();
 
-    Assert.assertEquals(context.values().commandStatement(0).expression(0).identifier().interpolation(0).variableName().getText(), "$var1");
-    Assert.assertEquals(context.block().property(0).identifier().Identifier(0).getText(), "color-");
-    Assert.assertEquals(context.block().property(0).identifier().interpolation(0).variableName().getText(), "$var2");
+    Assert.assertEquals(context.values().commandStatement(0).expression(0).identifier().identifierVariableName().getText(), "$var1");
+    Assert.assertEquals(context.block().property(0).identifier().Identifier().getText(), "color-");
+    Assert.assertEquals(context.block().property(0).identifier().identifierPart(0).identifierVariableName().getText(), "$var2");
 
   }
 

--- a/scss/src/test/java/TestMixins.java
+++ b/scss/src/test/java/TestMixins.java
@@ -178,11 +178,11 @@ public class TestMixins extends TestBase
 
 
     Assert.assertEquals(context.block().statement(1).ruleset().selectors()
-                            .selector(0).element(0).TIMES().getText(), "*");
+                            .selector(0).element(0).getText(), "*");
     Assert.assertEquals(context.block().statement(1).ruleset().selectors()
                             .selector(0).element(1).identifier().getText(), "html");
     Assert.assertEquals(context.block().statement(1).ruleset().selectors()
-                            .selector(0).element(2).AND().getText(), "&");
+                            .selector(0).element(2).getText(), "&");
 
     Assert.assertEquals(context.block().statement(1).ruleset().block().property(0).identifier().getText(), "height");
     Assert.assertEquals(context.block().statement(1).ruleset().block().property(0).values()
@@ -201,8 +201,8 @@ public class TestMixins extends TestBase
     };
     ScssParser.MixinDeclarationContext context = parseImport(lines);
     Assert.assertEquals(context.Identifier().getText(), "test");
-    Assert.assertEquals(context.block().property(0).identifier().interpolation(0).variableName().getText(), "$attr");
-    Assert.assertEquals(context.block().property(0).identifier().Identifier(0).getText(), "-color");
+    Assert.assertEquals(context.block().property(0).identifier().identifierVariableName().getText(), "$attr");
+    Assert.assertEquals(context.block().property(0).identifier().identifierPart(0).IdentifierAfter().getText(), "-color");
   }
 
   @Test


### PR DESCRIPTION
Fixed an issue where you were not able to determine the difference between:
hello-#{world}
and
hello #{world}

where the first implies its 1 selector with a variable in it, while the second one is two selectors.
