### PR TITLE
Modified function call, selected name and slice grammar rules.

### DIFF
--- a/vhdl/examples/arith.vhd
+++ b/vhdl/examples/arith.vhd
@@ -1,0 +1,2406 @@
+--------------------------------------------------------------------------
+--                                                                      --
+-- Copyright (c) 1990,1991,1992 by Synopsys, Inc.  All rights reserved. --
+--                                                                      --
+-- This source file may be used and distributed without restriction     --
+-- provided that this copyright statement is not removed from the file  --
+-- and that any derivative work contains this copyright notice.         --
+--                                                                      --
+--    Package name: STD_LOGIC_ARITH                                     --
+--                                                                      --
+--    Purpose:                                                          --
+--     A set of arithemtic, conversion, and comparison functions        --
+--     for SIGNED, UNSIGNED, SMALL_INT, INTEGER,                        --
+--     STD_ULOGIC, STD_LOGIC, and STD_LOGIC_VECTOR.                     --
+--                                                                      --
+--------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+
+package std_logic_arith is
+
+    type UNSIGNED is array (NATURAL range <>) of STD_LOGIC;
+    type SIGNED is array (NATURAL range <>) of STD_LOGIC;
+    subtype SMALL_INT is INTEGER range 0 to 1;
+
+    ----------------
+    -- add operators
+    ----------------
+    function "+"(L: UNSIGNED; R: UNSIGNED) return UNSIGNED;
+
+    function "+"(L: SIGNED; R: SIGNED) return SIGNED;
+
+    function "+"(L: UNSIGNED; R: SIGNED) return SIGNED;
+
+    function "+"(L: SIGNED; R: UNSIGNED) return SIGNED;
+
+    function "+"(L: UNSIGNED; R: INTEGER) return UNSIGNED;
+
+    function "+"(L: INTEGER; R: UNSIGNED) return UNSIGNED;
+
+    function "+"(L: SIGNED; R: INTEGER) return SIGNED;
+
+    function "+"(L: INTEGER; R: SIGNED) return SIGNED;
+
+    function "+"(L: UNSIGNED; R: STD_ULOGIC) return UNSIGNED;
+
+    function "+"(L: STD_ULOGIC; R: UNSIGNED) return UNSIGNED;
+
+    function "+"(L: SIGNED; R: STD_ULOGIC) return SIGNED;
+
+    function "+"(L: STD_ULOGIC; R: SIGNED) return SIGNED;
+
+    function "+"(L: UNSIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: SIGNED; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: UNSIGNED; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: SIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: UNSIGNED; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "+"(L: INTEGER; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: SIGNED; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "+"(L: INTEGER; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: UNSIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_ULOGIC; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: SIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_ULOGIC; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    ---------------------
+    -- subtract operators
+    ---------------------
+    function "-"(L: UNSIGNED; R: UNSIGNED) return UNSIGNED;
+
+    function "-"(L: SIGNED; R: SIGNED) return SIGNED;
+
+    function "-"(L: UNSIGNED; R: SIGNED) return SIGNED;
+
+    function "-"(L: SIGNED; R: UNSIGNED) return SIGNED;
+
+    function "-"(L: UNSIGNED; R: INTEGER) return UNSIGNED;
+
+    function "-"(L: INTEGER; R: UNSIGNED) return UNSIGNED;
+
+    function "-"(L: SIGNED; R: INTEGER) return SIGNED;
+
+    function "-"(L: INTEGER; R: SIGNED) return SIGNED;
+
+    function "-"(L: UNSIGNED; R: STD_ULOGIC) return UNSIGNED;
+
+    function "-"(L: STD_ULOGIC; R: UNSIGNED) return UNSIGNED;
+
+    function "-"(L: SIGNED; R: STD_ULOGIC) return SIGNED;
+
+    function "-"(L: STD_ULOGIC; R: SIGNED) return SIGNED;
+
+    function "-"(L: UNSIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: SIGNED; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: UNSIGNED; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: SIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: UNSIGNED; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "-"(L: INTEGER; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: SIGNED; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "-"(L: INTEGER; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: UNSIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_ULOGIC; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: SIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_ULOGIC; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    ------------------
+    -- unary operators
+    ------------------
+    function "+"(L: UNSIGNED) return UNSIGNED;
+
+    function "+"(L: SIGNED) return SIGNED;
+
+    function "-"(L: SIGNED) return SIGNED;
+
+    function "ABS"(L: SIGNED) return SIGNED;
+
+    function "+"(L: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "+"(L: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "-"(L: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "ABS"(L: SIGNED) return STD_LOGIC_VECTOR;
+
+    ---------------------------
+    -- multiplication operators
+    ---------------------------
+    function "*"(L: UNSIGNED; R: UNSIGNED) return UNSIGNED;
+
+    function "*"(L: SIGNED; R: SIGNED) return SIGNED;
+
+    function "*"(L: SIGNED; R: UNSIGNED) return SIGNED;
+
+    function "*"(L: UNSIGNED; R: SIGNED) return SIGNED;
+
+    function "*"(L: UNSIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "*"(L: SIGNED; R: SIGNED) return STD_LOGIC_VECTOR;
+
+    function "*"(L: SIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR;
+
+    function "*"(L: UNSIGNED; R: SIGNED) return STD_LOGIC_VECTOR;
+
+
+    -----------------------
+    -- less_than comparison
+    -----------------------
+    function "<"(L: UNSIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "<"(L: SIGNED; R: SIGNED) return BOOLEAN;
+
+    function "<"(L: UNSIGNED; R: SIGNED) return BOOLEAN;
+
+    function "<"(L: SIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "<"(L: UNSIGNED; R: INTEGER) return BOOLEAN;
+
+    function "<"(L: INTEGER; R: UNSIGNED) return BOOLEAN;
+
+    function "<"(L: SIGNED; R: INTEGER) return BOOLEAN;
+
+    function "<"(L: INTEGER; R: SIGNED) return BOOLEAN;
+
+
+    --------------------------------
+    -- less_than_or_equal comparison
+    --------------------------------
+    function "<="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "<="(L: SIGNED; R: SIGNED) return BOOLEAN;
+
+    function "<="(L: UNSIGNED; R: SIGNED) return BOOLEAN;
+
+    function "<="(L: SIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "<="(L: UNSIGNED; R: INTEGER) return BOOLEAN;
+
+    function "<="(L: INTEGER; R: UNSIGNED) return BOOLEAN;
+
+    function "<="(L: SIGNED; R: INTEGER) return BOOLEAN;
+
+    function "<="(L: INTEGER; R: SIGNED) return BOOLEAN;
+
+
+    --------------------------
+    -- greater_than comparison
+    --------------------------
+    function ">"(L: UNSIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function ">"(L: SIGNED; R: SIGNED) return BOOLEAN;
+
+    function ">"(L: UNSIGNED; R: SIGNED) return BOOLEAN;
+
+    function ">"(L: SIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function ">"(L: UNSIGNED; R: INTEGER) return BOOLEAN;
+
+    function ">"(L: INTEGER; R: UNSIGNED) return BOOLEAN;
+
+    function ">"(L: SIGNED; R: INTEGER) return BOOLEAN;
+
+    function ">"(L: INTEGER; R: SIGNED) return BOOLEAN;
+
+
+    -----------------------------------
+    -- greater_than_or_equal comparison
+    -----------------------------------
+    function ">="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function ">="(L: SIGNED; R: SIGNED) return BOOLEAN;
+
+    function ">="(L: UNSIGNED; R: SIGNED) return BOOLEAN;
+
+    function ">="(L: SIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function ">="(L: UNSIGNED; R: INTEGER) return BOOLEAN;
+
+    function ">="(L: INTEGER; R: UNSIGNED) return BOOLEAN;
+
+    function ">="(L: SIGNED; R: INTEGER) return BOOLEAN;
+
+    function ">="(L: INTEGER; R: SIGNED) return BOOLEAN;
+
+
+    -------------------
+    -- equal comparison
+    -------------------
+    function "="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "="(L: SIGNED; R: SIGNED) return BOOLEAN;
+
+    function "="(L: UNSIGNED; R: SIGNED) return BOOLEAN;
+
+    function "="(L: SIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "="(L: UNSIGNED; R: INTEGER) return BOOLEAN;
+
+    function "="(L: INTEGER; R: UNSIGNED) return BOOLEAN;
+
+    function "="(L: SIGNED; R: INTEGER) return BOOLEAN;
+
+    function "="(L: INTEGER; R: SIGNED) return BOOLEAN;
+
+
+    -----------------------
+    -- not equal comparison
+    -----------------------
+    function "/="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "/="(L: SIGNED; R: SIGNED) return BOOLEAN;
+
+    function "/="(L: UNSIGNED; R: SIGNED) return BOOLEAN;
+
+    function "/="(L: SIGNED; R: UNSIGNED) return BOOLEAN;
+
+    function "/="(L: UNSIGNED; R: INTEGER) return BOOLEAN;
+
+    function "/="(L: INTEGER; R: UNSIGNED) return BOOLEAN;
+
+    function "/="(L: SIGNED; R: INTEGER) return BOOLEAN;
+
+    function "/="(L: INTEGER; R: SIGNED) return BOOLEAN;
+
+
+    ------------------
+    -- shift operators
+    ------------------
+    function SHL(ARG: UNSIGNED; COUNT: UNSIGNED) return UNSIGNED;
+
+    function SHL(ARG: SIGNED; COUNT: UNSIGNED) return SIGNED;
+
+    function SHR(ARG: UNSIGNED; COUNT: UNSIGNED) return UNSIGNED;
+
+    function SHR(ARG: SIGNED; COUNT: UNSIGNED) return SIGNED;
+
+
+    -----------------------
+    -- conversion operators
+    -----------------------
+    function CONV_INTEGER(ARG: INTEGER) return INTEGER;
+
+    function CONV_INTEGER(ARG: UNSIGNED) return INTEGER;
+
+    function CONV_INTEGER(ARG: SIGNED) return INTEGER;
+
+    function CONV_INTEGER(ARG: STD_ULOGIC) return SMALL_INT;
+
+    function CONV_UNSIGNED(ARG: INTEGER; SIZE: INTEGER) return UNSIGNED;
+
+    function CONV_UNSIGNED(ARG: UNSIGNED; SIZE: INTEGER) return UNSIGNED;
+
+    function CONV_UNSIGNED(ARG: SIGNED; SIZE: INTEGER) return UNSIGNED;
+
+    function CONV_UNSIGNED(ARG: STD_ULOGIC; SIZE: INTEGER) return UNSIGNED;
+
+    function CONV_SIGNED(ARG: INTEGER; SIZE: INTEGER) return SIGNED;
+
+    function CONV_SIGNED(ARG: UNSIGNED; SIZE: INTEGER) return SIGNED;
+
+    function CONV_SIGNED(ARG: SIGNED; SIZE: INTEGER) return SIGNED;
+
+    function CONV_SIGNED(ARG: STD_ULOGIC; SIZE: INTEGER) return SIGNED;
+
+    function CONV_STD_LOGIC_VECTOR(ARG: INTEGER; SIZE: INTEGER) return STD_LOGIC_VECTOR;
+
+    function CONV_STD_LOGIC_VECTOR(ARG: UNSIGNED; SIZE: INTEGER) return STD_LOGIC_VECTOR;
+
+    function CONV_STD_LOGIC_VECTOR(ARG: SIGNED; SIZE: INTEGER) return STD_LOGIC_VECTOR;
+
+    function CONV_STD_LOGIC_VECTOR(ARG: STD_ULOGIC; SIZE: INTEGER) return STD_LOGIC_VECTOR;
+
+
+    ----------------------------------------------
+    -- zero extend STD_LOGIC_VECTOR (ARG) to SIZE, 
+    -- SIZE < 0 is same as SIZE = 0
+    -- returns STD_LOGIC_VECTOR(SIZE-1 downto 0)
+    ----------------------------------------------
+    function EXT(ARG: STD_LOGIC_VECTOR; SIZE: INTEGER) return STD_LOGIC_VECTOR;
+
+    ----------------------------------------------
+    -- sign extend STD_LOGIC_VECTOR (ARG) to SIZE, 
+    -- SIZE < 0 is same as SIZE = 0
+    -- return STD_LOGIC_VECTOR(SIZE-1 downto 0)
+    ----------------------------------------------
+    function SXT(ARG: STD_LOGIC_VECTOR; SIZE: INTEGER) return STD_LOGIC_VECTOR;
+
+end Std_logic_arith;
+
+
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+
+package body std_logic_arith is
+
+    function max(L, R: INTEGER) return INTEGER is
+    begin
+    if L > R then
+        return L;
+    else
+        return R;
+    end if;
+    end;
+
+
+    function min(L, R: INTEGER) return INTEGER is
+    begin
+    if L < R then
+        return L;
+    else
+        return R;
+    end if;
+    end;
+
+    -- synopsys synthesis_off
+    type tbl_type is array (STD_ULOGIC) of STD_ULOGIC;
+    constant tbl_BINARY : tbl_type :=
+    ('X', 'X', '0', '1', 'X', 'X', '0', '1', 'X');
+    -- synopsys synthesis_on
+
+    -- synopsys synthesis_off
+    type tbl_mvl9_boolean is array (STD_ULOGIC) of boolean;
+    constant IS_X : tbl_mvl9_boolean :=
+        (true, true, false, false, true, true, false, false, true);
+    -- synopsys synthesis_on
+
+
+
+    function MAKE_BINARY(A : STD_ULOGIC) return STD_ULOGIC is
+    -- synopsys built_in SYN_FEED_THRU
+    begin
+    -- synopsys synthesis_off
+        if (IS_X(A)) then
+        assert false 
+        report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+        severity warning;
+            return ('X');
+        end if;
+        return tbl_BINARY(A);
+    -- synopsys synthesis_on
+    end;
+
+    function MAKE_BINARY(A : UNSIGNED) return UNSIGNED is
+    -- synopsys built_in SYN_FEED_THRU
+    variable one_bit : STD_ULOGIC;
+    variable result : UNSIGNED (A'range);
+    begin
+    -- synopsys synthesis_off
+        for i in A'range loop
+            if (IS_X(A(i))) then
+            assert false 
+            report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+            severity warning;
+            result := (others => 'X');
+                return result;
+            end if;
+        result(i) := tbl_BINARY(A(i));
+        end loop;
+        return result;
+    -- synopsys synthesis_on
+    end;
+
+    function MAKE_BINARY(A : UNSIGNED) return SIGNED is
+    -- synopsys built_in SYN_FEED_THRU
+    variable one_bit : STD_ULOGIC;
+    variable result : SIGNED (A'range);
+    begin
+    -- synopsys synthesis_off
+        for i in A'range loop
+            if (IS_X(A(i))) then
+            assert false 
+            report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+            severity warning;
+            result := (others => 'X');
+                return result;
+            end if;
+        result(i) := tbl_BINARY(A(i));
+        end loop;
+        return result;
+    -- synopsys synthesis_on
+    end;
+
+    function MAKE_BINARY(A : SIGNED) return UNSIGNED is
+    -- synopsys built_in SYN_FEED_THRU
+    variable one_bit : STD_ULOGIC;
+    variable result : UNSIGNED (A'range);
+    begin
+    -- synopsys synthesis_off
+        for i in A'range loop
+            if (IS_X(A(i))) then
+            assert false 
+            report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+            severity warning;
+            result := (others => 'X');
+                return result;
+            end if;
+        result(i) := tbl_BINARY(A(i));
+        end loop;
+        return result;
+    -- synopsys synthesis_on
+    end;
+
+    function MAKE_BINARY(A : SIGNED) return SIGNED is
+    -- synopsys built_in SYN_FEED_THRU
+    variable one_bit : STD_ULOGIC;
+    variable result : SIGNED (A'range);
+    begin
+    -- synopsys synthesis_off
+        for i in A'range loop
+            if (IS_X(A(i))) then
+            assert false 
+            report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+            severity warning;
+            result := (others => 'X');
+                return result;
+            end if;
+        result(i) := tbl_BINARY(A(i));
+        end loop;
+        return result;
+    -- synopsys synthesis_on
+    end;
+
+    function MAKE_BINARY(A : STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+    -- synopsys built_in SYN_FEED_THRU
+    variable one_bit : STD_ULOGIC;
+    variable result : STD_LOGIC_VECTOR (A'range);
+    begin
+    -- synopsys synthesis_off
+        for i in A'range loop
+            if (IS_X(A(i))) then
+            assert false 
+            report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+            severity warning;
+            result := (others => 'X');
+                return result;
+            end if;
+        result(i) := tbl_BINARY(A(i));
+        end loop;
+        return result;
+    -- synopsys synthesis_on
+    end;
+
+    function MAKE_BINARY(A : UNSIGNED) return STD_LOGIC_VECTOR is
+    -- synopsys built_in SYN_FEED_THRU
+    variable one_bit : STD_ULOGIC;
+    variable result : STD_LOGIC_VECTOR (A'range);
+    begin
+    -- synopsys synthesis_off
+        for i in A'range loop
+            if (IS_X(A(i))) then
+            assert false 
+            report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+            severity warning;
+            result := (others => 'X');
+                return result;
+            end if;
+        result(i) := tbl_BINARY(A(i));
+        end loop;
+        return result;
+    -- synopsys synthesis_on
+    end;
+
+    function MAKE_BINARY(A : SIGNED) return STD_LOGIC_VECTOR is
+    -- synopsys built_in SYN_FEED_THRU
+    variable one_bit : STD_ULOGIC;
+    variable result : STD_LOGIC_VECTOR (A'range);
+    begin
+    -- synopsys synthesis_off
+        for i in A'range loop
+            if (IS_X(A(i))) then
+            assert false 
+            report "There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, the result will be 'X'(es)."
+            severity warning;
+            result := (others => 'X');
+                return result;
+            end if;
+        result(i) := tbl_BINARY(A(i));
+        end loop;
+        return result;
+    -- synopsys synthesis_on
+    end;
+
+
+
+    -- Type propagation function which returns a signed type with the
+    -- size of the left arg.
+    function LEFT_SIGNED_ARG(A,B: SIGNED) return SIGNED is
+      variable Z: SIGNED (A'left downto 0);
+      -- pragma return_port_name Z
+    begin
+      return(Z);
+    end;
+    
+    -- Type propagation function which returns an unsigned type with the
+    -- size of the left arg.
+    function LEFT_UNSIGNED_ARG(A,B: UNSIGNED) return UNSIGNED is
+      variable Z: UNSIGNED (A'left downto 0);
+      -- pragma return_port_name Z
+    begin
+      return(Z);
+    end;
+    
+    -- Type propagation function which returns a signed type with the
+    -- size of the result of a signed multiplication
+    function MULT_SIGNED_ARG(A,B: SIGNED) return SIGNED is
+      variable Z: SIGNED ((A'length+B'length-1) downto 0);
+      -- pragma return_port_name Z
+    begin
+      return(Z);
+    end;
+    
+    -- Type propagation function which returns an unsigned type with the
+    -- size of the result of a unsigned multiplication
+    function MULT_UNSIGNED_ARG(A,B: UNSIGNED) return UNSIGNED is
+      variable Z: UNSIGNED ((A'length+B'length-1) downto 0);
+      -- pragma return_port_name Z
+    begin
+      return(Z);
+    end;
+
+
+
+    function mult(A,B: SIGNED) return SIGNED is
+
+      variable BA: SIGNED((A'length+B'length-1) downto 0);
+      variable PA: SIGNED((A'length+B'length-1) downto 0);
+      variable AA: SIGNED(A'length downto 0);
+      variable neg: STD_ULOGIC;
+      constant one : UNSIGNED(1 downto 0) := "01";
+      
+      -- pragma map_to_operator MULT_TC_OP
+      -- pragma type_function MULT_SIGNED_ARG
+      -- pragma return_port_name Z
+
+      begin
+    if (A(A'left) = 'X' or B(B'left) = 'X') then
+            PA := (others => 'X');
+            return(PA);
+    end if;
+        PA := (others => '0');
+        neg := B(B'left) xor A(A'left);
+        BA := CONV_SIGNED(('0' & ABS(B)),(A'length+B'length));
+        AA := '0' & ABS(A);
+        for i in 0 to A'length-1 loop
+          if AA(i) = '1' then
+            PA := PA+BA;
+          end if;
+          BA := SHL(BA,one);
+        end loop;
+        if (neg= '1') then
+          return(-PA);
+        else 
+          return(PA);
+        end if;
+      end;
+
+    function mult(A,B: UNSIGNED) return UNSIGNED is
+
+      variable BA: UNSIGNED((A'length+B'length-1) downto 0);
+      variable PA: UNSIGNED((A'length+B'length-1) downto 0);
+      constant one : UNSIGNED(1 downto 0) := "01";
+      
+      -- pragma map_to_operator MULT_UNS_OP
+      -- pragma type_function MULT_UNSIGNED_ARG
+      -- pragma return_port_name Z
+
+      begin
+    if (A(A'left) = 'X' or B(B'left) = 'X') then
+            PA := (others => 'X');
+            return(PA);
+    end if;
+        PA := (others => '0');
+        BA := CONV_UNSIGNED(B,(A'length+B'length));
+        for i in 0 to A'length-1 loop
+          if A(i) = '1' then
+            PA := PA+BA;
+          end if;
+          BA := SHL(BA,one);
+        end loop;
+        return(PA);
+      end;
+
+    -- subtract two signed numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function minus(A, B: SIGNED) return SIGNED is
+    variable carry: STD_ULOGIC;
+    variable BV: STD_ULOGIC_VECTOR (A'left downto 0);
+    variable sum: SIGNED (A'left downto 0);
+
+    -- pragma map_to_operator SUB_TC_OP
+
+    -- pragma type_function LEFT_SIGNED_ARG
+        -- pragma return_port_name Z
+
+    begin
+    if (A(A'left) = 'X' or B(B'left) = 'X') then
+            sum := (others => 'X');
+            return(sum);
+    end if;
+    carry := '1';
+    BV := not STD_ULOGIC_VECTOR(B);
+
+    for i in 0 to A'left loop
+        sum(i) := A(i) xor BV(i) xor carry;
+        carry := (A(i) and BV(i)) or
+            (A(i) and carry) or
+            (carry and BV(i));
+    end loop;
+    return sum;
+    end;
+
+    -- add two signed numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function plus(A, B: SIGNED) return SIGNED is
+    variable carry: STD_ULOGIC;
+    variable BV, sum: SIGNED (A'left downto 0);
+
+    -- pragma map_to_operator ADD_TC_OP
+    -- pragma type_function LEFT_SIGNED_ARG
+        -- pragma return_port_name Z
+
+    begin
+    if (A(A'left) = 'X' or B(B'left) = 'X') then
+            sum := (others => 'X');
+            return(sum);
+    end if;
+    carry := '0';
+    BV := B;
+
+    for i in 0 to A'left loop
+        sum(i) := A(i) xor BV(i) xor carry;
+        carry := (A(i) and BV(i)) or
+            (A(i) and carry) or
+            (carry and BV(i));
+    end loop;
+    return sum;
+    end;
+
+
+    -- subtract two unsigned numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function unsigned_minus(A, B: UNSIGNED) return UNSIGNED is
+    variable carry: STD_ULOGIC;
+    variable BV: STD_ULOGIC_VECTOR (A'left downto 0);
+    variable sum: UNSIGNED (A'left downto 0);
+
+    -- pragma map_to_operator SUB_UNS_OP
+    -- pragma type_function LEFT_UNSIGNED_ARG
+        -- pragma return_port_name Z
+
+    begin
+    if (A(A'left) = 'X' or B(B'left) = 'X') then
+            sum := (others => 'X');
+            return(sum);
+    end if;
+    carry := '1';
+    BV := not STD_ULOGIC_VECTOR(B);
+
+    for i in 0 to A'left loop
+        sum(i) := A(i) xor BV(i) xor carry;
+        carry := (A(i) and BV(i)) or
+            (A(i) and carry) or
+            (carry and BV(i));
+    end loop;
+    return sum;
+    end;
+
+    -- add two unsigned numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function unsigned_plus(A, B: UNSIGNED) return UNSIGNED is
+    variable carry: STD_ULOGIC;
+    variable BV, sum: UNSIGNED (A'left downto 0);
+
+    -- pragma map_to_operator ADD_UNS_OP
+    -- pragma type_function LEFT_UNSIGNED_ARG
+        -- pragma return_port_name Z
+
+    begin
+    if (A(A'left) = 'X' or B(B'left) = 'X') then
+            sum := (others => 'X');
+            return(sum);
+    end if;
+    carry := '0';
+    BV := B;
+
+    for i in 0 to A'left loop
+        sum(i) := A(i) xor BV(i) xor carry;
+        carry := (A(i) and BV(i)) or
+            (A(i) and carry) or
+            (carry and BV(i));
+    end loop;
+    return sum;
+    end;
+
+
+
+    function "*"(L: SIGNED; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to mult
+    begin
+          return     mult(CONV_SIGNED(L, L'length),
+                  CONV_SIGNED(R, R'length)); -- pragma label mult 
+    end;
+      
+    function "*"(L: UNSIGNED; R: UNSIGNED) return UNSIGNED is
+    -- pragma label_applies_to mult
+    begin
+      return   mult(CONV_UNSIGNED(L, L'length),
+                    CONV_UNSIGNED(R, R'length)); -- pragma label mult 
+end;
+    
+    function "*"(L: UNSIGNED; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to plus
+    begin
+     return       mult(CONV_SIGNED(L, L'length+1),
+                  CONV_SIGNED(R, R'length)); -- pragma label mult 
+    end;
+
+    function "*"(L: SIGNED; R: UNSIGNED) return SIGNED is
+    -- pragma label_applies_to plus
+    begin
+    return      mult(CONV_SIGNED(L, L'length),
+                 CONV_SIGNED(R, R'length+1)); -- pragma label mult 
+    end;
+
+
+    function "*"(L: SIGNED; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to mult
+    begin
+          return STD_LOGIC_VECTOR (mult(CONV_SIGNED(L, L'length),
+                  CONV_SIGNED(R, R'length))); -- pragma label mult 
+    end;
+      
+    function "*"(L: UNSIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to mult
+    begin
+          return STD_LOGIC_VECTOR (mult(CONV_UNSIGNED(L, L'length),
+                        CONV_UNSIGNED(R, R'length))); -- pragma label mult 
+    end;
+        
+    function "*"(L: UNSIGNED; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    begin
+     return STD_LOGIC_VECTOR (mult(CONV_SIGNED(L, L'length+1),
+                  CONV_SIGNED(R, R'length))); -- pragma label mult 
+    end;
+
+    function "*"(L: SIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    begin
+    return STD_LOGIC_VECTOR (mult(CONV_SIGNED(L, L'length),
+                 CONV_SIGNED(R, R'length+1))); -- pragma label mult 
+    end;
+
+
+    function "+"(L: UNSIGNED; R: UNSIGNED) return UNSIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return unsigned_plus(CONV_UNSIGNED(L, length),
+                 CONV_UNSIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: SIGNED; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: UNSIGNED; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: SIGNED; R: UNSIGNED) return SIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: UNSIGNED; R: INTEGER) return UNSIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length + 1;
+    begin
+    return CONV_UNSIGNED(
+        plus( -- pragma label plus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1);
+    end;
+
+
+    function "+"(L: INTEGER; R: UNSIGNED) return UNSIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length + 1;
+    begin
+    return CONV_UNSIGNED(
+        plus( -- pragma label plus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1);
+    end;
+
+
+    function "+"(L: SIGNED; R: INTEGER) return SIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length;
+    begin
+    return plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: INTEGER; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length;
+    begin
+    return plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: UNSIGNED; R: STD_ULOGIC) return UNSIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length;
+    begin
+    return unsigned_plus(CONV_UNSIGNED(L, length),
+             CONV_UNSIGNED(R, length)) ; -- pragma label plus
+    end;
+
+
+    function "+"(L: STD_ULOGIC; R: UNSIGNED) return UNSIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length;
+    begin
+    return unsigned_plus(CONV_UNSIGNED(L, length),
+             CONV_UNSIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: SIGNED; R: STD_ULOGIC) return SIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length;
+    begin
+    return plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label plus
+    end;
+
+
+    function "+"(L: STD_ULOGIC; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length;
+    begin
+    return plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label plus
+    end;
+
+
+
+    function "+"(L: UNSIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return STD_LOGIC_VECTOR (unsigned_plus(CONV_UNSIGNED(L, length),
+                 CONV_UNSIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: SIGNED; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return STD_LOGIC_VECTOR (plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: UNSIGNED; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return STD_LOGIC_VECTOR (plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: SIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return STD_LOGIC_VECTOR (plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: UNSIGNED; R: INTEGER) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length + 1;
+    begin
+    return STD_LOGIC_VECTOR (CONV_UNSIGNED(
+        plus( -- pragma label plus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1));
+    end;
+
+
+    function "+"(L: INTEGER; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length + 1;
+    begin
+    return STD_LOGIC_VECTOR (CONV_UNSIGNED(
+        plus( -- pragma label plus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1));
+    end;
+
+
+    function "+"(L: SIGNED; R: INTEGER) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length;
+    begin
+    return STD_LOGIC_VECTOR (plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: INTEGER; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length;
+    begin
+    return STD_LOGIC_VECTOR (plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: UNSIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length;
+    begin
+    return STD_LOGIC_VECTOR (unsigned_plus(CONV_UNSIGNED(L, length),
+             CONV_UNSIGNED(R, length))) ; -- pragma label plus
+    end;
+
+
+    function "+"(L: STD_ULOGIC; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length;
+    begin
+    return STD_LOGIC_VECTOR (unsigned_plus(CONV_UNSIGNED(L, length),
+             CONV_UNSIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: SIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := L'length;
+    begin
+    return STD_LOGIC_VECTOR (plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length))); -- pragma label plus
+    end;
+
+
+    function "+"(L: STD_ULOGIC; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to plus
+    constant length: INTEGER := R'length;
+    begin
+    return STD_LOGIC_VECTOR (plus(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length))); -- pragma label plus
+    end;
+
+
+
+    function "-"(L: UNSIGNED; R: UNSIGNED) return UNSIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return unsigned_minus(CONV_UNSIGNED(L, length),
+                        CONV_UNSIGNED(R, length)); -- pragma label minus
+    end;
+
+
+    function "-"(L: SIGNED; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length)); -- pragma label minus
+    end;
+
+
+    function "-"(L: UNSIGNED; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length)); -- pragma label minus
+    end;
+
+
+    function "-"(L: SIGNED; R: UNSIGNED) return SIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length)); -- pragma label minus
+    end;
+
+
+    function "-"(L: UNSIGNED; R: INTEGER) return UNSIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length + 1;
+    begin
+    return CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1);
+    end;
+
+
+    function "-"(L: INTEGER; R: UNSIGNED) return UNSIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length + 1;
+    begin
+    return CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1);
+    end;
+
+
+    function "-"(L: SIGNED; R: INTEGER) return SIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length;
+    begin
+    return minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length)); -- pragma label minus
+    end;
+
+
+    function "-"(L: INTEGER; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length;
+    begin
+    return minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length)); -- pragma label minus
+    end;
+
+
+    function "-"(L: UNSIGNED; R: STD_ULOGIC) return UNSIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length + 1;
+    begin
+    return CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1);
+    end;
+
+
+    function "-"(L: STD_ULOGIC; R: UNSIGNED) return UNSIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length + 1;
+    begin
+    return CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1);
+    end;
+
+
+    function "-"(L: SIGNED; R: STD_ULOGIC) return SIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length;
+    begin
+    return minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length)); -- pragma label minus
+    end;
+
+
+    function "-"(L: STD_ULOGIC; R: SIGNED) return SIGNED is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length;
+    begin
+    return minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length)); -- pragma label minus
+    end;
+
+
+
+
+    function "-"(L: UNSIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return STD_LOGIC_VECTOR (unsigned_minus(CONV_UNSIGNED(L, length),
+                        CONV_UNSIGNED(R, length))); -- pragma label minus
+    end;
+
+
+    function "-"(L: SIGNED; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return STD_LOGIC_VECTOR (minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length))); -- pragma label minus
+    end;
+
+
+    function "-"(L: UNSIGNED; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return STD_LOGIC_VECTOR (minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length))); -- pragma label minus
+    end;
+
+
+    function "-"(L: SIGNED; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return STD_LOGIC_VECTOR (minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length))); -- pragma label minus
+    end;
+
+
+    function "-"(L: UNSIGNED; R: INTEGER) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length + 1;
+    begin
+    return STD_LOGIC_VECTOR (CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1));
+    end;
+
+
+    function "-"(L: INTEGER; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length + 1;
+    begin
+    return STD_LOGIC_VECTOR (CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1));
+    end;
+
+
+    function "-"(L: SIGNED; R: INTEGER) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length;
+    begin
+    return STD_LOGIC_VECTOR (minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length))); -- pragma label minus
+    end;
+
+
+    function "-"(L: INTEGER; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length;
+    begin
+    return STD_LOGIC_VECTOR (minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length))); -- pragma label minus
+    end;
+
+
+    function "-"(L: UNSIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length + 1;
+    begin
+    return STD_LOGIC_VECTOR (CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1));
+    end;
+
+
+    function "-"(L: STD_ULOGIC; R: UNSIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length + 1;
+    begin
+    return STD_LOGIC_VECTOR (CONV_UNSIGNED(
+        minus( -- pragma label minus
+            CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)),
+        length-1));
+    end;
+
+
+    function "-"(L: SIGNED; R: STD_ULOGIC) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := L'length;
+    begin
+    return STD_LOGIC_VECTOR (minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length))); -- pragma label minus
+    end;
+
+
+    function "-"(L: STD_ULOGIC; R: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    constant length: INTEGER := R'length;
+    begin
+    return STD_LOGIC_VECTOR (minus(CONV_SIGNED(L, length),
+             CONV_SIGNED(R, length))); -- pragma label minus
+    end;
+
+
+
+
+    function "+"(L: UNSIGNED) return UNSIGNED is
+    begin
+    return L;
+    end;
+
+
+    function "+"(L: SIGNED) return SIGNED is
+    begin
+    return L;
+    end;
+
+
+    function "-"(L: SIGNED) return SIGNED is
+    -- pragma label_applies_to minus
+    begin
+    return 0 - L; -- pragma label minus
+    end;
+
+
+    function "ABS"(L: SIGNED) return SIGNED is
+    begin
+    if (L(L'left) = '0' or L(L'left) = 'L') then
+        return L;
+    else
+        return 0 - L;
+    end if;
+    end;
+
+
+    function "+"(L: UNSIGNED) return STD_LOGIC_VECTOR is
+    begin
+    return STD_LOGIC_VECTOR (L);
+    end;
+
+
+    function "+"(L: SIGNED) return STD_LOGIC_VECTOR is
+    begin
+    return STD_LOGIC_VECTOR (L);
+    end;
+
+
+    function "-"(L: SIGNED) return STD_LOGIC_VECTOR is
+    -- pragma label_applies_to minus
+    variable tmp: SIGNED(L'length-1 downto 0);
+    begin
+    tmp := 0 - L;  -- pragma label minus
+    return STD_LOGIC_VECTOR (tmp); 
+    end;
+
+
+    function "ABS"(L: SIGNED) return STD_LOGIC_VECTOR is
+    variable tmp: SIGNED(L'length-1 downto 0);
+    begin
+    if (L(L'left) = '0' or L(L'left) = 'L') then
+        return STD_LOGIC_VECTOR (L);
+    else
+        tmp := 0 - L;
+        return STD_LOGIC_VECTOR (tmp);
+    end if;
+    end;
+
+
+    -- Type propagation function which returns the type BOOLEAN
+    function UNSIGNED_RETURN_BOOLEAN(A,B: UNSIGNED) return BOOLEAN is
+      variable Z: BOOLEAN;
+      -- pragma return_port_name Z
+    begin
+      return(Z);
+    end;
+    
+    -- Type propagation function which returns the type BOOLEAN
+    function SIGNED_RETURN_BOOLEAN(A,B: SIGNED) return BOOLEAN is
+      variable Z: BOOLEAN;
+      -- pragma return_port_name Z
+    begin
+      return(Z);
+    end;
+    
+
+    -- compare two signed numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function is_less(A, B: SIGNED) return BOOLEAN is
+    constant sign: INTEGER := A'left;
+    variable a_is_0, b_is_1, result : boolean;
+
+    -- pragma map_to_operator LT_TC_OP
+    -- pragma type_function SIGNED_RETURN_BOOLEAN
+        -- pragma return_port_name Z
+
+    begin
+    if A(sign) /= B(sign) then
+        result := A(sign) = '1';
+    else
+        result := FALSE;
+        for i in 0 to sign-1 loop
+        a_is_0 := A(i) = '0';
+        b_is_1 := B(i) = '1';
+        result := (a_is_0 and b_is_1) or
+              (a_is_0 and result) or
+              (b_is_1 and result);
+        end loop;
+    end if;
+    return result;
+    end;
+
+
+    -- compare two signed numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function is_less_or_equal(A, B: SIGNED) return BOOLEAN is
+    constant sign: INTEGER := A'left;
+    variable a_is_0, b_is_1, result : boolean;
+
+    -- pragma map_to_operator LEQ_TC_OP
+    -- pragma type_function SIGNED_RETURN_BOOLEAN
+        -- pragma return_port_name Z
+
+    begin
+    if A(sign) /= B(sign) then
+        result := A(sign) = '1';
+    else
+        result := TRUE;
+        for i in 0 to sign-1 loop
+        a_is_0 := A(i) = '0';
+        b_is_1 := B(i) = '1';
+        result := (a_is_0 and b_is_1) or
+              (a_is_0 and result) or
+              (b_is_1 and result);
+        end loop;
+    end if;
+    return result;
+    end;
+
+
+
+    -- compare two unsigned numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function unsigned_is_less(A, B: UNSIGNED) return BOOLEAN is
+    constant sign: INTEGER := A'left;
+    variable a_is_0, b_is_1, result : boolean;
+
+    -- pragma map_to_operator LT_UNS_OP
+    -- pragma type_function UNSIGNED_RETURN_BOOLEAN
+        -- pragma return_port_name Z
+
+    begin
+    result := FALSE;
+    for i in 0 to sign loop
+        a_is_0 := A(i) = '0';
+        b_is_1 := B(i) = '1';
+        result := (a_is_0 and b_is_1) or
+              (a_is_0 and result) or
+              (b_is_1 and result);
+    end loop;
+    return result;
+    end;
+
+
+    -- compare two unsigned numbers of the same length
+    -- both arrays must have range (msb downto 0)
+    function unsigned_is_less_or_equal(A, B: UNSIGNED) return BOOLEAN is
+    constant sign: INTEGER := A'left;
+    variable a_is_0, b_is_1, result : boolean;
+
+    -- pragma map_to_operator LEQ_UNS_OP
+    -- pragma type_function UNSIGNED_RETURN_BOOLEAN
+        -- pragma return_port_name Z
+
+    begin
+    result := TRUE;
+    for i in 0 to sign loop
+        a_is_0 := A(i) = '0';
+        b_is_1 := B(i) = '1';
+        result := (a_is_0 and b_is_1) or
+              (a_is_0 and result) or
+              (b_is_1 and result);
+    end loop;
+    return result;
+    end;
+
+
+
+
+    function "<"(L: UNSIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return unsigned_is_less(CONV_UNSIGNED(L, length),
+                CONV_UNSIGNED(R, length)); -- pragma label lt
+    end;
+
+
+    function "<"(L: SIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return is_less(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label lt
+    end;
+
+
+    function "<"(L: UNSIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return is_less(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label lt
+    end;
+
+
+    function "<"(L: SIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return is_less(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label lt
+    end;
+
+
+    function "<"(L: UNSIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := L'length + 1;
+    begin
+    return is_less(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label lt
+    end;
+
+
+    function "<"(L: INTEGER; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := R'length + 1;
+    begin
+    return is_less(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label lt
+    end;
+
+
+    function "<"(L: SIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := L'length;
+    begin
+    return is_less(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label lt
+    end;
+
+
+    function "<"(L: INTEGER; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to lt
+    constant length: INTEGER := R'length;
+    begin
+    return is_less(CONV_SIGNED(L, length),
+            CONV_SIGNED(R, length)); -- pragma label lt
+    end;
+
+
+
+
+    function "<="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return unsigned_is_less_or_equal(CONV_UNSIGNED(L, length),
+                 CONV_UNSIGNED(R, length)); -- pragma label leq
+    end;
+
+
+    function "<="(L: SIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return is_less_or_equal(CONV_SIGNED(L, length),
+                CONV_SIGNED(R, length)); -- pragma label leq
+    end;
+
+
+    function "<="(L: UNSIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return is_less_or_equal(CONV_SIGNED(L, length),
+                CONV_SIGNED(R, length)); -- pragma label leq
+    end;
+
+
+    function "<="(L: SIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return is_less_or_equal(CONV_SIGNED(L, length),
+                CONV_SIGNED(R, length)); -- pragma label leq
+    end;
+
+
+    function "<="(L: UNSIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := L'length + 1;
+    begin
+    return is_less_or_equal(CONV_SIGNED(L, length),
+                CONV_SIGNED(R, length)); -- pragma label leq
+    end;
+
+
+    function "<="(L: INTEGER; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := R'length + 1;
+    begin
+    return is_less_or_equal(CONV_SIGNED(L, length),
+                CONV_SIGNED(R, length)); -- pragma label leq
+    end;
+
+
+    function "<="(L: SIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := L'length;
+    begin
+    return is_less_or_equal(CONV_SIGNED(L, length),
+                CONV_SIGNED(R, length)); -- pragma label leq
+    end;
+
+
+    function "<="(L: INTEGER; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to leq
+    constant length: INTEGER := R'length;
+    begin
+    return is_less_or_equal(CONV_SIGNED(L, length),
+                CONV_SIGNED(R, length)); -- pragma label leq
+    end;
+
+
+
+
+    function ">"(L: UNSIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return unsigned_is_less(CONV_UNSIGNED(R, length),
+                CONV_UNSIGNED(L, length)); -- pragma label gt
+    end;
+
+
+    function ">"(L: SIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return is_less(CONV_SIGNED(R, length),
+               CONV_SIGNED(L, length)); -- pragma label gt
+    end;
+
+
+    function ">"(L: UNSIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return is_less(CONV_SIGNED(R, length),
+               CONV_SIGNED(L, length)); -- pragma label gt
+    end;
+
+
+    function ">"(L: SIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return is_less(CONV_SIGNED(R, length),
+               CONV_SIGNED(L, length)); -- pragma label gt
+    end;
+
+
+    function ">"(L: UNSIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := L'length + 1;
+    begin
+    return is_less(CONV_SIGNED(R, length),
+               CONV_SIGNED(L, length)); -- pragma label gt
+    end;
+
+
+    function ">"(L: INTEGER; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := R'length + 1;
+    begin
+    return is_less(CONV_SIGNED(R, length),
+               CONV_SIGNED(L, length)); -- pragma label gt
+    end;
+
+
+    function ">"(L: SIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := L'length;
+    begin
+    return is_less(CONV_SIGNED(R, length),
+               CONV_SIGNED(L, length)); -- pragma label gt
+    end;
+
+
+    function ">"(L: INTEGER; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to gt
+    constant length: INTEGER := R'length;
+    begin
+    return is_less(CONV_SIGNED(R, length),
+               CONV_SIGNED(L, length)); -- pragma label gt
+    end;
+
+
+
+
+    function ">="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return unsigned_is_less_or_equal(CONV_UNSIGNED(R, length),
+                 CONV_UNSIGNED(L, length)); -- pragma label geq
+    end;
+
+
+    function ">="(L: SIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return is_less_or_equal(CONV_SIGNED(R, length),
+                CONV_SIGNED(L, length)); -- pragma label geq
+    end;
+
+
+    function ">="(L: UNSIGNED; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return is_less_or_equal(CONV_SIGNED(R, length),
+                CONV_SIGNED(L, length)); -- pragma label geq
+    end;
+
+
+    function ">="(L: SIGNED; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return is_less_or_equal(CONV_SIGNED(R, length),
+                CONV_SIGNED(L, length)); -- pragma label geq
+    end;
+
+
+    function ">="(L: UNSIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := L'length + 1;
+    begin
+    return is_less_or_equal(CONV_SIGNED(R, length),
+                CONV_SIGNED(L, length)); -- pragma label geq
+    end;
+
+
+    function ">="(L: INTEGER; R: UNSIGNED) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := R'length + 1;
+    begin
+    return is_less_or_equal(CONV_SIGNED(R, length),
+                CONV_SIGNED(L, length)); -- pragma label geq
+    end;
+
+
+    function ">="(L: SIGNED; R: INTEGER) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := L'length;
+    begin
+    return is_less_or_equal(CONV_SIGNED(R, length),
+                CONV_SIGNED(L, length)); -- pragma label geq
+    end;
+
+
+    function ">="(L: INTEGER; R: SIGNED) return BOOLEAN is
+    -- pragma label_applies_to geq
+    constant length: INTEGER := R'length;
+    begin
+    return is_less_or_equal(CONV_SIGNED(R, length),
+                CONV_SIGNED(L, length)); -- pragma label geq
+    end;
+
+
+
+
+    -- for internal use only.  Assumes SIGNED arguments of equal length.
+    function bitwise_eql(L: STD_ULOGIC_VECTOR; R: STD_ULOGIC_VECTOR)
+                        return BOOLEAN is
+    -- pragma built_in SYN_EQL
+    begin
+    for i in L'range loop
+        if L(i) /= R(i) then
+        return FALSE;
+        end if;
+    end loop;
+    return TRUE;
+    end;
+
+    -- for internal use only.  Assumes SIGNED arguments of equal length.
+    function bitwise_neq(L: STD_ULOGIC_VECTOR; R: STD_ULOGIC_VECTOR)
+                        return BOOLEAN is
+    -- pragma built_in SYN_NEQ
+    begin
+    for i in L'range loop
+        if L(i) /= R(i) then
+        return TRUE;
+        end if;
+    end loop;
+    return FALSE;
+    end;
+
+
+    function "="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_UNSIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_UNSIGNED(R, length) ) );
+    end;
+
+
+    function "="(L: SIGNED; R: SIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "="(L: UNSIGNED; R: SIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "="(L: SIGNED; R: UNSIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "="(L: UNSIGNED; R: INTEGER) return BOOLEAN is
+    constant length: INTEGER := L'length + 1;
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "="(L: INTEGER; R: UNSIGNED) return BOOLEAN is
+    constant length: INTEGER := R'length + 1;
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "="(L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant length: INTEGER := L'length;
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "="(L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant length: INTEGER := R'length;
+    begin
+    return bitwise_eql( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+
+
+    function "/="(L: UNSIGNED; R: UNSIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_UNSIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_UNSIGNED(R, length) ) );
+    end;
+
+
+    function "/="(L: SIGNED; R: SIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length, R'length);
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "/="(L: UNSIGNED; R: SIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length + 1, R'length);
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "/="(L: SIGNED; R: UNSIGNED) return BOOLEAN is
+    constant length: INTEGER := max(L'length, R'length + 1);
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "/="(L: UNSIGNED; R: INTEGER) return BOOLEAN is
+    constant length: INTEGER := L'length + 1;
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "/="(L: INTEGER; R: UNSIGNED) return BOOLEAN is
+    constant length: INTEGER := R'length + 1;
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "/="(L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant length: INTEGER := L'length;
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+    function "/="(L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant length: INTEGER := R'length;
+    begin
+    return bitwise_neq( STD_ULOGIC_VECTOR( CONV_SIGNED(L, length) ),
+        STD_ULOGIC_VECTOR( CONV_SIGNED(R, length) ) );
+    end;
+
+
+
+    function SHL(ARG: UNSIGNED; COUNT: UNSIGNED) return UNSIGNED is
+    constant control_msb: INTEGER := COUNT'length - 1;
+    variable control: UNSIGNED (control_msb downto 0);
+    constant result_msb: INTEGER := ARG'length-1;
+    subtype rtype is UNSIGNED (result_msb downto 0);
+    variable result, temp: rtype;
+    begin
+    control := MAKE_BINARY(COUNT);
+    if (control(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := ARG;
+    for i in 0 to control_msb loop
+        if control(i) = '1' then
+        temp := rtype'(others => '0');
+        if 2**i <= result_msb then
+            temp(result_msb downto 2**i) := 
+                    result(result_msb - 2**i downto 0);
+        end if;
+        result := temp;
+        end if;
+    end loop;
+    return result;
+    end;
+
+    function SHL(ARG: SIGNED; COUNT: UNSIGNED) return SIGNED is
+    constant control_msb: INTEGER := COUNT'length - 1;
+    variable control: UNSIGNED (control_msb downto 0);
+    constant result_msb: INTEGER := ARG'length-1;
+    subtype rtype is SIGNED (result_msb downto 0);
+    variable result, temp: rtype;
+    begin
+    control := MAKE_BINARY(COUNT);
+    if (control(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := ARG;
+    for i in 0 to control_msb loop
+        if control(i) = '1' then
+        temp := rtype'(others => '0');
+        if 2**i <= result_msb then
+            temp(result_msb downto 2**i) := 
+                    result(result_msb - 2**i downto 0);
+        end if;
+        result := temp;
+        end if;
+    end loop;
+    return result;
+    end;
+
+
+    function SHR(ARG: UNSIGNED; COUNT: UNSIGNED) return UNSIGNED is
+    constant control_msb: INTEGER := COUNT'length - 1;
+    variable control: UNSIGNED (control_msb downto 0);
+    constant result_msb: INTEGER := ARG'length-1;
+    subtype rtype is UNSIGNED (result_msb downto 0);
+    variable result, temp: rtype;
+    begin
+    control := MAKE_BINARY(COUNT);
+    if (control(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := ARG;
+    for i in 0 to control_msb loop
+        if control(i) = '1' then
+        temp := rtype'(others => '0');
+        if 2**i <= result_msb then
+            temp(result_msb - 2**i downto 0) := 
+                    result(result_msb downto 2**i);
+        end if;
+        result := temp;
+        end if;
+    end loop;
+    return result;
+    end;
+
+    function SHR(ARG: SIGNED; COUNT: UNSIGNED) return SIGNED is
+    constant control_msb: INTEGER := COUNT'length - 1;
+    variable control: UNSIGNED (control_msb downto 0);
+    constant result_msb: INTEGER := ARG'length-1;
+    subtype rtype is SIGNED (result_msb downto 0);
+    variable result, temp: rtype;
+    variable sign_bit: STD_ULOGIC;
+    begin
+    control := MAKE_BINARY(COUNT);
+    if (control(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := ARG;
+    sign_bit := ARG(ARG'left);
+    for i in 0 to control_msb loop
+        if control(i) = '1' then
+        temp := rtype'(others => sign_bit);
+        if 2**i <= result_msb then
+            temp(result_msb - 2**i downto 0) := 
+                    result(result_msb downto 2**i);
+        end if;
+        result := temp;
+        end if;
+    end loop;
+    return result;
+    end;
+
+
+
+
+    function CONV_INTEGER(ARG: INTEGER) return INTEGER is
+    begin
+    return ARG;
+    end;
+
+    function CONV_INTEGER(ARG: UNSIGNED) return INTEGER is
+    variable result: INTEGER;
+    variable tmp: STD_ULOGIC;
+    -- synopsys built_in SYN_UNSIGNED_TO_INTEGER
+    begin
+    -- synopsys synthesis_off
+    assert ARG'length <= 31
+        report "ARG is too large in CONV_INTEGER"
+        severity FAILURE;
+    result := 0;
+    for i in ARG'range loop
+        result := result * 2;
+        tmp := tbl_BINARY(ARG(i));
+        if tmp = '1' then
+        result := result + 1;
+        elsif tmp = 'X' then
+        assert false
+        report "CONV_INTEGER: There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, and it has been converted to 0."
+        severity WARNING;
+        end if;
+    end loop;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_INTEGER(ARG: SIGNED) return INTEGER is
+    variable result: INTEGER;
+    variable tmp: STD_ULOGIC;
+    -- synopsys built_in SYN_SIGNED_TO_INTEGER
+    begin
+    -- synopsys synthesis_off
+    assert ARG'length <= 32
+        report "ARG is too large in CONV_INTEGER"
+        severity FAILURE;
+    result := 0;
+    for i in ARG'range loop
+        if i /= ARG'left then
+        result := result * 2;
+            tmp := tbl_BINARY(ARG(i));
+            if tmp = '1' then
+            result := result + 1;
+            elsif tmp = 'X' then
+            assert false
+            report "CONV_INTEGER: There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, and it has been converted to 0."
+            severity WARNING;
+            end if;
+        end if;
+    end loop;
+    tmp := MAKE_BINARY(ARG(ARG'left));
+    if tmp = '1' then
+        if ARG'length = 32 then
+        result := (result - 2**30) - 2**30;
+        else
+        result := result - (2 ** (ARG'length-1));
+        end if;
+    end if;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_INTEGER(ARG: STD_ULOGIC) return SMALL_INT is
+    variable tmp: STD_ULOGIC;
+    -- synopsys built_in SYN_FEED_THRU
+    begin
+    -- synopsys synthesis_off
+    tmp := tbl_BINARY(ARG);
+    if tmp = '1' then
+        return 1;
+    elsif tmp = 'X' then
+        assert false
+        report "CONV_INTEGER: There is an 'U'|'X'|'W'|'Z'|'-' in an arithmetic operand, and it has been converted to 0."
+        severity WARNING;
+        return 0;
+    else
+        return 0;
+    end if;
+    -- synopsys synthesis_on
+    end;
+
+
+    -- convert an integer to a unsigned STD_ULOGIC_VECTOR
+    function CONV_UNSIGNED(ARG: INTEGER; SIZE: INTEGER) return UNSIGNED is
+    variable result: UNSIGNED(SIZE-1 downto 0);
+    variable temp: integer;
+    -- synopsys built_in SYN_INTEGER_TO_UNSIGNED
+    begin
+    -- synopsys synthesis_off
+    temp := ARG;
+    for i in 0 to SIZE-1 loop
+        if (temp mod 2) = 1 then
+        result(i) := '1';
+        else 
+        result(i) := '0';
+        end if;
+        if temp > 0 then
+        temp := temp / 2;
+        else
+        temp := (temp - 1) / 2; -- simulate ASR
+        end if;
+    end loop;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_UNSIGNED(ARG: UNSIGNED; SIZE: INTEGER) return UNSIGNED is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is UNSIGNED (SIZE-1 downto 0);
+    variable new_bounds: UNSIGNED (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_ZERO_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => '0');
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_UNSIGNED(ARG: SIGNED; SIZE: INTEGER) return UNSIGNED is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is UNSIGNED (SIZE-1 downto 0);
+    variable new_bounds: UNSIGNED (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_SIGN_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => new_bounds(new_bounds'left));
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_UNSIGNED(ARG: STD_ULOGIC; SIZE: INTEGER) return UNSIGNED is
+    subtype rtype is UNSIGNED (SIZE-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_ZERO_EXTEND
+    begin
+    -- synopsys synthesis_off
+    result := rtype'(others => '0');
+    result(0) := MAKE_BINARY(ARG);
+    if (result(0) = 'X') then
+        result := rtype'(others => 'X');
+    end if;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    -- convert an integer to a 2's complement STD_ULOGIC_VECTOR
+    function CONV_SIGNED(ARG: INTEGER; SIZE: INTEGER) return SIGNED is
+    variable result: SIGNED (SIZE-1 downto 0);
+    variable temp: integer;
+    -- synopsys built_in SYN_INTEGER_TO_SIGNED
+    begin
+    -- synopsys synthesis_off
+    temp := ARG;
+    for i in 0 to SIZE-1 loop
+        if (temp mod 2) = 1 then
+        result(i) := '1';
+        else 
+        result(i) := '0';
+        end if;
+        if temp > 0 then
+        temp := temp / 2;
+        else
+        temp := (temp - 1) / 2; -- simulate ASR
+        end if;
+    end loop;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_SIGNED(ARG: UNSIGNED; SIZE: INTEGER) return SIGNED is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is SIGNED (SIZE-1 downto 0);
+    variable new_bounds : SIGNED (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_ZERO_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => '0');
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+    function CONV_SIGNED(ARG: SIGNED; SIZE: INTEGER) return SIGNED is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is SIGNED (SIZE-1 downto 0);
+    variable new_bounds : SIGNED (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_SIGN_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => new_bounds(new_bounds'left));
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_SIGNED(ARG: STD_ULOGIC; SIZE: INTEGER) return SIGNED is
+    subtype rtype is SIGNED (SIZE-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_ZERO_EXTEND
+    begin
+    -- synopsys synthesis_off
+    result := rtype'(others => '0');
+    result(0) := MAKE_BINARY(ARG);
+    if (result(0) = 'X') then
+        result := rtype'(others => 'X');
+    end if;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    -- convert an integer to an STD_LOGIC_VECTOR
+    function CONV_STD_LOGIC_VECTOR(ARG: INTEGER; SIZE: INTEGER) return STD_LOGIC_VECTOR is
+    variable result: STD_LOGIC_VECTOR (SIZE-1 downto 0);
+    variable temp: integer;
+    -- synopsys built_in SYN_INTEGER_TO_SIGNED
+    begin
+    -- synopsys synthesis_off
+    temp := ARG;
+    for i in 0 to SIZE-1 loop
+        if (temp mod 2) = 1 then
+        result(i) := '1';
+        else 
+        result(i) := '0';
+        end if;
+        if temp > 0 then
+        temp := temp / 2;
+        else
+        temp := (temp - 1) / 2; -- simulate ASR
+        end if;
+    end loop;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_STD_LOGIC_VECTOR(ARG: UNSIGNED; SIZE: INTEGER) return STD_LOGIC_VECTOR is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is STD_LOGIC_VECTOR (SIZE-1 downto 0);
+    variable new_bounds : STD_LOGIC_VECTOR (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_ZERO_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => '0');
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+    function CONV_STD_LOGIC_VECTOR(ARG: SIGNED; SIZE: INTEGER) return STD_LOGIC_VECTOR is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is STD_LOGIC_VECTOR (SIZE-1 downto 0);
+    variable new_bounds : STD_LOGIC_VECTOR (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_SIGN_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => new_bounds(new_bounds'left));
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function CONV_STD_LOGIC_VECTOR(ARG: STD_ULOGIC; SIZE: INTEGER) return STD_LOGIC_VECTOR is
+    subtype rtype is STD_LOGIC_VECTOR (SIZE-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_ZERO_EXTEND
+    begin
+    -- synopsys synthesis_off
+    result := rtype'(others => '0');
+    result(0) := MAKE_BINARY(ARG);
+    if (result(0) = 'X') then
+        result := rtype'(others => 'X');
+    end if;
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+    function EXT(ARG: STD_LOGIC_VECTOR; SIZE: INTEGER) 
+                        return STD_LOGIC_VECTOR is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is STD_LOGIC_VECTOR (SIZE-1 downto 0);
+    variable new_bounds: STD_LOGIC_VECTOR (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_ZERO_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => '0');
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+    function SXT(ARG: STD_LOGIC_VECTOR; SIZE: INTEGER) return STD_LOGIC_VECTOR is
+    constant msb: INTEGER := min(ARG'length, SIZE) - 1;
+    subtype rtype is STD_LOGIC_VECTOR (SIZE-1 downto 0);
+    variable new_bounds : STD_LOGIC_VECTOR (ARG'length-1 downto 0);
+    variable result: rtype;
+    -- synopsys built_in SYN_SIGN_EXTEND
+    begin
+    -- synopsys synthesis_off
+    new_bounds := MAKE_BINARY(ARG);
+    if (new_bounds(0) = 'X') then
+        result := rtype'(others => 'X');
+        return result;
+    end if;
+    result := rtype'(others => new_bounds(new_bounds'left));
+    result(msb downto 0) := new_bounds(msb downto 0);
+    return result;
+    -- synopsys synthesis_on
+    end;
+
+
+end std_logic_arith;

--- a/vhdl/examples/misc.vhd
+++ b/vhdl/examples/misc.vhd
@@ -1,0 +1,968 @@
+--------------------------------------------------------------------------
+--
+-- Copyright (c) 1990, 1991, 1992 by Synopsys, Inc.  All rights reserved.
+-- 
+-- This source file may be used and distributed without restriction 
+-- provided that this copyright statement is not removed from the file 
+-- and that any derivative work contains this copyright notice.
+--
+--	Package name: std_logic_misc
+--
+--	Purpose: This package defines supplemental types, subtypes, 
+--		 constants, and functions for the Std_logic_1164 Package.
+--
+--	Author:  GWH
+--
+--------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.all;
+--library SYNOPSYS;
+--use SYNOPSYS.attributes.all;
+
+
+
+package std_logic_misc is
+
+    -- output-strength types
+
+    type STRENGTH is (strn_X01, strn_X0H, strn_XL1, strn_X0Z, strn_XZ1, 
+		      strn_WLH, strn_WLZ, strn_WZH, strn_W0H, strn_WL1);
+
+
+--synopsys synthesis_off
+
+    type MINOMAX is array (1 to 3) of TIME;
+    
+
+    ---------------------------------------------------------------------
+    --
+    -- functions for mapping the STD_(U)LOGIC according to STRENGTH
+    --
+    ---------------------------------------------------------------------
+
+    function strength_map(input: STD_ULOGIC; strn: STRENGTH) return STD_LOGIC;
+
+    function strength_map_z(input:STD_ULOGIC; strn:STRENGTH) return STD_LOGIC;
+
+    ---------------------------------------------------------------------
+    --
+    -- conversion functions for STD_ULOGIC_VECTOR and STD_LOGIC_VECTOR
+    --
+    ---------------------------------------------------------------------
+
+--synopsys synthesis_on
+    function Drive (V: STD_ULOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function Drive (V: STD_LOGIC_VECTOR) return STD_ULOGIC_VECTOR;
+--synopsys synthesis_off
+
+    
+    --attribute CLOSELY_RELATED_TCF of Drive: function is TRUE;
+
+    ---------------------------------------------------------------------
+    --
+    -- conversion functions for sensing various types
+    -- (the second argument allows the user to specify the value to
+    --  be returned when the network is undriven)
+    --
+    ---------------------------------------------------------------------
+
+    function Sense (V: STD_ULOGIC; vZ, vU, vDC: STD_ULOGIC) return STD_LOGIC;
+
+    function Sense (V: STD_ULOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					   return STD_LOGIC_VECTOR;
+    function Sense (V: STD_ULOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					   return STD_ULOGIC_VECTOR;
+
+    function Sense (V: STD_LOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					   return STD_LOGIC_VECTOR;
+    function Sense (V: STD_LOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					   return STD_ULOGIC_VECTOR;
+
+--synopsys synthesis_on
+
+
+    ---------------------------------------------------------------------
+    --
+    --	Function: STD_LOGIC_VECTORtoBIT_VECTOR STD_ULOGIC_VECTORtoBIT_VECTOR
+    --
+    --	Purpose: Conversion fun. from STD_(U)LOGIC_VECTOR to BIT_VECTOR
+    --
+    --	Mapping:	0, L --> 0
+    --			1, H --> 1
+    --			X, W --> vX if Xflag is TRUE
+    --			X, W --> 0  if Xflag is FALSE
+    --			Z --> vZ if Zflag is TRUE
+    --			Z --> 0  if Zflag is FALSE
+    --			U --> vU if Uflag is TRUE
+    --			U --> 0  if Uflag is FALSE
+    --			- --> vDC if DCflag is TRUE
+    --			- --> 0  if DCflag is FALSE
+    --
+    ---------------------------------------------------------------------
+
+    function STD_LOGIC_VECTORtoBIT_VECTOR (V: STD_LOGIC_VECTOR
+--synopsys synthesis_off
+    	; vX, vZ, vU, vDC: BIT := '0'; 
+    	  Xflag, Zflag, Uflag, DCflag: BOOLEAN := FALSE
+--synopsys synthesis_on
+    	) return BIT_VECTOR;
+
+    function STD_ULOGIC_VECTORtoBIT_VECTOR (V: STD_ULOGIC_VECTOR
+--synopsys synthesis_off
+    	; vX, vZ, vU, vDC: BIT := '0'; 
+    	  Xflag, Zflag, Uflag, DCflag: BOOLEAN := FALSE
+--synopsys synthesis_on
+    	) return BIT_VECTOR;
+    
+
+    ---------------------------------------------------------------------
+    --
+    --	Function: STD_ULOGICtoBIT
+    --
+    --	Purpose: Conversion function from STD_(U)LOGIC to BIT
+    --
+    --	Mapping:	0, L --> 0
+    --			1, H --> 1
+    --			X, W --> vX if Xflag is TRUE
+    --			X, W --> 0  if Xflag is FALSE
+    --			Z --> vZ if Zflag is TRUE
+    --			Z --> 0  if Zflag is FALSE
+    --			U --> vU if Uflag is TRUE
+    --			U --> 0  if Uflag is FALSE
+    --			- --> vDC if DCflag is TRUE
+    --			- --> 0  if DCflag is FALSE
+    --
+    ---------------------------------------------------------------------
+
+    function STD_ULOGICtoBIT (V: STD_ULOGIC
+--synopsys synthesis_off
+    	; vX, vZ, vU, vDC: BIT := '0'; 
+    	  Xflag, Zflag, Uflag, DCflag: BOOLEAN := FALSE
+--synopsys synthesis_on
+    	) return BIT;
+
+        --------------------------------------------------------------------
+        function AND_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01;
+        function NAND_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01;
+        function OR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01;
+        function NOR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01;
+        function XOR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01;
+        function XNOR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01;
+    
+        function AND_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01;
+        function NAND_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01;
+        function OR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01;
+        function NOR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01;
+        function XOR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01;
+        function XNOR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01;
+    
+--synopsys synthesis_off
+	
+        function fun_BUF3S(Input, Enable: UX01; Strn: STRENGTH) return STD_LOGIC;
+        function fun_BUF3SL(Input, Enable: UX01; Strn: STRENGTH) return STD_LOGIC;
+        function fun_MUX2x1(Input0, Input1, Sel: UX01) return UX01;
+
+        function fun_MAJ23(Input0, Input1, Input2: UX01) return UX01;
+        function fun_WiredX(Input0, Input1: std_ulogic) return STD_LOGIC;
+
+--synopsys synthesis_on
+	
+end;
+
+
+package body std_logic_misc is
+
+--synopsys synthesis_off
+
+    type STRN_STD_ULOGIC_TABLE is array (STD_ULOGIC,STRENGTH) of STD_ULOGIC;
+
+    --------------------------------------------------------------------
+    --
+    -- Truth tables for output strength --> STD_ULOGIC lookup
+    --
+    --------------------------------------------------------------------
+
+    -- truth table for output strength --> STD_ULOGIC lookup
+    constant tbl_STRN_STD_ULOGIC: STRN_STD_ULOGIC_TABLE := 
+    --  ------------------------------------------------------------------
+    --  | X01  X0H  XL1  X0Z  XZ1  WLH  WLZ  WZH  W0H  WL1 | strn/ output|
+    --  ------------------------------------------------------------------
+        (('U', 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U'),  -- |   U   |
+         ('X', 'X', 'X', 'X', 'X', 'W', 'W', 'W', 'W', 'W'),  -- |   X   |
+         ('0', '0', 'L', '0', 'Z', 'L', 'L', 'Z', '0', 'L'),  -- |   0   |
+         ('1', 'H', '1', 'Z', '1', 'H', 'Z', 'H', 'H', '1'),  -- |   1   |
+         ('X', 'X', 'X', 'X', 'X', 'W', 'W', 'W', 'W', 'W'),  -- |   Z   |
+         ('X', 'X', 'X', 'X', 'X', 'W', 'W', 'W', 'W', 'W'),  -- |   W   |
+         ('0', '0', 'L', '0', 'Z', 'L', 'L', 'Z', '0', 'L'),  -- |   L   |
+         ('1', 'H', '1', 'Z', '1', 'H', 'Z', 'H', 'H', '1'),  -- |   H   |
+         ('X', 'X', 'X', 'X', 'X', 'W', 'W', 'W', 'W', 'W')); -- |   -   |
+
+
+
+    --------------------------------------------------------------------
+    --
+    -- Truth tables for strength --> STD_ULOGIC mapping ('Z' pass through)
+    --
+    --------------------------------------------------------------------
+
+    -- truth table for output strength --> STD_ULOGIC lookup
+    constant tbl_STRN_STD_ULOGIC_Z: STRN_STD_ULOGIC_TABLE := 
+    --  ------------------------------------------------------------------
+    --  | X01  X0H  XL1  X0Z  XZ1  WLH  WLZ  WZH  W0H  WL1 | strn/ output|
+    --  ------------------------------------------------------------------
+        (('U', 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U'),  -- |   U   |
+         ('X', 'X', 'X', 'X', 'X', 'W', 'W', 'W', 'W', 'W'),  -- |   X   |
+         ('0', '0', 'L', '0', 'Z', 'L', 'L', 'Z', '0', 'L'),  -- |   0   |
+         ('1', 'H', '1', 'Z', '1', 'H', 'Z', 'H', 'H', '1'),  -- |   1   |
+         ('Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z'),  -- |   Z   |
+         ('X', 'X', 'X', 'X', 'X', 'W', 'W', 'W', 'W', 'W'),  -- |   W   |
+         ('0', '0', 'L', '0', 'Z', 'L', 'L', 'Z', '0', 'L'),  -- |   L   |
+         ('1', 'H', '1', 'Z', '1', 'H', 'Z', 'H', 'H', '1'),  -- |   H   |
+         ('X', 'X', 'X', 'X', 'X', 'W', 'W', 'W', 'W', 'W')); -- |   -   |
+
+
+
+    ---------------------------------------------------------------------
+    --
+    -- functions for mapping the STD_(U)LOGIC according to STRENGTH
+    --
+    ---------------------------------------------------------------------
+
+    function strength_map(input: STD_ULOGIC; strn: STRENGTH) return STD_LOGIC is
+	-- pragma subpgm_id 387
+    begin
+    	return tbl_STRN_STD_ULOGIC(input, strn);
+    end strength_map;
+
+
+    function strength_map_z(input:STD_ULOGIC; strn:STRENGTH) return STD_LOGIC is
+	-- pragma subpgm_id 388
+    begin
+    	return tbl_STRN_STD_ULOGIC_Z(input, strn);
+    end strength_map_z;
+
+
+    ---------------------------------------------------------------------
+    --
+    -- conversion functions for STD_LOGIC_VECTOR and STD_ULOGIC_VECTOR
+    --
+    ---------------------------------------------------------------------
+
+--synopsys synthesis_on
+    function Drive (V: STD_LOGIC_VECTOR) return STD_ULOGIC_VECTOR is
+      -- pragma built_in SYN_FEED_THRU
+      -- pragma subpgm_id 389
+--synopsys synthesis_off
+        alias Value: STD_LOGIC_VECTOR (V'length-1 downto 0) is V;
+--synopsys synthesis_on
+    begin
+--synopsys synthesis_off
+    	return STD_ULOGIC_VECTOR(Value);
+--synopsys synthesis_on
+    end Drive;
+
+
+    function Drive (V: STD_ULOGIC_VECTOR) return STD_LOGIC_VECTOR is
+      -- pragma built_in SYN_FEED_THRU
+      -- pragma subpgm_id 390
+--synopsys synthesis_off
+        alias Value: STD_ULOGIC_VECTOR (V'length-1 downto 0) is V;
+--synopsys synthesis_on
+    begin
+--synopsys synthesis_off
+    	return STD_LOGIC_VECTOR(Value);
+--synopsys synthesis_on
+    end Drive;
+--synopsys synthesis_off
+
+
+    ---------------------------------------------------------------------
+    --
+    -- conversion functions for sensing various types
+    --
+    -- (the second argument allows the user to specify the value to
+    --  be returned when the network is undriven)
+    --
+    ---------------------------------------------------------------------
+
+    function Sense (V: STD_ULOGIC; vZ, vU, vDC: STD_ULOGIC) 
+    					        return STD_LOGIC is
+	-- pragma subpgm_id 391
+    begin
+    	if V = 'Z' then
+    		return vZ;
+	elsif V = 'U' then
+		return vU;
+	elsif V = '-' then
+		return vDC;
+    	else
+    		return V;
+    	end if;
+    end Sense;
+
+
+    function Sense (V: STD_ULOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					return STD_LOGIC_VECTOR is
+	-- pragma subpgm_id 392
+    	alias Value: STD_ULOGIC_VECTOR (V'length-1 downto 0) is V;
+    	variable Result: STD_LOGIC_VECTOR (V'length-1 downto 0);
+    begin
+    	for i in Value'range loop
+    		if ( Value(i) = 'Z' ) then
+    			Result(i) := vZ;
+		elsif Value(i) = 'U' then
+			Result(i) :=  vU;
+		elsif Value(i) = '-' then
+			Result(i) := vDC;
+    		else
+    			Result(i) := Value(i);
+    		end if;
+    	end loop;
+    	return Result;
+    end Sense;
+
+
+    function Sense (V: STD_ULOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					return STD_ULOGIC_VECTOR is
+	-- pragma subpgm_id 393
+    	alias Value: STD_ULOGIC_VECTOR (V'length-1 downto 0) is V;
+    	variable Result: STD_ULOGIC_VECTOR (V'length-1 downto 0);
+    begin
+    	for i in Value'range loop
+    		if ( Value(i) = 'Z' ) then
+    			Result(i) := vZ;
+		elsif Value(i) = 'U' then
+			Result(i) :=  vU;
+		elsif Value(i) = '-' then
+			Result(i) := vDC;
+    		else
+    			Result(i) := Value(i);
+    		end if;
+    	end loop;
+    	return Result;
+    end Sense;
+
+
+    function Sense (V: STD_LOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					return STD_LOGIC_VECTOR is
+	-- pragma subpgm_id 394
+    	alias Value: STD_LOGIC_VECTOR (V'length-1 downto 0) is V;
+    	variable Result: STD_LOGIC_VECTOR (V'length-1 downto 0);
+    begin
+    	for i in Value'range loop
+    		if ( Value(i) = 'Z' ) then
+    			Result(i) := vZ;
+		elsif Value(i) = 'U' then
+			Result(i) :=  vU;
+		elsif Value(i) = '-' then
+			Result(i) := vDC;
+    		else
+    			Result(i) := Value(i);
+    		end if;
+    	end loop;
+    	return Result;
+    end Sense;
+
+
+    function Sense (V: STD_LOGIC_VECTOR; vZ, vU, vDC: STD_ULOGIC) 
+    					return STD_ULOGIC_VECTOR is
+	-- pragma subpgm_id 395
+    	alias Value: STD_LOGIC_VECTOR (V'length-1 downto 0) is V;
+    	variable Result: STD_ULOGIC_VECTOR (V'length-1 downto 0);
+    begin
+    	for i in Value'range loop
+    		if ( Value(i) = 'Z' ) then
+    			Result(i) := vZ;
+		elsif Value(i) = 'U' then
+			Result(i) :=  vU;
+		elsif Value(i) = '-' then
+			Result(i) := vDC;
+    		else
+    			Result(i) := Value(i);
+    		end if;
+    	end loop;
+    	return Result;
+    end Sense;
+
+    ---------------------------------------------------------------------
+    --
+    --	Function: STD_LOGIC_VECTORtoBIT_VECTOR
+    --
+    --	Purpose: Conversion fun. from STD_LOGIC_VECTOR to BIT_VECTOR
+    --
+    --	Mapping:	0, L --> 0
+    --			1, H --> 1
+    --			X, W --> vX if Xflag is TRUE
+    --			X, W --> 0  if Xflag is FALSE
+    --			Z --> vZ if Zflag is TRUE
+    --			Z --> 0  if Zflag is FALSE
+    --			U --> vU if Uflag is TRUE
+    --			U --> 0  if Uflag is FALSE
+    --			- --> vDC if DCflag is TRUE
+    --			- --> 0  if DCflag is FALSE
+    --
+    ---------------------------------------------------------------------
+
+--synopsys synthesis_on
+    function STD_LOGIC_VECTORtoBIT_VECTOR (V: STD_LOGIC_VECTOR
+--synopsys synthesis_off
+    	; vX, vZ, vU, vDC: BIT := '0'; 
+    	  Xflag, Zflag, Uflag, DCflag: BOOLEAN := FALSE
+--synopsys synthesis_on
+    		   ) return BIT_VECTOR is
+      -- pragma built_in SYN_FEED_THRU
+      -- pragma subpgm_id 396
+--synopsys synthesis_off
+    	alias Value: STD_LOGIC_VECTOR (V'length-1 downto 0) is V;
+    	variable Result: BIT_VECTOR (V'length-1 downto 0);
+--synopsys synthesis_on
+    begin
+--synopsys synthesis_off
+    	for i in Value'range loop
+    		case Value(i) is
+    			when '0' | 'L' =>
+    				Result(i) := '0';
+    			when '1' | 'H' =>
+    				Result(i) := '1';
+	    		when 'X' =>
+    				if ( Xflag ) then
+    					Result(i) := vX;
+    				else
+    					Result(i) := '0';
+	    		 		assert FALSE
+    				 	    report "STD_LOGIC_VECTORtoBIT_VECTOR: X --> 0"
+    				 	    severity WARNING;
+    				end if;
+	    		when 'W' =>
+    				if ( Xflag ) then
+    					Result(i) := vX;
+    				else
+    					Result(i) := '0';
+	    		 		assert FALSE
+    				 	    report "STD_LOGIC_VECTORtoBIT_VECTOR: W --> 0"
+    				 	    severity WARNING;
+    				end if;
+	    		when 'Z' =>
+    				if ( Zflag ) then
+    					Result(i) := vZ;
+	    			else
+    					Result(i) := '0';
+    					assert FALSE
+    					    report "STD_LOGIC_VECTORtoBIT_VECTOR: Z --> 0"
+    					    severity WARNING;
+	    			end if;
+    			when 'U' =>
+    				if ( Uflag ) then
+    					Result(i) := vU;
+	    			else
+    					Result(i) := '0';
+    					assert FALSE
+    					    report "STD_LOGIC_VECTORtoBIT_VECTOR: U --> 0"
+    					    severity WARNING;
+				end if;
+    			when '-' =>
+    				if ( DCflag ) then
+    					Result(i) := vDC;
+	    			else
+    					Result(i) := '0';
+    					assert FALSE
+    					    report "STD_LOGIC_VECTORtoBIT_VECTOR: - --> 0"
+    					    severity WARNING;
+	    			end if;
+    			end case;
+	    	end loop;
+    	return Result;
+--synopsys synthesis_on
+    end STD_LOGIC_VECTORtoBIT_VECTOR;
+
+
+
+
+    ---------------------------------------------------------------------
+    --
+    --	Function: STD_ULOGIC_VECTORtoBIT_VECTOR
+    --
+    --	Purpose: Conversion fun. from STD_ULOGIC_VECTOR to BIT_VECTOR
+    --
+    --	Mapping:	0, L --> 0
+    --			1, H --> 1
+    --			X, W --> vX if Xflag is TRUE
+    --			X, W --> 0  if Xflag is FALSE
+    --			Z --> vZ if Zflag is TRUE
+    --			Z --> 0  if Zflag is FALSE
+    --			U --> vU if Uflag is TRUE
+    --			U --> 0  if Uflag is FALSE
+    --			- --> vDC if DCflag is TRUE
+    --			- --> 0  if DCflag is FALSE
+    --
+    ---------------------------------------------------------------------
+
+    function STD_ULOGIC_VECTORtoBIT_VECTOR (V: STD_ULOGIC_VECTOR
+--synopsys synthesis_off
+    	; vX, vZ, vU, vDC: BIT := '0'; 
+    	  Xflag, Zflag, Uflag, DCflag: BOOLEAN := FALSE
+--synopsys synthesis_on
+    		   ) return BIT_VECTOR is
+      -- pragma built_in SYN_FEED_THRU
+      -- pragma subpgm_id 397
+--synopsys synthesis_off
+    	alias Value: STD_ULOGIC_VECTOR (V'length-1 downto 0) is V;
+    	variable Result: BIT_VECTOR (V'length-1 downto 0);
+--synopsys synthesis_on
+    begin
+--synopsys synthesis_off
+    	for i in Value'range loop
+    		case Value(i) is
+    			when '0' | 'L' =>
+    				Result(i) := '0';
+    			when '1' | 'H' =>
+    				Result(i) := '1';
+	    		when 'X' =>
+    				if ( Xflag ) then
+    					Result(i) := vX;
+	    			else
+    					Result(i) := '0';
+	    		 		assert FALSE
+    				 	    report "STD_ULOGIC_VECTORtoBIT_VECTOR: X --> 0"
+    				 	    severity WARNING;
+	    			end if;
+    			when 'W' =>
+	    			if ( Xflag ) then
+    					Result(i) := vX;
+    				else
+    					Result(i) := '0';
+	    		 		assert FALSE
+    				 	    report "STD_ULOGIC_VECTORtoBIT_VECTOR: W --> 0"
+    				 	    severity WARNING;
+	    			end if;
+    			when 'Z' =>
+    				if ( Zflag ) then
+	    				Result(i) := vZ;
+    				else
+    					Result(i) := '0';
+    					assert FALSE
+    					    report "STD_ULOGIC_VECTORtoBIT_VECTOR: Z --> 0"
+	    				    severity WARNING;
+    				end if;
+	    		when 'U' =>
+    				if ( Uflag ) then
+    					Result(i) := vU;
+	    			else
+    					Result(i) := '0';
+    					assert FALSE
+    					    report "STD_ULOGIC_VECTORtoBIT_VECTOR: U --> 0"
+    					    severity WARNING;
+				end if;
+    			when '-' =>
+    				if ( DCflag ) then
+    					Result(i) := vDC;
+	    			else
+    					Result(i) := '0';
+    					assert FALSE
+    					    report "STD_ULOGIC_VECTORtoBIT_VECTOR: - --> 0"
+    					    severity WARNING;
+	    			end if;
+    			end case;
+    	end loop;
+    	return Result;
+--synopsys synthesis_on
+    end STD_ULOGIC_VECTORtoBIT_VECTOR;
+
+
+
+
+    ---------------------------------------------------------------------
+    --
+    --	Function: STD_ULOGICtoBIT
+    --
+    --	Purpose: Conversion function from STD_ULOGIC to BIT
+    --
+    --	Mapping:	0, L --> 0
+    --			1, H --> 1
+    --			X, W --> vX if Xflag is TRUE
+    --			X, W --> 0  if Xflag is FALSE
+    --			Z --> vZ if Zflag is TRUE
+    --			Z --> 0  if Zflag is FALSE
+    --			U --> vU if Uflag is TRUE
+    --			U --> 0  if Uflag is FALSE
+    --			- --> vDC if DCflag is TRUE
+    --			- --> 0  if DCflag is FALSE
+    --
+    ---------------------------------------------------------------------
+
+    function STD_ULOGICtoBIT (V: STD_ULOGIC
+--synopsys synthesis_off
+    	; vX, vZ, vU, vDC: BIT := '0'; 
+    	  Xflag, Zflag, Uflag, DCflag: BOOLEAN := FALSE
+--synopsys synthesis_on
+    		   ) return BIT is
+      -- pragma built_in SYN_FEED_THRU
+      -- pragma subpgm_id 398
+    	variable Result: BIT;
+    begin
+--synopsys synthesis_off
+    	case V is
+    		when '0' | 'L' =>
+    			Result := '0';
+    		when '1' | 'H' =>
+    			Result := '1';
+    		when 'X' =>
+    			if ( Xflag ) then
+    				Result := vX;
+    			else
+    				Result := '0';
+    		 		assert FALSE
+    			 	    report "STD_ULOGICtoBIT: X --> 0"
+    			 	    severity WARNING;
+    			end if;
+    		when 'W' =>
+    			if ( Xflag ) then
+    				Result := vX;
+    			else
+    				Result := '0';
+    		 		assert FALSE
+    			 	    report "STD_ULOGICtoBIT: W --> 0"
+    			 	    severity WARNING;
+    			end if;
+    		when 'Z' =>
+    			if ( Zflag ) then
+    				Result := vZ;
+    			else
+    				Result := '0';
+    				assert FALSE
+    				    report "STD_ULOGICtoBIT: Z --> 0"
+    				    severity WARNING;
+    			end if;
+    		when 'U' =>
+    			if ( Uflag ) then
+    				Result := vU;
+    			else
+    				Result := '0';
+    				assert FALSE
+    				    report "STD_ULOGICtoBIT: U --> 0"
+    				    severity WARNING;
+			end if;
+    		when '-' =>
+    			if ( DCflag ) then
+    				Result := vDC;
+    			else
+    				Result := '0';
+    				assert FALSE
+    				    report "STD_ULOGICtoBIT: - --> 0"
+    				    severity WARNING;
+    			end if;
+    	end case;
+    	return Result;
+--synopsys synthesis_on
+    end STD_ULOGICtoBIT;
+
+
+    --------------------------------------------------------------------------
+
+    function AND_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 399
+	variable result: STD_LOGIC;
+    begin
+	result := '1';
+	for i in ARG'range loop
+	    result := result and ARG(i);
+	end loop;
+        return result;
+    end;
+
+    function NAND_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 400
+    begin
+        return not AND_REDUCE(ARG);
+    end;
+
+    function OR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 401
+	variable result: STD_LOGIC;
+    begin
+	result := '0';
+	for i in ARG'range loop
+	    result := result or ARG(i);
+	end loop;
+        return result;
+    end;
+
+    function NOR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 402
+    begin
+        return not OR_REDUCE(ARG);
+    end;
+
+    function XOR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 403
+	variable result: STD_LOGIC;
+    begin
+	result := '0';
+	for i in ARG'range loop
+	    result := result xor ARG(i);
+	end loop;
+        return result;
+    end;
+
+    function XNOR_REDUCE(ARG: STD_LOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 404
+    begin
+        return not XOR_REDUCE(ARG);
+    end;
+
+    function AND_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 405
+	variable result: STD_LOGIC;
+    begin
+	result := '1';
+	for i in ARG'range loop
+	    result := result and ARG(i);
+	end loop;
+        return result;
+    end;
+
+    function NAND_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 406
+    begin
+        return not AND_REDUCE(ARG);
+    end;
+
+    function OR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 407
+	variable result: STD_LOGIC;
+    begin
+	result := '0';
+	for i in ARG'range loop
+	    result := result or ARG(i);
+	end loop;
+        return result;
+    end;
+
+    function NOR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 408
+    begin
+        return not OR_REDUCE(ARG);
+    end;
+
+    function XOR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 409
+	variable result: STD_LOGIC;
+    begin
+	result := '0';
+	for i in ARG'range loop
+	    result := result xor ARG(i);
+	end loop;
+        return result;
+    end;
+
+    function XNOR_REDUCE(ARG: STD_ULOGIC_VECTOR) return UX01 is
+	-- pragma subpgm_id 410
+    begin
+        return not XOR_REDUCE(ARG);
+    end;
+
+--synopsys synthesis_off
+	
+    function fun_BUF3S(Input, Enable: UX01; Strn: STRENGTH) return STD_LOGIC is
+	-- pragma subpgm_id 411
+	type TRISTATE_TABLE is array(STRENGTH, UX01, UX01) of STD_LOGIC;
+
+	-- truth table for tristate "buf" function (Enable active Low)
+          constant tbl_BUF3S: TRISTATE_TABLE := 
+          -- ----------------------------------------------------
+          -- | Input   U    X    0    1       | Enable Strength |
+          -- ---------------------------------|-----------------|
+        	   ((('U', 'U', 'U', 'U'),  --|   U       X01   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       X01   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       X01   |
+        	     ('U', 'X', '0', '1')), --|   1       X01   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       X0H   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       X0H   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       X0H   |
+        	     ('U', 'X', '0', 'H')), --|   1       X0H   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       XL1   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       XL1   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       XL1   |
+        	     ('U', 'X', 'L', '1')), --|   1       XL1   |
+        	    (('U', 'U', 'U', 'Z'),  --|   U       X0Z   |
+        	     ('U', 'X', 'X', 'Z'),  --|   X       X0Z   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       X0Z   |
+        	     ('U', 'X', '0', 'Z')), --|   1       X0Z   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       XZ1   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       XZ1   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       XZ1   |
+        	     ('U', 'X', 'Z', '1')), --|   1       XZ1   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WLH   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       WLH   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       WLH   |
+        	     ('U', 'W', 'L', 'H')), --|   1       WLH   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WLZ   |
+        	     ('U', 'W', 'W', 'Z'),  --|   X       WLZ   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       WLZ   |
+        	     ('U', 'W', 'L', 'Z')), --|   1       WLZ   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WZH   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       WZH   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       WZH   |
+        	     ('U', 'W', 'Z', 'H')), --|   1       WZH   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       W0H   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       W0H   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       W0H   |
+        	     ('U', 'W', '0', 'H')), --|   1       W0H   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WL1   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       WL1   |
+        	     ('Z', 'Z', 'Z', 'Z'),  --|   0       WL1   |
+        	     ('U', 'W', 'L', '1')));--|   1       WL1   |
+    begin
+	return tbl_BUF3S(Strn, Enable, Input);
+    end fun_BUF3S;
+
+
+    function fun_BUF3SL(Input, Enable: UX01; Strn: STRENGTH) return STD_LOGIC is
+	-- pragma subpgm_id 412
+	type TRISTATE_TABLE is array(STRENGTH, UX01, UX01) of STD_LOGIC;
+
+	-- truth table for tristate "buf" function (Enable active Low)
+          constant tbl_BUF3SL: TRISTATE_TABLE := 
+          -- ----------------------------------------------------
+          -- | Input   U    X    0    1       | Enable Strength |
+          -- ---------------------------------|-----------------|
+        	   ((('U', 'U', 'U', 'U'),  --|   U       X01   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       X01   |
+        	     ('U', 'X', '0', '1'),  --|   0       X01   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       X01   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       X0H   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       X0H   |
+        	     ('U', 'X', '0', 'H'),  --|   0       X0H   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       X0H   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       XL1   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       XL1   |
+        	     ('U', 'X', 'L', '1'),  --|   0       XL1   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       XL1   |
+        	    (('U', 'U', 'U', 'Z'),  --|   U       X0Z   |
+        	     ('U', 'X', 'X', 'Z'),  --|   X       X0Z   |
+        	     ('U', 'X', '0', 'Z'),  --|   0       X0Z   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       X0Z   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       XZ1   |
+        	     ('U', 'X', 'X', 'X'),  --|   X       XZ1   |
+        	     ('U', 'X', 'Z', '1'),  --|   0       XZ1   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       XZ1   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WLH   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       WLH   |
+        	     ('U', 'W', 'L', 'H'),  --|   0       WLH   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       WLH   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WLZ   |
+        	     ('U', 'W', 'W', 'Z'),  --|   X       WLZ   |
+        	     ('U', 'W', 'L', 'Z'),  --|   0       WLZ   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       WLZ   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WZH   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       WZH   |
+        	     ('U', 'W', 'Z', 'H'),  --|   0       WZH   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       WZH   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       W0H   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       W0H   |
+        	     ('U', 'W', '0', 'H'),  --|   0       W0H   |
+        	     ('Z', 'Z', 'Z', 'Z')), --|   1       W0H   |
+        	    (('U', 'U', 'U', 'U'),  --|   U       WL1   |
+        	     ('U', 'W', 'W', 'W'),  --|   X       WL1   |
+        	     ('U', 'W', 'L', '1'),  --|   0       WL1   |
+        	     ('Z', 'Z', 'Z', 'Z')));--|   1       WL1   |
+    begin
+	return tbl_BUF3SL(Strn, Enable, Input);
+    end fun_BUF3SL;
+
+
+    function fun_MUX2x1(Input0, Input1, Sel: UX01) return UX01 is
+	-- pragma subpgm_id 413
+	type MUX_TABLE is array (UX01, UX01, UX01) of UX01;
+
+	-- truth table for "MUX2x1" function
+	constant tbl_MUX2x1: MUX_TABLE :=
+	--------------------------------------------
+        --| In0  'U'  'X'  '0'  '1'      | Sel In1 |
+	--------------------------------------------
+	      ((('U', 'U', 'U', 'U'),  --| 'U' 'U' |
+	        ('U', 'U', 'U', 'U'),  --| 'X' 'U' |
+		('U', 'X', '0', '1'),  --| '0' 'U' |
+		('U', 'U', 'U', 'U')), --| '1' 'U' |
+	       (('U', 'X', 'U', 'U'),  --| 'U' 'X' |
+	        ('U', 'X', 'X', 'X'),  --| 'X' 'X' |
+		('U', 'X', '0', '1'),  --| '0' 'X' |
+		('X', 'X', 'X', 'X')), --| '1' 'X' |
+	       (('U', 'U', '0', 'U'),  --| 'U' '0' |
+	        ('U', 'X', '0', 'X'),  --| 'X' '0' |
+		('U', 'X', '0', '1'),  --| '0' '0' |
+		('0', '0', '0', '0')), --| '1' '0' |
+	       (('U', 'U', 'U', '1'),  --| 'U' '1' |
+	        ('U', 'X', 'X', '1'),  --| 'X' '1' |
+		('U', 'X', '0', '1'),  --| '0' '1' |
+		('1', '1', '1', '1')));--| '1' '1' |
+    begin
+	return tbl_MUX2x1(Input1, Sel, Input0);
+    end fun_MUX2x1;
+
+
+    function fun_MAJ23(Input0, Input1, Input2: UX01) return UX01 is
+	-- pragma subpgm_id 414
+	type MAJ23_TABLE is array (UX01, UX01, UX01) of UX01;
+
+	----------------------------------------------------------------------------
+	--	The "tbl_MAJ23" truth table return 1 if the majority of three
+	--	inputs is 1, a 0 if the majority is 0, a X if unknown, and a U if
+	--	uninitialized.
+	----------------------------------------------------------------------------
+	constant tbl_MAJ23: MAJ23_TABLE :=
+        --------------------------------------------
+        --| In0  'U'  'X'  '0'  '1'      | In1 In2 |
+        --------------------------------------------
+              ((('U', 'U', 'U', 'U'),  --| 'U' 'U' |
+                ('U', 'U', 'U', 'U'),  --| 'X' 'U' |
+                ('U', 'U', '0', 'U'),  --| '0' 'U' |
+                ('U', 'U', 'U', '1')), --| '1' 'U' |
+               (('U', 'U', 'U', 'U'),  --| 'U' 'X' |
+                ('U', 'X', 'X', 'X'),  --| 'X' 'X' |
+                ('U', 'X', '0', 'X'),  --| '0' 'X' |
+                ('U', 'X', 'X', '1')), --| '1' 'X' |
+               (('U', 'U', '0', 'U'),  --| 'U' '0' |
+                ('U', 'X', '0', 'X'),  --| 'X' '0' |
+                ('0', '0', '0', '0'),  --| '0' '0' |
+                ('U', 'X', '0', '1')), --| '1' '0' |
+               (('U', 'U', 'U', '1'),  --| 'U' '1' |
+                ('U', 'X', 'X', '1'),  --| 'X' '1' |
+                ('U', 'X', '0', '1'),  --| '0' '1' |
+                ('1', '1', '1', '1')));--| '1' '1' |
+
+    begin
+	return tbl_MAJ23(Input0, Input1, Input2);
+    end fun_MAJ23;
+
+
+    function fun_WiredX(Input0, Input1: STD_ULOGIC) return STD_LOGIC is
+	-- pragma subpgm_id 415
+        TYPE stdlogic_table IS ARRAY(STD_ULOGIC, STD_ULOGIC) OF STD_LOGIC;
+
+	-- truth table for "WiredX" function
+        -------------------------------------------------------------------    
+        -- resolution function
+        -------------------------------------------------------------------    
+        CONSTANT resolution_table : stdlogic_table := (
+        --      ---------------------------------------------------------
+        --      |  U    X    0    1    Z    W    L    H    -        |   |  
+        --      ---------------------------------------------------------
+                ( 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U' ), -- | U |
+                ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' ), -- | X |
+                ( 'U', 'X', '0', 'X', '0', '0', '0', '0', 'X' ), -- | 0 |
+                ( 'U', 'X', 'X', '1', '1', '1', '1', '1', 'X' ), -- | 1 |
+                ( 'U', 'X', '0', '1', 'Z', 'W', 'L', 'H', 'X' ), -- | Z |
+                ( 'U', 'X', '0', '1', 'W', 'W', 'W', 'W', 'X' ), -- | W |
+                ( 'U', 'X', '0', '1', 'L', 'W', 'L', 'W', 'X' ), -- | L |
+                ( 'U', 'X', '0', '1', 'H', 'W', 'W', 'H', 'X' ), -- | H |
+                ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' ));-- | - |
+    begin
+	return resolution_table(Input0, Input1);
+    end fun_WiredX;
+
+--synopsys synthesis_on
+	
+end;

--- a/vhdl/examples/numeric_bit-body.vhd
+++ b/vhdl/examples/numeric_bit-body.vhd
@@ -1,0 +1,1818 @@
+-- -----------------------------------------------------------------------------
+--
+-- Copyright 1995 by IEEE. All rights reserved.
+--
+-- This source file is considered by the IEEE to be an essential part of the use
+-- of the standard 1076.3 and as such may be distributed without change, except
+-- as permitted by the standard. This source file may not be sold or distributed
+-- for profit. This package may be modified to include additional data required
+-- by tools, but must in no way change the external interfaces or simulation
+-- behaviour of the description. It is permissible to add comments and/or
+-- attributes to the package declarations, but not to change or delete any
+-- original lines of the approved package declaration. The package body may be
+-- changed only in accordance with the terms of clauses 7.1 and 7.2 of the
+-- standard.
+--
+-- Title      : Standard VHDL Synthesis Package (1076.3, NUMERIC_BIT)
+--
+-- Library    : This package shall be compiled into a library symbolically
+--            : named IEEE.
+--
+-- Developers : IEEE DASC Synthesis Working Group, PAR 1076.3
+--
+-- Purpose    : This package defines numeric types and arithmetic functions
+--            : for use with synthesis tools. Two numeric types are defined:
+--            : -- > UNSIGNED: represents an UNSIGNED number in vector form
+--            : -- > SIGNED: represents a SIGNED number in vector form
+--            : The base element type is type BIT.
+--            : The leftmost bit is treated as the most significant bit.
+--            : Signed vectors are represented in two's complement form.
+--            : This package contains overloaded arithmetic operators on
+--            : the SIGNED and UNSIGNED types. The package also contains
+--            : useful type conversions functions, clock detection
+--            : functions, and other utility functions.
+--            :
+--            : If any argument to a function is a null array, a null array is
+--            : returned (exceptions, if any, are noted individually).
+--
+-- Limitation :
+--
+-- Note       : No declarations or definitions shall be included in,
+--            : or excluded from this package. The "package declaration"
+--            : defines the types, subtypes and declarations of
+--            : NUMERIC_BIT. The NUMERIC_BIT package body shall be
+--            : considered the formal definition of the semantics of
+--            : this package. Tool developers may choose to implement
+--            : the package body in the most efficient manner available
+--            : to them.
+--            :
+-- -----------------------------------------------------------------------------
+-- Version    : 2.4
+-- Date       : 12 April 1995
+-- -----------------------------------------------------------------------------
+
+--==============================================================================
+--======================= Package Body =========================================
+--==============================================================================
+
+package body NUMERIC_BIT is
+
+  -- null range array constants
+
+  constant NAU: UNSIGNED(0 downto 1) := (others => '0');
+  constant NAS: SIGNED(0 downto 1) := (others => '0');
+
+  -- implementation controls
+
+  constant NO_WARNING: BOOLEAN := FALSE; -- default to emit warnings
+
+  --=========================Local Subprograms =================================
+
+  function MAX (LEFT, RIGHT: INTEGER) return INTEGER is
+  begin
+    if LEFT > RIGHT then return LEFT;
+    else return RIGHT;
+    end if;
+  end MAX;
+
+  function MIN (LEFT, RIGHT: INTEGER) return INTEGER is
+  begin
+    if LEFT < RIGHT then return LEFT;
+    else return RIGHT;
+    end if;
+  end MIN;
+
+  function SIGNED_NUM_BITS (ARG: INTEGER) return NATURAL is
+    variable NBITS: NATURAL;
+    variable N: NATURAL;
+  begin
+    if ARG >= 0 then
+      N := ARG;
+    else
+      N := -(ARG+1);
+    end if;
+    NBITS := 1;
+    while N > 0 loop
+      NBITS := NBITS+1;
+      N := N / 2;
+    end loop;
+    return NBITS;
+  end SIGNED_NUM_BITS;
+
+  function UNSIGNED_NUM_BITS (ARG: NATURAL) return NATURAL is
+    variable NBITS: NATURAL;
+    variable N: NATURAL;
+  begin
+    N := ARG;
+    NBITS := 1;
+    while N > 1 loop
+      NBITS := NBITS+1;
+      N := N / 2;
+    end loop;
+    return NBITS;
+  end UNSIGNED_NUM_BITS;
+
+  ------------------------------------------------------------------------------
+  -- this internal function computes the addition of two UNSIGNED
+  -- with input carry
+  -- * the two arguments are of the same length
+
+  function ADD_UNSIGNED (L, R: UNSIGNED; C: BIT) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(L_LEFT downto 0) is R;
+    variable RESULT: UNSIGNED(L_LEFT downto 0);
+    variable CBIT: BIT := C;
+  begin
+    for I in 0 to L_LEFT loop
+      RESULT(I) := CBIT xor XL(I) xor XR(I);
+      CBIT := (CBIT and XL(I)) or (CBIT and XR(I)) or (XL(I) and XR(I));
+    end loop;
+    return RESULT;
+  end ADD_UNSIGNED;
+
+  -- this internal function computes the addition of two SIGNED
+  -- with input carry
+  -- * the two arguments are of the same length
+
+  function ADD_SIGNED (L, R: SIGNED; C: BIT) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(L_LEFT downto 0) is R;
+    variable RESULT: SIGNED(L_LEFT downto 0);
+    variable CBIT: BIT := C;
+  begin
+    for I in 0 to L_LEFT loop
+      RESULT(I) := CBIT xor XL(I) xor XR(I);
+      CBIT := (CBIT and XL(I)) or (CBIT and XR(I)) or (XL(I) and XR(I));
+    end loop;
+    return RESULT;
+  end ADD_SIGNED;
+
+  ------------------------------------------------------------------------------
+
+  -- this internal procedure computes UNSIGNED division
+  -- giving the quotient and remainder.
+  procedure DIVMOD (NUM, XDENOM: UNSIGNED; XQUOT, XREMAIN: out UNSIGNED) is
+    variable TEMP: UNSIGNED(NUM'LENGTH downto 0);
+    variable QUOT: UNSIGNED(MAX(NUM'LENGTH, XDENOM'LENGTH)-1 downto 0);
+    alias DENOM: UNSIGNED(XDENOM'LENGTH-1 downto 0) is XDENOM;
+    variable TOPBIT: INTEGER;
+  begin
+    TEMP := "0"&NUM;
+    QUOT := (others => '0');
+    TOPBIT := -1;
+    for J in DENOM'RANGE loop
+      if DENOM(J)='1' then
+        TOPBIT := J;
+        exit;
+      end if;
+    end loop;
+    assert TOPBIT >= 0 report "DIV, MOD, or REM by zero" severity ERROR;
+
+    for J in NUM'LENGTH-(TOPBIT+1) downto 0 loop
+      if TEMP(TOPBIT+J+1 downto J) >= "0"&DENOM(TOPBIT downto 0) then
+        TEMP(TOPBIT+J+1 downto J) := (TEMP(TOPBIT+J+1 downto J))
+            -("0"&DENOM(TOPBIT downto 0));
+        QUOT(J) := '1';
+      end if;
+      assert TEMP(TOPBIT+J+1)='0'
+          report "internal error in the division algorithm"
+          severity ERROR;
+    end loop;
+    XQUOT := RESIZE(QUOT, XQUOT'LENGTH);
+    XREMAIN := RESIZE(TEMP, XREMAIN'LENGTH);
+  end DIVMOD;
+
+  -----------------Local Subprograms - shift/rotate ops-------------------------
+
+  function XSLL (ARG: BIT_VECTOR; COUNT: NATURAL) return BIT_VECTOR is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: BIT_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: BIT_VECTOR(ARG_L downto 0) := (others => '0');
+  begin
+    if COUNT <= ARG_L then
+      RESULT(ARG_L downto COUNT) := XARG(ARG_L-COUNT downto 0);
+    end if;
+    return RESULT;
+  end XSLL;
+
+  function XSRL (ARG: BIT_VECTOR; COUNT: NATURAL) return BIT_VECTOR is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: BIT_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: BIT_VECTOR(ARG_L downto 0) := (others => '0');
+  begin
+    if COUNT <= ARG_L then
+      RESULT(ARG_L-COUNT downto 0) := XARG(ARG_L downto COUNT);
+    end if;
+    return RESULT;
+  end XSRL;
+
+  function XSRA (ARG: BIT_VECTOR; COUNT: NATURAL) return BIT_VECTOR is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: BIT_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: BIT_VECTOR(ARG_L downto 0);
+    variable XCOUNT: NATURAL := COUNT;
+  begin
+    if ((ARG'LENGTH <= 1) or (XCOUNT = 0)) then return ARG;
+    else
+      if (XCOUNT > ARG_L) then XCOUNT := ARG_L;
+      end if;
+      RESULT(ARG_L-XCOUNT downto 0) := XARG(ARG_L downto XCOUNT);
+      RESULT(ARG_L downto (ARG_L - XCOUNT + 1)) := (others => XARG(ARG_L));
+    end if;
+    return RESULT;
+  end XSRA;
+
+  function XROL (ARG: BIT_VECTOR; COUNT: NATURAL) return BIT_VECTOR is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: BIT_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: BIT_VECTOR(ARG_L downto 0) := XARG;
+    variable COUNTM: INTEGER;
+  begin
+    COUNTM := COUNT mod (ARG_L + 1);
+    if COUNTM /= 0 then
+      RESULT(ARG_L downto COUNTM) := XARG(ARG_L-COUNTM downto 0);
+      RESULT(COUNTM-1 downto 0) := XARG(ARG_L downto ARG_L-COUNTM+1);
+    end if;
+    return RESULT;
+  end XROL;
+
+  function XROR (ARG: BIT_VECTOR; COUNT: NATURAL) return BIT_VECTOR is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: BIT_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: BIT_VECTOR(ARG_L downto 0) := XARG;
+    variable COUNTM: INTEGER;
+  begin
+    COUNTM := COUNT mod (ARG_L + 1);
+    if COUNTM /= 0 then
+      RESULT(ARG_L-COUNTM downto 0) := XARG(ARG_L downto COUNTM);
+      RESULT(ARG_L downto ARG_L-COUNTM+1) := XARG(COUNTM-1 downto 0);
+    end if;
+    return RESULT;
+  end XROR;
+
+  ---------------- Local Subprograms - Relational Operators --------------------
+
+  -- General "=" for UNSIGNED vectors, same length
+  --
+  function UNSIGNED_EQUAL (L, R: UNSIGNED) return BOOLEAN is
+  begin
+    return BIT_VECTOR(L) = BIT_VECTOR(R);
+  end UNSIGNED_EQUAL;
+
+  --
+  -- General "=" for SIGNED vectors, same length
+  --
+  function SIGNED_EQUAL (L, R: SIGNED) return BOOLEAN is
+  begin
+    return BIT_VECTOR(L) = BIT_VECTOR(R);
+  end SIGNED_EQUAL;
+
+  --
+  -- General "<" for UNSIGNED vectors, same length
+  --
+  function UNSIGNED_LESS (L, R: UNSIGNED) return BOOLEAN is
+  begin
+    return BIT_VECTOR(L) < BIT_VECTOR(R);
+  end UNSIGNED_LESS;
+
+  --
+  -- General "<" function for SIGNED vectors, same length
+  --
+  function SIGNED_LESS (L, R: SIGNED) return BOOLEAN is
+    -- Need aliases to assure index direction
+    variable INTERN_L: SIGNED(0 to L'LENGTH-1);
+    variable INTERN_R: SIGNED(0 to R'LENGTH-1);
+  begin
+    INTERN_L := L;
+    INTERN_R := R;
+    INTERN_L(0) := not INTERN_L(0);
+    INTERN_R(0) := not INTERN_R(0);
+    return BIT_VECTOR(INTERN_L) < BIT_VECTOR(INTERN_R);
+  end SIGNED_LESS;
+
+  --
+  -- General "<=" function for UNSIGNED vectors, same length
+  --
+  function UNSIGNED_LESS_OR_EQUAL (L, R: UNSIGNED) return BOOLEAN is
+  begin
+    return BIT_VECTOR(L) <= BIT_VECTOR(R);
+  end UNSIGNED_LESS_OR_EQUAL;
+
+  --
+  -- General "<=" function for SIGNED vectors, same length
+  --
+  function SIGNED_LESS_OR_EQUAL (L, R: SIGNED) return BOOLEAN is
+    -- Need aliases to assure index direction
+    variable INTERN_L: SIGNED(0 to L'LENGTH-1);
+    variable INTERN_R: SIGNED(0 to R'LENGTH-1);
+  begin
+    INTERN_L := L;
+    INTERN_R := R;
+    INTERN_L(0) := not INTERN_L(0);
+    INTERN_R(0) := not INTERN_R(0);
+    return BIT_VECTOR(INTERN_L) <= BIT_VECTOR(INTERN_R);
+  end SIGNED_LESS_OR_EQUAL;
+
+  --====================== Exported Functions ==================================
+
+  -- Id: A.1
+  function "abs" (ARG: SIGNED) return SIGNED is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    variable RESULT: SIGNED(ARG_LEFT downto 0);
+  begin
+    if ARG'LENGTH < 1 then return NAS;
+    end if;
+    RESULT := ARG;
+    if RESULT(RESULT'LEFT) = '1' then
+      RESULT := -RESULT;
+    end if;
+    return RESULT;
+  end "abs";
+
+  -- Id: A.2
+  function "-" (ARG: SIGNED) return SIGNED is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    alias XARG: SIGNED(ARG_LEFT downto 0) is ARG;
+    variable RESULT: SIGNED(ARG_LEFT downto 0);
+    variable CBIT: BIT := '1';
+  begin
+    if ARG'LENGTH < 1 then return NAS;
+    end if;
+    for I in 0 to RESULT'LEFT loop
+      RESULT(I) := not(XARG(I)) xor CBIT;
+      CBIT := CBIT and not(XARG(I));
+    end loop;
+    return RESULT;
+  end "-";
+
+  --============================================================================
+
+  -- Id: A.3
+  function "+" (L, R: UNSIGNED) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    return ADD_UNSIGNED(RESIZE(L, SIZE), RESIZE(R, SIZE), '0');
+  end "+";
+
+  -- Id: A.4
+  function "+" (L, R: SIGNED) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    return ADD_SIGNED(RESIZE(L, SIZE), RESIZE(R, SIZE), '0');
+  end "+";
+
+  -- Id: A.5
+  function "+" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+  begin
+    return L + TO_UNSIGNED(R, L'LENGTH);
+  end "+";
+
+  -- Id: A.6
+  function "+" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+  begin
+    return TO_UNSIGNED(L, R'LENGTH) + R;
+  end "+";
+
+  -- Id: A.7
+  function "+" (L: SIGNED; R: INTEGER) return SIGNED is
+  begin
+    return L + TO_SIGNED(R, L'LENGTH);
+  end "+";
+
+  -- Id: A.8
+  function "+" (L: INTEGER; R: SIGNED) return SIGNED is
+  begin
+    return TO_SIGNED(L, R'LENGTH) + R;
+  end "+";
+
+  --============================================================================
+
+  -- Id: A.9
+  function "-" (L, R: UNSIGNED) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    return ADD_UNSIGNED(RESIZE(L, SIZE),
+        not(RESIZE(R, SIZE)),
+        '1');
+  end "-";
+
+  -- Id: A.10
+  function "-" (L, R: SIGNED) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    return ADD_SIGNED(RESIZE(L, SIZE),
+        not(RESIZE(R, SIZE)),
+        '1');
+  end "-";
+
+  -- Id: A.11
+  function "-" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+  begin
+    return L - TO_UNSIGNED(R, L'LENGTH);
+  end "-";
+
+  -- Id: A.12
+  function "-" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+  begin
+    return TO_UNSIGNED(L, R'LENGTH) - R;
+  end "-";
+
+  -- Id: A.13
+  function "-" (L: SIGNED; R: INTEGER) return SIGNED is
+  begin
+    return L - TO_SIGNED(R, L'LENGTH);
+  end "-";
+
+  -- Id: A.14
+  function "-" (L: INTEGER; R: SIGNED) return SIGNED is
+  begin
+    return TO_SIGNED(L, R'LENGTH) - R;
+  end "-";
+
+  --============================================================================
+
+  -- Id: A.15
+  function "*" (L, R: UNSIGNED) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    variable RESULT: UNSIGNED((L'LENGTH+R'LENGTH-1) downto 0) := (others => '0');
+    variable ADVAL: UNSIGNED((L'LENGTH+R'LENGTH-1) downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    ADVAL := RESIZE(XR, RESULT'LENGTH);
+    for I in 0 to L_LEFT loop
+      if XL(I)='1' then RESULT := RESULT + ADVAL;
+      end if;
+      ADVAL := SHIFT_LEFT(ADVAL, 1);
+    end loop;
+    return RESULT;
+  end "*";
+
+  -- Id: A.16
+  function "*" (L, R: SIGNED) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    variable XL: SIGNED(L_LEFT downto 0);
+    variable XR: SIGNED(R_LEFT downto 0);
+    variable RESULT: SIGNED((L_LEFT+R_LEFT+1) downto 0) := (others => '0');
+    variable ADVAL: SIGNED((L_LEFT+R_LEFT+1) downto 0);
+  begin
+    if ((L_LEFT < 0) or (R_LEFT < 0)) then return NAS;
+    end if;
+    XL := L;
+    XR := R;
+    ADVAL := RESIZE(XR, RESULT'LENGTH);
+    for I in 0 to L_LEFT-1 loop
+      if XL(I)='1' then RESULT := RESULT + ADVAL;
+      end if;
+      ADVAL := SHIFT_LEFT(ADVAL, 1);
+    end loop;
+    if XL(L_LEFT)='1' then
+      RESULT := RESULT - ADVAL;
+    end if;
+    return RESULT;
+  end "*";
+
+  -- Id: A.17
+  function "*" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+  begin
+    return L * TO_UNSIGNED(R, L'LENGTH);
+  end "*";
+
+  -- Id: A.18
+  function "*" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+  begin
+    return TO_UNSIGNED(L, R'LENGTH) * R;
+  end "*";
+
+  -- Id: A.19
+  function "*" (L: SIGNED; R: INTEGER) return SIGNED is
+  begin
+    return L * TO_SIGNED(R, L'LENGTH);
+  end "*";
+
+  -- Id: A.20
+  function "*" (L: INTEGER; R: SIGNED) return SIGNED is
+  begin
+    return TO_SIGNED(L, R'LENGTH) * R;
+  end "*";
+
+  --============================================================================
+
+  -- Id: A.21
+  function "/" (L, R: UNSIGNED) return UNSIGNED is
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    DIVMOD(L, R, FQUOT, FREMAIN);
+    return FQUOT;
+  end "/";
+
+  -- Id: A.22
+  function "/" (L, R: SIGNED) return SIGNED is
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+    variable XNUM: UNSIGNED(L'LENGTH-1 downto 0);
+    variable XDENOM: UNSIGNED(R'LENGTH-1 downto 0);
+    variable QNEG: BOOLEAN := FALSE;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    if L(L'LEFT)='1' then
+      XNUM := UNSIGNED(-L);
+      QNEG := TRUE;
+    else
+      XNUM := UNSIGNED(L);
+    end if;
+    if R(R'LEFT)='1' then
+      XDENOM := UNSIGNED(-R);
+      QNEG := not QNEG;
+    else
+      XDENOM := UNSIGNED(R);
+    end if;
+    DIVMOD(XNUM, XDENOM, FQUOT, FREMAIN);
+    if QNEG then FQUOT := "0"-FQUOT;
+    end if;
+    return SIGNED(FQUOT);
+  end "/";
+
+  -- Id: A.23
+  function "/" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, UNSIGNED_NUM_BITS(R));
+    variable XR, QUOT: UNSIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAU;
+    end if;
+    if (R_LENGTH > L'LENGTH) then
+      QUOT := (others => '0');
+      return RESIZE(QUOT, L'LENGTH);
+    end if;
+    XR := TO_UNSIGNED(R, R_LENGTH);
+    QUOT := RESIZE((L / XR), QUOT'LENGTH);
+    return RESIZE(QUOT, L'LENGTH);
+  end "/";
+
+  -- Id: A.24
+  function "/" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+    constant L_LENGTH: NATURAL := MAX(UNSIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, QUOT: UNSIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAU;
+    end if;
+    XL := TO_UNSIGNED(L, L_LENGTH);
+    QUOT := RESIZE((XL / R), QUOT'LENGTH);
+    if L_LENGTH > R'LENGTH
+        and QUOT(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""/"": Quotient Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(QUOT, R'LENGTH);
+  end "/";
+
+  -- Id: A.25
+  function "/" (L: SIGNED; R: INTEGER) return SIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, SIGNED_NUM_BITS(R));
+    variable XR, QUOT: SIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAS;
+    end if;
+    if (R_LENGTH > L'LENGTH) then
+      QUOT := (others => '0');
+      return RESIZE(QUOT, L'LENGTH);
+    end if;
+    XR := TO_SIGNED(R, R_LENGTH);
+    QUOT := RESIZE((L / XR), QUOT'LENGTH);
+    return RESIZE(QUOT, L'LENGTH);
+  end "/";
+
+  -- Id: A.26
+  function "/" (L: INTEGER; R: SIGNED) return SIGNED is
+    constant L_LENGTH: NATURAL := MAX(SIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, QUOT: SIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAS;
+    end if;
+    XL := TO_SIGNED(L, L_LENGTH);
+    QUOT := RESIZE((XL / R), QUOT'LENGTH);
+    if L_LENGTH > R'LENGTH and QUOT(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => QUOT(R'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""/"": Quotient Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(QUOT, R'LENGTH);
+  end "/";
+
+  --============================================================================
+
+  -- Id: A.27
+  function "rem" (L, R: UNSIGNED) return UNSIGNED is
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    DIVMOD(L, R, FQUOT, FREMAIN);
+    return FREMAIN;
+  end "rem";
+
+  -- Id: A.28
+  function "rem" (L, R: SIGNED) return SIGNED is
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+    variable XNUM: UNSIGNED(L'LENGTH-1 downto 0);
+    variable XDENOM: UNSIGNED(R'LENGTH-1 downto 0);
+    variable RNEG: BOOLEAN := FALSE;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    if L(L'LEFT)='1' then
+      XNUM := UNSIGNED(-L);
+      RNEG := TRUE;
+    else
+      XNUM := UNSIGNED(L);
+    end if;
+    if R(R'LEFT)='1' then
+      XDENOM := UNSIGNED(-R);
+    else
+      XDENOM := UNSIGNED(R);
+    end if;
+    DIVMOD(XNUM, XDENOM, FQUOT, FREMAIN);
+    if RNEG then
+      FREMAIN := "0"-FREMAIN;
+    end if;
+    return SIGNED(FREMAIN);
+  end "rem";
+
+  -- Id: A.29
+  function "rem" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, UNSIGNED_NUM_BITS(R));
+    variable XR, XREM: UNSIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAU;
+    end if;
+    XR := TO_UNSIGNED(R, R_LENGTH);
+    XREM := RESIZE((L rem XR), XREM'LENGTH);
+    if R_LENGTH > L'LENGTH and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "rem";
+
+  -- Id: A.30
+  function "rem" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+    constant L_LENGTH: NATURAL := MAX(UNSIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: UNSIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAU;
+    end if;
+    XL := TO_UNSIGNED(L, L_LENGTH);
+    XREM := RESIZE((XL rem R), XREM'LENGTH);
+    if L_LENGTH > R'LENGTH and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "rem";
+
+  -- Id: A.31
+  function "rem" (L: SIGNED; R: INTEGER) return SIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, SIGNED_NUM_BITS(R));
+    variable XR, XREM: SIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAS;
+    end if;
+    XR := TO_SIGNED(R, R_LENGTH);
+    XREM := RESIZE((L rem XR), XREM'LENGTH);
+    if R_LENGTH > L'LENGTH and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => XREM(L'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "rem";
+
+  -- Id: A.32
+  function "rem" (L: INTEGER; R: SIGNED) return SIGNED is
+    constant L_LENGTH: NATURAL := MAX(SIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: SIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAS;
+    end if;
+    XL := TO_SIGNED(L, L_LENGTH);
+    XREM := RESIZE((XL rem R), XREM'LENGTH);
+    if L_LENGTH > R'LENGTH and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => XREM(R'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "rem";
+
+  --============================================================================
+
+  -- Id: A.33
+  function "mod" (L, R: UNSIGNED) return UNSIGNED is
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    DIVMOD(L, R, FQUOT, FREMAIN);
+    return FREMAIN;
+  end "mod";
+
+  -- Id: A.34
+  function "mod" (L, R: SIGNED) return SIGNED is
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+    variable XNUM: UNSIGNED(L'LENGTH-1 downto 0);
+    variable XDENOM: UNSIGNED(R'LENGTH-1 downto 0);
+    variable RNEG: BOOLEAN := FALSE;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    if L(L'LEFT)='1' then
+      XNUM := UNSIGNED(-L);
+    else
+      XNUM := UNSIGNED(L);
+    end if;
+    if R(R'LEFT)='1' then
+      XDENOM := UNSIGNED(-R);
+      RNEG := TRUE;
+    else
+      XDENOM := UNSIGNED(R);
+    end if;
+    DIVMOD(XNUM, XDENOM, FQUOT, FREMAIN);
+    if RNEG and L(L'LEFT)='1' then
+      FREMAIN := "0"-FREMAIN;
+      elsif RNEG and FREMAIN/="0" then
+          FREMAIN := FREMAIN-XDENOM;
+      elsif L(L'LEFT)='1' and FREMAIN/="0" then
+          FREMAIN := XDENOM-FREMAIN;
+    end if;
+    return SIGNED(FREMAIN);
+  end "mod";
+
+  -- Id: A.35
+  function "mod" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, UNSIGNED_NUM_BITS(R));
+    variable XR, XREM: UNSIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAU;
+    end if;
+    XR := TO_UNSIGNED(R, R_LENGTH);
+    XREM := RESIZE((L mod XR), XREM'LENGTH);
+    if R_LENGTH > L'LENGTH and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""mod"": modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "mod";
+
+  -- Id: A.36
+  function "mod" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+    constant L_LENGTH: NATURAL := MAX(UNSIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: UNSIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAU;
+    end if;
+    XL := TO_UNSIGNED(L, L_LENGTH);
+    XREM := RESIZE((XL mod R), XREM'LENGTH);
+    if L_LENGTH > R'LENGTH and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""mod"": modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "mod";
+
+  -- Id: A.37
+  function "mod" (L: SIGNED; R: INTEGER) return SIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, SIGNED_NUM_BITS(R));
+    variable XR, XREM: SIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAS;
+    end if;
+    XR := TO_SIGNED(R, R_LENGTH);
+    XREM := RESIZE((L mod XR), XREM'LENGTH);
+    if R_LENGTH > L'LENGTH and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => XREM(L'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""mod"": modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "mod";
+
+  -- Id: A.38
+  function "mod" (L: INTEGER; R: SIGNED) return SIGNED is
+    constant L_LENGTH: NATURAL := MAX(SIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: SIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAS;
+    end if;
+    XL := TO_SIGNED(L, L_LENGTH);
+    XREM := RESIZE((XL mod R), XREM'LENGTH);
+    if L_LENGTH > R'LENGTH and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => XREM(R'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_BIT.""mod"": modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "mod";
+
+  --============================================================================
+
+  -- Id: C.1
+  function ">" (L, R: UNSIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not UNSIGNED_LESS_OR_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end ">";
+
+  -- Id: C.2
+  function ">" (L, R: SIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not SIGNED_LESS_OR_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end ">";
+
+  -- Id: C.3
+  function ">" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return TRUE;
+    end if;
+    return not UNSIGNED_LESS_OR_EQUAL(TO_UNSIGNED(L, R'LENGTH), R);
+  end ">";
+
+  -- Id: C.4
+  function ">" (L: INTEGER; R: SIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L > 0;
+    end if;
+    return not SIGNED_LESS_OR_EQUAL(TO_SIGNED(L, R'LENGTH), R);
+  end ">";
+
+  -- Id: C.5
+  function ">" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return FALSE;
+    end if;
+    return not UNSIGNED_LESS_OR_EQUAL(L, TO_UNSIGNED(R, L'LENGTH));
+  end ">";
+
+  -- Id: C.6
+  function ">" (L: SIGNED; R: INTEGER) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 > R;
+    end if;
+    return not SIGNED_LESS_OR_EQUAL(L, TO_SIGNED(R, L'LENGTH));
+  end ">";
+
+  --============================================================================
+
+  -- Id: C.7
+  function "<" (L, R: UNSIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return UNSIGNED_LESS(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end "<";
+
+  -- Id: C.8
+  function "<" (L, R: SIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return SIGNED_LESS(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end "<";
+
+  -- Id: C.9
+  function "<" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return UNSIGNED_LESS(TO_UNSIGNED(L, R'LENGTH), R);
+  end "<";
+
+  -- Id: C.10
+  function "<" (L: INTEGER; R: SIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return SIGNED_LESS(TO_SIGNED(L, R'LENGTH), R);
+  end "<";
+
+  -- Id: C.11
+  function "<" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return UNSIGNED_LESS(L, TO_UNSIGNED(R, L'LENGTH));
+  end "<";
+
+  -- Id: C.12
+  function "<" (L: SIGNED; R: INTEGER) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return SIGNED_LESS(L, TO_SIGNED(R, L'LENGTH));
+  end "<";
+
+  --============================================================================
+
+  -- Id: C.13
+  function "<=" (L, R: UNSIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return UNSIGNED_LESS_OR_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end "<=";
+
+  -- Id: C.14
+  function "<=" (L, R: SIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return SIGNED_LESS_OR_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end "<=";
+
+  -- Id: C.15
+  function "<=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return UNSIGNED_LESS_OR_EQUAL(TO_UNSIGNED(L, R'LENGTH), R);
+  end "<=";
+
+  -- Id: C.16
+  function "<=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return SIGNED_LESS_OR_EQUAL(TO_SIGNED(L, R'LENGTH), R);
+  end "<=";
+
+  -- Id: C.17
+  function "<=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return UNSIGNED_LESS_OR_EQUAL(L, TO_UNSIGNED(R, L'LENGTH));
+  end "<=";
+
+  -- Id: C.18
+  function "<=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return SIGNED_LESS_OR_EQUAL(L, TO_SIGNED(R, L'LENGTH));
+  end "<=";
+
+  --============================================================================
+
+  -- Id: C.19
+  function ">=" (L, R: UNSIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not UNSIGNED_LESS(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end ">=";
+
+  -- Id: C.20
+  function ">=" (L, R: SIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not SIGNED_LESS(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end ">=";
+
+  -- Id: C.21
+  function ">=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return L > 0;
+    end if;
+    return not UNSIGNED_LESS(TO_UNSIGNED(L, R'LENGTH), R);
+  end ">=";
+
+  -- Id: C.22
+  function ">=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L > 0;
+    end if;
+    return not SIGNED_LESS(TO_SIGNED(L, R'LENGTH), R);
+  end ">=";
+
+  -- Id: C.23
+  function ">=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return 0 > R;
+    end if;
+    return not UNSIGNED_LESS(L, TO_UNSIGNED(R, L'LENGTH));
+  end ">=";
+
+  -- Id: C.24
+  function ">=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 > R;
+    end if;
+    return not SIGNED_LESS(L, TO_SIGNED(R, L'LENGTH));
+  end ">=";
+
+  --============================================================================
+
+  -- Id: C.25
+  function "=" (L, R: UNSIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return UNSIGNED_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end "=";
+
+  -- Id: C.26
+  function "=" (L, R: SIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return SIGNED_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE));
+  end "=";
+
+  -- Id: C.27
+  function "=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return FALSE;
+    end if;
+    return UNSIGNED_EQUAL(TO_UNSIGNED(L, R'LENGTH), R);
+  end "=";
+
+  -- Id: C.28
+  function "=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return FALSE;
+    end if;
+    return SIGNED_EQUAL(TO_SIGNED(L, R'LENGTH), R);
+  end "=";
+
+  -- Id: C.29
+  function "=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return FALSE;
+    end if;
+    return UNSIGNED_EQUAL(L, TO_UNSIGNED(R, L'LENGTH));
+  end "=";
+
+  -- Id: C.30
+  function "=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return FALSE;
+    end if;
+    return SIGNED_EQUAL(L, TO_SIGNED(R, L'LENGTH));
+  end "=";
+
+  --============================================================================
+
+  -- Id: C.31
+  function "/=" (L, R: UNSIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    return not(UNSIGNED_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE)));
+  end "/=";
+
+  -- Id: C.32
+  function "/=" (L, R: SIGNED) return BOOLEAN is
+    variable SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    return not(SIGNED_EQUAL(RESIZE(L, SIZE), RESIZE(R, SIZE)));
+  end "/=";
+
+  -- Id: C.33
+  function "/=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return TRUE;
+    end if;
+    return not(UNSIGNED_EQUAL(TO_UNSIGNED(L, R'LENGTH), R));
+  end "/=";
+
+  -- Id: C.34
+  function "/=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return TRUE;
+    end if;
+    return not(SIGNED_EQUAL(TO_SIGNED(L, R'LENGTH), R));
+  end "/=";
+
+  -- Id: C.35
+  function "/=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return TRUE;
+    end if;
+    return not(UNSIGNED_EQUAL(L, TO_UNSIGNED(R, L'LENGTH)));
+  end "/=";
+
+  -- Id: C.36
+  function "/=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return TRUE;
+    end if;
+    return not(SIGNED_EQUAL(L, TO_SIGNED(R, L'LENGTH)));
+  end "/=";
+
+  --============================================================================
+
+  -- Id: S.1
+  function SHIFT_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XSLL(BIT_VECTOR(ARG), COUNT));
+  end SHIFT_LEFT;
+
+  -- Id: S.2
+  function SHIFT_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XSRL(BIT_VECTOR(ARG), COUNT));
+  end SHIFT_RIGHT;
+
+  -- Id: S.3
+  function SHIFT_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XSLL(BIT_VECTOR(ARG), COUNT));
+  end SHIFT_LEFT;
+
+  -- Id: S.4
+  function SHIFT_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XSRA(BIT_VECTOR(ARG), COUNT));
+  end SHIFT_RIGHT;
+
+  --============================================================================
+
+  -- Id: S.5
+  function ROTATE_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XROL(BIT_VECTOR(ARG), COUNT));
+  end ROTATE_LEFT;
+
+  -- Id: S.6
+  function ROTATE_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XROR(BIT_VECTOR(ARG), COUNT));
+  end ROTATE_RIGHT;
+
+  -- Id: S.7
+  function ROTATE_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XROL(BIT_VECTOR(ARG), COUNT));
+  end ROTATE_LEFT;
+
+  -- Id: S.8
+  function ROTATE_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XROR(BIT_VECTOR(ARG), COUNT));
+  end ROTATE_RIGHT;
+
+  --============================================================================
+
+--START-V93
+  ------------------------------------------------------------------------------
+  -- Note : Function S.9 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.9
+  function "sll" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SHIFT_LEFT(ARG, COUNT);
+    else
+      return SHIFT_RIGHT(ARG, -COUNT);
+    end if;
+  end "sll";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.10 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.10
+  function "sll" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SHIFT_LEFT(ARG, COUNT);
+    else
+      return SIGNED(SHIFT_RIGHT(UNSIGNED(ARG), -COUNT));
+    end if;
+  end "sll";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.11 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.11
+  function "srl" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SHIFT_RIGHT(ARG, COUNT);
+    else
+      return SHIFT_LEFT(ARG, -COUNT);
+    end if;
+  end "srl";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.12 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.12
+  function "srl" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SIGNED(SHIFT_RIGHT(UNSIGNED(ARG), COUNT));
+    else
+      return SHIFT_LEFT(ARG, -COUNT);
+    end if;
+  end "srl";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.13 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.13
+  function "rol" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_LEFT(ARG, COUNT);
+    else
+      return ROTATE_RIGHT(ARG, -COUNT);
+    end if;
+  end "rol";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.14 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.14
+  function "rol" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_LEFT(ARG, COUNT);
+    else
+      return ROTATE_RIGHT(ARG, -COUNT);
+    end if;
+  end "rol";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.15 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.15
+  function "ror" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_RIGHT(ARG, COUNT);
+    else
+      return ROTATE_LEFT(ARG, -COUNT);
+    end if;
+  end "ror";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.16 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.16
+  function "ror" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_RIGHT(ARG, COUNT);
+    else
+      return ROTATE_LEFT(ARG, -COUNT);
+    end if;
+  end "ror";
+
+--END-V93
+  --============================================================================
+
+  -- Id: D.1
+  function TO_INTEGER (ARG: UNSIGNED) return NATURAL is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    alias XARG: UNSIGNED(ARG_LEFT downto 0) is ARG;
+    variable RESULT: NATURAL := 0;
+  begin
+    if (ARG'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.TO_INTEGER: null detected, returning 0"
+          severity WARNING;
+      return 0;
+    end if;
+    for I in XARG'RANGE loop
+      RESULT := RESULT+RESULT;
+      if XARG(I) = '1' then
+        RESULT := RESULT + 1;
+      end if;
+    end loop;
+    return RESULT;
+  end TO_INTEGER;
+
+  -- Id: D.2
+  function TO_INTEGER (ARG: SIGNED) return INTEGER is
+  begin
+    if (ARG'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.TO_INTEGER: null detected, returning 0"
+          severity WARNING;
+      return 0;
+    end if;
+    if ARG(ARG'LEFT) = '0' then
+      return TO_INTEGER(UNSIGNED(ARG));
+    else
+      return (- (TO_INTEGER(UNSIGNED(- (ARG + 1)))) -1);
+    end if;
+  end TO_INTEGER;
+
+  -- Id: D.3
+  function TO_UNSIGNED (ARG, SIZE: NATURAL) return UNSIGNED is
+    variable RESULT: UNSIGNED(SIZE-1 downto 0);
+    variable I_VAL: NATURAL := ARG;
+  begin
+    if (SIZE < 1) then return NAU;
+    end if;
+    for I in 0 to RESULT'LEFT loop
+      if (I_VAL mod 2) = 0 then
+        RESULT(I) := '0';
+      else RESULT(I) := '1';
+      end if;
+      I_VAL := I_VAL/2;
+    end loop;
+    if not(I_VAL =0) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.TO_UNSIGNED: vector truncated"
+          severity WARNING;
+    end if;
+    return RESULT;
+  end TO_UNSIGNED;
+
+  -- Id: D.4
+  function TO_SIGNED (ARG: INTEGER;
+    SIZE: NATURAL) return SIGNED is
+        variable RESULT: SIGNED(SIZE-1 downto 0);
+    variable B_VAL: BIT := '0';
+    variable I_VAL: INTEGER := ARG;
+  begin
+    if (SIZE < 1) then return NAS;
+    end if;
+    if (ARG < 0) then
+      B_VAL := '1';
+      I_VAL := -(ARG+1);
+    end if;
+    for I in 0 to RESULT'LEFT loop
+      if (I_VAL mod 2) = 0 then
+        RESULT(I) := B_VAL;
+      else
+        RESULT(I) := not B_VAL;
+      end if;
+      I_VAL := I_VAL/2;
+    end loop;
+    if ((I_VAL/=0) or (B_VAL/=RESULT(RESULT'LEFT))) then
+      assert NO_WARNING
+          report "NUMERIC_BIT.TO_SIGNED: vector truncated"
+          severity WARNING;
+    end if;
+    return RESULT;
+  end TO_SIGNED;
+
+  --============================================================================
+
+  -- Id: R.1
+  function RESIZE (ARG: SIGNED; NEW_SIZE: NATURAL) return SIGNED is
+    alias INVEC: SIGNED(ARG'LENGTH-1 downto 0) is ARG;
+    variable RESULT: SIGNED(NEW_SIZE-1 downto 0) := (others => '0');
+    constant BOUND: INTEGER := MIN(ARG'LENGTH, RESULT'LENGTH)-2;
+  begin
+    if (NEW_SIZE < 1) then return NAS;
+    end if;
+    if (ARG'LENGTH = 0) then return RESULT;
+    end if;
+    RESULT := (others => ARG(ARG'LEFT));
+    if BOUND >= 0 then
+      RESULT(BOUND downto 0) := INVEC(BOUND downto 0);
+    end if;
+    return RESULT;
+  end RESIZE;
+
+  -- Id: R.2
+  function RESIZE (ARG: UNSIGNED; NEW_SIZE: NATURAL) return UNSIGNED is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    alias XARG: UNSIGNED(ARG_LEFT downto 0) is ARG;
+    variable RESULT: UNSIGNED(NEW_SIZE-1 downto 0) := (others => '0');
+  begin
+    if (NEW_SIZE < 1) then return NAU;
+    end if;
+    if XARG'LENGTH =0 then return RESULT;
+    end if;
+    if (RESULT'LENGTH < ARG'LENGTH) then
+      RESULT(RESULT'LEFT downto 0) := XARG(RESULT'LEFT downto 0);
+    else
+      RESULT(RESULT'LEFT downto XARG'LEFT+1) := (others => '0');
+      RESULT(XARG'LEFT downto 0) := XARG;
+    end if;
+    return RESULT;
+  end RESIZE;
+
+  --============================================================================
+
+  -- Id: L.1
+  function "not" (L: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(not(BIT_VECTOR(L)));
+    return RESULT;
+  end "not";
+
+  -- Id: L.2
+  function "and" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(BIT_VECTOR(L) and BIT_VECTOR(R));
+    return RESULT;
+  end "and";
+
+  -- Id: L.3
+  function "or" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(BIT_VECTOR(L) or BIT_VECTOR(R));
+    return RESULT;
+  end "or";
+
+  -- Id: L.4
+  function "nand" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(BIT_VECTOR(L) nand BIT_VECTOR(R));
+    return RESULT;
+  end "nand";
+
+  -- Id: L.5
+  function "nor" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(BIT_VECTOR(L) nor BIT_VECTOR(R));
+    return RESULT;
+  end "nor";
+
+  -- Id: L.6
+  function "xor" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(BIT_VECTOR(L) xor BIT_VECTOR(R));
+    return RESULT;
+  end "xor";
+
+--START-V93
+  ------------------------------------------------------------------------------
+  -- Note : Function L.7 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: L.7
+  function "xnor" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(BIT_VECTOR(L) xnor BIT_VECTOR(R));
+    return RESULT;
+  end "xnor";
+--END-V93
+
+  -- Id: L.8
+  function "not" (L: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(not(BIT_VECTOR(L)));
+    return RESULT;
+  end "not";
+
+  -- Id: L.9
+  function "and" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(BIT_VECTOR(L) and BIT_VECTOR(R));
+    return RESULT;
+  end "and";
+
+  -- Id: L.10
+  function "or" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(BIT_VECTOR(L) or BIT_VECTOR(R));
+    return RESULT;
+  end "or";
+
+  -- Id: L.11
+  function "nand" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(BIT_VECTOR(L) nand BIT_VECTOR(R));
+    return RESULT;
+  end "nand";
+
+  -- Id: L.12
+  function "nor" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(BIT_VECTOR(L) nor BIT_VECTOR(R));
+    return RESULT;
+  end "nor";
+
+  -- Id: L.13
+  function "xor" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(BIT_VECTOR(L) xor BIT_VECTOR(R));
+    return RESULT;
+  end "xor";
+
+--START-V93
+  ------------------------------------------------------------------------------
+  -- Note : Function L.14 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: L.14
+  function "xnor" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(BIT_VECTOR(L) xnor BIT_VECTOR(R));
+    return RESULT;
+  end "xnor";
+--END-V93
+
+  --============================================================================
+
+  -- Id: E.1
+  function RISING_EDGE (signal S: BIT) return BOOLEAN is
+  begin
+    return S'EVENT and S = '1';
+  end RISING_EDGE;
+
+  -- Id: E.2
+  function FALLING_EDGE (signal S: BIT) return BOOLEAN is
+  begin
+    return S'EVENT and S = '0';
+  end FALLING_EDGE;
+
+  --============================================================================
+end NUMERIC_BIT;

--- a/vhdl/examples/numeric_bit.vhd
+++ b/vhdl/examples/numeric_bit.vhd
@@ -1,0 +1,813 @@
+-- -----------------------------------------------------------------------------
+--
+-- Copyright 1995 by IEEE. All rights reserved.
+--
+-- This source file is considered by the IEEE to be an essential part of the use
+-- of the standard 1076.3 and as such may be distributed without change, except
+-- as permitted by the standard. This source file may not be sold or distributed
+-- for profit. This package may be modified to include additional data required
+-- by tools, but must in no way change the external interfaces or simulation
+-- behaviour of the description. It is permissible to add comments and/or
+-- attributes to the package declarations, but not to change or delete any
+-- original lines of the approved package declaration. The package body may be
+-- changed only in accordance with the terms of clauses 7.1 and 7.2 of the
+-- standard.
+--
+-- Title      : Standard VHDL Synthesis Package (1076.3, NUMERIC_BIT)
+--
+-- Library    : This package shall be compiled into a library symbolically
+--            : named IEEE.
+--
+-- Developers : IEEE DASC Synthesis Working Group, PAR 1076.3
+--
+-- Purpose    : This package defines numeric types and arithmetic functions
+--            : for use with synthesis tools. Two numeric types are defined:
+--            : -- > UNSIGNED: represents an UNSIGNED number in vector form
+--            : -- > SIGNED: represents a SIGNED number in vector form
+--            : The base element type is type BIT.
+--            : The leftmost bit is treated as the most significant bit.
+--            : Signed vectors are represented in two's complement form.
+--            : This package contains overloaded arithmetic operators on
+--            : the SIGNED and UNSIGNED types. The package also contains
+--            : useful type conversions functions, clock detection
+--            : functions, and other utility functions.
+--            :
+--            : If any argument to a function is a null array, a null array is
+--            : returned (exceptions, if any, are noted individually).
+--
+-- Limitation :
+--
+-- Note       : No declarations or definitions shall be included in,
+--            : or excluded from this package. The "package declaration"
+--            : defines the types, subtypes and declarations of
+--            : NUMERIC_BIT. The NUMERIC_BIT package body shall be
+--            : considered the formal definition of the semantics of
+--            : this package. Tool developers may choose to implement
+--            : the package body in the most efficient manner available
+--            : to them.
+--            :
+-- -----------------------------------------------------------------------------
+-- Version    : 2.4
+-- Date       : 12 April 1995
+-- -----------------------------------------------------------------------------
+
+package NUMERIC_BIT is
+  constant CopyRightNotice: STRING
+      := "Copyright 1995 IEEE. All rights reserved.";
+
+  --============================================================================
+  -- Numeric array type definitions
+  --============================================================================
+
+  type UNSIGNED is array (NATURAL range <> ) of BIT;
+  type SIGNED is array (NATURAL range <> ) of BIT;
+
+  --============================================================================
+  -- Arithmetic Operators:
+  --============================================================================
+
+  -- Id: A.1
+  function "abs" (ARG: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0).
+  -- Result: Returns the absolute value of a SIGNED vector ARG.
+
+  -- Id: A.2
+  function "-" (ARG: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0).
+  -- Result: Returns the value of the unary minus operation on a
+  --         SIGNED vector ARG.
+
+  --============================================================================
+
+  -- Id: A.3
+  function "+" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Adds two UNSIGNED vectors that may be of different lengths.
+
+  -- Id: A.4
+  function "+" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Adds two SIGNED vectors that may be of different lengths.
+
+  -- Id: A.5
+  function "+" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0).
+  -- Result: Adds an UNSIGNED vector, L, with a non-negative INTEGER, R.
+
+  -- Id: A.6
+  function "+" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0).
+  -- Result: Adds a non-negative INTEGER, L, with an UNSIGNED vector, R.
+
+  -- Id: A.7
+  function "+" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0).
+  -- Result: Adds an INTEGER, L(may be positive or negative), to a SIGNED
+  -- vector, R.
+
+  -- Id: A.8
+  function "+" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0).
+  -- Result: Adds a SIGNED vector, L, to an INTEGER, R.
+
+  --============================================================================
+
+  -- Id: A.9
+  function "-" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Subtracts two UNSIGNED vectors that may be of different lengths.
+
+  -- Id: A.10
+  function "-" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Subtracts a SIGNED vector, R, from another SIGNED vector, L,
+  --         that may possibly be of different lengths.
+
+  -- Id: A.11
+  function "-" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0).
+  -- Result: Subtracts a non-negative INTEGER, R, from an UNSIGNED vector, L.
+
+  -- Id: A.12
+  function "-" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0).
+  -- Result: Subtracts an UNSIGNED vector, R, from a non-negative INTEGER, L.
+
+  -- Id: A.13
+  function "-" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0).
+  -- Result: Subtracts an INTEGER, R, from a SIGNED vector, L.
+
+  -- Id: A.14
+  function "-" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0).
+  -- Result: Subtracts a SIGNED vector, R, from an INTEGER, L.
+
+  --============================================================================
+
+  -- Id: A.15
+  function "*" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED((L'LENGTH+R'LENGTH-1) downto 0).
+  -- Result: Performs the multiplication operation on two UNSIGNED vectors
+  --         that may possibly be of different lengths.
+
+  -- Id: A.16
+  function "*" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED((L'LENGTH+R'LENGTH-1) downto 0)
+  -- Result: Multiplies two SIGNED vectors that may possibly be of
+  --         different lengths.
+
+  -- Id: A.17
+  function "*" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED((L'LENGTH+L'LENGTH-1) downto 0).
+  -- Result: Multiplies an UNSIGNED vector, L, with a non-negative
+  --         INTEGER, R. R is converted to an UNSIGNED vector of
+  --         size L'LENGTH before multiplication.
+
+  -- Id: A.18
+  function "*" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED((R'LENGTH+R'LENGTH-1) downto 0).
+  -- Result: Multiplies an UNSIGNED vector, R, with a non-negative
+  --         INTEGER, L. L is converted to an UNSIGNED vector of
+  --         size R'LENGTH before multiplication.
+
+  -- Id: A.19
+  function "*" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED((L'LENGTH+L'LENGTH-1) downto 0)
+  -- Result: Multiplies a SIGNED vector, L, with an INTEGER, R. R is
+  --         converted to a SIGNED vector of size L'LENGTH before
+  --         multiplication.
+
+  -- Id: A.20
+  function "*" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED((R'LENGTH+R'LENGTH-1) downto 0)
+  -- Result: Multiplies a SIGNED vector, R, with an INTEGER, L. L is
+  --         converted to a SIGNED vector of size R'LENGTH before
+  --         multiplication.
+
+  --============================================================================
+  --
+  -- NOTE: If second argument is zero for "/" operator, a severity level
+  --       of ERROR is issued.
+
+  -- Id: A.21
+  function "/" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides an UNSIGNED vector, L, by another UNSIGNED vector, R.
+
+  -- Id: A.22
+  function "/" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides an SIGNED vector, L, by another SIGNED vector, R.
+
+  -- Id: A.23
+  function "/" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides an UNSIGNED vector, L, by a non-negative INTEGER, R.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.24
+  function "/" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Divides a non-negative INTEGER, L, by an UNSIGNED vector, R.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  -- Id: A.25
+  function "/" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides a SIGNED vector, L, by an INTEGER, R.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.26
+  function "/" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Divides an INTEGER, L, by a SIGNED vector, R.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  --============================================================================
+  --
+  -- NOTE: If second argument is zero for "rem" operator, a severity level
+  --       of ERROR is issued.
+
+  -- Id: A.27
+  function "rem" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L and R are UNSIGNED vectors.
+
+  -- Id: A.28
+  function "rem" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L and R are SIGNED vectors.
+
+  -- Id: A.29
+  function "rem" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L is an UNSIGNED vector and R is a
+  --         non-negative INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.30
+  function "rem" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where R is an UNSIGNED vector and L is a
+  --         non-negative INTEGER.
+  -- If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  -- Id: A.31
+  function "rem" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L is SIGNED vector and R is an INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.32
+  function "rem" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where R is SIGNED vector and L is an INTEGER.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  --============================================================================
+  --
+  -- NOTE: If second argument is zero for "mod" operator, a severity level
+  --       of ERROR is issued.
+
+  -- Id: A.33
+  function "mod" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L and R are UNSIGNED vectors.
+
+  -- Id: A.34
+  function "mod" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L and R are SIGNED vectors.
+
+  -- Id: A.35
+  function "mod" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L is an UNSIGNED vector and R
+  --         is a non-negative INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.36
+  function "mod" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where R is an UNSIGNED vector and L
+  --         is a non-negative INTEGER.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  -- Id: A.37
+  function "mod" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.38
+  function "mod" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  --============================================================================
+  -- Comparison Operators
+  --============================================================================
+
+  -- Id: C.1
+  function ">" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.2
+  function ">" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.3
+  function ">" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.4
+  function ">" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is a INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.5
+  function ">" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.6
+  function ">" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is a SIGNED vector and
+  --         R is a INTEGER.
+
+  --============================================================================
+
+  -- Id: C.7
+  function "<" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.8
+  function "<" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.9
+  function "<" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.10
+  function "<" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.11
+  function "<" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.12
+  function "<" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.13
+  function "<=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.14
+  function "<=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.15
+  function "<=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.16
+  function "<=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.17
+  function "<=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.18
+  function "<=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.19
+  function ">=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.20
+  function ">=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.21
+  function ">=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.22
+  function ">=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.23
+  function ">=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.24
+  function ">=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.25
+  function "=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.26
+  function "=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.27
+  function "=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.28
+  function "=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.29
+  function "=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.30
+  function "=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.31
+  function "/=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.32
+  function "/=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.33
+  function "/=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.34
+  function "/=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.35
+  function "/=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.36
+  function "/=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+  -- Shift and Rotate Functions
+  --============================================================================
+
+  -- Id: S.1
+  function SHIFT_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-left on an UNSIGNED vector COUNT times.
+  --         The vacated positions are filled with Bit '0'.
+  --         The COUNT leftmost bits are lost.
+
+  -- Id: S.2
+  function SHIFT_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-right on an UNSIGNED vector COUNT times.
+  --         The vacated positions are filled with Bit '0'.
+  --         The COUNT rightmost bits are lost.
+
+  -- Id: S.3
+  function SHIFT_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-left on a SIGNED vector COUNT times.
+  --         The vacated positions are filled with Bit '0'.
+  --         The COUNT leftmost bits, except ARG'LEFT, are lost.
+
+  -- Id: S.4
+  function SHIFT_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-right on a SIGNED vector COUNT times.
+  --         The vacated positions are filled with the leftmost bit, ARG'LEFT.
+  --         The COUNT rightmost bits are lost.
+
+  --============================================================================
+
+  -- Id: S.5
+  function ROTATE_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a rotate-left of an UNSIGNED vector COUNT times.
+
+  -- Id: S.6
+  function ROTATE_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a rotate-right of an UNSIGNED vector COUNT times.
+
+  -- Id: S.7
+  function ROTATE_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a logical rotate-left of a SIGNED vector COUNT times.
+
+  -- Id: S.8
+  function ROTATE_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a logical rotate-right of a SIGNED vector COUNT times.
+
+  --============================================================================
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.9 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.9
+  function "sll" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SHIFT_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.10 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.10
+  function "sll" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SHIFT_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.11 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.11
+  function "srl" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SHIFT_RIGHT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.12 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.12
+  function "srl" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SIGNED(SHIFT_RIGHT(UNSIGNED(ARG), COUNT))
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.13 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.13
+  function "rol" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.14 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.14
+  function "rol" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.15 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.15
+  function "ror" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_RIGHT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.16 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.16
+  function "ror" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_RIGHT(ARG, COUNT)
+
+  --============================================================================
+  -- RESIZE Functions
+  --============================================================================
+
+  -- Id: R.1
+  function RESIZE (ARG: SIGNED; NEW_SIZE: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(NEW_SIZE-1 downto 0)
+  -- Result: Resizes the SIGNED vector ARG to the specified size.
+  --         To create a larger vector, the new [leftmost] bit positions
+  --         are filled with the sign bit (ARG'LEFT). When truncating,
+  --         the sign bit is retained along with the rightmost part.
+
+  -- Id: R.2
+  function RESIZE (ARG: UNSIGNED; NEW_SIZE: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(NEW_SIZE-1 downto 0)
+  -- Result: Resizes the UNSIGNED vector ARG to the specified size.
+  --         To create a larger vector, the new [leftmost] bit positions
+  --         are filled with '0'. When truncating, the leftmost bits
+  --         are dropped.
+
+  --============================================================================
+  -- Conversion Functions
+  --============================================================================
+
+  -- Id: D.1
+  function TO_INTEGER (ARG: UNSIGNED) return NATURAL;
+  -- Result subtype: NATURAL. Value cannot be negative since parameter is an
+  --         UNSIGNED vector.
+  -- Result: Converts the UNSIGNED vector to an INTEGER.
+
+  -- Id: D.2
+  function TO_INTEGER (ARG: SIGNED) return INTEGER;
+  -- Result subtype: INTEGER
+  -- Result: Converts a SIGNED vector to an INTEGER.
+
+  -- Id: D.3
+  function TO_UNSIGNED (ARG, SIZE: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(SIZE-1 downto 0)
+  -- Result: Converts a non-negative INTEGER to an UNSIGNED vector with
+  --         the specified size.
+
+  -- Id: D.4
+  function TO_SIGNED (ARG: INTEGER; SIZE: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(SIZE-1 downto 0)
+  -- Result: Converts an INTEGER to a SIGNED vector of the specified size.
+
+  --============================================================================
+  -- Logical Operators
+  --============================================================================
+
+  -- Id: L.1
+  function "not" (L: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Termwise inversion
+
+  -- Id: L.2
+  function "and" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector AND operation
+
+  -- Id: L.3
+  function "or" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector OR operation
+
+  -- Id: L.4
+  function "nand" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NAND operation
+
+  -- Id: L.5
+  function "nor" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NOR operation
+
+  -- Id: L.6
+  function "xor" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XOR operation
+
+  ------------------------------------------------------------------------------
+  -- Note : Function L.7 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: L.7
+  function "xnor" (L, R: UNSIGNED) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XNOR operation
+
+  -- Id: L.8
+  function "not" (L: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Termwise inversion
+
+  -- Id: L.9
+  function "and" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector AND operation
+
+  -- Id: L.10
+  function "or" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector OR operation
+
+  -- Id: L.11
+  function "nand" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NAND operation
+
+  -- Id: L.12
+  function "nor" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NOR operation
+
+  -- Id: L.13
+  function "xor" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XOR operation
+
+  ------------------------------------------------------------------------------
+  -- Note : Function L.14 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: L.14
+  function "xnor" (L, R: SIGNED) return SIGNED; --V93
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XNOR operation
+
+  --============================================================================
+  -- Edge Detection Functions
+  --============================================================================
+
+  -- Id: E.1
+  function RISING_EDGE (signal S: BIT) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Returns TRUE if an event is detected on signal S and the
+  --         value changed from a '0' to a '1'.
+
+  -- Id: E.2
+  function FALLING_EDGE (signal S: BIT) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Returns TRUE if an event is detected on signal S and the
+  --         value changed from a '1' to a '0'.
+
+end NUMERIC_BIT;

--- a/vhdl/examples/numeric_std-body.vhd
+++ b/vhdl/examples/numeric_std-body.vhd
@@ -1,0 +1,2545 @@
+-- --------------------------------------------------------------------
+--
+-- Copyright 1995 by IEEE. All rights reserved.
+--
+-- This source file is considered by the IEEE to be an essential part of the use
+-- of the standard 1076.3 and as such may be distributed without change, except
+-- as permitted by the standard. This source file may not be sold or distributed
+-- for profit. This package may be modified to include additional data required
+-- by tools, but must in no way change the external interfaces or simulation
+-- behaviour of the description. It is permissible to add comments and/or
+-- attributes to the package declarations, but not to change or delete any
+-- original lines of the approved package declaration. The package body may be
+-- changed only in accordance with the terms of clauses 7.1 and 7.2 of the
+-- standard.
+--
+-- Title      : Standard VHDL Synthesis Package (1076.3, NUMERIC_STD)
+--
+-- Library    : This package shall be compiled into a library symbolically
+--            : named IEEE.
+--
+-- Developers : IEEE DASC Synthesis Working Group, PAR 1076.3
+--
+-- Purpose    : This package defines numeric types and arithmetic functions
+--            : for use with synthesis tools. Two numeric types are defined:
+--            : -- > UNSIGNED: represents UNSIGNED number in vector form
+--            : -- > SIGNED: represents a SIGNED number in vector form
+--            : The base element type is type STD_LOGIC.
+--            : The leftmost bit is treated as the most significant bit.
+--            : Signed vectors are represented in two's complement form.
+--            : This package contains overloaded arithmetic operators on
+--            : the SIGNED and UNSIGNED types. The package also contains
+--            : useful type conversions functions.
+--            :
+--            : If any argument to a function is a null array, a null array is
+--            : returned (exceptions, if any, are noted individually).
+--
+-- Limitation :
+--
+-- Note       : No declarations or definitions shall be included in,
+--            : or excluded from this package. The "package declaration"
+--            : defines the types, subtypes and declarations of
+--            : NUMERIC_STD. The NUMERIC_STD package body shall be
+--            : considered the formal definition of the semantics of
+--            : this package. Tool developers may choose to implement
+--            : the package body in the most efficient manner available
+--            : to them.
+--
+-- --------------------------------------------------------------------
+--   modification history :
+-- --------------------------------------------------------------------
+--   Version:  2.4
+--   Date   :  12 April 1995
+-- -----------------------------------------------------------------------------
+
+--==============================================================================
+--============================= Package Body ===================================
+--==============================================================================
+
+package body NUMERIC_STD is
+
+  -- null range array constants
+
+  constant NAU: UNSIGNED(0 downto 1) := (others => '0');
+  constant NAS: SIGNED(0 downto 1) := (others => '0');
+
+  -- implementation controls
+
+  constant NO_WARNING: BOOLEAN := FALSE; -- default to emit warnings
+
+  --=========================Local Subprograms =================================
+
+  function MAX (LEFT, RIGHT: INTEGER) return INTEGER is
+  begin
+    if LEFT > RIGHT then return LEFT;
+    else return RIGHT;
+    end if;
+  end MAX;
+
+  function MIN (LEFT, RIGHT: INTEGER) return INTEGER is
+  begin
+    if LEFT < RIGHT then return LEFT;
+    else return RIGHT;
+    end if;
+  end MIN;
+
+  function SIGNED_NUM_BITS (ARG: INTEGER) return NATURAL is
+    variable NBITS: NATURAL;
+    variable N: NATURAL;
+  begin
+    if ARG >= 0 then
+      N := ARG;
+    else
+      N := -(ARG+1);
+    end if;
+    NBITS := 1;
+    while N > 0 loop
+      NBITS := NBITS+1;
+      N := N / 2;
+    end loop;
+    return NBITS;
+  end SIGNED_NUM_BITS;
+
+  function UNSIGNED_NUM_BITS (ARG: NATURAL) return NATURAL is
+    variable NBITS: NATURAL;
+    variable N: NATURAL;
+  begin
+    N := ARG;
+    NBITS := 1;
+    while N > 1 loop
+      NBITS := NBITS+1;
+      N := N / 2;
+    end loop;
+    return NBITS;
+  end UNSIGNED_NUM_BITS;
+
+  ------------------------------------------------------------------------
+
+  -- this internal function computes the addition of two UNSIGNED
+  -- with input CARRY
+  -- * the two arguments are of the same length
+
+  function ADD_UNSIGNED (L, R: UNSIGNED; C: STD_LOGIC) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(L_LEFT downto 0) is R;
+    variable RESULT: UNSIGNED(L_LEFT downto 0);
+    variable CBIT: STD_LOGIC := C;
+  begin
+    for I in 0 to L_LEFT loop
+      RESULT(I) := CBIT xor XL(I) xor XR(I);
+      CBIT := (CBIT and XL(I)) or (CBIT and XR(I)) or (XL(I) and XR(I));
+    end loop;
+    return RESULT;
+  end ADD_UNSIGNED;
+
+  -- this internal function computes the addition of two SIGNED
+  -- with input CARRY
+  -- * the two arguments are of the same length
+
+  function ADD_SIGNED (L, R: SIGNED; C: STD_LOGIC) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(L_LEFT downto 0) is R;
+    variable RESULT: SIGNED(L_LEFT downto 0);
+    variable CBIT: STD_LOGIC := C;
+  begin
+    for I in 0 to L_LEFT loop
+      RESULT(I) := CBIT xor XL(I) xor XR(I);
+      CBIT := (CBIT and XL(I)) or (CBIT and XR(I)) or (XL(I) and XR(I));
+    end loop;
+    return RESULT;
+  end ADD_SIGNED;
+
+  -----------------------------------------------------------------------------
+
+  -- this internal procedure computes UNSIGNED division
+  -- giving the quotient and remainder.
+  procedure DIVMOD (NUM, XDENOM: UNSIGNED; XQUOT, XREMAIN: out UNSIGNED) is
+    variable TEMP: UNSIGNED(NUM'LENGTH downto 0);
+    variable QUOT: UNSIGNED(MAX(NUM'LENGTH, XDENOM'LENGTH)-1 downto 0);
+    alias DENOM: UNSIGNED(XDENOM'LENGTH-1 downto 0) is XDENOM;
+    variable TOPBIT: INTEGER;
+  begin
+    TEMP := "0"&NUM;
+    QUOT := (others => '0');
+    TOPBIT := -1;
+    for J in DENOM'RANGE loop
+      if DENOM(J)='1' then
+        TOPBIT := J;
+        exit;
+      end if;
+    end loop;
+    assert TOPBIT >= 0 report "DIV, MOD, or REM by zero" severity ERROR;
+
+    for J in NUM'LENGTH-(TOPBIT+1) downto 0 loop
+      if TEMP(TOPBIT+J+1 downto J) >= "0"&DENOM(TOPBIT downto 0) then
+        TEMP(TOPBIT+J+1 downto J) := (TEMP(TOPBIT+J+1 downto J))
+            -("0"&DENOM(TOPBIT downto 0));
+        QUOT(J) := '1';
+      end if;
+      assert TEMP(TOPBIT+J+1)='0'
+          report "internal error in the division algorithm"
+          severity ERROR;
+    end loop;
+    XQUOT := RESIZE(QUOT, XQUOT'LENGTH);
+    XREMAIN := RESIZE(TEMP, XREMAIN'LENGTH);
+  end DIVMOD;
+
+  -----------------Local Subprograms - shift/rotate ops-------------------------
+
+  function XSLL (ARG: STD_LOGIC_VECTOR; COUNT: NATURAL) return STD_LOGIC_VECTOR
+      is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: STD_LOGIC_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: STD_LOGIC_VECTOR(ARG_L downto 0) := (others => '0');
+  begin
+    if COUNT <= ARG_L then
+      RESULT(ARG_L downto COUNT) := XARG(ARG_L-COUNT downto 0);
+    end if;
+    return RESULT;
+  end XSLL;
+
+  function XSRL (ARG: STD_LOGIC_VECTOR; COUNT: NATURAL) return STD_LOGIC_VECTOR
+      is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: STD_LOGIC_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: STD_LOGIC_VECTOR(ARG_L downto 0) := (others => '0');
+  begin
+    if COUNT <= ARG_L then
+      RESULT(ARG_L-COUNT downto 0) := XARG(ARG_L downto COUNT);
+    end if;
+    return RESULT;
+  end XSRL;
+
+  function XSRA (ARG: STD_LOGIC_VECTOR; COUNT: NATURAL) return STD_LOGIC_VECTOR
+      is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: STD_LOGIC_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: STD_LOGIC_VECTOR(ARG_L downto 0);
+    variable XCOUNT: NATURAL := COUNT;
+  begin
+    if ((ARG'LENGTH <= 1) or (XCOUNT = 0)) then return ARG;
+    else
+      if (XCOUNT > ARG_L) then XCOUNT := ARG_L;
+      end if;
+      RESULT(ARG_L-XCOUNT downto 0) := XARG(ARG_L downto XCOUNT);
+      RESULT(ARG_L downto (ARG_L - XCOUNT + 1)) := (others => XARG(ARG_L));
+    end if;
+    return RESULT;
+  end XSRA;
+
+  function XROL (ARG: STD_LOGIC_VECTOR; COUNT: NATURAL) return STD_LOGIC_VECTOR
+      is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: STD_LOGIC_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: STD_LOGIC_VECTOR(ARG_L downto 0) := XARG;
+    variable COUNTM: INTEGER;
+  begin
+    COUNTM := COUNT mod (ARG_L + 1);
+    if COUNTM /= 0 then
+      RESULT(ARG_L downto COUNTM) := XARG(ARG_L-COUNTM downto 0);
+      RESULT(COUNTM-1 downto 0) := XARG(ARG_L downto ARG_L-COUNTM+1);
+    end if;
+    return RESULT;
+  end XROL;
+
+  function XROR (ARG: STD_LOGIC_VECTOR; COUNT: NATURAL) return STD_LOGIC_VECTOR
+      is
+    constant ARG_L: INTEGER := ARG'LENGTH-1;
+    alias XARG: STD_LOGIC_VECTOR(ARG_L downto 0) is ARG;
+    variable RESULT: STD_LOGIC_VECTOR(ARG_L downto 0) := XARG;
+    variable COUNTM: INTEGER;
+  begin
+    COUNTM := COUNT mod (ARG_L + 1);
+    if COUNTM /= 0 then
+      RESULT(ARG_L-COUNTM downto 0) := XARG(ARG_L downto COUNTM);
+      RESULT(ARG_L downto ARG_L-COUNTM+1) := XARG(COUNTM-1 downto 0);
+    end if;
+    return RESULT;
+  end XROR;
+
+  -----------------Local Subprograms - Relational ops---------------------------
+
+  --
+  -- General "=" for UNSIGNED vectors, same length
+  --
+  function UNSIGNED_EQUAL (L, R: UNSIGNED) return BOOLEAN is
+  begin
+    return STD_LOGIC_VECTOR(L) = STD_LOGIC_VECTOR(R);
+  end UNSIGNED_EQUAL;
+
+  --
+  -- General "=" for SIGNED vectors, same length
+  --
+  function SIGNED_EQUAL (L, R: SIGNED) return BOOLEAN is
+  begin
+    return STD_LOGIC_VECTOR(L) = STD_LOGIC_VECTOR(R);
+  end SIGNED_EQUAL;
+
+  --
+  -- General "<" for UNSIGNED vectors, same length
+  --
+  function UNSIGNED_LESS (L, R: UNSIGNED) return BOOLEAN is
+  begin
+    return STD_LOGIC_VECTOR(L) < STD_LOGIC_VECTOR(R);
+  end UNSIGNED_LESS;
+
+  --
+  -- General "<" function for SIGNED vectors, same length
+  --
+  function SIGNED_LESS (L, R: SIGNED) return BOOLEAN is
+    variable INTERN_L: SIGNED(0 to L'LENGTH-1);
+    variable INTERN_R: SIGNED(0 to R'LENGTH-1);
+  begin
+    INTERN_L := L;
+    INTERN_R := R;
+    INTERN_L(0) := not INTERN_L(0);
+    INTERN_R(0) := not INTERN_R(0);
+    return STD_LOGIC_VECTOR(INTERN_L) < STD_LOGIC_VECTOR(INTERN_R);
+  end SIGNED_LESS;
+
+  --
+  -- General "<=" function for UNSIGNED vectors, same length
+  --
+  function UNSIGNED_LESS_OR_EQUAL (L, R: UNSIGNED) return BOOLEAN is
+  begin
+    return STD_LOGIC_VECTOR(L) <= STD_LOGIC_VECTOR(R);
+  end UNSIGNED_LESS_OR_EQUAL;
+
+  --
+  -- General "<=" function for SIGNED vectors, same length
+  --
+  function SIGNED_LESS_OR_EQUAL (L, R: SIGNED) return BOOLEAN is
+    -- Need aliases to assure index direction
+    variable INTERN_L: SIGNED(0 to L'LENGTH-1);
+    variable INTERN_R: SIGNED(0 to R'LENGTH-1);
+  begin
+    INTERN_L := L;
+    INTERN_R := R;
+    INTERN_L(0) := not INTERN_L(0);
+    INTERN_R(0) := not INTERN_R(0);
+    return STD_LOGIC_VECTOR(INTERN_L) <= STD_LOGIC_VECTOR(INTERN_R);
+  end SIGNED_LESS_OR_EQUAL;
+
+  --=========================Exported Functions ==========================
+
+  -- Id: A.1
+  function "abs" (ARG: SIGNED) return SIGNED is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    alias XARG: SIGNED(ARG_LEFT downto 0) is ARG;
+    variable RESULT: SIGNED(ARG_LEFT downto 0);
+  begin
+    if ARG'LENGTH < 1 then return NAS;
+    end if;
+    RESULT := TO_01(XARG, 'X');
+    if (RESULT(RESULT'LEFT)='X') then return RESULT;
+    end if;
+    if RESULT(RESULT'LEFT) = '1' then
+      RESULT := -RESULT;
+    end if;
+    return RESULT;
+  end "abs";
+
+  -- Id: A.2
+  function "-" (ARG: SIGNED) return SIGNED is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    alias XARG: SIGNED(ARG_LEFT downto 0) is ARG;
+    variable RESULT, XARG01 : SIGNED(ARG_LEFT downto 0);
+    variable CBIT: STD_LOGIC := '1';
+  begin
+    if ARG'LENGTH < 1 then return NAS;
+    end if;
+    XARG01 := TO_01(ARG, 'X');
+    if (XARG01(XARG01'LEFT)='X') then return XARG01;
+    end if;
+    for I in 0 to RESULT'LEFT loop
+      RESULT(I) := not(XARG01(I)) xor CBIT;
+      CBIT := CBIT and not(XARG01(I));
+    end loop;
+    return RESULT;
+  end "-";
+
+  --============================================================================
+
+  -- Id: A.3
+  function "+" (L, R: UNSIGNED) return UNSIGNED is
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(SIZE-1 downto 0);
+    variable R01 : UNSIGNED(SIZE-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    L01 := TO_01(RESIZE(L, SIZE), 'X');
+    if (L01(L01'LEFT)='X') then return L01;
+    end if;
+    R01 := TO_01(RESIZE(R, SIZE), 'X');
+    if (R01(R01'LEFT)='X') then return R01;
+    end if;
+    return ADD_UNSIGNED(L01, R01, '0');
+  end "+";
+
+  -- Id: A.4
+  function "+" (L, R: SIGNED) return SIGNED is
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(SIZE-1 downto 0);
+    variable R01 : SIGNED(SIZE-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    L01 := TO_01(RESIZE(L, SIZE), 'X');
+    if (L01(L01'LEFT)='X') then return L01;
+    end if;
+    R01 := TO_01(RESIZE(R, SIZE), 'X');
+    if (R01(R01'LEFT)='X') then return R01;
+    end if;
+    return ADD_SIGNED(L01, R01, '0');
+  end "+";
+
+  -- Id: A.5
+  function "+" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+  begin
+    return L + TO_UNSIGNED(R, L'LENGTH);
+  end "+";
+
+  -- Id: A.6
+  function "+" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+  begin
+    return TO_UNSIGNED(L, R'LENGTH) + R;
+  end "+";
+
+  -- Id: A.7
+  function "+" (L: SIGNED; R: INTEGER) return SIGNED is
+  begin
+    return L + TO_SIGNED(R, L'LENGTH);
+  end "+";
+
+  -- Id: A.8
+  function "+" (L: INTEGER; R: SIGNED) return SIGNED is
+  begin
+    return TO_SIGNED(L, R'LENGTH) + R;
+  end "+";
+
+  --============================================================================
+
+  -- Id: A.9
+  function "-" (L, R: UNSIGNED) return UNSIGNED is
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(SIZE-1 downto 0);
+    variable R01 : UNSIGNED(SIZE-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    L01 := TO_01(RESIZE(L, SIZE), 'X');
+    if (L01(L01'LEFT)='X') then return L01;
+    end if;
+    R01 := TO_01(RESIZE(R, SIZE), 'X');
+    if (R01(R01'LEFT)='X') then return R01;
+    end if;
+    return ADD_UNSIGNED(L01, not(R01), '1');
+  end "-";
+
+  -- Id: A.10
+  function "-" (L, R: SIGNED) return SIGNED is
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(SIZE-1 downto 0);
+    variable R01 : SIGNED(SIZE-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    L01 := TO_01(RESIZE(L, SIZE), 'X');
+    if (L01(L01'LEFT)='X') then return L01;
+    end if;
+    R01 := TO_01(RESIZE(R, SIZE), 'X');
+    if (R01(R01'LEFT)='X') then return R01;
+    end if;
+    return ADD_SIGNED(L01, not(R01), '1');
+  end "-";
+
+  -- Id: A.11
+  function "-" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+  begin
+    return L - TO_UNSIGNED(R, L'LENGTH);
+  end "-";
+
+  -- Id: A.12
+  function "-" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+  begin
+    return TO_UNSIGNED(L, R'LENGTH) - R;
+  end "-";
+
+  -- Id: A.13
+  function "-" (L: SIGNED; R: INTEGER) return SIGNED is
+  begin
+    return L - TO_SIGNED(R, L'LENGTH);
+  end "-";
+
+  -- Id: A.14
+  function "-" (L: INTEGER; R: SIGNED) return SIGNED is
+  begin
+    return TO_SIGNED(L, R'LENGTH) - R;
+  end "-";
+
+  --============================================================================
+
+  -- Id: A.15
+  function "*" (L, R: UNSIGNED) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XXL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XXR: UNSIGNED(R_LEFT downto 0) is R;
+    variable XL: UNSIGNED(L_LEFT downto 0);
+    variable XR: UNSIGNED(R_LEFT downto 0);
+    variable RESULT: UNSIGNED((L'LENGTH+R'LENGTH-1) downto 0) :=
+        (others => '0');
+    variable ADVAL: UNSIGNED((L'LENGTH+R'LENGTH-1) downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    XL := TO_01(XXL, 'X');
+    XR := TO_01(XXR, 'X');
+    if ((XL(XL'LEFT)='X') or (XR(XR'LEFT)='X')) then
+      RESULT := (others => 'X');
+      return RESULT;
+    end if;
+    ADVAL := RESIZE(XR, RESULT'LENGTH);
+    for I in 0 to L_LEFT loop
+      if XL(I)='1' then RESULT := RESULT + ADVAL;
+      end if;
+      ADVAL := SHIFT_LEFT(ADVAL, 1);
+    end loop;
+    return RESULT;
+  end "*";
+
+  -- Id: A.16
+  function "*" (L, R: SIGNED) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    variable XL: SIGNED(L_LEFT downto 0);
+    variable XR: SIGNED(R_LEFT downto 0);
+    variable RESULT: SIGNED((L_LEFT+R_LEFT+1) downto 0) := (others => '0');
+    variable ADVAL: SIGNED((L_LEFT+R_LEFT+1) downto 0);
+  begin
+    if ((L_LEFT < 0) or (R_LEFT < 0)) then return NAS;
+    end if;
+    XL := TO_01(L, 'X');
+    XR := TO_01(R, 'X');
+    if ((XL(L_LEFT)='X') or (XR(R_LEFT)='X')) then
+      RESULT := (others => 'X');
+      return RESULT;
+    end if;
+    ADVAL := RESIZE(XR, RESULT'LENGTH);
+    for I in 0 to L_LEFT-1 loop
+      if XL(I)='1' then RESULT := RESULT + ADVAL;
+      end if;
+      ADVAL := SHIFT_LEFT(ADVAL, 1);
+    end loop;
+    if XL(L_LEFT)='1' then
+      RESULT := RESULT - ADVAL;
+    end if;
+    return RESULT;
+  end "*";
+
+  -- Id: A.17
+  function "*" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+  begin
+    return L * TO_UNSIGNED(R, L'LENGTH);
+  end "*";
+
+  -- Id: A.18
+  function "*" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+  begin
+    return TO_UNSIGNED(L, R'LENGTH) * R;
+  end "*";
+
+  -- Id: A.19
+  function "*" (L: SIGNED; R: INTEGER) return SIGNED is
+  begin
+    return L * TO_SIGNED(R, L'LENGTH);
+  end "*";
+
+  -- Id: A.20
+  function "*" (L: INTEGER; R: SIGNED) return SIGNED is
+  begin
+    return TO_SIGNED(L, R'LENGTH) * R;
+  end "*";
+
+  --============================================================================
+
+  -- Id: A.21
+  function "/" (L, R: UNSIGNED) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XXL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XXR: UNSIGNED(R_LEFT downto 0) is R;
+    variable XL: UNSIGNED(L_LEFT downto 0);
+    variable XR: UNSIGNED(R_LEFT downto 0);
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    XL := TO_01(XXL, 'X');
+    XR := TO_01(XXR, 'X');
+    if ((XL(XL'LEFT)='X') or (XR(XR'LEFT)='X')) then
+      FQUOT := (others => 'X');
+      return FQUOT;
+    end if;
+    DIVMOD(XL, XR, FQUOT, FREMAIN);
+    return FQUOT;
+  end "/";
+
+  -- Id: A.22
+  function "/" (L, R: SIGNED) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XXL: SIGNED(L_LEFT downto 0) is L;
+    alias XXR: SIGNED(R_LEFT downto 0) is R;
+    variable XL: SIGNED(L_LEFT downto 0);
+    variable XR: SIGNED(R_LEFT downto 0);
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+    variable XNUM: UNSIGNED(L'LENGTH-1 downto 0);
+    variable XDENOM: UNSIGNED(R'LENGTH-1 downto 0);
+    variable QNEG: BOOLEAN := FALSE;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    XL := TO_01(XXL, 'X');
+    XR := TO_01(XXR, 'X');
+    if ((XL(XL'LEFT)='X') or (XR(XR'LEFT)='X')) then
+      FQUOT := (others => 'X');
+      return SIGNED(FQUOT);
+    end if;
+    if XL(XL'LEFT)='1' then
+      XNUM := UNSIGNED(-XL);
+      QNEG := TRUE;
+    else
+      XNUM := UNSIGNED(XL);
+    end if;
+    if XR(XR'LEFT)='1' then
+      XDENOM := UNSIGNED(-XR);
+      QNEG := not QNEG;
+    else
+      XDENOM := UNSIGNED(XR);
+    end if;
+    DIVMOD(XNUM, XDENOM, FQUOT, FREMAIN);
+    if QNEG then FQUOT := "0"-FQUOT;
+    end if;
+    return SIGNED(FQUOT);
+  end "/";
+
+  -- Id: A.23
+  function "/" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, UNSIGNED_NUM_BITS(R));
+    variable XR, QUOT: UNSIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAU;
+    end if;
+    if (R_LENGTH > L'LENGTH) then
+      QUOT := (others => '0');
+      return RESIZE(QUOT, L'LENGTH);
+    end if;
+    XR := TO_UNSIGNED(R, R_LENGTH);
+    QUOT := RESIZE((L / XR), QUOT'LENGTH);
+    return RESIZE(QUOT, L'LENGTH);
+  end "/";
+
+  -- Id: A.24
+  function "/" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+    constant L_LENGTH: NATURAL := MAX(UNSIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, QUOT: UNSIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAU;
+    end if;
+    XL := TO_UNSIGNED(L, L_LENGTH);
+    QUOT := RESIZE((XL / R), QUOT'LENGTH);
+    if L_LENGTH > R'LENGTH and QUOT(0)/='X'
+        and QUOT(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_STD.""/"": Quotient Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(QUOT, R'LENGTH);
+  end "/";
+
+  -- Id: A.25
+  function "/" (L: SIGNED; R: INTEGER) return SIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, SIGNED_NUM_BITS(R));
+    variable XR, QUOT: SIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAS;
+    end if;
+    if (R_LENGTH > L'LENGTH) then
+      QUOT := (others => '0');
+      return RESIZE(QUOT, L'LENGTH);
+    end if;
+    XR := TO_SIGNED(R, R_LENGTH);
+    QUOT := RESIZE((L / XR), QUOT'LENGTH);
+    return RESIZE(QUOT, L'LENGTH);
+  end "/";
+
+  -- Id: A.26
+  function "/" (L: INTEGER; R: SIGNED) return SIGNED is
+    constant L_LENGTH: NATURAL := MAX(SIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, QUOT: SIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAS;
+    end if;
+    XL := TO_SIGNED(L, L_LENGTH);
+    QUOT := RESIZE((XL / R), QUOT'LENGTH);
+    if L_LENGTH > R'LENGTH and QUOT(0)/='X'
+        and QUOT(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => QUOT(R'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_STD.""/"": Quotient Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(QUOT, R'LENGTH);
+  end "/";
+
+  --============================================================================
+
+  -- Id: A.27
+  function "rem" (L, R: UNSIGNED) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XXL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XXR: UNSIGNED(R_LEFT downto 0) is R;
+    variable XL: UNSIGNED(L_LEFT downto 0);
+    variable XR: UNSIGNED(R_LEFT downto 0);
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    XL := TO_01(XXL, 'X');
+    XR := TO_01(XXR, 'X');
+    if ((XL(XL'LEFT)='X') or (XR(XR'LEFT)='X')) then
+      FREMAIN := (others => 'X');
+      return FREMAIN;
+    end if;
+    DIVMOD(XL, XR, FQUOT, FREMAIN);
+    return FREMAIN;
+  end "rem";
+
+  -- Id: A.28
+  function "rem" (L, R: SIGNED) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XXL: SIGNED(L_LEFT downto 0) is L;
+    alias XXR: SIGNED(R_LEFT downto 0) is R;
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+    variable XNUM: UNSIGNED(L'LENGTH-1 downto 0);
+    variable XDENOM: UNSIGNED(R'LENGTH-1 downto 0);
+    variable RNEG: BOOLEAN := FALSE;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    XNUM := UNSIGNED(TO_01(XXL, 'X'));
+    XDENOM := UNSIGNED(TO_01(XXR, 'X'));
+    if ((XNUM(XNUM'LEFT)='X') or (XDENOM(XDENOM'LEFT)='X')) then
+      FREMAIN := (others => 'X');
+      return SIGNED(FREMAIN);
+    end if;
+    if XNUM(XNUM'LEFT)='1' then
+      XNUM := UNSIGNED(-SIGNED(XNUM));
+      RNEG := TRUE;
+    else
+      XNUM := UNSIGNED(XNUM);
+    end if;
+    if XDENOM(XDENOM'LEFT)='1' then
+      XDENOM := UNSIGNED(-SIGNED(XDENOM));
+    else
+      XDENOM := UNSIGNED(XDENOM);
+    end if;
+    DIVMOD(XNUM, XDENOM, FQUOT, FREMAIN);
+    if RNEG then
+      FREMAIN := "0"-FREMAIN;
+    end if;
+    return SIGNED(FREMAIN);
+  end "rem";
+
+  -- Id: A.29
+  function "rem" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, UNSIGNED_NUM_BITS(R));
+    variable XR, XREM: UNSIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAU;
+    end if;
+    XR := TO_UNSIGNED(R, R_LENGTH);
+    XREM := L rem XR;
+    if R_LENGTH > L'LENGTH and XREM(0)/='X'
+        and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_STD.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "rem";
+
+  -- Id: A.30
+  function "rem" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+    constant L_LENGTH: NATURAL := MAX(UNSIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: UNSIGNED(L_LENGTH-1 downto 0);
+  begin
+    XL := TO_UNSIGNED(L, L_LENGTH);
+    XREM := XL rem R;
+    if L_LENGTH > R'LENGTH and XREM(0)/='X'
+        and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_STD.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "rem";
+
+  -- Id: A.31
+  function "rem" (L: SIGNED; R: INTEGER) return SIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, SIGNED_NUM_BITS(R));
+    variable XR, XREM: SIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAS;
+    end if;
+    XR := TO_SIGNED(R, R_LENGTH);
+    XREM := RESIZE((L rem XR), XREM'LENGTH);
+    if R_LENGTH > L'LENGTH and XREM(0)/='X'
+        and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => XREM(L'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_STD.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "rem";
+
+  -- Id: A.32
+  function "rem" (L: INTEGER; R: SIGNED) return SIGNED is
+    constant L_LENGTH: NATURAL := MAX(SIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: SIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAS;
+    end if;
+    XL := TO_SIGNED(L, L_LENGTH);
+    XREM := RESIZE((XL rem R), XREM'LENGTH);
+    if L_LENGTH > R'LENGTH and XREM(0)/='X'
+        and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => XREM(R'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_STD.""rem"": Remainder Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "rem";
+
+  --============================================================================
+
+  -- Id: A.33
+  function "mod" (L, R: UNSIGNED) return UNSIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XXL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XXR: UNSIGNED(R_LEFT downto 0) is R;
+    variable XL: UNSIGNED(L_LEFT downto 0);
+    variable XR: UNSIGNED(R_LEFT downto 0);
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAU;
+    end if;
+    XL := TO_01(XXL, 'X');
+    XR := TO_01(XXR, 'X');
+    if ((XL(XL'LEFT)='X') or (XR(XR'LEFT)='X')) then
+      FREMAIN := (others => 'X');
+      return FREMAIN;
+    end if;
+    DIVMOD(XL, XR, FQUOT, FREMAIN);
+    return FREMAIN;
+  end "mod";
+
+  -- Id: A.34
+  function "mod" (L, R: SIGNED) return SIGNED is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XXL: SIGNED(L_LEFT downto 0) is L;
+    alias XXR: SIGNED(R_LEFT downto 0) is R;
+    variable XL: SIGNED(L_LEFT downto 0);
+    variable XR: SIGNED(R_LEFT downto 0);
+    variable FQUOT: UNSIGNED(L'LENGTH-1 downto 0);
+    variable FREMAIN: UNSIGNED(R'LENGTH-1 downto 0);
+    variable XNUM: UNSIGNED(L'LENGTH-1 downto 0);
+    variable XDENOM: UNSIGNED(R'LENGTH-1 downto 0);
+    variable RNEG: BOOLEAN := FALSE;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then return NAS;
+    end if;
+    XL := TO_01(XXL, 'X');
+    XR := TO_01(XXR, 'X');
+    if ((XL(XL'LEFT)='X') or (XR(XR'LEFT)='X')) then
+      FREMAIN := (others => 'X');
+      return SIGNED(FREMAIN);
+    end if;
+    if XL(XL'LEFT)='1' then
+      XNUM := UNSIGNED(-XL);
+    else
+      XNUM := UNSIGNED(XL);
+    end if;
+    if XR(XR'LEFT)='1' then
+      XDENOM := UNSIGNED(-XR);
+      RNEG := TRUE;
+    else
+      XDENOM := UNSIGNED(XR);
+    end if;
+    DIVMOD(XNUM, XDENOM, FQUOT, FREMAIN);
+    if RNEG and L(L'LEFT)='1' then
+      FREMAIN := "0"-FREMAIN;
+    elsif RNEG and FREMAIN/="0" then
+      FREMAIN := FREMAIN-XDENOM;
+    elsif L(L'LEFT)='1' and FREMAIN/="0" then
+      FREMAIN := XDENOM-FREMAIN;
+    end if;
+    return SIGNED(FREMAIN);
+  end "mod";
+
+  -- Id: A.35
+  function "mod" (L: UNSIGNED; R: NATURAL) return UNSIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, UNSIGNED_NUM_BITS(R));
+    variable XR, XREM: UNSIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAU;
+    end if;
+    XR := TO_UNSIGNED(R, R_LENGTH);
+    XREM := RESIZE((L mod XR), XREM'LENGTH);
+    if R_LENGTH > L'LENGTH and XREM(0)/='X'
+        and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_STD.""mod"": Modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "mod";
+
+  -- Id: A.36
+  function "mod" (L: NATURAL; R: UNSIGNED) return UNSIGNED is
+    constant L_LENGTH: NATURAL := MAX(UNSIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: UNSIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAU;
+    end if;
+    XL := TO_UNSIGNED(L, L_LENGTH);
+    XREM := RESIZE((XL mod R), XREM'LENGTH);
+    if L_LENGTH > R'LENGTH and XREM(0)/='X'
+        and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => '0')
+        then
+      assert NO_WARNING report "NUMERIC_STD.""mod"": Modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "mod";
+
+  -- Id: A.37
+  function "mod" (L: SIGNED; R: INTEGER) return SIGNED is
+    constant R_LENGTH: NATURAL := MAX(L'LENGTH, SIGNED_NUM_BITS(R));
+    variable XR, XREM: SIGNED(R_LENGTH-1 downto 0);
+  begin
+    if (L'LENGTH < 1) then return NAS;
+    end if;
+    XR := TO_SIGNED(R, R_LENGTH);
+    XREM := RESIZE((L mod XR), XREM'LENGTH);
+    if R_LENGTH > L'LENGTH and XREM(0)/='X'
+        and XREM(R_LENGTH-1 downto L'LENGTH)
+        /= (R_LENGTH-1 downto L'LENGTH => XREM(L'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_STD.""mod"": Modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, L'LENGTH);
+  end "mod";
+
+  -- Id: A.38
+  function "mod" (L: INTEGER; R: SIGNED) return SIGNED is
+    constant L_LENGTH: NATURAL := MAX(SIGNED_NUM_BITS(L), R'LENGTH);
+    variable XL, XREM: SIGNED(L_LENGTH-1 downto 0);
+  begin
+    if (R'LENGTH < 1) then return NAS;
+    end if;
+    XL := TO_SIGNED(L, L_LENGTH);
+    XREM := RESIZE((XL mod R), XREM'LENGTH);
+    if L_LENGTH > R'LENGTH and XREM(0)/='X'
+        and XREM(L_LENGTH-1 downto R'LENGTH)
+        /= (L_LENGTH-1 downto R'LENGTH => XREM(R'LENGTH-1))
+        then
+      assert NO_WARNING report "NUMERIC_STD.""mod"": Modulus Truncated"
+          severity WARNING;
+    end if;
+    return RESIZE(XREM, R'LENGTH);
+  end "mod";
+
+  --============================================================================
+
+  -- Id: C.1
+  function ">" (L, R: UNSIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not UNSIGNED_LESS_OR_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end ">";
+
+  -- Id: C.2
+  function ">" (L, R: SIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(L_LEFT downto 0);
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not SIGNED_LESS_OR_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end ">";
+
+  -- Id: C.3
+  function ">" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return TRUE;
+    end if;
+    return not UNSIGNED_LESS_OR_EQUAL(TO_UNSIGNED(L, R01'LENGTH), R01);
+  end ">";
+
+  -- Id: C.4
+  function ">" (L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L > 0;
+    end if;
+    return not SIGNED_LESS_OR_EQUAL(TO_SIGNED(L, R01'LENGTH), R01);
+  end ">";
+
+  -- Id: C.5
+  function ">" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return FALSE;
+    end if;
+    return not UNSIGNED_LESS_OR_EQUAL(L01, TO_UNSIGNED(R, L01'LENGTH));
+  end ">";
+
+  -- Id: C.6
+  function ">" (L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    variable L01 : SIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 > R;
+    end if;
+    return not SIGNED_LESS_OR_EQUAL(L01, TO_SIGNED(R, L01'LENGTH));
+  end ">";
+
+  --============================================================================
+
+  -- Id: C.7
+  function "<" (L, R: UNSIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return UNSIGNED_LESS(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end "<";
+
+  -- Id: C.8
+  function "<" (L, R: SIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(L_LEFT downto 0);
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return SIGNED_LESS(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end "<";
+
+  -- Id: C.9
+  function "<" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return UNSIGNED_LESS(TO_UNSIGNED(L, R01'LENGTH), R01);
+  end "<";
+
+  -- Id: C.10
+  function "<" (L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return SIGNED_LESS(TO_SIGNED(L, R01'LENGTH), R01);
+  end "<";
+
+  -- Id: C.11
+  function "<" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return UNSIGNED_LESS(L01, TO_UNSIGNED(R, L01'LENGTH));
+  end "<";
+
+  -- Id: C.12
+  function "<" (L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    variable L01 : SIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<"": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return SIGNED_LESS(L01, TO_SIGNED(R, L01'LENGTH));
+  end "<";
+
+  --============================================================================
+
+  -- Id: C.13
+  function "<=" (L, R: UNSIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return UNSIGNED_LESS_OR_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end "<=";
+
+  -- Id: C.14
+  function "<=" (L, R: SIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(L_LEFT downto 0);
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return SIGNED_LESS_OR_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end "<=";
+
+  -- Id: C.15
+  function "<=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return UNSIGNED_LESS_OR_EQUAL(TO_UNSIGNED(L, R01'LENGTH), R01);
+  end "<=";
+
+  -- Id: C.16
+  function "<=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L < 0;
+    end if;
+    return SIGNED_LESS_OR_EQUAL(TO_SIGNED(L, R01'LENGTH), R01);
+  end "<=";
+
+  -- Id: C.17
+  function "<=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+  begin
+    if (L_LEFT < 0) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return UNSIGNED_LESS_OR_EQUAL(L01, TO_UNSIGNED(R, L01'LENGTH));
+  end "<=";
+
+  -- Id: C.18
+  function "<=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    variable L01 : SIGNED(L_LEFT downto 0);
+  begin
+    if (L_LEFT < 0) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""<="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 < R;
+    end if;
+    return SIGNED_LESS_OR_EQUAL(L01, TO_SIGNED(R, L01'LENGTH));
+  end "<=";
+
+  --============================================================================
+
+  -- Id: C.19
+  function ">=" (L, R: UNSIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not UNSIGNED_LESS(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end ">=";
+
+  -- Id: C.20
+  function ">=" (L, R: SIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(L_LEFT downto 0);
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return not SIGNED_LESS(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end ">=";
+
+  -- Id: C.21
+  function ">=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return L > 0;
+    end if;
+    return not UNSIGNED_LESS(TO_UNSIGNED(L, R01'LENGTH), R01);
+  end ">=";
+
+  -- Id: C.22
+  function ">=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return L > 0;
+    end if;
+    return not SIGNED_LESS(TO_SIGNED(L, R01'LENGTH), R01);
+  end ">=";
+
+  -- Id: C.23
+  function ">=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return 0 > R;
+    end if;
+    return not UNSIGNED_LESS(L01, TO_UNSIGNED(R, L01'LENGTH));
+  end ">=";
+
+  -- Id: C.24
+  function ">=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    variable L01 : SIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD."">="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return 0 > R;
+    end if;
+    return not SIGNED_LESS(L01, TO_SIGNED(R, L01'LENGTH));
+  end ">=";
+
+  --============================================================================
+
+  -- Id: C.25
+  function "=" (L, R: UNSIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return UNSIGNED_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end "=";
+
+  -- Id: C.26
+  function "=" (L, R: SIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(L_LEFT downto 0);
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    return SIGNED_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE));
+  end "=";
+
+  -- Id: C.27
+  function "=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return FALSE;
+    end if;
+    return UNSIGNED_EQUAL(TO_UNSIGNED(L, R01'LENGTH), R01);
+  end "=";
+
+  -- Id: C.28
+  function "=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return FALSE;
+    end if;
+    return SIGNED_EQUAL(TO_SIGNED(L, R01'LENGTH), R01);
+  end "=";
+
+  -- Id: C.29
+  function "=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return FALSE;
+    end if;
+    return UNSIGNED_EQUAL(L01, TO_UNSIGNED(R, L01'LENGTH));
+  end "=";
+
+  -- Id: C.30
+  function "=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    variable L01 : SIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": null argument detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""="": metavalue detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return FALSE;
+    end if;
+    return SIGNED_EQUAL(L01, TO_SIGNED(R, L01'LENGTH));
+  end "=";
+
+  --============================================================================
+
+  -- Id: C.31
+  function "/=" (L, R: UNSIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": metavalue detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    return not(UNSIGNED_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE)));
+  end "/=";
+
+  -- Id: C.32
+  function "/=" (L, R: SIGNED) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    constant SIZE: NATURAL := MAX(L'LENGTH, R'LENGTH);
+    variable L01 : SIGNED(L_LEFT downto 0);
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    R01 := TO_01(XR, 'X');
+    if ((L01(L01'LEFT)='X') or (R01(R01'LEFT)='X')) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": metavalue detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    return not(SIGNED_EQUAL(RESIZE(L01, SIZE), RESIZE(R01, SIZE)));
+  end "/=";
+
+  -- Id: C.33
+  function "/=" (L: NATURAL; R: UNSIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: UNSIGNED(R_LEFT downto 0) is R;
+    variable R01 : UNSIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": metavalue detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if UNSIGNED_NUM_BITS(L) > R'LENGTH then return TRUE;
+    end if;
+    return not(UNSIGNED_EQUAL(TO_UNSIGNED(L, R01'LENGTH), R01));
+  end "/=";
+
+  -- Id: C.34
+  function "/=" (L: INTEGER; R: SIGNED) return BOOLEAN is
+    constant R_LEFT: INTEGER := R'LENGTH-1;
+    alias XR: SIGNED(R_LEFT downto 0) is R;
+    variable R01 : SIGNED(R_LEFT downto 0);
+  begin
+    if (R'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    R01 := TO_01(XR, 'X');
+    if (R01(R01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": metavalue detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if SIGNED_NUM_BITS(L) > R'LENGTH then return TRUE;
+    end if;
+    return not(SIGNED_EQUAL(TO_SIGNED(L, R01'LENGTH), R01));
+  end "/=";
+
+  -- Id: C.35
+  function "/=" (L: UNSIGNED; R: NATURAL) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: UNSIGNED(L_LEFT downto 0) is L;
+    variable L01 : UNSIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": metavalue detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if UNSIGNED_NUM_BITS(R) > L'LENGTH then return TRUE;
+    end if;
+    return not(UNSIGNED_EQUAL(L01, TO_UNSIGNED(R, L01'LENGTH)));
+  end "/=";
+
+  -- Id: C.36
+  function "/=" (L: SIGNED; R: INTEGER) return BOOLEAN is
+    constant L_LEFT: INTEGER := L'LENGTH-1;
+    alias XL: SIGNED(L_LEFT downto 0) is L;
+    variable L01 : SIGNED(L_LEFT downto 0);
+  begin
+    if (L'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": null argument detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    L01 := TO_01(XL, 'X');
+    if (L01(L01'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.""/="": metavalue detected, returning TRUE"
+          severity WARNING;
+      return TRUE;
+    end if;
+    if SIGNED_NUM_BITS(R) > L'LENGTH then return TRUE;
+    end if;
+    return not(SIGNED_EQUAL(L01, TO_SIGNED(R, L01'LENGTH)));
+  end "/=";
+
+  --============================================================================
+
+  -- Id: S.1
+  function SHIFT_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XSLL(STD_LOGIC_VECTOR(ARG), COUNT));
+  end SHIFT_LEFT;
+
+  -- Id: S.2
+  function SHIFT_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XSRL(STD_LOGIC_VECTOR(ARG), COUNT));
+  end SHIFT_RIGHT;
+
+  -- Id: S.3
+  function SHIFT_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XSLL(STD_LOGIC_VECTOR(ARG), COUNT));
+  end SHIFT_LEFT;
+
+  -- Id: S.4
+  function SHIFT_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XSRA(STD_LOGIC_VECTOR(ARG), COUNT));
+  end SHIFT_RIGHT;
+
+  --============================================================================
+
+  -- Id: S.5
+  function ROTATE_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XROL(STD_LOGIC_VECTOR(ARG), COUNT));
+  end ROTATE_LEFT;
+
+  -- Id: S.6
+  function ROTATE_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAU;
+    end if;
+    return UNSIGNED(XROR(STD_LOGIC_VECTOR(ARG), COUNT));
+  end ROTATE_RIGHT;
+
+
+  -- Id: S.7
+  function ROTATE_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XROL(STD_LOGIC_VECTOR(ARG), COUNT));
+  end ROTATE_LEFT;
+
+  -- Id: S.8
+  function ROTATE_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED is
+  begin
+    if (ARG'LENGTH < 1) then return NAS;
+    end if;
+    return SIGNED(XROR(STD_LOGIC_VECTOR(ARG), COUNT));
+  end ROTATE_RIGHT;
+
+  --============================================================================
+--START-V93
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.9 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.9
+  function "sll" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SHIFT_LEFT(ARG, COUNT);
+    else
+      return SHIFT_RIGHT(ARG, -COUNT);
+    end if;
+  end "sll";
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.10 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.10
+  function "sll" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SHIFT_LEFT(ARG, COUNT);
+    else
+      return SIGNED(SHIFT_RIGHT(UNSIGNED(ARG), -COUNT));
+    end if;
+  end "sll";
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.11 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.11
+  function "srl" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SHIFT_RIGHT(ARG, COUNT);
+    else
+      return SHIFT_LEFT(ARG, -COUNT);
+    end if;
+  end "srl";
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.12 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.12
+  function "srl" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return SIGNED(SHIFT_RIGHT(UNSIGNED(ARG), COUNT));
+    else
+      return SHIFT_LEFT(ARG, -COUNT);
+    end if;
+  end "srl";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.13 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.13
+  function "rol" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_LEFT(ARG, COUNT);
+    else
+      return ROTATE_RIGHT(ARG, -COUNT);
+    end if;
+  end "rol";
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.14 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.14
+  function "rol" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_LEFT(ARG, COUNT);
+    else
+      return ROTATE_RIGHT(ARG, -COUNT);
+    end if;
+  end "rol";
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.15 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.15
+  function "ror" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_RIGHT(ARG, COUNT);
+    else
+      return ROTATE_LEFT(ARG, -COUNT);
+    end if;
+  end "ror";
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.16 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.16
+  function "ror" (ARG: SIGNED; COUNT: INTEGER) return SIGNED is
+  begin
+    if (COUNT >= 0) then
+      return ROTATE_RIGHT(ARG, COUNT);
+    else
+      return ROTATE_LEFT(ARG, -COUNT);
+    end if;
+  end "ror";
+
+--END-V93
+  --============================================================================
+
+  -- Id: D.1
+  function TO_INTEGER (ARG: UNSIGNED) return NATURAL is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    alias XXARG: UNSIGNED(ARG_LEFT downto 0) is ARG;
+    variable XARG: UNSIGNED(ARG_LEFT downto 0);
+    variable RESULT: NATURAL := 0;
+  begin
+    if (ARG'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_INTEGER: null detected, returning 0"
+          severity WARNING;
+      return 0;
+    end if;
+    XARG := TO_01(XXARG, 'X');
+    if (XARG(XARG'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0"
+          severity WARNING;
+      return 0;
+    end if;
+    for I in XARG'RANGE loop
+      RESULT := RESULT+RESULT;
+      if XARG(I) = '1' then
+        RESULT := RESULT + 1;
+      end if;
+    end loop;
+    return RESULT;
+  end TO_INTEGER;
+
+  -- Id: D.2
+  function TO_INTEGER (ARG: SIGNED) return INTEGER is
+    variable XARG: SIGNED(ARG'LENGTH-1 downto 0);
+  begin
+    if (ARG'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_INTEGER: null detected, returning 0"
+          severity WARNING;
+      return 0;
+    end if;
+    XARG := TO_01(ARG, 'X');
+    if (XARG(XARG'LEFT)='X') then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0"
+          severity WARNING;
+      return 0;
+    end if;
+    if XARG(XARG'LEFT) = '0' then
+      return TO_INTEGER(UNSIGNED(XARG));
+    else
+      return (- (TO_INTEGER(UNSIGNED(- (XARG + 1)))) -1);
+    end if;
+  end TO_INTEGER;
+
+  -- Id: D.3
+  function TO_UNSIGNED (ARG, SIZE: NATURAL) return UNSIGNED is
+    variable RESULT: UNSIGNED(SIZE-1 downto 0);
+    variable I_VAL: NATURAL := ARG;
+  begin
+    if (SIZE < 1) then return NAU;
+    end if;
+    for I in 0 to RESULT'LEFT loop
+      if (I_VAL mod 2) = 0 then
+        RESULT(I) := '0';
+      else RESULT(I) := '1';
+      end if;
+      I_VAL := I_VAL/2;
+    end loop;
+    if not(I_VAL =0) then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_UNSIGNED: vector truncated"
+          severity WARNING;
+    end if;
+    return RESULT;
+  end TO_UNSIGNED;
+
+  -- Id: D.4
+  function TO_SIGNED (ARG: INTEGER; SIZE: NATURAL) return SIGNED is
+    variable RESULT: SIGNED(SIZE-1 downto 0);
+    variable B_VAL: STD_LOGIC := '0';
+    variable I_VAL: INTEGER := ARG;
+  begin
+    if (SIZE < 1) then return NAS;
+    end if;
+    if (ARG < 0) then
+      B_VAL := '1';
+      I_VAL := -(ARG+1);
+    end if;
+    for I in 0 to RESULT'LEFT loop
+      if (I_VAL mod 2) = 0 then
+        RESULT(I) := B_VAL;
+      else
+        RESULT(I) := not B_VAL;
+      end if;
+      I_VAL := I_VAL/2;
+    end loop;
+    if ((I_VAL/=0) or (B_VAL/=RESULT(RESULT'LEFT))) then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_SIGNED: vector truncated"
+          severity WARNING;
+    end if;
+    return RESULT;
+  end TO_SIGNED;
+
+  --============================================================================
+
+  -- Id: R.1
+  function RESIZE (ARG: SIGNED; NEW_SIZE: NATURAL) return SIGNED is
+    alias INVEC: SIGNED(ARG'LENGTH-1 downto 0) is ARG;
+    variable RESULT: SIGNED(NEW_SIZE-1 downto 0) := (others => '0');
+    constant BOUND: INTEGER := MIN(ARG'LENGTH, RESULT'LENGTH)-2;
+  begin
+    if (NEW_SIZE < 1) then return NAS;
+    end if;
+    if (ARG'LENGTH = 0) then return RESULT;
+    end if;
+    RESULT := (others => ARG(ARG'LEFT));
+    if BOUND >= 0 then
+      RESULT(BOUND downto 0) := INVEC(BOUND downto 0);
+    end if;
+    return RESULT;
+  end RESIZE;
+
+  -- Id: R.2
+  function RESIZE (ARG: UNSIGNED; NEW_SIZE: NATURAL) return UNSIGNED is
+    constant ARG_LEFT: INTEGER := ARG'LENGTH-1;
+    alias XARG: UNSIGNED(ARG_LEFT downto 0) is ARG;
+    variable RESULT: UNSIGNED(NEW_SIZE-1 downto 0) := (others => '0');
+  begin
+    if (NEW_SIZE < 1) then return NAU;
+    end if;
+    if XARG'LENGTH =0 then return RESULT;
+    end if;
+    if (RESULT'LENGTH < ARG'LENGTH) then
+      RESULT(RESULT'LEFT downto 0) := XARG(RESULT'LEFT downto 0);
+    else
+      RESULT(RESULT'LEFT downto XARG'LEFT+1) := (others => '0');
+      RESULT(XARG'LEFT downto 0) := XARG;
+    end if;
+    return RESULT;
+  end RESIZE;
+
+  --============================================================================
+
+  -- Id: L.1
+  function "not" (L: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(not(STD_LOGIC_VECTOR(L)));
+    return RESULT;
+  end "not";
+
+  -- Id: L.2
+  function "and" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(STD_LOGIC_VECTOR(L) and STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "and";
+
+  -- Id: L.3
+  function "or" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(STD_LOGIC_VECTOR(L) or STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "or";
+
+  -- Id: L.4
+  function "nand" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(STD_LOGIC_VECTOR(L) nand STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "nand";
+
+  -- Id: L.5
+  function "nor" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(STD_LOGIC_VECTOR(L) nor STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "nor";
+
+  -- Id: L.6
+  function "xor" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(STD_LOGIC_VECTOR(L) xor STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "xor";
+
+--START-V93
+  ------------------------------------------------------------------------------
+  -- Note : Function L.7 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: L.7
+  function "xnor" (L, R: UNSIGNED) return UNSIGNED is
+    variable RESULT: UNSIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := UNSIGNED(STD_LOGIC_VECTOR(L) xnor STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "xnor";
+--END-V93
+
+  -- Id: L.8
+  function "not" (L: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(not(STD_LOGIC_VECTOR(L)));
+    return RESULT;
+  end "not";
+
+  -- Id: L.9
+  function "and" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(STD_LOGIC_VECTOR(L) and STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "and";
+
+  -- Id: L.10
+  function "or" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(STD_LOGIC_VECTOR(L) or STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "or";
+
+  -- Id: L.11
+  function "nand" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(STD_LOGIC_VECTOR(L) nand STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "nand";
+
+  -- Id: L.12
+  function "nor" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(STD_LOGIC_VECTOR(L) nor STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "nor";
+
+  -- Id: L.13
+  function "xor" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(STD_LOGIC_VECTOR(L) xor STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "xor";
+
+--START-V93
+  ------------------------------------------------------------------------------
+  -- Note : Function L.14 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: L.14
+  function "xnor" (L, R: SIGNED) return SIGNED is
+    variable RESULT: SIGNED(L'LENGTH-1 downto 0);
+  begin
+    RESULT := SIGNED(STD_LOGIC_VECTOR(L) xnor STD_LOGIC_VECTOR(R));
+    return RESULT;
+  end "xnor";
+--END-V93
+
+  --============================================================================
+
+  -- support constants for STD_MATCH:
+
+  type BOOLEAN_TABLE is array(STD_ULOGIC, STD_ULOGIC) of BOOLEAN;
+
+  constant MATCH_TABLE: BOOLEAN_TABLE := (
+      --------------------------------------------------------------------------
+      -- U      X      0      1      Z      W      L      H      -
+      --------------------------------------------------------------------------
+      (FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,  TRUE), -- | U |
+      (FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,  TRUE), -- | X |
+      (FALSE, FALSE,  TRUE, FALSE, FALSE, FALSE,  TRUE, FALSE,  TRUE), -- | 0 |
+      (FALSE, FALSE, FALSE,  TRUE, FALSE, FALSE, FALSE,  TRUE,  TRUE), -- | 1 |
+      (FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,  TRUE), -- | Z |
+      (FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,  TRUE), -- | W |
+      (FALSE, FALSE,  TRUE, FALSE, FALSE, FALSE,  TRUE, FALSE,  TRUE), -- | L |
+      (FALSE, FALSE, FALSE,  TRUE, FALSE, FALSE, FALSE,  TRUE,  TRUE), -- | H |
+      ( TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE)  -- | - |
+      );
+
+  -- Id: M.1
+  function STD_MATCH (L, R: STD_ULOGIC) return BOOLEAN is
+    variable VALUE: STD_ULOGIC;
+  begin
+    return MATCH_TABLE(L, R);
+  end STD_MATCH;
+
+  -- Id: M.2
+  function STD_MATCH (L, R: UNSIGNED) return BOOLEAN is
+    alias LV: UNSIGNED(1 to L'LENGTH) is L;
+    alias RV: UNSIGNED(1 to R'LENGTH) is R;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: null detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if LV'LENGTH /= RV'LENGTH then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: L'LENGTH /= R'LENGTH, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    else
+      for I in LV'LOW to LV'HIGH loop
+        if not (MATCH_TABLE(LV(I), RV(I))) then
+          return FALSE;
+        end if;
+      end loop;
+      return TRUE;
+    end if;
+  end STD_MATCH;
+
+  -- Id: M.3
+  function STD_MATCH (L, R: SIGNED) return BOOLEAN is
+    alias LV: SIGNED(1 to L'LENGTH) is L;
+    alias RV: SIGNED(1 to R'LENGTH) is R;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: null detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if LV'LENGTH /= RV'LENGTH then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: L'LENGTH /= R'LENGTH, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    else
+      for I in LV'LOW to LV'HIGH loop
+        if not (MATCH_TABLE(LV(I), RV(I))) then
+          return FALSE;
+        end if;
+      end loop;
+      return TRUE;
+    end if;
+  end STD_MATCH;
+
+  -- Id: M.4
+  function STD_MATCH (L, R: STD_LOGIC_VECTOR) return BOOLEAN is
+    alias LV: STD_LOGIC_VECTOR(1 to L'LENGTH) is L;
+    alias RV: STD_LOGIC_VECTOR(1 to R'LENGTH) is R;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: null detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if LV'LENGTH /= RV'LENGTH then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: L'LENGTH /= R'LENGTH, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    else
+      for I in LV'LOW to LV'HIGH loop
+        if not (MATCH_TABLE(LV(I), RV(I))) then
+          return FALSE;
+        end if;
+      end loop;
+      return TRUE;
+    end if;
+  end STD_MATCH;
+
+  -- Id: M.5
+  function STD_MATCH (L, R: STD_ULOGIC_VECTOR) return BOOLEAN is
+    alias LV: STD_ULOGIC_VECTOR(1 to L'LENGTH) is L;
+    alias RV: STD_ULOGIC_VECTOR(1 to R'LENGTH) is R;
+  begin
+    if ((L'LENGTH < 1) or (R'LENGTH < 1)) then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: null detected, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    end if;
+    if LV'LENGTH /= RV'LENGTH then
+      assert NO_WARNING
+          report "NUMERIC_STD.STD_MATCH: L'LENGTH /= R'LENGTH, returning FALSE"
+          severity WARNING;
+      return FALSE;
+    else
+      for I in LV'LOW to LV'HIGH loop
+        if not (MATCH_TABLE(LV(I), RV(I))) then
+          return FALSE;
+        end if;
+      end loop;
+      return TRUE;
+    end if;
+  end STD_MATCH;
+
+  --============================================================================
+
+  -- function TO_01 is used to convert vectors to the
+  --          correct form for exported functions,
+  --          and to report if there is an element which
+  --          is not in (0, 1, H, L).
+
+  -- Id: T.1
+  function TO_01 (S: UNSIGNED; XMAP: STD_LOGIC := '0') return UNSIGNED is
+    variable RESULT: UNSIGNED(S'LENGTH-1 downto 0);
+    variable BAD_ELEMENT: BOOLEAN := FALSE;
+    alias XS: UNSIGNED(S'LENGTH-1 downto 0) is S;
+  begin
+    if (S'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_01: null detected, returning NAU"
+          severity WARNING;
+      return NAU;
+    end if;
+    for I in RESULT'RANGE loop
+      case XS(I) is
+        when '0' | 'L' => RESULT(I) := '0';
+        when '1' | 'H' => RESULT(I) := '1';
+        when others => BAD_ELEMENT := TRUE;
+      end case;
+    end loop;
+    if BAD_ELEMENT then
+      for I in RESULT'RANGE loop
+        RESULT(I) := XMAP; -- standard fixup
+      end loop;
+    end if;
+    return RESULT;
+  end TO_01;
+
+  -- Id: T.2
+  function TO_01 (S: SIGNED; XMAP: STD_LOGIC := '0') return SIGNED is
+    variable RESULT: SIGNED(S'LENGTH-1 downto 0);
+    variable BAD_ELEMENT: BOOLEAN := FALSE;
+    alias XS: SIGNED(S'LENGTH-1 downto 0) is S;
+  begin
+    if (S'LENGTH < 1) then
+      assert NO_WARNING
+          report "NUMERIC_STD.TO_01: null detected, returning NAS"
+          severity WARNING;
+      return NAS;
+    end if;
+    for I in RESULT'RANGE loop
+      case XS(I) is
+        when '0' | 'L' => RESULT(I) := '0';
+        when '1' | 'H' => RESULT(I) := '1';
+        when others => BAD_ELEMENT := TRUE;
+      end case;
+    end loop;
+    if BAD_ELEMENT then
+      for I in RESULT'RANGE loop
+        RESULT(I) := XMAP; -- standard fixup
+      end loop;
+    end if;
+    return RESULT;
+  end TO_01;
+
+  --============================================================================
+
+end NUMERIC_STD;

--- a/vhdl/examples/numeric_std.vhd
+++ b/vhdl/examples/numeric_std.vhd
@@ -1,0 +1,853 @@
+-- --------------------------------------------------------------------
+--
+-- Copyright 1995 by IEEE. All rights reserved.
+--
+-- This source file is considered by the IEEE to be an essential part of the use
+-- of the standard 1076.3 and as such may be distributed without change, except
+-- as permitted by the standard. This source file may not be sold or distributed
+-- for profit. This package may be modified to include additional data required
+-- by tools, but must in no way change the external interfaces or simulation
+-- behaviour of the description. It is permissible to add comments and/or
+-- attributes to the package declarations, but not to change or delete any
+-- original lines of the approved package declaration. The package body may be
+-- changed only in accordance with the terms of clauses 7.1 and 7.2 of the
+-- standard.
+--
+-- Title      : Standard VHDL Synthesis Package (1076.3, NUMERIC_STD)
+--
+-- Library    : This package shall be compiled into a library symbolically
+--            : named IEEE.
+--
+-- Developers : IEEE DASC Synthesis Working Group, PAR 1076.3
+--
+-- Purpose    : This package defines numeric types and arithmetic functions
+--            : for use with synthesis tools. Two numeric types are defined:
+--            : -- > UNSIGNED: represents UNSIGNED number in vector form
+--            : -- > SIGNED: represents a SIGNED number in vector form
+--            : The base element type is type STD_LOGIC.
+--            : The leftmost bit is treated as the most significant bit.
+--            : Signed vectors are represented in two's complement form.
+--            : This package contains overloaded arithmetic operators on
+--            : the SIGNED and UNSIGNED types. The package also contains
+--            : useful type conversions functions.
+--            :
+--            : If any argument to a function is a null array, a null array is
+--            : returned (exceptions, if any, are noted individually).
+--
+-- Limitation :
+--
+-- Note       : No declarations or definitions shall be included in,
+--            : or excluded from this package. The "package declaration"
+--            : defines the types, subtypes and declarations of
+--            : NUMERIC_STD. The NUMERIC_STD package body shall be
+--            : considered the formal definition of the semantics of
+--            : this package. Tool developers may choose to implement
+--            : the package body in the most efficient manner available
+--            : to them.
+--
+-- --------------------------------------------------------------------
+--   modification history :
+-- --------------------------------------------------------------------
+--   Version:  2.4
+--   Date   :  12 April 1995
+-- -----------------------------------------------------------------------------
+library IEEE;
+use IEEE.STD_LOGIC_1164.all;
+
+package NUMERIC_STD is
+  constant CopyRightNotice: STRING
+      := "Copyright 1995 IEEE. All rights reserved.";
+
+  --============================================================================
+  -- Numeric array type definitions
+  --============================================================================
+
+  type UNSIGNED is array (NATURAL range <>) of STD_LOGIC;
+  type SIGNED is array (NATURAL range <>) of STD_LOGIC;
+
+  --============================================================================
+  -- Arithmetic Operators:
+  --===========================================================================
+
+  -- Id: A.1
+  function "abs" (ARG: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0).
+  -- Result: Returns the absolute value of a SIGNED vector ARG.
+
+  -- Id: A.2
+  function "-" (ARG: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0).
+  -- Result: Returns the value of the unary minus operation on a
+  --         SIGNED vector ARG.
+
+  --============================================================================
+
+  -- Id: A.3
+  function "+" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Adds two UNSIGNED vectors that may be of different lengths.
+
+  -- Id: A.4
+  function "+" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Adds two SIGNED vectors that may be of different lengths.
+
+  -- Id: A.5
+  function "+" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0).
+  -- Result: Adds an UNSIGNED vector, L, with a non-negative INTEGER, R.
+
+  -- Id: A.6
+  function "+" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0).
+  -- Result: Adds a non-negative INTEGER, L, with an UNSIGNED vector, R.
+
+  -- Id: A.7
+  function "+" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0).
+  -- Result: Adds an INTEGER, L(may be positive or negative), to a SIGNED
+  --         vector, R.
+
+  -- Id: A.8
+  function "+" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0).
+  -- Result: Adds a SIGNED vector, L, to an INTEGER, R.
+
+  --============================================================================
+
+  -- Id: A.9
+  function "-" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Subtracts two UNSIGNED vectors that may be of different lengths.
+
+  -- Id: A.10
+  function "-" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(MAX(L'LENGTH, R'LENGTH)-1 downto 0).
+  -- Result: Subtracts a SIGNED vector, R, from another SIGNED vector, L,
+  --         that may possibly be of different lengths.
+
+  -- Id: A.11
+  function "-" (L: UNSIGNED;R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0).
+  -- Result: Subtracts a non-negative INTEGER, R, from an UNSIGNED vector, L.
+
+  -- Id: A.12
+  function "-" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0).
+  -- Result: Subtracts an UNSIGNED vector, R, from a non-negative INTEGER, L.
+
+  -- Id: A.13
+  function "-" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0).
+  -- Result: Subtracts an INTEGER, R, from a SIGNED vector, L.
+
+  -- Id: A.14
+  function "-" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0).
+  -- Result: Subtracts a SIGNED vector, R, from an INTEGER, L.
+
+  --============================================================================
+
+  -- Id: A.15
+  function "*" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED((L'LENGTH+R'LENGTH-1) downto 0).
+  -- Result: Performs the multiplication operation on two UNSIGNED vectors
+  --         that may possibly be of different lengths.
+
+  -- Id: A.16
+  function "*" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED((L'LENGTH+R'LENGTH-1) downto 0)
+  -- Result: Multiplies two SIGNED vectors that may possibly be of
+  --         different lengths.
+
+  -- Id: A.17
+  function "*" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED((L'LENGTH+L'LENGTH-1) downto 0).
+  -- Result: Multiplies an UNSIGNED vector, L, with a non-negative
+  --         INTEGER, R. R is converted to an UNSIGNED vector of
+  --         SIZE L'LENGTH before multiplication.
+
+  -- Id: A.18
+  function "*" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED((R'LENGTH+R'LENGTH-1) downto 0).
+  -- Result: Multiplies an UNSIGNED vector, R, with a non-negative
+  --         INTEGER, L. L is converted to an UNSIGNED vector of
+  --         SIZE R'LENGTH before multiplication.
+
+  -- Id: A.19
+  function "*" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED((L'LENGTH+L'LENGTH-1) downto 0)
+  -- Result: Multiplies a SIGNED vector, L, with an INTEGER, R. R is
+  --         converted to a SIGNED vector of SIZE L'LENGTH before
+  --         multiplication.
+
+  -- Id: A.20
+  function "*" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED((R'LENGTH+R'LENGTH-1) downto 0)
+  -- Result: Multiplies a SIGNED vector, R, with an INTEGER, L. L is
+  --         converted to a SIGNED vector of SIZE R'LENGTH before
+  --         multiplication.
+
+  --============================================================================
+  --
+  -- NOTE: If second argument is zero for "/" operator, a severity level
+  --       of ERROR is issued.
+
+  -- Id: A.21
+  function "/" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides an UNSIGNED vector, L, by another UNSIGNED vector, R.
+
+  -- Id: A.22
+  function "/" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides an SIGNED vector, L, by another SIGNED vector, R.
+
+  -- Id: A.23
+  function "/" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides an UNSIGNED vector, L, by a non-negative INTEGER, R.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.24
+  function "/" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Divides a non-negative INTEGER, L, by an UNSIGNED vector, R.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  -- Id: A.25
+  function "/" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Divides a SIGNED vector, L, by an INTEGER, R.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.26
+  function "/" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Divides an INTEGER, L, by a SIGNED vector, R.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  --============================================================================
+  --
+  -- NOTE: If second argument is zero for "rem" operator, a severity level
+  --       of ERROR is issued.
+
+  -- Id: A.27
+  function "rem" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L and R are UNSIGNED vectors.
+
+  -- Id: A.28
+  function "rem" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L and R are SIGNED vectors.
+
+  -- Id: A.29
+  function "rem" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L is an UNSIGNED vector and R is a
+  --         non-negative INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.30
+  function "rem" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where R is an UNSIGNED vector and L is a
+  --         non-negative INTEGER.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  -- Id: A.31
+  function "rem" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where L is SIGNED vector and R is an INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.32
+  function "rem" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L rem R" where R is SIGNED vector and L is an INTEGER.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  --============================================================================
+  --
+  -- NOTE: If second argument is zero for "mod" operator, a severity level
+  --       of ERROR is issued.
+
+  -- Id: A.33
+  function "mod" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L and R are UNSIGNED vectors.
+
+  -- Id: A.34
+  function "mod" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L and R are SIGNED vectors.
+
+  -- Id: A.35
+  function "mod" (L: UNSIGNED; R: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L is an UNSIGNED vector and R
+  --         is a non-negative INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.36
+  function "mod" (L: NATURAL; R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where R is an UNSIGNED vector and L
+  --         is a non-negative INTEGER.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  -- Id: A.37
+  function "mod" (L: SIGNED; R: INTEGER) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+  --         If NO_OF_BITS(R) > L'LENGTH, result is truncated to L'LENGTH.
+
+  -- Id: A.38
+  function "mod" (L: INTEGER; R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(R'LENGTH-1 downto 0)
+  -- Result: Computes "L mod R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+  --         If NO_OF_BITS(L) > R'LENGTH, result is truncated to R'LENGTH.
+
+  --============================================================================
+  -- Comparison Operators
+  --============================================================================
+
+  -- Id: C.1
+  function ">" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.2
+  function ">" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.3
+  function ">" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.4
+  function ">" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is a INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.5
+  function ">" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.6
+  function ">" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L > R" where L is a SIGNED vector and
+  --         R is a INTEGER.
+
+  --============================================================================
+
+  -- Id: C.7
+  function "<" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.8
+  function "<" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.9
+  function "<" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.10
+  function "<" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.11
+  function "<" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.12
+  function "<" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L < R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.13
+  function "<=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.14
+  function "<=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.15
+  function "<=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.16
+  function "<=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.17
+  function "<=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.18
+  function "<=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L <= R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.19
+  function ">=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.20
+  function ">=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.21
+  function ">=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.22
+  function ">=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.23
+  function ">=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.24
+  function ">=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L >= R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.25
+  function "=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.26
+  function "=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.27
+  function "=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.28
+  function "=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.29
+  function "=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.30
+  function "=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L = R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+
+  -- Id: C.31
+  function "/=" (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L and R are UNSIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.32
+  function "/=" (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L and R are SIGNED vectors possibly
+  --         of different lengths.
+
+  -- Id: C.33
+  function "/=" (L: NATURAL; R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is a non-negative INTEGER and
+  --         R is an UNSIGNED vector.
+
+  -- Id: C.34
+  function "/=" (L: INTEGER; R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is an INTEGER and
+  --         R is a SIGNED vector.
+
+  -- Id: C.35
+  function "/=" (L: UNSIGNED; R: NATURAL) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is an UNSIGNED vector and
+  --         R is a non-negative INTEGER.
+
+  -- Id: C.36
+  function "/=" (L: SIGNED; R: INTEGER) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: Computes "L /= R" where L is a SIGNED vector and
+  --         R is an INTEGER.
+
+  --============================================================================
+  -- Shift and Rotate Functions
+  --============================================================================
+
+  -- Id: S.1
+  function SHIFT_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-left on an UNSIGNED vector COUNT times.
+  --         The vacated positions are filled with '0'.
+  --         The COUNT leftmost elements are lost.
+
+  -- Id: S.2
+  function SHIFT_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-right on an UNSIGNED vector COUNT times.
+  --         The vacated positions are filled with '0'.
+  --         The COUNT rightmost elements are lost.
+
+  -- Id: S.3
+  function SHIFT_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-left on a SIGNED vector COUNT times.
+  --         The vacated positions are filled with '0'.
+  --         The COUNT leftmost elements are lost.
+
+  -- Id: S.4
+  function SHIFT_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a shift-right on a SIGNED vector COUNT times.
+  --         The vacated positions are filled with the leftmost
+  --         element, ARG'LEFT. The COUNT rightmost elements are lost.
+
+  --============================================================================
+
+  -- Id: S.5
+  function ROTATE_LEFT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a rotate-left of an UNSIGNED vector COUNT times.
+
+  -- Id: S.6
+  function ROTATE_RIGHT (ARG: UNSIGNED; COUNT: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a rotate-right of an UNSIGNED vector COUNT times.
+
+  -- Id: S.7
+  function ROTATE_LEFT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a logical rotate-left of a SIGNED
+  --         vector COUNT times.
+
+  -- Id: S.8
+  function ROTATE_RIGHT (ARG: SIGNED; COUNT: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: Performs a logical rotate-right of a SIGNED
+  --         vector COUNT times.
+
+  --============================================================================
+
+  --============================================================================
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.9 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.9
+  function "sll" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SHIFT_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.10 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.10
+  function "sll" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SHIFT_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.11 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.11
+  function "srl" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SHIFT_RIGHT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.12 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.12
+  function "srl" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: SIGNED(SHIFT_RIGHT(UNSIGNED(ARG), COUNT))
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.13 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.13
+  function "rol" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.14 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.14
+  function "rol" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_LEFT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  -- Note : Function S.15 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.15
+  function "ror" (ARG: UNSIGNED; COUNT: INTEGER) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_RIGHT(ARG, COUNT)
+
+  ------------------------------------------------------------------------------
+  --   Note : Function S.16 is not compatible with VHDL 1076-1987. Comment
+  --   out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  ------------------------------------------------------------------------------
+  -- Id: S.16
+  function "ror" (ARG: SIGNED; COUNT: INTEGER) return SIGNED; --V93
+  -- Result subtype: SIGNED(ARG'LENGTH-1 downto 0)
+  -- Result: ROTATE_RIGHT(ARG, COUNT)
+
+  --============================================================================
+  --   RESIZE Functions
+  --============================================================================
+
+  -- Id: R.1
+  function RESIZE (ARG: SIGNED; NEW_SIZE: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(NEW_SIZE-1 downto 0)
+  -- Result: Resizes the SIGNED vector ARG to the specified size.
+  --         To create a larger vector, the new [leftmost] bit positions
+  --         are filled with the sign bit (ARG'LEFT). When truncating,
+  --         the sign bit is retained along with the rightmost part.
+
+  -- Id: R.2
+  function RESIZE (ARG: UNSIGNED; NEW_SIZE: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(NEW_SIZE-1 downto 0)
+  -- Result: Resizes the SIGNED vector ARG to the specified size.
+  --         To create a larger vector, the new [leftmost] bit positions
+  --         are filled with '0'. When truncating, the leftmost bits
+  --         are dropped.
+
+  --============================================================================
+  -- Conversion Functions
+  --============================================================================
+
+  -- Id: D.1
+  function TO_INTEGER (ARG: UNSIGNED) return NATURAL;
+  -- Result subtype: NATURAL. Value cannot be negative since parameter is an
+  --             UNSIGNED vector.
+  -- Result: Converts the UNSIGNED vector to an INTEGER.
+
+  -- Id: D.2
+  function TO_INTEGER (ARG: SIGNED) return INTEGER;
+  -- Result subtype: INTEGER
+  -- Result: Converts a SIGNED vector to an INTEGER.
+
+  -- Id: D.3
+  function TO_UNSIGNED (ARG, SIZE: NATURAL) return UNSIGNED;
+  -- Result subtype: UNSIGNED(SIZE-1 downto 0)
+  -- Result: Converts a non-negative INTEGER to an UNSIGNED vector with
+  --         the specified SIZE.
+
+  -- Id: D.4
+  function TO_SIGNED (ARG: INTEGER; SIZE: NATURAL) return SIGNED;
+  -- Result subtype: SIGNED(SIZE-1 downto 0)
+  -- Result: Converts an INTEGER to a SIGNED vector of the specified SIZE.
+
+  --============================================================================
+  -- Logical Operators
+  --============================================================================
+
+  -- Id: L.1
+  function "not" (L: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Termwise inversion
+
+  -- Id: L.2
+  function "and" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector AND operation
+
+  -- Id: L.3
+  function "or" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector OR operation
+
+  -- Id: L.4
+  function "nand" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NAND operation
+
+  -- Id: L.5
+  function "nor" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NOR operation
+
+  -- Id: L.6
+  function "xor" (L, R: UNSIGNED) return UNSIGNED;
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XOR operation
+
+  -- ---------------------------------------------------------------------------
+  -- Note : Function L.7 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  -- ---------------------------------------------------------------------------
+  -- Id: L.7
+  function "xnor" (L, R: UNSIGNED) return UNSIGNED; --V93
+  -- Result subtype: UNSIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XNOR operation
+
+  -- Id: L.8
+  function "not" (L: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Termwise inversion
+
+  -- Id: L.9
+  function "and" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector AND operation
+
+  -- Id: L.10
+  function "or" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector OR operation
+
+  -- Id: L.11
+  function "nand" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NAND operation
+
+  -- Id: L.12
+  function "nor" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector NOR operation
+
+  -- Id: L.13
+  function "xor" (L, R: SIGNED) return SIGNED;
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XOR operation
+
+  -- ---------------------------------------------------------------------------
+  -- Note : Function L.14 is not compatible with VHDL 1076-1987. Comment
+  -- out the function (declaration and body) for VHDL 1076-1987 compatibility.
+  -- ---------------------------------------------------------------------------
+  -- Id: L.14
+  function "xnor" (L, R: SIGNED) return SIGNED; --V93
+  -- Result subtype: SIGNED(L'LENGTH-1 downto 0)
+  -- Result: Vector XNOR operation
+
+  --============================================================================
+  -- Match Functions
+  --============================================================================
+
+  -- Id: M.1
+  function STD_MATCH (L, R: STD_ULOGIC) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: terms compared per STD_LOGIC_1164 intent
+
+  -- Id: M.2
+  function STD_MATCH (L, R: UNSIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: terms compared per STD_LOGIC_1164 intent
+
+  -- Id: M.3
+  function STD_MATCH (L, R: SIGNED) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: terms compared per STD_LOGIC_1164 intent
+
+  -- Id: M.4
+  function STD_MATCH (L, R: STD_LOGIC_VECTOR) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: terms compared per STD_LOGIC_1164 intent
+
+  -- Id: M.5
+  function STD_MATCH (L, R: STD_ULOGIC_VECTOR) return BOOLEAN;
+  -- Result subtype: BOOLEAN
+  -- Result: terms compared per STD_LOGIC_1164 intent
+
+  --============================================================================
+  -- Translation Functions
+  --============================================================================
+
+  -- Id: T.1
+  function TO_01 (S: UNSIGNED; XMAP: STD_LOGIC := '0') return UNSIGNED;
+  -- Result subtype: UNSIGNED(S'RANGE)
+  -- Result: Termwise, 'H' is translated to '1', and 'L' is translated
+  --         to '0'. If a value other than '0'|'1'|'H'|'L' is found,
+  --         the array is set to (others => XMAP), and a warning is
+  --         issued.
+
+  -- Id: T.2
+  function TO_01 (S: SIGNED; XMAP: STD_LOGIC := '0') return SIGNED;
+  -- Result subtype: SIGNED(S'RANGE)
+  -- Result: Termwise, 'H' is translated to '1', and 'L' is translated
+  --         to '0'. If a value other than '0'|'1'|'H'|'L' is found,
+  --         the array is set to (others => XMAP), and a warning is
+  --         issued.
+
+end NUMERIC_STD;

--- a/vhdl/examples/signed.vhd
+++ b/vhdl/examples/signed.vhd
@@ -1,0 +1,336 @@
+--------------------------------------------------------------------------
+--                                                                      --
+-- Copyright (c) 1990, 1991, 1992 by Synopsys, Inc.                     --
+--                                             All rights reserved.     --
+--                                                                      --
+-- This source file may be used and distributed without restriction     --
+-- provided that this copyright statement is not removed from the file  --
+-- and that any derivative work contains this copyright notice.         --
+--                                                                      --
+--	Package name: STD_LOGIC_SIGNED                                  --
+--                                 					--
+--									--
+--      Date:        09/11/91 KN                                        --
+--                   10/08/92 AMT change std_ulogic to signed std_logic --
+--		     10/28/92 AMT added signed functions, -, ABS	--
+--									--
+--	Purpose: 							--
+--	 A set of signed arithemtic, conversion,                        --
+--           and comparision functions for STD_LOGIC_VECTOR.            --
+--									--
+--	Note:	Comparision of same length std_logic_vector is defined  --
+--		in the LRM.  The interpretation is for unsigned vectors --
+--		This package will "overload" that definition.		--
+--									--
+--------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.std_logic_arith.all;
+
+package STD_LOGIC_SIGNED is
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "+"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "-"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "ABS"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "*"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "<"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "<"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "<"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "<="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function ">"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function ">="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "/="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function CONV_INTEGER(ARG: STD_LOGIC_VECTOR) return INTEGER;
+
+    function SHL(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function SHR(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+end STD_LOGIC_SIGNED;
+
+
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.std_logic_arith.all;
+
+package body STD_LOGIC_SIGNED is
+
+
+    function maximum(L, R: INTEGER) return INTEGER is
+    begin
+        if L > R then
+            return L;
+        else
+            return R;
+        end if;
+    end;
+
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        constant length: INTEGER := maximum(L'length, R'length);
+        variable result  : STD_LOGIC_VECTOR (length-1 downto 0);
+    begin
+        result  := SIGNED(L) + SIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := SIGNED(L) + R;
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L + SIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := SIGNED(L) + R;
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L + SIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        constant length: INTEGER := maximum(L'length, R'length);
+        variable result  : STD_LOGIC_VECTOR (length-1 downto 0);
+    begin
+        result  := SIGNED(L) - SIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := SIGNED(L) - R;
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L - SIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := SIGNED(L) - R;
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L - SIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := + SIGNED(L);
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := - SIGNED(L);
+        return   std_logic_vector(result);
+    end;
+
+    function "ABS"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := ABS( SIGNED(L));
+        return   std_logic_vector(result);
+    end;
+
+    function "*"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        constant length: INTEGER := maximum(L'length, R'length);
+        variable result  : STD_LOGIC_VECTOR ((L'length+R'length-1) downto 0);
+    begin
+        result  := SIGNED(L) * SIGNED(R);
+        return   std_logic_vector(result);
+    end;
+        
+    function "<"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+        constant length: INTEGER := maximum(L'length, R'length);
+    begin
+        return   SIGNED(L) < SIGNED(R);
+    end;
+
+    function "<"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   SIGNED(L) < R;
+    end;
+
+    function "<"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L < SIGNED(R);
+    end;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   SIGNED(L) <= SIGNED(R);
+    end;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   SIGNED(L) <= R;
+    end;
+
+    function "<="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L <= SIGNED(R);
+    end;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   SIGNED(L) > SIGNED(R);
+    end;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   SIGNED(L) > R;
+    end;
+
+    function ">"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L > SIGNED(R);
+    end;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   SIGNED(L) >= SIGNED(R);
+    end;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   SIGNED(L) >= R;
+    end;
+
+    function ">="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L >= SIGNED(R);
+    end;
+
+    function "="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   SIGNED(L) = SIGNED(R);
+    end;
+
+    function "="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   SIGNED(L) = R;
+    end;
+
+    function "="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L = SIGNED(R);
+    end;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   SIGNED(L) /= SIGNED(R);
+    end;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   SIGNED(L) /= R;
+    end;
+
+    function "/="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L /= SIGNED(R);
+    end;
+
+--  This function converts std_logic_vector to a signed integer value
+--  using a conversion function in std_logic_arith
+    function CONV_INTEGER(ARG: STD_LOGIC_VECTOR) return INTEGER is
+        variable result    : SIGNED(ARG'range);
+    begin
+        result    := SIGNED(ARG);
+        return   CONV_INTEGER(result);
+    end;
+
+
+    function SHL(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is 
+    begin
+       return STD_LOGIC_VECTOR(SHL(SIGNED(ARG),UNSIGNED(COUNT)));
+    end; 
+
+    function SHR(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+    begin
+       return STD_LOGIC_VECTOR(SHR(SIGNED(ARG),UNSIGNED(COUNT)));
+    end;
+ 
+end STD_LOGIC_SIGNED;

--- a/vhdl/examples/standard.vhd
+++ b/vhdl/examples/standard.vhd
@@ -1,0 +1,66 @@
+-- This is Package STANDARD as defined in the VHDL 1992 Language Reference Manual.
+
+package standard is 
+	type boolean is (false,true); 
+	type bit is ('0', '1'); 
+	type character is (
+		nul, soh, stx, etx, eot, enq, ack, bel, 
+		bs,  ht,  lf,  vt,  ff,  cr,  so,  si, 
+		dle, dc1, dc2, dc3, dc4, nak, syn, etb, 
+		can, em,  sub, esc, fsp, gsp, rsp, usp, 
+
+		' ', '!', '"', '#', '$', '%', '&', ''', 
+		'(', ')', '*', '+', ',', '-', '.', '/', 
+		'0', '1', '2', '3', '4', '5', '6', '7', 
+		'8', '9', ':', ';', '<', '=', '>', '?', 
+
+		'@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 
+		'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 
+		'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 
+		'X', 'Y', 'Z', '[', '\', ']', '^', '_', 
+
+		'`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 
+		'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 
+		'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 
+		'x', 'y', 'z', '{', '|', '}', '~', del,
+
+		c128, c129, c130, c131, c132, c133, c134, c135,
+		c136, c137, c138, c139, c140, c141, c142, c143,
+		c144, c145, c146, c147, c148, c149, c150, c151,
+		c152, c153, c154, c155, c156, c157, c158, c159
+
+		-- the character code for 160 is there (NBSP), 
+		-- but prints as no char 
+		); 
+
+	type severity_level is (note, warning, error, failure); 
+	type integer is range -2147483647 to 2147483647; 
+	type real is range -1.0E308 to 1.0E308; 
+	type time is range -2147483647 to 2147483647 
+		units 
+			fs;
+			ps = 1000 fs;
+			ns = 1000 ps;
+			us = 1000 ns; 
+			ms = 1000 us; 
+			sec = 1000 ms; 
+			min = 60 sec; 
+			hr = 60 min; 
+		end units; 
+	subtype delay_length is time range 0 fs to time'high;
+	impure function now return delay_length; 
+	subtype natural is integer range 0 to integer'high; 
+	subtype positive is integer range 1 to integer'high; 
+	type string is array (positive range <>) of character; 
+	type bit_vector is array (natural range <>) of bit; 
+	type file_open_kind is (
+		read_mode,
+		write_mode,
+		append_mode);
+	type file_open_status is (
+		open_ok,
+		status_error,
+		name_error,
+		mode_error);
+	attribute foreign : string;
+end standard; 

--- a/vhdl/examples/std_logic_1164.vhd
+++ b/vhdl/examples/std_logic_1164.vhd
@@ -1,0 +1,175 @@
+-- --------------------------------------------------------------------
+--
+--   Title     :  std_logic_1164 multi-value logic system
+--   Library   :  This package shall be compiled into a library
+--             :  symbolically named IEEE.
+--             :
+--   Developers:  IEEE model standards group (par 1164)
+--   Purpose   :  This packages defines a standard for designers
+--             :  to use in describing the interconnection data types
+--             :  used in vhdl modeling.
+--             :
+--   Limitation:  The logic system defined in this package may
+--             :  be insufficient for modeling switched transistors,
+--             :  since such a requirement is out of the scope of this
+--             :  effort. Furthermore, mathematics, primitives,
+--             :  timing standards, etc. are considered orthogonal
+--             :  issues as it relates to this package and are therefore
+--             :  beyond the scope of this effort.
+--             :
+--   Note      :  No declarations or definitions shall be included in,
+--             :  or excluded from this package. The "package declaration"
+--             :  defines the types, subtypes and declarations of
+--             :  std_logic_1164. The std_logic_1164 package body shall be
+--             :  considered the formal definition of the semantics of
+--             :  this package. Tool developers may choose to implement
+--             :  the package body in the most efficient manner available
+--             :  to them.
+--             :
+-- --------------------------------------------------------------------
+--   modification history :
+-- --------------------------------------------------------------------
+--  version | mod. date:|
+--   v4.200 | 01/02/92  |
+-- --------------------------------------------------------------------
+
+PACKAGE std_logic_1164 IS
+
+    -------------------------------------------------------------------
+    -- logic state system  (unresolved)
+    -------------------------------------------------------------------
+    TYPE std_ulogic IS ( 'U',  -- Uninitialized
+                         'X',  -- Forcing  Unknown
+                         '0',  -- Forcing  0
+                         '1',  -- Forcing  1
+                         'Z',  -- High Impedance
+                         'W',  -- Weak     Unknown
+                         'L',  -- Weak     0
+                         'H',  -- Weak     1
+                         '-'   -- Don't care
+                       );
+    -------------------------------------------------------------------
+    -- unconstrained array of std_ulogic for use with the resolution function
+    -------------------------------------------------------------------
+    TYPE std_ulogic_vector IS ARRAY ( NATURAL RANGE <> ) OF std_ulogic;
+
+    -------------------------------------------------------------------
+    -- resolution function
+    -------------------------------------------------------------------
+    FUNCTION resolved ( s : std_ulogic_vector ) RETURN std_ulogic;
+
+    -------------------------------------------------------------------
+    -- *** industry standard logic type ***
+    -------------------------------------------------------------------
+    SUBTYPE std_logic IS resolved std_ulogic;
+
+    -------------------------------------------------------------------
+    -- unconstrained array of std_logic for use in declaring signal arrays
+    -------------------------------------------------------------------
+    TYPE std_logic_vector IS ARRAY ( NATURAL RANGE <>) OF std_logic;
+
+    -------------------------------------------------------------------
+    -- common subtypes
+    -------------------------------------------------------------------
+    SUBTYPE X01     IS resolved std_ulogic RANGE 'X' TO '1'; -- ('X','0','1')
+    SUBTYPE X01Z    IS resolved std_ulogic RANGE 'X' TO 'Z'; -- ('X','0','1','Z')
+    SUBTYPE UX01    IS resolved std_ulogic RANGE 'U' TO '1'; -- ('U','X','0','1')
+    SUBTYPE UX01Z   IS resolved std_ulogic RANGE 'U' TO 'Z'; -- ('U','X','0','1','Z')
+
+    -------------------------------------------------------------------
+    -- overloaded logical operators
+    -------------------------------------------------------------------
+
+    FUNCTION "and"  ( l : std_ulogic; r : std_ulogic ) RETURN UX01;
+    FUNCTION "nand" ( l : std_ulogic; r : std_ulogic ) RETURN UX01;
+    FUNCTION "or"   ( l : std_ulogic; r : std_ulogic ) RETURN UX01;
+    FUNCTION "nor"  ( l : std_ulogic; r : std_ulogic ) RETURN UX01;
+    FUNCTION "xor"  ( l : std_ulogic; r : std_ulogic ) RETURN UX01;
+    FUNCTION "xnor" ( l : std_ulogic; r : std_ulogic ) RETURN UX01; --V93
+    FUNCTION "not"  ( l : std_ulogic                 ) RETURN UX01;
+
+    -------------------------------------------------------------------
+    -- vectorized overloaded logical operators
+    -------------------------------------------------------------------
+    FUNCTION "and"  ( l, r : std_logic_vector  ) RETURN std_logic_vector;
+    FUNCTION "and"  ( l, r : std_ulogic_vector ) RETURN std_ulogic_vector;
+
+    FUNCTION "nand" ( l, r : std_logic_vector  ) RETURN std_logic_vector;
+    FUNCTION "nand" ( l, r : std_ulogic_vector ) RETURN std_ulogic_vector;
+
+    FUNCTION "or"   ( l, r : std_logic_vector  ) RETURN std_logic_vector;
+    FUNCTION "or"   ( l, r : std_ulogic_vector ) RETURN std_ulogic_vector;
+
+    FUNCTION "nor"  ( l, r : std_logic_vector  ) RETURN std_logic_vector;
+    FUNCTION "nor"  ( l, r : std_ulogic_vector ) RETURN std_ulogic_vector;
+
+    FUNCTION "xor"  ( l, r : std_logic_vector  ) RETURN std_logic_vector;
+    FUNCTION "xor"  ( l, r : std_ulogic_vector ) RETURN std_ulogic_vector;
+
+--  -----------------------------------------------------------------------
+--  Note : The declaration and implementation of the "xnor" function is
+--  specifically commented until at which time the VHDL language has been
+--  officially adopted as containing such a function. At such a point,
+--  the following comments may be removed along with this notice without
+--  further "official" ballotting of this std_logic_1164 package. It is
+--  the intent of this effort to provide such a function once it becomes
+--  available in the VHDL standard.
+--  -----------------------------------------------------------------------
+    FUNCTION "xnor" ( l, r : std_logic_vector  ) RETURN std_logic_vector; --V93
+    FUNCTION "xnor" ( l, r : std_ulogic_vector ) RETURN std_ulogic_vector;--V93
+
+    FUNCTION "not"  ( l : std_logic_vector  ) RETURN std_logic_vector;
+    FUNCTION "not"  ( l : std_ulogic_vector ) RETURN std_ulogic_vector;
+
+    -------------------------------------------------------------------
+    -- conversion functions
+    -------------------------------------------------------------------
+    FUNCTION To_bit       ( s : std_ulogic;        xmap : BIT := '0') RETURN BIT;
+    FUNCTION To_bitvector ( s : std_logic_vector ; xmap : BIT := '0') RETURN BIT_VECTOR;
+    FUNCTION To_bitvector ( s : std_ulogic_vector; xmap : BIT := '0') RETURN BIT_VECTOR;
+
+    FUNCTION To_StdULogic       ( b : BIT               ) RETURN std_ulogic;
+    FUNCTION To_StdLogicVector  ( b : BIT_VECTOR        ) RETURN std_logic_vector;
+    FUNCTION To_StdLogicVector  ( s : std_ulogic_vector ) RETURN std_logic_vector;
+    FUNCTION To_StdULogicVector ( b : BIT_VECTOR        ) RETURN std_ulogic_vector;
+    FUNCTION To_StdULogicVector ( s : std_logic_vector  ) RETURN std_ulogic_vector;
+
+    -------------------------------------------------------------------
+    -- strength strippers and type convertors
+    -------------------------------------------------------------------
+
+    FUNCTION To_X01  ( s : std_logic_vector  ) RETURN  std_logic_vector;
+    FUNCTION To_X01  ( s : std_ulogic_vector ) RETURN  std_ulogic_vector;
+    FUNCTION To_X01  ( s : std_ulogic        ) RETURN  X01;
+    FUNCTION To_X01  ( b : BIT_VECTOR        ) RETURN  std_logic_vector;
+    FUNCTION To_X01  ( b : BIT_VECTOR        ) RETURN  std_ulogic_vector;
+    FUNCTION To_X01  ( b : BIT               ) RETURN  X01;
+
+    FUNCTION To_X01Z ( s : std_logic_vector  ) RETURN  std_logic_vector;
+    FUNCTION To_X01Z ( s : std_ulogic_vector ) RETURN  std_ulogic_vector;
+    FUNCTION To_X01Z ( s : std_ulogic        ) RETURN  X01Z;
+    FUNCTION To_X01Z ( b : BIT_VECTOR        ) RETURN  std_logic_vector;
+    FUNCTION To_X01Z ( b : BIT_VECTOR        ) RETURN  std_ulogic_vector;
+    FUNCTION To_X01Z ( b : BIT               ) RETURN  X01Z;
+
+    FUNCTION To_UX01  ( s : std_logic_vector  ) RETURN  std_logic_vector;
+    FUNCTION To_UX01  ( s : std_ulogic_vector ) RETURN  std_ulogic_vector;
+    FUNCTION To_UX01  ( s : std_ulogic        ) RETURN  UX01;
+    FUNCTION To_UX01  ( b : BIT_VECTOR        ) RETURN  std_logic_vector;
+    FUNCTION To_UX01  ( b : BIT_VECTOR        ) RETURN  std_ulogic_vector;
+    FUNCTION To_UX01  ( b : BIT               ) RETURN  UX01;
+
+    -------------------------------------------------------------------
+    -- edge detection
+    -------------------------------------------------------------------
+    FUNCTION rising_edge  (SIGNAL s : std_ulogic) RETURN BOOLEAN;
+    FUNCTION falling_edge (SIGNAL s : std_ulogic) RETURN BOOLEAN;
+
+    -------------------------------------------------------------------
+    -- object contains an unknown
+    -------------------------------------------------------------------
+    FUNCTION Is_X ( s : std_ulogic_vector ) RETURN  BOOLEAN;
+    FUNCTION Is_X ( s : std_logic_vector  ) RETURN  BOOLEAN;
+    FUNCTION Is_X ( s : std_ulogic        ) RETURN  BOOLEAN;
+
+END std_logic_1164;

--- a/vhdl/examples/std_logic_1164_body.vhd
+++ b/vhdl/examples/std_logic_1164_body.vhd
@@ -1,0 +1,830 @@
+-- --------------------------------------------------------------------
+--
+--   Title     :  std_logic_1164 multi-value logic system
+--   Library   :  This package shall be compiled into a library
+--             :  symbolically named IEEE.
+--             :
+--   Developers:  IEEE model standards group (par 1164)
+--   Purpose   :  This packages defines a standard for designers
+--             :  to use in describing the interconnection data types
+--             :  used in vhdl modeling.
+--             :
+--   Limitation:  The logic system defined in this package may
+--             :  be insufficient for modeling switched transistors,
+--             :  since such a requirement is out of the scope of this
+--             :  effort. Furthermore, mathematics, primitives,
+--             :  timing standards, etc. are considered orthogonal
+--             :  issues as it relates to this package and are therefore
+--             :  beyond the scope of this effort.
+--             :
+--   Note      :  No declarations or definitions shall be included in,
+--             :  or excluded from this package. The "package declaration"
+--             :  defines the types, subtypes and declarations of
+--             :  std_logic_1164. The std_logic_1164 package body shall be
+--             :  considered the formal definition of the semantics of
+--             :  this package. Tool developers may choose to implement
+--             :  the package body in the most efficient manner available
+--             :  to them.
+--             :
+-- --------------------------------------------------------------------
+--   modification history :
+-- --------------------------------------------------------------------
+--  version | mod. date:|
+--   v4.200 | 01/02/91  |
+-- --------------------------------------------------------------------
+
+PACKAGE BODY std_logic_1164 IS
+    -------------------------------------------------------------------
+    -- local types
+    -------------------------------------------------------------------
+    TYPE stdlogic_1d IS ARRAY (std_ulogic) OF std_ulogic;
+    TYPE stdlogic_table IS ARRAY(std_ulogic, std_ulogic) OF std_ulogic;
+
+    -------------------------------------------------------------------
+    -- resolution function
+    -------------------------------------------------------------------
+    CONSTANT resolution_table : stdlogic_table := (
+    --      ---------------------------------------------------------
+    --      |  U    X    0    1    Z    W    L    H    -        |   |
+    --      ---------------------------------------------------------
+            ( 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U' ), -- | U |
+            ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' ), -- | X |
+            ( 'U', 'X', '0', 'X', '0', '0', '0', '0', 'X' ), -- | 0 |
+            ( 'U', 'X', 'X', '1', '1', '1', '1', '1', 'X' ), -- | 1 |
+            ( 'U', 'X', '0', '1', 'Z', 'W', 'L', 'H', 'X' ), -- | Z |
+            ( 'U', 'X', '0', '1', 'W', 'W', 'W', 'W', 'X' ), -- | W |
+            ( 'U', 'X', '0', '1', 'L', 'W', 'L', 'W', 'X' ), -- | L |
+            ( 'U', 'X', '0', '1', 'H', 'W', 'W', 'H', 'X' ), -- | H |
+            ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' )  -- | - |
+        );
+
+    FUNCTION resolved ( s : std_ulogic_vector ) RETURN std_ulogic IS
+        VARIABLE result : std_ulogic := 'Z';  -- weakest state default
+    BEGIN
+        -- the test for a single driver is essential otherwise the
+        -- loop would return 'X' for a single driver of '-' and that
+        -- would conflict with the value of a single driver unresolved
+        -- signal.
+        IF    (s'LENGTH = 1) THEN    RETURN s(s'LOW);
+        ELSE
+            FOR i IN s'RANGE LOOP
+                result := resolution_table(result, s(i));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END resolved;
+
+    -------------------------------------------------------------------
+    -- tables for logical operations
+    -------------------------------------------------------------------
+
+    -- truth table for "and" function
+    CONSTANT and_table : stdlogic_table := (
+    --      ----------------------------------------------------
+    --      |  U    X    0    1    Z    W    L    H    -         |   |
+    --      ----------------------------------------------------
+            ( 'U', 'U', '0', 'U', 'U', 'U', '0', 'U', 'U' ),  -- | U |
+            ( 'U', 'X', '0', 'X', 'X', 'X', '0', 'X', 'X' ),  -- | X |
+            ( '0', '0', '0', '0', '0', '0', '0', '0', '0' ),  -- | 0 |
+            ( 'U', 'X', '0', '1', 'X', 'X', '0', '1', 'X' ),  -- | 1 |
+            ( 'U', 'X', '0', 'X', 'X', 'X', '0', 'X', 'X' ),  -- | Z |
+            ( 'U', 'X', '0', 'X', 'X', 'X', '0', 'X', 'X' ),  -- | W |
+            ( '0', '0', '0', '0', '0', '0', '0', '0', '0' ),  -- | L |
+            ( 'U', 'X', '0', '1', 'X', 'X', '0', '1', 'X' ),  -- | H |
+            ( 'U', 'X', '0', 'X', 'X', 'X', '0', 'X', 'X' )   -- | - |
+    );
+
+    -- truth table for "or" function
+    CONSTANT or_table : stdlogic_table := (
+    --      ----------------------------------------------------
+    --      |  U    X    0    1    Z    W    L    H    -         |   |
+    --      ----------------------------------------------------
+            ( 'U', 'U', 'U', '1', 'U', 'U', 'U', '1', 'U' ),  -- | U |
+            ( 'U', 'X', 'X', '1', 'X', 'X', 'X', '1', 'X' ),  -- | X |
+            ( 'U', 'X', '0', '1', 'X', 'X', '0', '1', 'X' ),  -- | 0 |
+            ( '1', '1', '1', '1', '1', '1', '1', '1', '1' ),  -- | 1 |
+            ( 'U', 'X', 'X', '1', 'X', 'X', 'X', '1', 'X' ),  -- | Z |
+            ( 'U', 'X', 'X', '1', 'X', 'X', 'X', '1', 'X' ),  -- | W |
+            ( 'U', 'X', '0', '1', 'X', 'X', '0', '1', 'X' ),  -- | L |
+            ( '1', '1', '1', '1', '1', '1', '1', '1', '1' ),  -- | H |
+            ( 'U', 'X', 'X', '1', 'X', 'X', 'X', '1', 'X' )   -- | - |
+    );
+
+    -- truth table for "xor" function
+    CONSTANT xor_table : stdlogic_table := (
+    --      ----------------------------------------------------
+    --      |  U    X    0    1    Z    W    L    H    -         |   |
+    --      ----------------------------------------------------
+            ( 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U', 'U' ),  -- | U |
+            ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' ),  -- | X |
+            ( 'U', 'X', '0', '1', 'X', 'X', '0', '1', 'X' ),  -- | 0 |
+            ( 'U', 'X', '1', '0', 'X', 'X', '1', '0', 'X' ),  -- | 1 |
+            ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' ),  -- | Z |
+            ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' ),  -- | W |
+            ( 'U', 'X', '0', '1', 'X', 'X', '0', '1', 'X' ),  -- | L |
+            ( 'U', 'X', '1', '0', 'X', 'X', '1', '0', 'X' ),  -- | H |
+            ( 'U', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X' )   -- | - |
+    );
+
+    -- truth table for "not" function
+    CONSTANT not_table: stdlogic_1d :=
+    --  -------------------------------------------------
+    --  |   U    X    0    1    Z    W    L    H    -   |
+    --  -------------------------------------------------
+         ( 'U', 'X', '1', '0', 'X', 'X', '1', '0', 'X' );
+
+    -------------------------------------------------------------------
+    -- overloaded logical operators ( with optimizing hints )
+    -------------------------------------------------------------------
+
+    FUNCTION "and"  ( l : std_ulogic; r : std_ulogic ) RETURN UX01 IS
+    BEGIN
+        RETURN (and_table(l, r));
+    END "and";
+
+    FUNCTION "nand" ( l : std_ulogic; r : std_ulogic ) RETURN UX01 IS
+    BEGIN
+        RETURN  (not_table ( and_table(l, r)));
+    END "nand";
+
+    FUNCTION "or"   ( l : std_ulogic; r : std_ulogic ) RETURN UX01 IS
+    BEGIN
+        RETURN (or_table(l, r));
+    END "or";
+
+    FUNCTION "nor"  ( l : std_ulogic; r : std_ulogic ) RETURN UX01 IS
+    BEGIN
+        RETURN  (not_table ( or_table( l, r )));
+    END "nor";
+
+    FUNCTION "xor"  ( l : std_ulogic; r : std_ulogic ) RETURN UX01 IS
+    BEGIN
+        RETURN (xor_table(l, r));
+    END "xor";
+
+--START-V93
+    FUNCTION "xnor"  ( l : std_ulogic; r : std_ulogic ) RETURN UX01 IS
+    BEGIN
+        RETURN not_table(xor_table(l, r));
+    END "xnor";
+--END-V93
+
+    FUNCTION "not"  ( l : std_ulogic ) RETURN UX01 IS
+    BEGIN
+        RETURN (not_table(l));
+    END "not";
+
+    -------------------------------------------------------------------
+    -- and
+    -------------------------------------------------------------------
+    FUNCTION "and"  ( l,r : std_logic_vector ) RETURN std_logic_vector IS
+        ALIAS lv : std_logic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_logic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_logic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'and' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := and_table (lv(i), rv(i));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "and";
+    ---------------------------------------------------------------------
+    FUNCTION "and"  ( l,r : std_ulogic_vector ) RETURN std_ulogic_vector IS
+        ALIAS lv : std_ulogic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_ulogic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_ulogic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'and' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := and_table (lv(i), rv(i));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "and";
+    -------------------------------------------------------------------
+    -- nand
+    -------------------------------------------------------------------
+    FUNCTION "nand"  ( l,r : std_logic_vector ) RETURN std_logic_vector IS
+        ALIAS lv : std_logic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_logic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_logic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'nand' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := not_table(and_table (lv(i), rv(i)));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "nand";
+    ---------------------------------------------------------------------
+    FUNCTION "nand"  ( l,r : std_ulogic_vector ) RETURN std_ulogic_vector IS
+        ALIAS lv : std_ulogic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_ulogic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_ulogic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'nand' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := not_table(and_table (lv(i), rv(i)));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "nand";
+    -------------------------------------------------------------------
+    -- or
+    -------------------------------------------------------------------
+    FUNCTION "or"  ( l,r : std_logic_vector ) RETURN std_logic_vector IS
+        ALIAS lv : std_logic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_logic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_logic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'or' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := or_table (lv(i), rv(i));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "or";
+    ---------------------------------------------------------------------
+    FUNCTION "or"  ( l,r : std_ulogic_vector ) RETURN std_ulogic_vector IS
+        ALIAS lv : std_ulogic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_ulogic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_ulogic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'or' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := or_table (lv(i), rv(i));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "or";
+    -------------------------------------------------------------------
+    -- nor
+    -------------------------------------------------------------------
+    FUNCTION "nor"  ( l,r : std_logic_vector ) RETURN std_logic_vector IS
+        ALIAS lv : std_logic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_logic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_logic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'nor' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := not_table(or_table (lv(i), rv(i)));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "nor";
+    ---------------------------------------------------------------------
+    FUNCTION "nor"  ( l,r : std_ulogic_vector ) RETURN std_ulogic_vector IS
+        ALIAS lv : std_ulogic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_ulogic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_ulogic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'nor' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := not_table(or_table (lv(i), rv(i)));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "nor";
+    ---------------------------------------------------------------------
+    -- xor
+    -------------------------------------------------------------------
+    FUNCTION "xor"  ( l,r : std_logic_vector ) RETURN std_logic_vector IS
+        ALIAS lv : std_logic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_logic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_logic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'xor' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := xor_table (lv(i), rv(i));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "xor";
+    ---------------------------------------------------------------------
+    FUNCTION "xor"  ( l,r : std_ulogic_vector ) RETURN std_ulogic_vector IS
+        ALIAS lv : std_ulogic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_ulogic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_ulogic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'xor' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := xor_table (lv(i), rv(i));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "xor";
+--    -------------------------------------------------------------------
+--    -- xnor
+--    -------------------------------------------------------------------
+--  -----------------------------------------------------------------------
+--  Note : The declaration and implementation of the "xnor" function is
+--  specifically commented until at which time the VHDL language has been
+--  officially adopted as containing such a function. At such a point,
+--  the following comments may be removed along with this notice without
+--  further "official" ballotting of this std_logic_1164 package. It is
+--  the intent of this effort to provide such a function once it becomes
+--  available in the VHDL standard.
+--  -----------------------------------------------------------------------
+--START-V93
+    FUNCTION "xnor"  ( l,r : std_logic_vector ) RETURN std_logic_vector IS
+        ALIAS lv : std_logic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_logic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_logic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'xnor' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := not_table(xor_table (lv(i), rv(i)));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "xnor";
+    ---------------------------------------------------------------------
+    FUNCTION "xnor"  ( l,r : std_ulogic_vector ) RETURN std_ulogic_vector IS
+        ALIAS lv : std_ulogic_vector ( 1 TO l'LENGTH ) IS l;
+        ALIAS rv : std_ulogic_vector ( 1 TO r'LENGTH ) IS r;
+        VARIABLE result : std_ulogic_vector ( 1 TO l'LENGTH );
+    BEGIN
+        IF ( l'LENGTH /= r'LENGTH ) THEN
+            ASSERT FALSE
+            REPORT "arguments of overloaded 'xnor' operator are not of the same length"
+            SEVERITY FAILURE;
+        ELSE
+            FOR i IN result'RANGE LOOP
+                result(i) := not_table(xor_table (lv(i), rv(i)));
+            END LOOP;
+        END IF;
+        RETURN result;
+    END "xnor";
+--END-V93
+    -------------------------------------------------------------------
+    -- not
+    -------------------------------------------------------------------
+    FUNCTION "not"  ( l : std_logic_vector ) RETURN std_logic_vector IS
+        ALIAS lv : std_logic_vector ( 1 TO l'LENGTH ) IS l;
+        VARIABLE result : std_logic_vector ( 1 TO l'LENGTH ) := (OTHERS => 'X');
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := not_table( lv(i) );
+        END LOOP;
+        RETURN result;
+    END;
+    ---------------------------------------------------------------------
+    FUNCTION "not"  ( l : std_ulogic_vector ) RETURN std_ulogic_vector IS
+        ALIAS lv : std_ulogic_vector ( 1 TO l'LENGTH ) IS l;
+        VARIABLE result : std_ulogic_vector ( 1 TO l'LENGTH ) := (OTHERS => 'X');
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := not_table( lv(i) );
+        END LOOP;
+        RETURN result;
+    END;
+    -------------------------------------------------------------------
+    -- conversion tables
+    -------------------------------------------------------------------
+    TYPE logic_x01_table IS ARRAY (std_ulogic'LOW TO std_ulogic'HIGH) OF X01;
+    TYPE logic_x01z_table IS ARRAY (std_ulogic'LOW TO std_ulogic'HIGH) OF X01Z;
+    TYPE logic_ux01_table IS ARRAY (std_ulogic'LOW TO std_ulogic'HIGH) OF UX01;
+    ----------------------------------------------------------
+    -- table name : cvt_to_x01
+    --
+    -- parameters :
+    --        in  :  std_ulogic  -- some logic value
+    -- returns    :  x01         -- state value of logic value
+    -- purpose    :  to convert state-strength to state only
+    --
+    -- example    : if (cvt_to_x01 (input_signal) = '1' ) then ...
+    --
+    ----------------------------------------------------------
+    CONSTANT cvt_to_x01 : logic_x01_table := (
+                         'X',  -- 'U'
+                         'X',  -- 'X'
+                         '0',  -- '0'
+                         '1',  -- '1'
+                         'X',  -- 'Z'
+                         'X',  -- 'W'
+                         '0',  -- 'L'
+                         '1',  -- 'H'
+                         'X'   -- '-'
+                        );
+
+    ----------------------------------------------------------
+    -- table name : cvt_to_x01z
+    --
+    -- parameters :
+    --        in  :  std_ulogic  -- some logic value
+    -- returns    :  x01z        -- state value of logic value
+    -- purpose    :  to convert state-strength to state only
+    --
+    -- example    : if (cvt_to_x01z (input_signal) = '1' ) then ...
+    --
+    ----------------------------------------------------------
+    CONSTANT cvt_to_x01z : logic_x01z_table := (
+                         'X',  -- 'U'
+                         'X',  -- 'X'
+                         '0',  -- '0'
+                         '1',  -- '1'
+                         'Z',  -- 'Z'
+                         'X',  -- 'W'
+                         '0',  -- 'L'
+                         '1',  -- 'H'
+                         'X'   -- '-'
+                        );
+
+    ----------------------------------------------------------
+    -- table name : cvt_to_ux01
+    --
+    -- parameters :
+    --        in  :  std_ulogic  -- some logic value
+    -- returns    :  ux01        -- state value of logic value
+    -- purpose    :  to convert state-strength to state only
+    --
+    -- example    : if (cvt_to_ux01 (input_signal) = '1' ) then ...
+    --
+    ----------------------------------------------------------
+    CONSTANT cvt_to_ux01 : logic_ux01_table := (
+                         'U',  -- 'U'
+                         'X',  -- 'X'
+                         '0',  -- '0'
+                         '1',  -- '1'
+                         'X',  -- 'Z'
+                         'X',  -- 'W'
+                         '0',  -- 'L'
+                         '1',  -- 'H'
+                         'X'   -- '-'
+                        );
+
+    -------------------------------------------------------------------
+    -- conversion functions
+    -------------------------------------------------------------------
+    FUNCTION To_bit ( s : std_ulogic; xmap : BIT := '0') RETURN BIT IS
+    BEGIN
+            CASE s IS
+                WHEN '0' | 'L' => RETURN ('0');
+                WHEN '1' | 'H' => RETURN ('1');
+                WHEN OTHERS => RETURN xmap;
+            END CASE;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_bitvector ( s : std_logic_vector ; xmap : BIT := '0') RETURN BIT_VECTOR IS
+        ALIAS sv : std_logic_vector ( s'LENGTH-1 DOWNTO 0 ) IS s;
+        VARIABLE result : BIT_VECTOR ( s'LENGTH-1 DOWNTO 0 );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE sv(i) IS
+                WHEN '0' | 'L' => result(i) := '0';
+                WHEN '1' | 'H' => result(i) := '1';
+                WHEN OTHERS => result(i) := xmap;
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_bitvector ( s : std_ulogic_vector; xmap : BIT := '0') RETURN BIT_VECTOR IS
+        ALIAS sv : std_ulogic_vector ( s'LENGTH-1 DOWNTO 0 ) IS s;
+        VARIABLE result : BIT_VECTOR ( s'LENGTH-1 DOWNTO 0 );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE sv(i) IS
+                WHEN '0' | 'L' => result(i) := '0';
+                WHEN '1' | 'H' => result(i) := '1';
+                WHEN OTHERS => result(i) := xmap;
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_StdULogic       ( b : BIT               ) RETURN std_ulogic IS
+    BEGIN
+        CASE b IS
+            WHEN '0' => RETURN '0';
+            WHEN '1' => RETURN '1';
+        END CASE;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_StdLogicVector  ( b : BIT_VECTOR        ) RETURN std_logic_vector IS
+        ALIAS bv : BIT_VECTOR ( b'LENGTH-1 DOWNTO 0 ) IS b;
+        VARIABLE result : std_logic_vector ( b'LENGTH-1 DOWNTO 0 );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_StdLogicVector  ( s : std_ulogic_vector ) RETURN std_logic_vector IS
+        ALIAS sv : std_ulogic_vector ( s'LENGTH-1 DOWNTO 0 ) IS s;
+        VARIABLE result : std_logic_vector ( s'LENGTH-1 DOWNTO 0 );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := sv(i);
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_StdULogicVector ( b : BIT_VECTOR        ) RETURN std_ulogic_vector IS
+        ALIAS bv : BIT_VECTOR ( b'LENGTH-1 DOWNTO 0 ) IS b;
+        VARIABLE result : std_ulogic_vector ( b'LENGTH-1 DOWNTO 0 );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_StdULogicVector ( s : std_logic_vector ) RETURN std_ulogic_vector IS
+        ALIAS sv : std_logic_vector ( s'LENGTH-1 DOWNTO 0 ) IS s;
+        VARIABLE result : std_ulogic_vector ( s'LENGTH-1 DOWNTO 0 );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := sv(i);
+        END LOOP;
+        RETURN result;
+    END;
+
+    -------------------------------------------------------------------
+    -- strength strippers and type convertors
+    -------------------------------------------------------------------
+    -- to_x01
+    -------------------------------------------------------------------
+    FUNCTION To_X01  ( s : std_logic_vector ) RETURN  std_logic_vector IS
+        ALIAS sv : std_logic_vector ( 1 TO s'LENGTH ) IS s;
+        VARIABLE result : std_logic_vector ( 1 TO s'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := cvt_to_x01 (sv(i));
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01  ( s : std_ulogic_vector ) RETURN  std_ulogic_vector IS
+        ALIAS sv : std_ulogic_vector ( 1 TO s'LENGTH ) IS s;
+        VARIABLE result : std_ulogic_vector ( 1 TO s'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := cvt_to_x01 (sv(i));
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01  ( s : std_ulogic ) RETURN  X01 IS
+    BEGIN
+        RETURN (cvt_to_x01(s));
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01  ( b : BIT_VECTOR ) RETURN  std_logic_vector IS
+        ALIAS bv : BIT_VECTOR ( 1 TO b'LENGTH ) IS b;
+        VARIABLE result : std_logic_vector ( 1 TO b'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01  ( b : BIT_VECTOR ) RETURN  std_ulogic_vector IS
+        ALIAS bv : BIT_VECTOR ( 1 TO b'LENGTH ) IS b;
+        VARIABLE result : std_ulogic_vector ( 1 TO b'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01  ( b : BIT ) RETURN  X01 IS
+    BEGIN
+            CASE b IS
+                WHEN '0' => RETURN('0');
+                WHEN '1' => RETURN('1');
+            END CASE;
+    END;
+    --------------------------------------------------------------------
+    -- to_x01z
+    -------------------------------------------------------------------
+    FUNCTION To_X01Z  ( s : std_logic_vector ) RETURN  std_logic_vector IS
+        ALIAS sv : std_logic_vector ( 1 TO s'LENGTH ) IS s;
+        VARIABLE result : std_logic_vector ( 1 TO s'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := cvt_to_x01z (sv(i));
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01Z  ( s : std_ulogic_vector ) RETURN  std_ulogic_vector IS
+        ALIAS sv : std_ulogic_vector ( 1 TO s'LENGTH ) IS s;
+        VARIABLE result : std_ulogic_vector ( 1 TO s'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := cvt_to_x01z (sv(i));
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01Z  ( s : std_ulogic ) RETURN  X01Z IS
+    BEGIN
+        RETURN (cvt_to_x01z(s));
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01Z  ( b : BIT_VECTOR ) RETURN  std_logic_vector IS
+        ALIAS bv : BIT_VECTOR ( 1 TO b'LENGTH ) IS b;
+        VARIABLE result : std_logic_vector ( 1 TO b'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01Z  ( b : BIT_VECTOR ) RETURN  std_ulogic_vector IS
+        ALIAS bv : BIT_VECTOR ( 1 TO b'LENGTH ) IS b;
+        VARIABLE result : std_ulogic_vector ( 1 TO b'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_X01Z  ( b : BIT ) RETURN  X01Z IS
+    BEGIN
+            CASE b IS
+                WHEN '0' => RETURN('0');
+                WHEN '1' => RETURN('1');
+            END CASE;
+    END;
+    --------------------------------------------------------------------
+    -- to_ux01
+    -------------------------------------------------------------------
+    FUNCTION To_UX01  ( s : std_logic_vector ) RETURN  std_logic_vector IS
+        ALIAS sv : std_logic_vector ( 1 TO s'LENGTH ) IS s;
+        VARIABLE result : std_logic_vector ( 1 TO s'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := cvt_to_ux01 (sv(i));
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_UX01  ( s : std_ulogic_vector ) RETURN  std_ulogic_vector IS
+        ALIAS sv : std_ulogic_vector ( 1 TO s'LENGTH ) IS s;
+        VARIABLE result : std_ulogic_vector ( 1 TO s'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            result(i) := cvt_to_ux01 (sv(i));
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_UX01  ( s : std_ulogic ) RETURN  UX01 IS
+    BEGIN
+        RETURN (cvt_to_ux01(s));
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_UX01  ( b : BIT_VECTOR ) RETURN  std_logic_vector IS
+        ALIAS bv : BIT_VECTOR ( 1 TO b'LENGTH ) IS b;
+        VARIABLE result : std_logic_vector ( 1 TO b'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_UX01  ( b : BIT_VECTOR ) RETURN  std_ulogic_vector IS
+        ALIAS bv : BIT_VECTOR ( 1 TO b'LENGTH ) IS b;
+        VARIABLE result : std_ulogic_vector ( 1 TO b'LENGTH );
+    BEGIN
+        FOR i IN result'RANGE LOOP
+            CASE bv(i) IS
+                WHEN '0' => result(i) := '0';
+                WHEN '1' => result(i) := '1';
+            END CASE;
+        END LOOP;
+        RETURN result;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION To_UX01  ( b : BIT ) RETURN  UX01 IS
+    BEGIN
+            CASE b IS
+                WHEN '0' => RETURN('0');
+                WHEN '1' => RETURN('1');
+            END CASE;
+    END;
+
+    -------------------------------------------------------------------
+    -- edge detection
+    -------------------------------------------------------------------
+    FUNCTION rising_edge  (SIGNAL s : std_ulogic) RETURN BOOLEAN IS
+    BEGIN
+        RETURN (s'EVENT AND (To_X01(s) = '1') AND
+                            (To_X01(s'LAST_VALUE) = '0'));
+    END;
+
+    FUNCTION falling_edge (SIGNAL s : std_ulogic) RETURN BOOLEAN IS
+    BEGIN
+        RETURN (s'EVENT AND (To_X01(s) = '0') AND
+                            (To_X01(s'LAST_VALUE) = '1'));
+    END;
+
+    -------------------------------------------------------------------
+    -- object contains an unknown
+    -------------------------------------------------------------------
+    FUNCTION Is_X ( s : std_ulogic_vector ) RETURN  BOOLEAN IS
+    BEGIN
+        FOR i IN s'RANGE LOOP
+            CASE s(i) IS
+                WHEN 'U' | 'X' | 'Z' | 'W' | '-' => RETURN TRUE;
+                WHEN OTHERS => NULL;
+            END CASE;
+        END LOOP;
+        RETURN FALSE;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION Is_X ( s : std_logic_vector  ) RETURN  BOOLEAN IS
+    BEGIN
+        FOR i IN s'RANGE LOOP
+            CASE s(i) IS
+                WHEN 'U' | 'X' | 'Z' | 'W' | '-' => RETURN TRUE;
+                WHEN OTHERS => NULL;
+            END CASE;
+        END LOOP;
+        RETURN FALSE;
+    END;
+    --------------------------------------------------------------------
+    FUNCTION Is_X ( s : std_ulogic        ) RETURN  BOOLEAN IS
+    BEGIN
+        CASE s IS
+            WHEN 'U' | 'X' | 'Z' | 'W' | '-' => RETURN TRUE;
+            WHEN OTHERS => NULL;
+        END CASE;
+        RETURN FALSE;
+    END;
+
+END std_logic_1164;

--- a/vhdl/examples/std_logic_textio.vhd
+++ b/vhdl/examples/std_logic_textio.vhd
@@ -1,0 +1,626 @@
+----------------------------------------------------------------------------
+--
+-- Copyright (c) 1990, 1991, 1992 by Synopsys, Inc.  All rights reserved.
+-- 
+-- This source file may be used and distributed without restriction 
+-- provided that this copyright statement is not removed from the file 
+-- and that any derivative work contains this copyright notice.
+--
+--	Package name: STD_LOGIC_TEXTIO
+--
+--	Purpose: This package overloads the standard TEXTIO procedures
+--		 READ and WRITE.
+--
+--	Author: CRC, TS
+--
+----------------------------------------------------------------------------
+
+use STD.textio.all;
+library IEEE;
+use IEEE.std_logic_1164.all;
+
+package STD_LOGIC_TEXTIO is
+	-- Read and Write procedures for STD_ULOGIC and STD_ULOGIC_VECTOR
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC);
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC; GOOD: out BOOLEAN);
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR);
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR; GOOD: out BOOLEAN);
+	procedure WRITE(L:inout LINE; VALUE:in STD_ULOGIC;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0);
+	procedure WRITE(L:inout LINE; VALUE:in STD_ULOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0);
+
+	-- Read and Write procedures for STD_LOGIC_VECTOR
+	procedure READ(L:inout LINE; VALUE:out STD_LOGIC_VECTOR);
+	procedure READ(L:inout LINE; VALUE:out STD_LOGIC_VECTOR; GOOD: out BOOLEAN);
+	procedure WRITE(L:inout LINE; VALUE:in STD_LOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0);
+
+	--
+	-- Read and Write procedures for Hex and Octal values.
+	-- The values appear in the file as a series of characters
+	-- between 0-F (Hex), or 0-7 (Octal) respectively.
+	--
+
+	-- Hex
+	procedure HREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR);
+	procedure HREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR; GOOD: out BOOLEAN);
+	procedure HWRITE(L:inout LINE; VALUE:in STD_ULOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0);
+	procedure HREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR);
+	procedure HREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR; GOOD: out BOOLEAN);
+	procedure HWRITE(L:inout LINE; VALUE:in STD_LOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0);
+
+	-- Octal
+	procedure OREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR);
+	procedure OREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR; GOOD: out BOOLEAN);
+	procedure OWRITE(L:inout LINE; VALUE:in STD_ULOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0);
+	procedure OREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR);
+	procedure OREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR; GOOD: out BOOLEAN);
+	procedure OWRITE(L:inout LINE; VALUE:in STD_LOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0);
+
+	
+end STD_LOGIC_TEXTIO;
+
+package body STD_LOGIC_TEXTIO is
+
+	-- Type and constant definitions used to map STD_ULOGIC values 
+	-- into/from character values.
+
+	type MVL9plus is ('U', 'X', '0', '1', 'Z', 'W', 'L', 'H', '-', ERROR);
+	type char_indexed_by_MVL9 is array (STD_ULOGIC) of character;
+	type MVL9_indexed_by_char is array (character) of STD_ULOGIC;
+	type MVL9plus_indexed_by_char is array (character) of MVL9plus;
+
+	constant MVL9_to_char: char_indexed_by_MVL9 := "UX01ZWLH-";
+	constant char_to_MVL9: MVL9_indexed_by_char := 
+		('U' => 'U', 'X' => 'X', '0' => '0', '1' => '1', 'Z' => 'Z',
+		 'W' => 'W', 'L' => 'L', 'H' => 'H', '-' => '-', others => 'U');
+	constant char_to_MVL9plus: MVL9plus_indexed_by_char := 
+		('U' => 'U', 'X' => 'X', '0' => '0', '1' => '1', 'Z' => 'Z',
+		 'W' => 'W', 'L' => 'L', 'H' => 'H', '-' => '-', others => ERROR);
+
+
+	-- Overloaded procedures.
+
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC; GOOD:out BOOLEAN) is
+		variable c: character;
+	begin
+		loop					-- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		if (char_to_MVL9plus(c) = ERROR) then
+			value := 'U';
+			good := FALSE;
+		else
+			value := char_to_MVL9(c);
+			good := TRUE;
+		end if;
+	end READ;
+
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR; GOOD:out BOOLEAN) is
+		variable m: STD_ULOGIC;
+		variable c: character;
+		variable s: string(1 to value'length-1);
+		variable mv: STD_ULOGIC_VECTOR(0 to value'length-1);
+	begin
+		loop					-- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		if (char_to_MVL9plus(c) = ERROR) then
+			value(value'range) := (others => 'U');
+			good := FALSE;
+			return;
+		end if;
+
+		read(l, s);
+	    	for i in 1 to value'length-1 loop
+			if (char_to_MVL9plus(s(i)) = ERROR) then
+				value(value'range) := (others => 'U');
+				good := FALSE;
+			    	return;
+			end if;
+		end loop;
+
+		mv(0) := char_to_MVL9(c);
+	    	for i in 1 to value'length-1 loop
+			mv(i) := char_to_MVL9(s(i));
+	    	end loop;
+		value := mv;
+		good := TRUE;
+	end READ;
+	
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC) is
+		variable c: character;
+	begin
+		loop					-- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		if (char_to_MVL9plus(c) = ERROR) then
+			value := 'U';
+			assert FALSE report "READ(STD_ULOGIC) Error: Character '" &
+					c & "' read, expected STD_ULOGIC literal.";
+		else
+			value := char_to_MVL9(c);
+		end if;
+	end READ;
+
+	procedure READ(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR) is
+		variable m: STD_ULOGIC;
+		variable c: character;
+		variable s: string(1 to value'length-1);
+		variable mv: STD_ULOGIC_VECTOR(0 to value'length-1);
+	begin
+		loop					 -- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		if (char_to_MVL9plus(c) = ERROR) then
+			value(value'range) := (others => 'U');
+			assert FALSE report
+				"READ(STD_ULOGIC_VECTOR) Error: Character '" & 
+					c & "' read, expected STD_ULOGIC literal.";
+			return;
+		end if;
+
+		read(l, s);
+	    	for i in 1 to value'length-1 loop
+			if (char_to_MVL9plus(s(i)) = ERROR) then
+			    value(value'range) := (others => 'U');
+			    assert FALSE report 
+				"READ(STD_ULOGIC_VECTOR) Error: Character '" &
+					s(i) & "' read, expected STD_ULOGIC literal.";
+			    return;
+			end if;
+		end loop;
+
+		mv(0) := char_to_MVL9(c);
+	    	for i in 1 to value'length-1 loop
+			mv(i) := char_to_MVL9(s(i));
+	    	end loop;
+		value := mv;
+	end READ;
+
+	procedure WRITE(L:inout LINE; VALUE:in STD_ULOGIC;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+	begin
+		write(l, MVL9_to_char(value), justified, field);
+	end WRITE;
+	
+
+	procedure WRITE(L:inout LINE; VALUE:in STD_ULOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+		variable s: string(1 to value'length);
+		variable m: STD_ULOGIC_VECTOR(1 to value'length) := value;
+	begin
+	    	for i in 1 to value'length loop
+			s(i) := MVL9_to_char(m(i));
+		end loop;
+		write(l, s, justified, field);
+	end WRITE;
+
+	-- Read and Write procedures for STD_LOGIC_VECTOR
+	procedure READ(L:inout LINE; VALUE:out STD_LOGIC_VECTOR) is
+		variable tmp: STD_ULOGIC_VECTOR(VALUE'length-1 downto 0);
+	begin
+		READ(L, tmp);
+		VALUE := STD_LOGIC_VECTOR(tmp);
+	end READ;
+
+	procedure READ(L:inout LINE; VALUE:out STD_LOGIC_VECTOR; GOOD: out BOOLEAN) is
+		variable tmp: STD_ULOGIC_VECTOR(VALUE'length-1 downto 0);
+	begin
+		READ(L, tmp, GOOD);
+		VALUE := STD_LOGIC_VECTOR(tmp);
+	end READ;
+
+	procedure WRITE(L:inout LINE; VALUE:in STD_LOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+	begin
+		WRITE(L, STD_ULOGIC_VECTOR(VALUE), JUSTIFIED, FIELD);
+	end WRITE;
+
+
+	--
+	-- Hex Read and Write procedures.
+	--
+
+	--
+	-- Hex, and Octal Read and Write procedures for BIT_VECTOR
+	--  (these procedures are not exported, they are only used
+	--   by the STD_ULOGIC hex/octal reads and writes below.
+	--
+	--
+
+	procedure Char2QuadBits(C: Character; 
+				RESULT: out Bit_Vector(3 downto 0);
+				GOOD: out Boolean;
+				ISSUE_ERROR: in Boolean) is
+	begin
+		case c is
+			when '0' => result :=  x"0"; good := TRUE;
+			when '1' => result :=  x"1"; good := TRUE;
+			when '2' => result :=  x"2"; good := TRUE;
+			when '3' => result :=  x"3"; good := TRUE;
+			when '4' => result :=  x"4"; good := TRUE;
+			when '5' => result :=  x"5"; good := TRUE;
+			when '6' => result :=  x"6"; good := TRUE;
+			when '7' => result :=  x"7"; good := TRUE;
+			when '8' => result :=  x"8"; good := TRUE;
+			when '9' => result :=  x"9"; good := TRUE;
+			when 'A' => result :=  x"A"; good := TRUE;
+			when 'B' => result :=  x"B"; good := TRUE;
+			when 'C' => result :=  x"C"; good := TRUE;
+			when 'D' => result :=  x"D"; good := TRUE;
+			when 'E' => result :=  x"E"; good := TRUE;
+			when 'F' => result :=  x"F"; good := TRUE;
+ 
+			when 'a' => result :=  x"A"; good := TRUE;
+			when 'b' => result :=  x"B"; good := TRUE;
+			when 'c' => result :=  x"C"; good := TRUE;
+			when 'd' => result :=  x"D"; good := TRUE;
+			when 'e' => result :=  x"E"; good := TRUE;
+			when 'f' => result :=  x"F"; good := TRUE;
+			when others =>
+			   if ISSUE_ERROR then 
+				   assert FALSE report
+					"HREAD Error: Read a '" & c &
+					   "', expected a Hex character (0-F).";
+			   end if;
+			   good := FALSE;
+		end case;
+	end;
+
+	procedure HREAD(L:inout LINE; VALUE:out BIT_VECTOR)  is
+		variable ok: boolean;
+		variable c:  character;
+		constant ne: integer := value'length/4;
+		variable bv: bit_vector(0 to value'length-1);
+		variable s:  string(1 to ne-1);
+	begin
+		if value'length mod 4 /= 0 then
+			assert FALSE report 
+				"HREAD Error: Trying to read vector " &
+				   "with an odd (non multiple of 4) length";
+			return;
+		end if;
+
+		loop					-- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		Char2QuadBits(c, bv(0 to 3), ok, TRUE);
+		if not ok then 
+			return;
+		end if;
+
+		read(L, s, ok);
+		if not ok then
+			assert FALSE 
+				report "HREAD Error: Failed to read the STRING";
+			return;
+		end if;
+
+		for i in 1 to ne-1 loop
+			Char2QuadBits(s(i), bv(4*i to 4*i+3), ok, TRUE);
+			if not ok then
+				return;
+			end if;
+		end loop;
+		value := bv;
+	end HREAD; 
+
+	procedure HREAD(L:inout LINE; VALUE:out BIT_VECTOR;GOOD: out BOOLEAN) is
+		variable ok: boolean;
+		variable c:  character;
+		constant ne: integer := value'length/4;
+		variable bv: bit_vector(0 to value'length-1);
+		variable s:  string(1 to ne-1);
+	begin
+		if value'length mod 4 /= 0 then
+			good := FALSE;
+			return;
+		end if;
+
+		loop					-- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		Char2QuadBits(c, bv(0 to 3), ok, FALSE);
+		if not ok then 
+			good := FALSE;
+			return;
+		end if;
+
+		read(L, s, ok);
+		if not ok then
+			good := FALSE;
+			return;
+		end if;
+
+		for i in 1 to ne-1 loop
+			Char2QuadBits(s(i), bv(4*i to 4*i+3), ok, FALSE);
+			if not ok then
+				good := FALSE;
+				return;
+			end if;
+		end loop;
+		good := TRUE;
+		value := bv;
+	end HREAD; 
+
+
+	procedure HWRITE(L:inout LINE; VALUE:in BIT_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+		variable quad: bit_vector(0 to 3);
+		constant ne:   integer := value'length/4;
+		variable bv:   bit_vector(0 to value'length-1) := value;
+		variable s:    string(1 to ne);
+	begin
+		if value'length mod 4 /= 0 then
+			assert FALSE report 
+				"HREAD Error: Trying to read vector " &
+				   "with an odd (non multiple of 4) length";
+			return;
+		end if;
+
+		for i in 0 to ne-1 loop
+			quad := bv(4*i to 4*i+3);
+			case quad is
+				when x"0" => s(i+1) := '0';
+				when x"1" => s(i+1) := '1';
+				when x"2" => s(i+1) := '2';
+				when x"3" => s(i+1) := '3';
+				when x"4" => s(i+1) := '4';
+				when x"5" => s(i+1) := '5';
+				when x"6" => s(i+1) := '6';
+				when x"7" => s(i+1) := '7';
+				when x"8" => s(i+1) := '8';
+				when x"9" => s(i+1) := '9';
+				when x"A" => s(i+1) := 'A';
+				when x"B" => s(i+1) := 'B';
+				when x"C" => s(i+1) := 'C';
+				when x"D" => s(i+1) := 'D';
+				when x"E" => s(i+1) := 'E';
+				when x"F" => s(i+1) := 'F';
+			end case;
+		end loop;
+		write(L, s, JUSTIFIED, FIELD);
+	end HWRITE; 
+
+	procedure Char2TriBits(C: Character; 
+				RESULT: out bit_vector(2 downto 0);
+				GOOD: out Boolean;
+				ISSUE_ERROR: in Boolean) is
+	begin
+		case c is
+			when '0' => result :=  o"0"; good := TRUE;
+			when '1' => result :=  o"1"; good := TRUE;
+			when '2' => result :=  o"2"; good := TRUE;
+			when '3' => result :=  o"3"; good := TRUE;
+			when '4' => result :=  o"4"; good := TRUE;
+			when '5' => result :=  o"5"; good := TRUE;
+			when '6' => result :=  o"6"; good := TRUE;
+			when '7' => result :=  o"7"; good := TRUE;
+			when others =>
+			   if ISSUE_ERROR then 
+				   assert FALSE report
+					"OREAD Error: Read a '" & c &
+					"', expected an Octal character (0-7).";
+			   end if;
+			   good := FALSE;
+		end case;
+	end;
+
+	procedure OREAD(L:inout LINE; VALUE:out BIT_VECTOR)  is
+		variable c: character;
+		variable ok: boolean;
+		constant ne: integer := value'length/3;
+		variable bv: bit_vector(0 to value'length-1);
+		variable s: string(1 to ne-1);
+	begin
+		if value'length mod 3 /= 0 then
+			assert FALSE report 
+				"OREAD Error: Trying to read vector " &
+				   "with an odd (non multiple of 3) length";
+			return;
+		end if;
+
+		loop					-- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		Char2TriBits(c, bv(0 to 2), ok, TRUE);
+		if not ok then 
+			return;
+		end if;
+
+		read(L, s, ok);
+		if not ok then
+			assert FALSE 
+				report "OREAD Error: Failed to read the STRING";
+			return;
+		end if;
+
+		for i in 1 to ne-1 loop
+			Char2TriBits(s(i), bv(3*i to 3*i+2), ok, TRUE);
+			if not ok then
+				return;
+			end if;
+		end loop;
+		value := bv;
+	end OREAD; 
+
+	procedure OREAD(L:inout LINE; VALUE:out BIT_VECTOR;GOOD: out BOOLEAN) is
+		variable ok: boolean;
+		variable c:  character;
+		constant ne: integer := value'length/3;
+		variable bv: bit_vector(0 to value'length-1);
+		variable s:  string(1 to ne-1);
+	begin
+		if value'length mod 3 /= 0 then
+			good := FALSE;
+			return;
+		end if;
+
+		loop					-- skip white space
+			read(l,c);
+			exit when ((c /= ' ') and (c /= CR) and (c /= HT));
+		end loop;
+
+		Char2TriBits(c, bv(0 to 2), ok, FALSE);
+		if not ok then 
+			good := FALSE;
+			return;
+		end if;
+
+		read(L, s, ok);
+		if not ok then
+			good := FALSE;
+			return;
+		end if;
+
+		for i in 1 to ne-1 loop
+			Char2TriBits(s(i), bv(3*i to 3*i+2), ok, FALSE);
+			if not ok then
+				good := FALSE;
+				return;
+			end if;
+		end loop;
+		good := TRUE;
+		value := bv;
+	end OREAD; 
+
+
+	procedure OWRITE(L:inout LINE; VALUE:in BIT_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+		variable tri: bit_vector(0 to 2);
+		constant ne:  integer := value'length/3;
+		variable bv:  bit_vector(0 to value'length-1) := value;
+		variable s:   string(1 to ne);
+	begin
+		if value'length mod 3 /= 0 then
+			assert FALSE report 
+				"OREAD Error: Trying to read vector " &
+				   "with an odd (non multiple of 3) length";
+			return;
+		end if;
+
+		for i in 0 to ne-1 loop
+			tri := bv(3*i to 3*i+2);
+			case tri is
+				when o"0" => s(i+1) := '0';
+				when o"1" => s(i+1) := '1';
+				when o"2" => s(i+1) := '2';
+				when o"3" => s(i+1) := '3';
+				when o"4" => s(i+1) := '4';
+				when o"5" => s(i+1) := '5';
+				when o"6" => s(i+1) := '6';
+				when o"7" => s(i+1) := '7';
+			end case;
+		end loop;
+		write(L, s, JUSTIFIED, FIELD);
+	end OWRITE; 
+
+	-- Hex Read and Write procedures for STD_LOGIC_VECTOR
+	procedure HREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR;GOOD:out BOOLEAN) is
+		variable tmp: bit_vector(VALUE'length-1 downto 0);
+	begin
+		HREAD(L, tmp, GOOD);
+		VALUE := To_X01(tmp);
+	end HREAD;
+	
+	procedure HREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR) is
+		variable tmp: bit_vector(VALUE'length-1 downto 0);
+	begin
+		HREAD(L, tmp);
+		VALUE := To_X01(tmp);
+	end HREAD;
+
+	procedure HWRITE(L:inout LINE; VALUE:in STD_ULOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+	begin
+		HWRITE(L, To_bitvector(VALUE),JUSTIFIED, FIELD);
+	end HWRITE;
+
+	-- Hex Read and Write procedures for STD_LOGIC_VECTOR
+
+	procedure HREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR) is
+		variable tmp: STD_ULOGIC_VECTOR(VALUE'length-1 downto 0);
+	begin
+		HREAD(L, tmp);
+		VALUE := STD_LOGIC_VECTOR(tmp);
+	end HREAD;
+
+	procedure HREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR; GOOD: out BOOLEAN) is
+		variable tmp: STD_ULOGIC_VECTOR(VALUE'length-1 downto 0);
+	begin
+		HREAD(L, tmp, GOOD);
+		VALUE := STD_LOGIC_VECTOR(tmp);
+	end HREAD;
+
+	procedure HWRITE(L:inout LINE; VALUE:in STD_LOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+	begin
+		HWRITE(L, To_bitvector(VALUE), JUSTIFIED, FIELD);
+	end HWRITE;
+
+
+	-- Octal Read and Write procedures for STD_ULOGIC_VECTOR
+	procedure OREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR;GOOD:out BOOLEAN) is
+		variable tmp: bit_vector(VALUE'length-1 downto 0);
+	begin
+		OREAD(L, tmp, GOOD);
+		VALUE := To_X01(tmp);
+	end OREAD;
+	
+	procedure OREAD(L:inout LINE; VALUE:out STD_ULOGIC_VECTOR) is
+		variable tmp: bit_vector(VALUE'length-1 downto 0);
+	begin
+		OREAD(L, tmp);
+		VALUE := To_X01(tmp);
+	end OREAD;
+
+	procedure OWRITE(L:inout LINE; VALUE:in STD_ULOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+	begin
+		OWRITE(L, To_bitvector(VALUE),JUSTIFIED, FIELD);
+	end OWRITE;
+
+	-- Octal Read and Write procedures for STD_LOGIC_VECTOR
+
+	procedure OREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR) is
+		variable tmp: STD_ULOGIC_VECTOR(VALUE'length-1 downto 0);
+	begin
+		OREAD(L, tmp);
+		VALUE := STD_LOGIC_VECTOR(tmp);
+	end OREAD;
+
+	procedure OREAD(L:inout LINE; VALUE:out STD_LOGIC_VECTOR; GOOD: out BOOLEAN) is
+		variable tmp: STD_ULOGIC_VECTOR(VALUE'length-1 downto 0);
+	begin
+		OREAD(L, tmp, GOOD);
+		VALUE := STD_LOGIC_VECTOR(tmp);
+	end OREAD;
+
+	procedure OWRITE(L:inout LINE; VALUE:in STD_LOGIC_VECTOR;
+			JUSTIFIED:in SIDE := RIGHT; FIELD:in WIDTH := 0) is
+	begin
+		OWRITE(L, STD_ULOGIC_VECTOR(VALUE), JUSTIFIED, FIELD);
+	end OWRITE;
+
+
+end STD_LOGIC_TEXTIO;

--- a/vhdl/examples/textio.vhd
+++ b/vhdl/examples/textio.vhd
@@ -1,0 +1,97 @@
+---------------------------------------------------------------------------
+-- Package TEXTIO as defined in Chapter 14 of the IEEE Standard VHDL
+--   Language Reference Manual (IEEE Std. 1076-1987), as modified
+--   by the Issues Screening and Analysis Committee (ISAC), a subcommittee
+--   of the VHDL Analysis and Standardization Group (VASG) on 
+--   10 November, 1988.  See "The Sense of the VASG", October, 1989.
+---------------------------------------------------------------------------
+-- Version information: %W% %G%
+---------------------------------------------------------------------------
+
+package TEXTIO is
+    type LINE is access string;
+    type TEXT is file of string;
+    type SIDE is (right, left);
+    subtype WIDTH is natural;
+
+	-- changed for vhdl92 syntax:
+    file input : TEXT open read_mode is "STD_INPUT";
+    file output : TEXT open write_mode is "STD_OUTPUT";
+
+	-- changed for vhdl92 syntax (and now a built-in):
+    procedure READLINE(file f: TEXT; L: out LINE);
+
+    procedure READ(L:inout LINE; VALUE: out bit; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out bit);
+
+    procedure READ(L:inout LINE; VALUE: out bit_vector; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out bit_vector);
+
+    procedure READ(L:inout LINE; VALUE: out BOOLEAN; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out BOOLEAN);
+
+    procedure READ(L:inout LINE; VALUE: out character; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out character);
+
+    procedure READ(L:inout LINE; VALUE: out integer; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out integer);
+
+    procedure READ(L:inout LINE; VALUE: out real; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out real);
+
+    procedure READ(L:inout LINE; VALUE: out string; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out string);
+
+    procedure READ(L:inout LINE; VALUE: out time; GOOD : out BOOLEAN);
+    procedure READ(L:inout LINE; VALUE: out time);
+
+	-- changed for vhdl92 syntax (and now a built-in):
+    procedure WRITELINE(file f : TEXT; L : inout LINE);
+
+    procedure WRITE(L : inout LINE; VALUE : in bit;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0);
+
+    procedure WRITE(L : inout LINE; VALUE : in bit_vector;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0);
+
+    procedure WRITE(L : inout LINE; VALUE : in BOOLEAN;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0);
+
+    procedure WRITE(L : inout LINE; VALUE : in character;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0);
+
+    procedure WRITE(L : inout LINE; VALUE : in integer;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0);
+
+    procedure WRITE(L : inout LINE; VALUE : in real;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0;
+	      DIGITS: in NATURAL := 0);
+
+    procedure WRITE(L : inout LINE; VALUE : in string;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0);
+
+    procedure WRITE(L : inout LINE; VALUE : in time;
+	      JUSTIFIED: in SIDE := right;
+	      FIELD: in WIDTH := 0;
+	      UNIT: in TIME := ns);
+
+	-- is implicit built-in:
+	-- function ENDFILE(file F : TEXT) return boolean;
+
+    -- function ENDLINE(variable L : in LINE) return BOOLEAN;
+    --
+    -- Function ENDLINE as declared cannot be legal VHDL, and
+    --   the entire function was deleted from the definition
+    --   by the Issues Screening and Analysis Committee (ISAC),
+    --   a subcommittee of the VHDL Analysis and Standardization
+    --   Group (VASG) on 10 November, 1988.  See "The Sense of
+    --   the VASG", October, 1989, VHDL Issue Number 0032.
+end;
+

--- a/vhdl/examples/unsigned.vhd
+++ b/vhdl/examples/unsigned.vhd
@@ -1,0 +1,323 @@
+--------------------------------------------------------------------------
+--                                                                      --
+-- Copyright (c) 1990, 1991, 1992 by Synopsys, Inc.                     --
+--                                             All rights reserved.     --
+--                                                                      --
+-- This source file may be used and distributed without restriction     --
+-- provided that this copyright statement is not removed from the file  --
+-- and that any derivative work contains this copyright notice.         --
+--                                                                      --
+--	Package name: STD_LOGIC_UNSIGNED                                --
+--                                 					--
+--									--
+--      Date:        	09/11/92	KN				--
+--			10/08/92 	AMT				--
+--									--
+--	Purpose: 							--
+--	 A set of unsigned arithemtic, conversion,                      --
+--           and comparision functions for STD_LOGIC_VECTOR.            --
+--									--
+--	Note:  comparision of same length discrete arrays is defined	--
+--		by the LRM.  This package will "overload" those 	--
+--		definitions						--
+--									--
+--------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.std_logic_arith.all;
+
+package STD_LOGIC_UNSIGNED is
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "+"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR;
+
+    function "-"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR;
+
+    function "-"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "+"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "*"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function "<"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "<"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "<"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "<="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function ">"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function ">="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN;
+
+    function "/="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN;
+
+    function CONV_INTEGER(ARG: STD_LOGIC_VECTOR) return INTEGER;
+
+    function SHL(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+    function SHR(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR;
+
+end STD_LOGIC_UNSIGNED;
+
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.std_logic_arith.all;
+
+package body STD_LOGIC_UNSIGNED is
+
+
+    function maximum(L, R: INTEGER) return INTEGER is
+    begin
+        if L > R then
+            return L;
+        else
+            return R;
+        end if;
+    end;
+
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        constant length: INTEGER := maximum(L'length, R'length);
+        variable result  : STD_LOGIC_VECTOR (length-1 downto 0);
+    begin
+        result  := UNSIGNED(L) + UNSIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := UNSIGNED(L) + R;
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L + UNSIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := UNSIGNED(L) + R;
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L + UNSIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        constant length: INTEGER := maximum(L'length, R'length);
+        variable result  : STD_LOGIC_VECTOR (length-1 downto 0);
+    begin
+        result  := UNSIGNED(L) - UNSIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: INTEGER) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := UNSIGNED(L) - R;
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: INTEGER; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L - UNSIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC_VECTOR; R: STD_LOGIC) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := UNSIGNED(L) - R;
+        return   std_logic_vector(result);
+    end;
+
+    function "-"(L: STD_LOGIC; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (R'range);
+    begin
+        result  := L - UNSIGNED(R);
+        return   std_logic_vector(result);
+    end;
+
+    function "+"(L: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        variable result  : STD_LOGIC_VECTOR (L'range);
+    begin
+        result  := + UNSIGNED(L);
+        return   std_logic_vector(result);
+    end;
+
+    function "*"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+        constant length: INTEGER := maximum(L'length, R'length);
+        variable result  : STD_LOGIC_VECTOR ((L'length+R'length-1) downto 0);
+    begin
+        result  := UNSIGNED(L) * UNSIGNED(R);
+        return   std_logic_vector(result);
+    end;
+        
+    function "<"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+        constant length: INTEGER := maximum(L'length, R'length);
+    begin
+        return   UNSIGNED(L) < UNSIGNED(R);
+    end;
+
+    function "<"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) < R;
+    end;
+
+    function "<"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L < UNSIGNED(R);
+    end;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) <= UNSIGNED(R);
+    end;
+
+    function "<="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) <= R;
+    end;
+
+    function "<="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L <= UNSIGNED(R);
+    end;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) > UNSIGNED(R);
+    end;
+
+    function ">"(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) > R;
+    end;
+
+    function ">"(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L > UNSIGNED(R);
+    end;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) >= UNSIGNED(R);
+    end;
+
+    function ">="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) >= R;
+    end;
+
+    function ">="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L >= UNSIGNED(R);
+    end;
+
+    function "="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) = UNSIGNED(R);
+    end;
+
+    function "="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) = R;
+    end;
+
+    function "="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L = UNSIGNED(R);
+    end;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) /= UNSIGNED(R);
+    end;
+
+    function "/="(L: STD_LOGIC_VECTOR; R: INTEGER) return BOOLEAN is
+    begin
+        return   UNSIGNED(L) /= R;
+    end;
+
+    function "/="(L: INTEGER; R: STD_LOGIC_VECTOR) return BOOLEAN is
+    begin
+        return   L /= UNSIGNED(R);
+    end;
+
+    function CONV_INTEGER(ARG: STD_LOGIC_VECTOR) return INTEGER is
+        variable result    : UNSIGNED(ARG'range);
+    begin
+        result    := UNSIGNED(ARG);
+        return   CONV_INTEGER(result);
+    end;
+
+    function SHL(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+    begin
+       return STD_LOGIC_VECTOR(SHL(UNSIGNED(ARG),UNSIGNED(COUNT)));
+    end;
+ 
+    function SHR(ARG:STD_LOGIC_VECTOR;COUNT: STD_LOGIC_VECTOR) return STD_LOGIC_VECTOR is
+    begin
+       return STD_LOGIC_VECTOR(SHR(UNSIGNED(ARG),UNSIGNED(COUNT)));
+    end;
+
+-- remove this since it is already in std_logic_arith
+    --function CONV_STD_LOGIC_VECTOR(ARG: INTEGER; SIZE: INTEGER) return STD_LOGIC_VECTOR is
+        --variable result1 : UNSIGNED (SIZE-1 downto 0);
+        --variable result2 : STD_LOGIC_VECTOR (SIZE-1 downto 0);
+    --begin
+        --result1 := CONV_UNSIGNED(ARG,SIZE);
+        --return   std_logic_vector(result1);
+    --end;
+
+
+end STD_LOGIC_UNSIGNED;


### PR DESCRIPTION
New version of grammar successfully analyzed standard libraries (STD and
IEEE). Sources of that files added to example folder.

I found a problem that is quite impossible to solve on syntax analyze phase.
In VHDL there are 3 quite similar statements that is hard to determine.
- function call: <selected_function_name>(argument_0, argument_1 ... argument_N)
- slice of array: <selected_array_name>(range_0, range_1 ... range_N)
- array element: <selected_array_name>(index_0, index_1 ... index_N)

To solve this problem I used features of semantic analyzer to determine type of identifier that stands before braces. "function_call" grammar rule was removed.