### PR TITLE
Fix for escaped identifiers.

### DIFF
--- a/verilog/Verilog2001.g4
+++ b/verilog/Verilog2001.g4
@@ -1356,7 +1356,7 @@ escaped_hierarchical_branch ( '.' simple_hierarchical_branch | '.' escaped_hiera
 
 Escaped_identifier
 	:	'\\' ~[ \r\t\n]*
-        {_input.LA(1)!=' '&&_input.LA(1)!='\t'&&_input.LA(1)!='\t'&&_input.LA(1)!='\n'}?
+        {_input.LA(0)!=' '&&_input.LA(0)!='\t'&&_input.LA(0)!='\t'&&_input.LA(0)!='\n'}?
     ;
 
 event_identifier : identifier ;


### PR DESCRIPTION
In some Verilog generated by Xilinx's tools, they have wire declarations like the following.

  wire \blk00000001/sig0000017a ;

Without the change the name was cutting off the last letter. With the change it parses correctly. I'm not 100% sure I made the change correctly as I have only a little experience with look-ahead.