### PR TITLE
Fixed Escaped_identifier

### DIFF
--- a/verilog/Verilog2001.g4
+++ b/verilog/Verilog2001.g4
@@ -1356,7 +1356,6 @@ escaped_hierarchical_branch ( '.' simple_hierarchical_branch | '.' escaped_hiera
 
 Escaped_identifier
 	:	'\\' ~[ \r\t\n]*
-        {_input.LA(1)!=' '&&_input.LA(1)!='\t'&&_input.LA(1)!='\t'&&_input.LA(1)!='\n'}?
     ;
 
 event_identifier : identifier ;


### PR DESCRIPTION
The look-ahead causes the last character of the escaped identifier to be incorrectly excluded.