### PR TITLE
Updated Java.g4 to work with ANTLR 4.2

### DIFF
--- a/java/Java.g4
+++ b/java/Java.g4
@@ -520,19 +520,19 @@ expression
     |   expression '&&' expression
     |   expression '||' expression
     |   expression '?' expression ':' expression
-    |   expression
-        (   '='<assoc=right>
-        |   '+='<assoc=right>
-        |   '-='<assoc=right>
-        |   '*='<assoc=right>
-        |   '/='<assoc=right>
-        |   '&='<assoc=right>
-        |   '|='<assoc=right>
-        |   '^='<assoc=right>
-        |   '>>='<assoc=right>
-        |   '>>>='<assoc=right>
-        |   '<<='<assoc=right>
-        |   '%='<assoc=right>
+    |   <assoc=right> expression
+        (   '='
+        |   '+='
+        |   '-='
+        |   '*='
+        |   '/='
+        |   '&='
+        |   '|='
+        |   '^='
+        |   '>>='
+        |   '>>>='
+        |   '<<='
+        |   '%='
         )
         expression
     ;


### PR DESCRIPTION
Starting in ANTLR 4.2, the assoc option should be placed on the alternative itself.
