### PR TITLE
Removed \0x000c from WS

### DIFF
--- a/r/R.g4
+++ b/r/R.g4
@@ -190,4 +190,4 @@ COMMENT :   '#' .*? '\r'? '\n' -> type(NL) ;
 // Match both UNIX and Windows newlines
 NL      :   '\r'? '\n' ;
 
-WS      :   [ \t\0x000c]+ -> skip ;
+WS      :   [ \t]+ -> skip ;


### PR DESCRIPTION
I have no idea why, but \0x000c introduces an error parsing for example ' c(1,2)' ('c' as the function identifier and a whitespace preceding it).
