### PR TITLE
SPX Protocol rules - bug fixed.

### DIFF
--- a/tnsnames/tnsnames.g4
+++ b/tnsnames/tnsnames.g4
@@ -243,12 +243,20 @@ ipc_key          : L_PAREN KEY EQUAL ID R_PAREN ;
 
 
 //-----------------------------------------------------------------
-// SPX Protocol rules.
-// (PROTOCOL = SPX)(SERVICE = spx_service_name)
-//-----------------------------------------------------------------
-spx_protocol     : spx_spx spx_service ;
 
-spx_spx          : L_PAREN PROTOCOL EQUAL SPX R_PAREN ;
+// SPX Protocol rules.
+
+// (PROTOCOL = SPX)(SERVICE = spx_service_name)
+
+//-----------------------------------------------------------------
+spx_protocol     : spx_params ; 
+
+spx_params       : spx_parameter+ ; 
+
+spx_parameter    : spx_spx
+                 | spx_service ; 
+
+spx_spx          : L_PAREN PROTOCOL EQUAL SPX R_PAREN ; 
 
 spx_service      : L_PAREN SERVICE EQUAL ID R_PAREN ;
 


### PR DESCRIPTION
Hi Ter,

I've updated the tnsnames.g4 grammar again to fix a bug.

SPX Protocol rules were previously fixed order. They had to be Protocol then Service. This is not enforced by Oracle, so the grammar has to cater for any order.

Would you please pull my commit into the master grammar repository. Thanks.

Cheers,
Norm.
