### PR TITLE
Fixing getter/setter definitions in ECMAScript grammars

### DIFF
--- a/ecmascript/ECMAScript.CSharpTarget.g4
+++ b/ecmascript/ECMAScript.CSharpTarget.g4
@@ -732,11 +732,11 @@ futureReservedWord
  ;
 
 getter
- : {_input.Lt(1).Text.StartsWith("get")}? Identifier
+ : {_input.Lt(1).Text.Equals("get")}? Identifier propertyName
  ;
 
 setter
- : {_input.Lt(1).Text.StartsWith("set")}? Identifier
+ : {_input.Lt(1).Text.Equals("set")}? Identifier propertyName
  ;
 
 eos

--- a/ecmascript/ECMAScript.PythonTarget.g4
+++ b/ecmascript/ECMAScript.PythonTarget.g4
@@ -738,11 +738,11 @@ futureReservedWord
  ;
 
 getter
- : {self._input.LT(1).getText().startsWith("get")}? Identifier
+ : {self._input.LT(1).getText() == "get"}? Identifier propertyName
  ;
 
 setter
- : {self._input.LT(1).getText().startsWith("set")}? Identifier
+ : {self._input.LT(1).getText() == "set"}? Identifier propertyName
  ;
 
 eos

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -754,11 +754,11 @@ futureReservedWord
  ;
 
 getter
- : {_input.LT(1).getText().startsWith("get")}? Identifier
+ : {_input.LT(1).getText().equals("get")}? Identifier propertyName
  ;
 
 setter
- : {_input.LT(1).getText().startsWith("set")}? Identifier
+ : {_input.LT(1).getText().equals("set")}? Identifier propertyName
  ;
 
 eos


### PR DESCRIPTION
Earlier, the getter and setter rules only consumed the first
'get'/'set' part of an expression but not the following
property name.
The patch fixes this in the various ECMAScript grammars.