### PR TITLE
Parser rule for SEND_BUF_SIZE was missing an INT. Added.

### DIFF
--- a/tnsnames/tnsnames.g4
+++ b/tnsnames/tnsnames.g4
@@ -139,7 +139,7 @@ d_sdu            : L_PAREN SDU EQUAL INT R_PAREN ;
                  
 d_recv_buf       : L_PAREN RECV_BUF EQUAL INT R_PAREN ;
                  
-d_send_buf       : L_PAREN SEND_BUF EQUAL R_PAREN ;
+d_send_buf       : L_PAREN SEND_BUF EQUAL INT R_PAREN ;
                  
 d_service_type   : L_PAREN SERVICE_TYPE EQUAL ID R_PAREN ;
                  


### PR DESCRIPTION
Hi Ter,

while writing a proper "compiler" using  this grammar, I found a bug. The parser rule for send_buf_size was missing an INT. I have added and tested this. The file tnsnames.g4 is now, hopefully, fully correct!

Cheers,
Norm.
