### PR TITLE
Lexer rules must not refer to parser rules.

### DIFF
--- a/antlr4/ANTLRv4Parser.g4
+++ b/antlr4/ANTLRv4Parser.g4
@@ -345,7 +345,6 @@ ebnfSuffix
 lexerAtom
 	:	characterRange
 	|	terminal
-	|	RULE_REF
 	|	notSet
 	|	LEXER_CHAR_SET
 	|	DOT elementOptions?


### PR DESCRIPTION
Lexer rules can refer only to other tokens or fragments.
However the lexerAtom rule in the antlr4 parser grammar
enables parser rule references too.
The patch removes the wrong alternative.