### PR TITLE
'@' is not required for attributes in Swift

### DIFF
--- a/swift/Swift.g4
+++ b/swift/Swift.g4
@@ -581,7 +581,7 @@ expression_pattern : expression  ;
 
 // GRAMMAR OF AN ATTRIBUTE
 
-attribute : '@' attribute_name attribute_argument_clause? ;
+attribute : '@'? attribute_name attribute_argument_clause? ;
 attribute_name : identifier  ;
 attribute_argument_clause : '('  balanced_tokens?  ')'  ;
 attributes : attribute+ ;


### PR DESCRIPTION
@parrt PTAL