### PR TITLE
ECMAScript : Added missing SemiColon to ExpressionStatement rule and updated C# target

### DIFF
--- a/ecmascript/ECMAScript.CSharpTarget.g4
+++ b/ecmascript/ECMAScript.CSharpTarget.g4
@@ -248,7 +248,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : expressionSequence
+ : {(_input.La(1) != OpenBrace) && (_input.La(1) != Function)}? expressionSequence SemiColon
  ;
 
 /// IfStatement :

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -270,7 +270,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence
+ : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence SemiColon
  ;
 
 /// IfStatement :


### PR DESCRIPTION
The following code couldn't be parsed before:
```javascript
if (a) b;
else c;
```
Also updated C# target with latest changes. Couldn't test them but if I'm not mistaken and _input.La === _input.LA it should function exactly the same.