### PR TITLE
Exponent of a base literal was invalid

### DIFF
--- a/vhdl/vhdl.g4
+++ b/vhdl/vhdl.g4
@@ -1532,21 +1532,21 @@ waveform_element
 
 //------------------------------------------Lexer-----------------------------------------
 BASE_LITERAL
-   :  BINANRY_BASED_INTEGER
+   :  BINARY_BASED_INTEGER
    |  OCTAL_BASED_INTEGER
    |  HEXA_BASED_INTEGER
    ;
 
-BINANRY_BASED_INTEGER
-   : '2' '#' ('1' | '0' | '_')+ '#' (INTEGER)?
+BINARY_BASED_INTEGER
+   : '2' '#' ('1' | '0' | '_')+ '#' (PLUS_EXPONENT|NEUTRAL_EXPONENT)?
    ;
    
 OCTAL_BASED_INTEGER
-   : '8' '#' ('7' |'6' |'5' |'4' |'3' |'2' |'1' | '0' | '_')+ '#' (INTEGER)?
+   : '8' '#' ('7' |'6' |'5' |'4' |'3' |'2' |'1' | '0' | '_')+ '#' (PLUS_EXPONENT|NEUTRAL_EXPONENT)?
    ;
 
 HEXA_BASED_INTEGER
-   : '16' '#' ( 'f' |'e' |'d' |'c' |'b' |'a' | 'F' |'E' |'D' |'C' |'B' |'A' | '9' | '8' | '7' |'6' |'5' |'4' |'3' |'2' |'1' | '0' | '_')+ '#' (INTEGER)?
+   : '16' '#' ( 'f' |'e' |'d' |'c' |'b' |'a' | 'F' |'E' |'D' |'C' |'B' |'A' | '9' | '8' | '7' |'6' |'5' |'4' |'3' |'2' |'1' | '0' | '_')+ '#' (PLUS_EXPONENT|NEUTRAL_EXPONENT)?
    ;
 
 BIT_STRING_LITERAL
@@ -1661,9 +1661,25 @@ BACKSLASH     : '\\'  ;
   
 
 EXPONENT
-  :  'e' ( '+' | '-' )? INTEGER
+  : MINUS_EXPONENT
+  | PLUS_EXPONENT
+  | NEUTRAL_EXPONENT
   ;
 
+
+MINUS_EXPONENT
+  :  ('E'|'e') '-' INTEGER
+  ;
+
+
+PLUS_EXPONENT
+  :  ('E'|'e') '+' INTEGER
+  ;
+
+
+NEUTRAL_EXPONENT
+  :  ('E'|'e') INTEGER
+  ;
 
 HEXDIGIT
     :	('A'..'F'|'a'..'f')


### PR DESCRIPTION
Modified support for exponents in base literals to adhere to the standard of using an 'E' or 'e' as opposed to an integer. The standard also states:
"An exponent for a based integer literal shall not have a minus sign." hence the addition of the lexer rules.

Also fixed a spelling typo of BINANRY_BASED_INTEGER to BINARY_BASED_INTEGER