### PR TITLE
Bug fix in ECMAScript (related to issue #179)

### DIFF
--- a/ecmascript/ECMAScript.CSharpTarget.g4
+++ b/ecmascript/ECMAScript.CSharpTarget.g4
@@ -248,7 +248,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(_input.La(1) != OpenBrace) && (_input.La(1) != Function)}? expressionSequence SemiColon
+ : {(_input.La(1) != OpenBrace) && (_input.La(1) != Function)}? expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/ECMAScript.PythonTarget.g4
+++ b/ecmascript/ECMAScript.PythonTarget.g4
@@ -256,7 +256,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(self._input.LA(1) != ECMAScriptParser.OpenBrace) and (self._input.LA(1) != ECMAScriptParser.Function)}? expressionSequence SemiColon
+ : {(self._input.LA(1) != ECMAScriptParser.OpenBrace) and (self._input.LA(1) != ECMAScriptParser.Function)}? expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -270,7 +270,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence SemiColon
+ : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence eos
  ;
 
 /// IfStatement :


### PR DESCRIPTION
An expression statement can also be terminated by a new line character (not
just a semicolon) as per ECMAScript's automatic semicolon insertion rules
(Section 7.9 of Standard ECMA-262).

This does not completely solve the problems raised in issue #179, but goes some way towards solving it.