### PR TITLE
Allow E in exponent

### DIFF
--- a/vhdl/vhdl.g4
+++ b/vhdl/vhdl.g4
@@ -1661,7 +1661,7 @@ BACKSLASH     : '\\'  ;
   
 
 EXPONENT
-  :  'e' ( '+' | '-' )? INTEGER
+  :  ('E'|'e') ( '+' | '-' )? INTEGER
   ;
 
 


### PR DESCRIPTION
Extend the exponent definition to include either an uppercase E or a lowercase e