### PR TITLE
`iostream.h` is deprecated.

### DIFF
--- a/cpp/examples/helloworld.cpp
+++ b/cpp/examples/helloworld.cpp
@@ -1,4 +1,4 @@
-#include <iostream.h>
+#include <iostream>
 
 main()
 {


### PR DESCRIPTION
iostream.h is deprecated by those compilers that provide it, iostream is part of the C++ standard. There is no mention of iostream.h at all in the current C++14 standard.