### PR TITLE
Updating Clojure grammar to reflect other metadata

### DIFF
--- a/clojure/Clojure.g4
+++ b/clojure/Clojure.g4
@@ -96,7 +96,7 @@ lambda
     ;
 
 meta_data
-    : '#^' map form
+    : '#^' (map form | form) 
     ;
 
 var_quote


### PR DESCRIPTION
This commit updates the Clojure grammar to reflect the metadata tags
seen in, e.g. clojure.core around line 6278 (where `slurp` is defined).
In particular, we need to support metadata of the following form:
`#^java.io.Reader`