### PR TITLE
Fix exception_init pragma

### DIFF
--- a/plsql/plsql.g4
+++ b/plsql/plsql.g4
@@ -580,7 +580,7 @@ exception_declaration
 pragma_declaration
     : PRAGMA (SERIALLY_REUSABLE 
     | AUTONOMOUS_TRANSACTION
-    | EXCEPTION_INIT '(' exception_name ',' numeric ')'
+    | EXCEPTION_INIT '(' exception_name ',' numeric_negative ')'
     | INLINE '(' id1=id ',' expression ')'
     | RESTRICT_REFERENCES '(' (id | DEFAULT) (',' id)+ ')') ';'
     ;
@@ -2028,6 +2028,10 @@ constant
 numeric
     : UNSIGNED_INTEGER
     | APPROXIMATE_NUM_LIT
+    ;
+
+numeric_negative
+    : MINUS_SIGN numeric
     ;
 
 quoted_string


### PR DESCRIPTION
Now only accepts negative error codes.

As per issue #353 