### PR TITLE
Support Python target of the ANTLR4 grammar.

### DIFF
--- a/antlr4/ANTLRv4Lexer.PythonTarget.g4
+++ b/antlr4/ANTLRv4Lexer.PythonTarget.g4
@@ -1,0 +1,347 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012-2015 Terence Parr
+ *  Copyright (c) 2012-2015 Sam Harwell
+ *  Copyright (c) 2015 Gerald Rosenberg
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ *	A grammar for ANTLR v4 implemented using v4 syntax
+ *
+ *	Modified 2015.06.16 gbr
+ *	-- update for compatibility with Antlr v4.5
+ */
+
+lexer grammar ANTLRv4Lexer;
+
+options {
+	superClass = LexerAdaptor ;
+}
+
+import LexBasic;	// Standard set of fragments
+
+@header {
+from LexerAdaptor import LexerAdaptor
+}
+
+tokens {
+	TOKEN_REF,
+	RULE_REF,
+	LEXER_CHAR_SET
+}
+
+channels {
+	OFF_CHANNEL		// non-default channel for whitespace and comments
+}
+
+
+// ======================================================
+// Lexer specification
+//
+
+// -------------------------
+// Comments
+
+DOC_COMMENT
+	:	DocComment
+	;
+
+BLOCK_COMMENT
+	:	BlockComment	-> channel(OFF_CHANNEL)
+	;
+
+LINE_COMMENT
+	:	LineComment		-> channel(OFF_CHANNEL)
+	;
+
+
+// -------------------------
+// Integer
+//
+
+INT	: DecimalNumeral
+	;
+
+
+// -------------------------
+// Literal string
+//
+// ANTLR makes no distinction between a single character literal and a
+// multi-character string. All literals are single quote delimited and
+// may contain unicode escape sequences of the form \uxxxx, where x
+// is a valid hexadecimal number (per Unicode standard).
+
+STRING_LITERAL
+	: SQuoteLiteral
+	;
+
+UNTERMINATED_STRING_LITERAL
+	: USQuoteLiteral
+	;
+
+
+// -------------------------
+// Arguments
+//
+// Certain argument lists, such as those specifying call parameters
+// to a rule invocation, or input parameters to a rule specification
+// are contained within square brackets.
+
+BEGIN_ARGUMENT
+	:	LBrack		{ self.handleBeginArgument() }
+	;
+
+
+// -------------------------
+// Actions
+
+BEGIN_ACTION
+	:	LBrace		-> pushMode(Action)
+	;
+
+
+// -------------------------
+// Keywords
+//
+// Keywords may not be used as labels for rules or in any other context where
+// they would be ambiguous with the keyword vs some other identifier.  OPTIONS,
+// TOKENS, & CHANNELS blocks are handled idiomatically in dedicated lexical modes.
+
+OPTIONS		: 'options'		-> pushMode(Options)	;
+TOKENS		: 'tokens'		-> pushMode(Tokens)		;
+CHANNELS	: 'channels'	-> pushMode(Channels)	;
+
+IMPORT		: 'import'		;
+FRAGMENT	: 'fragment'	;
+LEXER		: 'lexer'		;
+PARSER		: 'parser'		;
+GRAMMAR		: 'grammar'		;
+PROTECTED	: 'protected'	;
+PUBLIC		: 'public'		;
+PRIVATE		: 'private'		;
+RETURNS		: 'returns'		;
+LOCALS		: 'locals'		;
+THROWS		: 'throws'		;
+CATCH		: 'catch'		;
+FINALLY		: 'finally'		;
+MODE		: 'mode'		;
+
+
+// -------------------------
+// Punctuation
+
+COLON		: Colon			;
+COLONCOLON	: DColon		;
+COMMA		: Comma			;
+SEMI		: Semi			;
+LPAREN		: LParen		;
+RPAREN		: RParen		;
+LBRACE		: LBrace		;
+RBRACE		: RBrace		;
+RARROW		: RArrow		;
+LT			: Lt			;
+GT			: Gt			;
+ASSIGN		: Equal			;
+QUESTION	: Question		;
+STAR		: Star			;
+PLUS_ASSIGN	: PlusAssign	;
+PLUS		: Plus			;
+OR			: Pipe			;
+DOLLAR		: Dollar		;
+RANGE		: Range			;
+DOT			: Dot			;
+AT			: At			;
+POUND		: Pound			;
+NOT			: Tilde			;
+
+
+// -------------------------
+// Identifiers - allows unicode rule/token names
+
+ID	: Id
+	;
+
+
+// -------------------------
+// Whitespace
+
+WS	:	Ws+		-> channel(OFF_CHANNEL)	;
+
+
+// -------------------------
+// Illegal Characters
+//
+// This is an illegal character trap which is always the last rule in the
+// lexer specification. It matches a single character of any value and being
+// the last rule in the file will match when no other rule knows what to do
+// about the character. It is reported as an error but is not passed on to the
+// parser. This means that the parser to deal with the gramamr file anyway
+// but we will not try to analyse or code generate from a file with lexical
+// errors.
+//
+// Comment this rule out to allow the error to be propagated to the parser
+
+ERRCHAR
+	:	.	-> channel(HIDDEN)
+	;
+
+
+// ======================================================
+// Lexer modes
+
+// -------------------------
+// Arguments
+
+mode Argument;			// E.g., [int x, List<String> a[]]
+
+	NESTED_ARGUMENT			: LBrack			-> type(ARGUMENT_CONTENT), pushMode(Argument)	;
+
+	ARGUMENT_ESCAPE			: EscAny			-> type(ARGUMENT_CONTENT)		;
+
+	ARGUMENT_STRING_LITERAL	: DQuoteLiteral	-> type(ARGUMENT_CONTENT)		;
+	ARGUMENT_CHAR_LITERAL	: SQuoteLiteral	-> type(ARGUMENT_CONTENT)		;
+
+	END_ARGUMENT			: RBrack	{ self.handleEndArgument() }	;
+
+	// added this to return non-EOF token type here. EOF does something weird
+	UNTERMINATED_ARGUMENT 	: EOF		-> popMode		;
+
+	ARGUMENT_CONTENT		: .							;
+
+
+// -------------------------
+// Actions
+//
+// Many language targets use {} as block delimiters and so we
+// must recursively match {} delimited blocks to balance the
+// braces. Additionally, we must make some assumptions about
+// literal string representation in the target language. We assume
+// that they are delimited by ' or " and so consume these
+// in their own alts so as not to inadvertantly match {}.
+
+mode Action;
+
+	NESTED_ACTION			: LBrace			-> type(ACTION_CONTENT), pushMode(Action)	;
+
+	ACTION_ESCAPE			: EscAny			-> type(ACTION_CONTENT)		;
+
+	ACTION_STRING_LITERAL	: DQuoteLiteral		-> type(ACTION_CONTENT)		;
+	ACTION_CHAR_LITERAL		: SQuoteLiteral		-> type(ACTION_CONTENT)		;
+
+	ACTION_DOC_COMMENT		: DocComment		-> type(ACTION_CONTENT)		;
+	ACTION_BLOCK_COMMENT	: BlockComment 		-> type(ACTION_CONTENT)		;
+	ACTION_LINE_COMMENT		: LineComment 		-> type(ACTION_CONTENT)		;
+
+	END_ACTION				: RBrace	{ self.handleEndAction() }	;
+
+	UNTERMINATED_ACTION		: EOF		-> popMode		;
+
+	ACTION_CONTENT			: .							;
+
+
+// -------------------------
+
+mode Options;
+
+	OPT_DOC_COMMENT		: DocComment		-> type(DOC_COMMENT), channel(OFF_CHANNEL)		;
+	OPT_BLOCK_COMMENT	: BlockComment 		-> type(BLOCK_COMMENT), channel(OFF_CHANNEL)	;
+	OPT_LINE_COMMENT	: LineComment 		-> type(LINE_COMMENT), channel(OFF_CHANNEL)		;
+
+	OPT_LBRACE			: LBrace			-> type(LBRACE)				;
+	OPT_RBRACE			: RBrace			-> type(RBRACE), popMode	;
+
+	OPT_ID				: Id				-> type(ID)					;
+	OPT_DOT				: Dot				-> type(DOT)				;
+	OPT_ASSIGN			: Equal				-> type(ASSIGN)				;
+	OPT_STRING_LITERAL	: SQuoteLiteral		-> type(STRING_LITERAL)		;
+	OPT_INT				: Int				-> type(INT)				;
+	OPT_STAR			: Star				-> type(STAR)				;
+	OPT_SEMI			: Semi				-> type(SEMI)				;
+
+	OPT_WS				: Ws+	-> type(WS), channel(OFF_CHANNEL) 	;
+
+
+// -------------------------
+
+mode Tokens;
+
+	TOK_DOC_COMMENT		: DocComment		-> type(DOC_COMMENT), channel(OFF_CHANNEL)		;
+	TOK_BLOCK_COMMENT	: BlockComment 		-> type(BLOCK_COMMENT), channel(OFF_CHANNEL)	;
+	TOK_LINE_COMMENT	: LineComment 		-> type(LINE_COMMENT), channel(OFF_CHANNEL)		;
+
+	TOK_LBRACE			: LBrace			-> type(LBRACE)				;
+	TOK_RBRACE			: RBrace			-> type(RBRACE), popMode	;
+
+	TOK_ID				: Id				-> type(ID)					;
+	TOK_DOT				: Dot				-> type(DOT)				;
+	TOK_COMMA			: Comma				-> type(COMMA)				;
+
+	TOK_WS				: Ws+	-> type(WS), channel(OFF_CHANNEL) 	;
+
+
+// -------------------------
+
+mode Channels;	// currently same as Tokens mode; distinguished by keyword
+
+	CHN_DOC_COMMENT		: DocComment		-> type(DOC_COMMENT), channel(OFF_CHANNEL)		;
+	CHN_BLOCK_COMMENT	: BlockComment 		-> type(BLOCK_COMMENT), channel(OFF_CHANNEL)	;
+	CHN_LINE_COMMENT	: LineComment 		-> type(LINE_COMMENT), channel(OFF_CHANNEL)		;
+
+	CHN_LBRACE			: LBrace			-> type(LBRACE)				;
+	CHN_RBRACE			: RBrace			-> type(RBRACE), popMode	;
+
+	CHN_ID				: Id				-> type(ID)					;
+	CHN_DOT				: Dot				-> type(DOT)				;
+	CHN_COMMA			: Comma				-> type(COMMA)				;
+
+	CHN_WS				: Ws+	-> type(WS), channel(OFF_CHANNEL) 	;
+
+
+// -------------------------
+
+mode LexerCharSet;
+
+	LEXER_CHAR_SET_BODY
+		:	(	~[\]\\]
+			|	EscAny
+			)+				-> more
+		;
+
+	LEXER_CHAR_SET
+		:	RBrack			-> popMode
+		;
+
+	UNTERMINATED_CHAR_SET
+		:	EOF				-> popMode
+		;
+
+
+// ------------------------------------------------------------------------------
+// Grammar specific Keywords, Punctuation, etc.
+
+fragment Id	: NameStartChar NameChar*	;
+

--- a/antlr4/ANTLRv4Parser.g4
+++ b/antlr4/ANTLRv4Parser.g4
@@ -47,7 +47,7 @@ options {
 // The main entry point for parsing a v4 grammar.
 grammarSpec
 	:	DOC_COMMENT?
-		grammarType id SEMI
+		grammarType identifier SEMI
 		prequelConstruct*
 		rules
 		modeSpec*
@@ -81,11 +81,11 @@ optionsSpec
 	;
 
 option
-	:	id ASSIGN optionValue
+	:	identifier ASSIGN optionValue
 	;
 
 optionValue
-	:	id (DOT id)*
+	:	identifier (DOT identifier)*
 	|	STRING_LITERAL
 	|	actionBlock			// TODO: is this valid?
 	|	INT
@@ -99,8 +99,8 @@ delegateGrammars
 	;
 
 delegateGrammar
-	:	id ASSIGN id
-	|	id
+	:	identifier ASSIGN identifier
+	|	identifier
 	;
 
 
@@ -116,18 +116,18 @@ channelsSpec
 	;
 
 idList
-	: id ( COMMA id )* COMMA?
+	: identifier ( COMMA identifier )* COMMA?
 	;
 
 
 // Match stuff like @parser::members {int i;}
 action
-	:	AT (actionScopeName COLONCOLON)? id actionBlock
+	:	AT (actionScopeName COLONCOLON)? identifier actionBlock
 	;
 
 // Scope names could collide with keywords; allow them as ids for action scopes
 actionScopeName
-	:	id
+	:	identifier
 	|	LEXER
 	|	PARSER
 	;
@@ -141,7 +141,7 @@ argActionBlock
 	;
 
 modeSpec
-	:	MODE id SEMI lexerRuleSpec*
+	:	MODE identifier SEMI lexerRuleSpec*
 	;
 
 rules
@@ -189,7 +189,7 @@ ruleReturns
 // Exception spec
 
 throwsSpec
-	:	THROWS id (COMMA id)*
+	:	THROWS identifier (COMMA identifier)*
 	;
 
 localsSpec
@@ -198,7 +198,7 @@ localsSpec
 
 /** Match stuff like @init {int i;} */
 ruleAction
-	:	AT id actionBlock
+	:	AT identifier actionBlock
 	;
 
 ruleModifiers
@@ -227,7 +227,7 @@ ruleAltList
 	;
 
 labeledAlt
-	:	alternative (POUND id)?
+	:	alternative (POUND identifier)?
 	;
 
 // --------------------
@@ -263,7 +263,7 @@ lexerElement
 	;							// but preds can be anywhere
 
 labeledLexerElement
-	:	id (ASSIGN|PLUS_ASSIGN)
+	:	identifier (ASSIGN|PLUS_ASSIGN)
 		(	lexerAtom
 		|	block
 		)
@@ -284,12 +284,12 @@ lexerCommand
 	;
 
 lexerCommandName
-	:	id
+	:	identifier
 	|	MODE
 	;
 
 lexerCommandExpr
-	:	id
+	:	identifier
 	|	INT
 	;
 
@@ -319,7 +319,7 @@ element
 	;
 
 labeledElement
-	:	id ( ASSIGN | PLUS_ASSIGN )
+	:	identifier ( ASSIGN | PLUS_ASSIGN )
 		(	atom
 		|	block
 		)
@@ -343,7 +343,7 @@ ebnfSuffix
 	;
 
 lexerAtom
-	:	range
+	:	characterRange
 	|	terminal
 	|	RULE_REF
 	|	notSet
@@ -352,7 +352,7 @@ lexerAtom
 	;
 
 atom
-	:	range 				// Range x..y - only valid in lexers
+	:	characterRange 				// Range x..y - only valid in lexers
 	|	terminal
 	|	ruleref
 	|	notSet
@@ -374,7 +374,7 @@ blockSet
 setElement
 	:	TOKEN_REF elementOptions?
 	|	STRING_LITERAL elementOptions?
-	|	range
+	|	characterRange
 	|	LEXER_CHAR_SET
 	;
 
@@ -398,7 +398,7 @@ ruleref
 // ---------------
 // Character Range
 
-range
+characterRange
 	: STRING_LITERAL RANGE STRING_LITERAL
 	;
 
@@ -414,10 +414,11 @@ elementOptions
 	;
 
 elementOption
-	:	id 									// default node option
-	|	id ASSIGN (id | STRING_LITERAL)		// option assignment
+	:	identifier 									// default node option
+	|	identifier ASSIGN (identifier | STRING_LITERAL)		// option assignment
 	;
 
-id	:	RULE_REF
+identifier
+	:	RULE_REF
 	|	TOKEN_REF
 	;

--- a/antlr4/LexBasic.g4
+++ b/antlr4/LexBasic.g4
@@ -95,7 +95,7 @@ fragment DecDigit		: [0-9]			;
 // -----------------------------------
 // Literals
 
-fragment BoolLiteral	: True | False								;
+fragment BoolLiteral	: 'true' | 'false'								;
 
 fragment CharLiteral	: SQuote ( EscSeq | ~['\r\n\\] )  SQuote	;
 fragment SQuoteLiteral	: SQuote ( EscSeq | ~['\r\n\\] )* SQuote	;
@@ -136,9 +136,6 @@ fragment NameStartChar
 // Types
 
 fragment Int			: 'int'		;
-
-fragment True			: 'true'	;
-fragment False			: 'false'	;
 
 
 // -----------------------------------

--- a/antlr4/LexerAdaptor.py
+++ b/antlr4/LexerAdaptor.py
@@ -1,0 +1,66 @@
+from antlr4 import *
+
+
+class LexerAdaptor(Lexer):
+
+    """
+      Track whether we are inside of a rule and whether it is lexical parser. _currentRuleType==Token.INVALID_TYPE
+      means that we are outside of a rule. At the first sign of a rule name reference and _currentRuleType==invalid, we
+      can assume that we are starting a parser rule. Similarly, seeing a token reference when not already in rule means
+      starting a token rule. The terminating ';' of a rule, flips this back to invalid type.
+
+      This is not perfect logic but works. For example, "grammar T;" means that we start and stop a lexical rule for
+      the "T;". Dangerous but works.
+
+      The whole point of this state information is to distinguish between [..arg actions..] and [charsets]. Char sets
+      can only occur in lexical rules and arg actions cannot occur.
+    """
+
+    _currentRuleType = Token.INVALID_TYPE
+
+    def __init__(self, inp):
+        Lexer.__init__(self, inp)
+
+    def getCurrentRuleType(self):
+        return self._currentRuleType
+
+    def setCurrentRuleType(self, ruleType):
+        self._currentRuleType = ruleType
+
+    def handleBeginArgument(self):
+        if self.inLexerRule():
+            self.pushMode(self.LexerCharSet)
+            self.more()
+        else:
+            self.pushMode(self.Argument)
+
+    def handleEndArgument(self):
+        self.popMode()
+        if self._modeStack.size() > 0:
+            self.setType(self.ARGUMENT_CONTENT)
+
+    def handleEndAction(self):
+        self.popMode()
+        if self._modeStack.size() > 0:
+            self.setType(self.ACTION_CONTENT)
+
+    def emit(self):
+        if self._type == self.ID:
+            firstChar = self._input.getText(self._tokenStartCharIndex, self._tokenStartCharIndex)
+            if firstChar[0].isupper():
+                self._type = self.TOKEN_REF
+            else:
+                self._type = self.RULE_REF
+
+            if self._currentRuleType == Token.INVALID_TYPE:  # if outside of rule def
+                self._currentRuleType = self._type  # set to inside lexer or parser rule
+
+        elif self._type == self.SEMI:  # exit rule def
+            self._currentRuleType = Token.INVALID_TYPE
+        return Lexer.emit(self)
+
+    def inLexerRule(self):
+        return self._currentRuleType == self.TOKEN_REF
+
+    def inParserRule(self):  # not used, but added for clarity
+        return self._currentRuleType == self.RULE_REF


### PR DESCRIPTION
To support Python target the following changes are needed:
* Reimplement LexerAdaptor in Python.
* Rename such parser (id, range) and lexer rules (True, False)
  whose identifier is a keyword in Python.
* Transform inline JAVA code snipets to Python in the lexer
  (because of this a new lexer grammar is added with PythonTarget
  postfix).