### PR TITLE
Fixed bug with square bracketed identifiers

### DIFF
--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -640,7 +640,6 @@ subscript : (valueStmt WS TO WS)? valueStmt;
 
 ambiguousIdentifier : 
 	(IDENTIFIER | ambiguousKeyword)+
-	| L_SQUARE_BRACKET (.+)+ R_SQUARE_BRACKET
 ;
 
 asTypeClause : AS WS? (NEW WS)? type (WS? fieldLength)?;
@@ -910,7 +909,7 @@ INTEGERLITERAL : (PLUS|MINUS)? ('0'..'9')+ ( ('e' | 'E') INTEGERLITERAL)* ('#' |
 DOUBLELITERAL : (PLUS|MINUS)? ('0'..'9')* '.' ('0'..'9')+ ( ('e' | 'E') (PLUS|MINUS)? ('0'..'9')+)* ('#' | '&')?;
 BYTELITERAL : ('0'..'9')+;
 // identifier
-IDENTIFIER : LETTER (LETTERORDIGIT)*;
+IDENTIFIER :  LETTER (LETTERORDIGIT)* | L_SQUARE_BRACKET (~[\]\r\n])+ R_SQUARE_BRACKET;
 // whitespace, line breaks, comments, ...
 LINE_CONTINUATION : [ \t]+ '_' '\r'? '\n' -> skip;
 NEWLINE : (':' WS?) | (WS? ('\r'? '\n') WS?); 


### PR DESCRIPTION
The `ambiguousIdentifier` parser rule was way too permissive for square-bracketed identifiers:

    ambiguousIdentifier : 
        (IDENTIFIER | ambiguousKeyword)+
        | L_SQUARE_BRACKET (.+)+ R_SQUARE_BRACKET
    ;

This would match literally *anything* between the first opening and the last closing square bracket in a code file, which obviously breaks the parse tree.