### PR TITLE
small fix for ports with default values

### DIFF
--- a/vhdl/vhdl.g4
+++ b/vhdl/vhdl.g4
@@ -863,7 +863,7 @@ interface_quantity_declaration
 
 interface_port_declaration
   : identifier_list COLON signal_mode subtype_indication
-    ( BUS )?
+    ( BUS )? ( VARASGN expression )?
   ;
 
 interface_signal_declaration


### PR DESCRIPTION
for example:
output_bus : out std_logic_vector(2 downto 0) := "000"