### PR TITLE
ECMAScript : Fixed missing lookahead

### DIFF
--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -270,7 +270,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : expressionSequence
+ : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence
  ;
 
 /// IfStatement :


### PR DESCRIPTION
Before 
```javascript
function f() {return 100}
```
or similar would be parsed as FunctionExpression while it should be parsed as FunctionDeclaration. This change should fix it.