### PR TITLE
Fix in purespecifier

### DIFF
--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -1091,7 +1091,7 @@ purespecifier:
  */
 purespecifier
 :
-	Assign val = Integerliteral
+	Assign val = Octalliteral
 	{if($val.text.compareTo("0")!=0) throw new InputMismatchException(this);}
 
 ;


### PR DESCRIPTION
The old rule fails with a declaration like that inside a class
    static const int CubeMapSize = 256;