### PR TITLE
Allow port mappings to include ranges. 

### DIFF
--- a/vhdl/vhdl.g4
+++ b/vhdl/vhdl.g4
@@ -696,6 +696,7 @@ formal_parameter_list
 
 formal_part
   : identifier
+   | identifier LPAREN explicit_range  RPAREN 
   ;
 
 free_quantity_declaration


### PR DESCRIPTION
I had the following vhdl, which I assume is valid because it synthesized. 

```
seven_seg_led_instance : seven_seg_led port map (
  mclk=>mclk,
  an(3 downto 0)=>an(3 downto 0),
  seg(6 downto 0)=>seg(6 downto 0),
  dp=>dp
);
```
The previous parser did not allow 'an(3 downto 0)' on the left side of the '=>'

This patch allowed the code to be parsed. 