### PR TITLE
PHP's grammar accepts an optional Comma after the last arrayEntry

### DIFF
--- a/php/PHPParser.g4
+++ b/php/PHPParser.g4
@@ -474,7 +474,7 @@ atomOrReference
     ;
 
 arrayDeclaration
-    : Array OpenRoundBracket (arrayEntry (Comma arrayEntry)*)? CloseRoundBracket 
+    : Array OpenRoundBracket (arrayEntry (Comma arrayEntry)* Comma?)? CloseRoundBracket
     ;
 
 arrayEntry

--- a/php/examples/array.php
+++ b/php/examples/array.php
@@ -1,0 +1,36 @@
+<?php
+
+$a = array();
+
+$a = array(
+);
+
+$a = array(1);
+
+$a = array(1,2);
+
+$a = array(1,2,);
+
+$a = array(
+    1,
+    2
+);
+
+$a = array(
+    1,
+    2,
+);
+
+$a = array(
+    1 => 1,
+    2 => 2
+);
+
+$a = array(
+    1 => 1,
+    2 => 2,
+);
+
+$a = array(
+    array(1,2)
+);


### PR DESCRIPTION
This could parse `array(1,)` which is valid PHP. See also [Array Creation Operator](https://github.com/php/php-langspec/blob/master/spec/10-expressions.md#array-creation-operator).