### PR TITLE
Fix Bug: RegularExpression Class with Backslash

### DIFF
--- a/ecmascript/ECMAScript.CSharpTarget.g4
+++ b/ecmascript/ECMAScript.CSharpTarget.g4
@@ -1463,4 +1463,5 @@ fragment RegularExpressionClass
 ///     RegularExpressionBackslashSequence
 fragment RegularExpressionClassChar
  : ~[\r\n\u2028\u2029\]\\]
+ | RegularExpressionBackslashSequence
  ;

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -1485,4 +1485,5 @@ fragment RegularExpressionClass
 ///     RegularExpressionBackslashSequence
 fragment RegularExpressionClassChar
  : ~[\r\n\u2028\u2029\]\\]
+ | RegularExpressionBackslashSequence
  ;


### PR DESCRIPTION
If there is any regular expression with a class with backslash inside like in /[\w]*/ the regular expression will not be recognized. This fix solve this bug.
