### PR TITLE
Typo in Hexadecimal_exponent

### DIFF
--- a/swift/Swift.g4
+++ b/swift/Swift.g4
@@ -830,7 +830,7 @@ Floating_point_literal
 fragment Decimal_fraction : '.' Decimal_literal ;
 fragment Decimal_exponent : Floating_point_e Sign? Decimal_literal ;
 fragment Hexadecimal_fraction : '.' Hexadecimal_literal? ;
-fragment Hexadecimal_exponent : Floating_point_p Sign? Hexadecimal_literal ;
+fragment Hexadecimal_exponent : Floating_point_p Sign? Decimal_literal ;
 fragment Floating_point_e : [eE] ;
 fragment Floating_point_p : [pP] ;
 fragment Sign : [+\-] ;


### PR DESCRIPTION
The rule for Hexadecimal_exponent should use Decimal_literal and not Hexadecimal_literal, cf. https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/swift/grammar/hexadecimal-exponent