### PR TITLE
Fixing an issue with tsql insert command

### DIFF
--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -130,8 +130,7 @@ delete_statement
 insert_statement
     : with_expression?
       INSERT (TOP '(' expression ')' PERCENT?)?
-      INTO? (ddl_object | rowset_function_limited)
-      with_table_hints?
+      INTO? (ddl_object | rowset_function_limited with_table_hints?)
       ('(' column_name_list ')')?
       output_clause?
       (VALUES '(' expression_list ')' (',' '(' expression_list ')')* |


### PR DESCRIPTION
The columns in the insert statement are being treated as table_hints instead of as columns.

Fixing rule as per documentation:
https://msdn.microsoft.com/en-us/library/ms174335.aspx


