### PR TITLE
Improve grammar specificity

### DIFF
--- a/clojure/Clojure.g4
+++ b/clojure/Clojure.g4
@@ -1,6 +1,10 @@
-/* Converted to ANTLR 4 by Terence Parr. Unsure of provence. I see
+/* Reworked for grammar specificity by Reid Mckenzie. Did a bunch of
+   work so that rather than reading "a bunch of crap in parens" some
+   syntactic information is preserved and recovered. Dec. 14 2014.
+
+   Converted to ANTLR 4 by Terence Parr. Unsure of provence. I see
    it commited by matthias.koester for clojure-eclipse project on
-   Oct 5, 2009: 
+   Oct 5, 2009:
 
    https://code.google.com/p/clojure-eclipse/
 
@@ -9,97 +13,252 @@
    Jan 1, 2011.
 
    https://github.com/laurentpetit/ccw/tree/master/clojure-antlr-grammar
-   
+
    Regardless, there are some issues perhaps related to "sugar";
    I've tried to fix them.
-   
+
    This parses https://github.com/weavejester/compojure project.
-   
-   I also note this is hardly a grammar; more like "match a bunch of 
+
+   I also note this is hardly a grammar; more like "match a bunch of
    crap in parens" but I guess that is LISP for you ;)
  */
 
 grammar Clojure;
 
-file: list*;
-  
+file: form *;
+
 form: literal
-    | list 
-    | vector 
-    | map 
+    | list
+    | vector
+    | map
     | reader_macro
-    | '#\'' SYMBOL // TJP added (get Var object instead of the value of a symbol)
     ;
-  
-list: '(' form* ')' ;
-  
-vector: '[' form* ']' ;
-  
+
+forms: form* ;
+
+list: '(' forms ')' ;
+
+vector: '[' forms ']' ;
+
 map: '{' (form form)* '}' ;
 
-// TJP added '&' (gather a variable number of arguments)
-special_form: ('\'' | '`' | '~' | '~@' | '^' | '@' | '&') form ;
-  
-lambda: '#(' form* ')' ;
-  
-meta_data: '#^' map form ;
-  
-var_quote: '\'' '#' SYMBOL ;
-  
-regex: '#' STRING  ;
-  
-reader_macro
-    : lambda 
-    | meta_data 
-    | special_form 
-    | regex 
-    | var_quote
-    | SYMBOL '#' // TJP added (auto-gensym)
-    ; 
-    
-literal
-    : STRING
-    | NUMBER 
-    | CHARACTER
-    | NIL
-    | BOOLEAN
-    | KEYWORD
-    | SYMBOL
-    | PARAM_NAME
-    ;   
-  
-STRING : '"' ( ~'"' | '\\' '"' )* '"' ;
-  
-NUMBER : '-'? [0-9]+ ('.' [0-9]+)? ([eE] '-'? [0-9]+)? ;
+set: '#{' forms '}' ;
 
-CHARACTER : '\\' . ;
+reader_macro
+    : lambda
+    | meta_data
+    | regex
+    | var_quote
+    | host_expr
+    | set
+    | tag
+    | discard
+    | dispatch
+    | deref
+    | quote
+    | backtick
+    | unquote
+    | unquote_splicing
+    | gensym
+    ;
+
+// TJP added '&' (gather a variable number of arguments)
+quote
+    : '\'' form
+    ;
+
+backtick
+    : '`' form
+    ;
+
+unquote
+    : '~' form
+    ;
+
+unquote_splicing
+    : '~@' form
+    ;
+
+tag
+    : '^' form form
+    ;
+
+deref
+    : '@' form
+    ;
+
+gensym
+    : SYMBOL '#'
+    ;
+
+lambda
+    : '#(' form* ')'
+    ;
+
+meta_data
+    : '#^' map form
+    ;
+
+var_quote
+    : '#\'' symbol
+    ;
+
+host_expr
+    : '#+' form form
+    ;
+
+discard
+    : '#_' form
+    ;
+
+dispatch
+    : '#' symbol form
+    ;
+
+regex
+    : '#' string
+    ;
+
+literal
+    : string
+    | number
+    | character
+    | nil
+    | boolean
+    | keyword
+    | symbol
+    | param_name
+    ;
+
+string: STRING;
+float: FLOAT;
+hex: HEX;
+bin: BIN;
+bign: BIGN;
+long: LONG;
+number
+    : float
+    | hex
+    | bin
+    | bign
+    | long
+    ;
+
+character
+    : named_char
+    | u_hex_quad
+    | any_char
+    ;
+named_char: CHAR_NAMED ;
+any_char: CHAR_ANY ;
+u_hex_quad: CHAR_U ;
+
+nil: NIL;
+boolean: BOOLEAN;
+
+keyword: macro_keyword | simple_keyword;
+simple_keyword: ':' symbol;
+macro_keyword: ':' ':' symbol;
+
+symbol: ns_symbol | simple_sym;
+simple_sym: SYMBOL;
+ns_symbol: NS_SYMBOL;
+
+param_name: PARAM_NAME;
+
+// Lexers
+//--------------------------------------------------------------------
+
+STRING : '"' ( ~'"' | '\\' '"' )* '"' ;
+
+// FIXME: Doesn't deal with arbitrary read radixes, BigNums
+FLOAT
+    : '-'? [0-9]+ FLOAT_TAIL
+    | '-'? 'Infinity'
+    | '-'? 'NaN'
+    ;
+
+fragment
+FLOAT_TAIL
+    : FLOAT_DECIMAL FLOAT_EXP
+    | FLOAT_DECIMAL
+    | FLOAT_EXP
+    ;
+
+fragment
+FLOAT_DECIMAL
+    : '.' [0-9]+
+    ;
+
+fragment
+FLOAT_EXP
+    : [eE] '-'? [0-9]+
+    ;
+fragment
+HEXD: [0-9a-fA-F] ;
+HEX: '0' [xX] HEXD+ ;
+BIN: '0' [bB] [10]+ ;
+LONG: '-'? [0-9]+[lL]?;
+BIGN: '-'? [0-9]+[nN];
+
+CHAR_U
+    : '\\' 'u'[0-9D-Fd-f] HEXD HEXD HEXD ;
+CHAR_NAMED
+    : '\\' ( 'newline'
+           | 'return'
+           | 'space'
+           | 'tab'
+           | 'formfeed'
+           | 'backspace' ) ;
+CHAR_ANY
+    : '\\' . ;
 
 NIL : 'nil';
-  
+
 BOOLEAN : 'true' | 'false' ;
 
-KEYWORD : ':' SYMBOL ;
+SYMBOL
+    : '.'
+    | '/'
+    | NAME
+    ;
 
-SYMBOL: '.' | '/' | NAME ('/' NAME)? ;
+NS_SYMBOL
+    : NAME '/' SYMBOL
+    ;
 
-PARAM_NAME: '%' (('1'..'9')('0'..'9')*)? ;
-  
+PARAM_NAME: '%' ((('1'..'9')('0'..'9')*)|'&')? ;
+
+// Fragments
+//--------------------------------------------------------------------
+
 fragment
 NAME: SYMBOL_HEAD SYMBOL_REST* (':' SYMBOL_REST+)* ;
 
 fragment
 SYMBOL_HEAD
-    :   'a'..'z' | 'A'..'Z' | '*' | '+' | '!' | '-' | '_' | '?' | '>' | '<' | '=' | '$'
+    : ~('0' .. '9'
+        | '^' | '`' | '\'' | '"' | '#' | '~' | '@' | ':' | '/' | '%' | '(' | ')' | '[' | ']' | '{' | '}' // FIXME: could be one group
+        | [ \n\r\t\,] // FIXME: could be WS
+        )
     ;
-    
+
 fragment
 SYMBOL_REST
     : SYMBOL_HEAD
-    | '&' // apparently this is legal in an ID: "(defn- assoc-&-binding ..." TJP
     | '0'..'9'
     | '.'
-    ;   
+    ;
 
-WS : [ \n\r\t\,] -> channel(HIDDEN) ;
+// Discard
+//--------------------------------------------------------------------
 
-COMMENT : ';' ~[\r\n]* -> channel(HIDDEN) ;
+fragment
+WS : [ \n\r\t\,] ;
+
+fragment
+COMMENT: ';' ~[\r\n]* ;
+
+TRASH
+    : ( WS | COMMENT ) -> channel(HIDDEN)
+    ;


### PR DESCRIPTION
While the original grammar worked, the resulting tree was very hard to analyze as it had little remaining tag information. This reworked grammar supports all the existing reader macros, host expressions as proposed for Clojure 1.7 and retains significantly more context information making it easy to manipulate the resulting tree.