### PR TITLE
HexDigit should be '[0-9a-fA-F]'

### DIFF
--- a/scala/Scala.g4
+++ b/scala/Scala.g4
@@ -371,7 +371,7 @@ fragment StringElement    :  '\u0020'| '\u0021'|'\u0023' .. '\u007F'  // (Printa
                           |  CharEscapeSeq;
 fragment MultiLineChars   :  ('"'? '"'? .*?)* '"'*;
 
-fragment HexDigit         :  '0' .. '9'  |  'A' .. 'Z'  |  'a' .. 'z' ;
+fragment HexDigit         :  '0' .. '9'  |  'A' .. 'F'  |  'a' .. 'f' ;
 fragment FloatType        :  'F' | 'f' | 'D' | 'd';
 fragment Upper            :  'A'  ..  'Z' | '$' | '_';  // and Unicode category Lu
 fragment Lower            :  'a' .. 'z'; // and Unicode category Ll


### PR DESCRIPTION
Very simple fix for the scala grammar. `HexDigit` should almost certainly be `[0-9a-fA-F]` and not `[0-9a-zA-Z]`.