### PR TITLE
Changed precedence between Comma and Assign.

### DIFF
--- a/ecmascript/ECMAScript.CSharpTarget.g4
+++ b/ecmascript/ECMAScript.CSharpTarget.g4
@@ -629,8 +629,8 @@ singleExpression
  | singleExpression '&&' singleExpression                                 # LogicalAndExpression
  | singleExpression '||' singleExpression                                 # LogicalOrExpression
  | singleExpression '?' singleExpression ':' singleExpression             # TernaryExpression
- | singleExpression '=' expressionSequence                                # AssignmentExpression
- | singleExpression assignmentOperator expressionSequence                 # AssignmentOperatorExpression
+ | singleExpression '=' singleExpression                                  # AssignmentExpression
+ | singleExpression assignmentOperator singleExpression                   # AssignmentOperatorExpression
  | This                                                                   # ThisExpression
  | Identifier                                                             # IdentifierExpression
  | literal                                                                # LiteralExpression

--- a/ecmascript/ECMAScript.PythonTarget.g4
+++ b/ecmascript/ECMAScript.PythonTarget.g4
@@ -635,8 +635,8 @@ singleExpression
  | singleExpression '&&' singleExpression                                 # LogicalAndExpression
  | singleExpression '||' singleExpression                                 # LogicalOrExpression
  | singleExpression '?' singleExpression ':' singleExpression             # TernaryExpression
- | singleExpression '=' expressionSequence                                # AssignmentExpression
- | singleExpression assignmentOperator expressionSequence                 # AssignmentOperatorExpression
+ | singleExpression '=' singleExpression                                  # AssignmentExpression
+ | singleExpression assignmentOperator singleExpression                   # AssignmentOperatorExpression
  | This                                                                   # ThisExpression
  | Identifier                                                             # IdentifierExpression
  | literal                                                                # LiteralExpression

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -651,8 +651,8 @@ singleExpression
  | singleExpression '&&' singleExpression                                 # LogicalAndExpression
  | singleExpression '||' singleExpression                                 # LogicalOrExpression
  | singleExpression '?' singleExpression ':' singleExpression             # TernaryExpression
- | singleExpression '=' expressionSequence                                # AssignmentExpression
- | singleExpression assignmentOperator expressionSequence                 # AssignmentOperatorExpression
+ | singleExpression '=' singleExpression                                  # AssignmentExpression
+ | singleExpression assignmentOperator singleExpression                   # AssignmentOperatorExpression
  | This                                                                   # ThisExpression
  | Identifier                                                             # IdentifierExpression
  | literal                                                                # LiteralExpression


### PR DESCRIPTION
I don't know well about behind things, but I think Comma operator (`expressionSequence`) should appear at top of Assignment operator (`# AssignmenExpression` and `#AssignmentOperatorExpression`). Not in a reversed order.

```javascript
// on both console of Firefox and Edge
var b;
b = 1, 2;
// -> 2
// <- b
// -> 1
```
This code is not a `b = (1, 2)`, but a `(b = 1), 2`. But grammar makes a first one, as of rule, maybe similar step to below:

`expressionStatement`
→ `expressionSequence`
→ `singleExpression '=' expressionSequence`
→ `singleExpression '=' singleExpression ',' singleExpression`

↓
```
expressionStatement
    expressionSequence (for b = 1, 2)
        singleExpression (for b)
        '='
        expressionSequence (for 1, 2)
            singleExpression (for 1)
            ','
            singleExpression (for 2)
```

And, as reference, [Esprima does second one](http://esprima.org/demo/parse.html?code=var%20b%3B%0D%0Ab%20%3D%201%2C%202%3B).
```
expression
    SequenceExpression
        expressions[2]
            AssignmentExpression (for b=1)
            Literal (for 2)
```

Thus changed some suspected part (some `expressionSequence` at Assignment related parts to `singleExpression`), and worked as expected, Although I can't sure that It is absolutely right.