### PR TITLE
Fix typo in the Python version of LexerAdaptor.

### DIFF
--- a/antlr4/LexerAdaptor.py
+++ b/antlr4/LexerAdaptor.py
@@ -36,12 +36,12 @@ class LexerAdaptor(Lexer):
 
     def handleEndArgument(self):
         self.popMode()
-        if self._modeStack.size() > 0:
+        if len(self._modeStack) > 0:
             self.setType(self.ARGUMENT_CONTENT)
 
     def handleEndAction(self):
         self.popMode()
-        if self._modeStack.size() > 0:
+        if len(self._modeStack) > 0:
             self.setType(self.ACTION_CONTENT)
 
     def emit(self):


### PR DESCRIPTION
Python uses the len() function to detect the size of a list.
However, in the LexerAdaptor of the antlr4 grammar size()
is used (mistakenly kept from the JAVA version).
This is fixed now.