### PR TITLE
Bug fix in ECMAScript grammar

### DIFF
--- a/ecmascript/ECMAScript.CSharpTarget.g4
+++ b/ecmascript/ECMAScript.CSharpTarget.g4
@@ -248,7 +248,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(_input.La(1) != OpenBrace) && (_input.La(1) != Function)}? expressionSequence SemiColon
+ : {(_input.La(1) != OpenBrace) && (_input.La(1) != Function)}? expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/ECMAScript.PythonTarget.g4
+++ b/ecmascript/ECMAScript.PythonTarget.g4
@@ -66,7 +66,7 @@ def lineTerminatorAhead(self):
     possibleIndexEosToken = self.getCurrentToken().tokenIndex - 1
     ahead = self._input.get(possibleIndexEosToken)
 
-    if ahead.channel == Lexer.HIDDEN:
+    if ahead.channel != Lexer.HIDDEN:
         # We're only interested in tokens on the HIDDEN channel.
         return False
 
@@ -256,7 +256,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(self._input.LA(1) != ECMAScriptParser.OpenBrace) and (self._input.LA(1) != ECMAScriptParser.Function)}? expressionSequence SemiColon
+ : {(self._input.LA(1) != ECMAScriptParser.OpenBrace) and (self._input.LA(1) != ECMAScriptParser.Function)}? expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -270,7 +270,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence SemiColon
+ : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence eos
  ;
 
 /// IfStatement :


### PR DESCRIPTION
An expression statement can also be terminated by a new line character (not
just a semicolon) as per ECMAScript's automatic semicolon insertion rules
(Section 7.9 of Standard ECMA-262).

Also fixed buh in lineTerminatorAhead method in the ECMAScript Python target.
The comparison should be for inequality