### PR TITLE
- fixed the order of the try_operator to prevent a statement from par…

### DIFF
--- a/swift/Swift.g4
+++ b/swift/Swift.g4
@@ -383,7 +383,8 @@ parameter_clauses : parameter_clause parameter_clauses? ;
 parameter_clause : '(' ')' |  '(' parameter_list ')'  ;
 parameter_list : parameter (',' parameter)*  ;
 parameter
- : 'let'?  external_parameter_name? local_parameter_name type_annotation default_argument_clause?
+ : 'let'?  external_parameter_name? local_parameter_name type_annotation? default_argument_clause?
+ | 'var'   external_parameter_name? local_parameter_name type_annotation? default_argument_clause?
  | 'inout' external_parameter_name? local_parameter_name type_annotation
  |         external_parameter_name? local_parameter_name type_annotation range_operator
  ;

--- a/swift/Swift.g4
+++ b/swift/Swift.g4
@@ -383,8 +383,7 @@ parameter_clauses : parameter_clause parameter_clauses? ;
 parameter_clause : '(' ')' |  '(' parameter_list ')'  ;
 parameter_list : parameter (',' parameter)*  ;
 parameter
- : 'let'?  external_parameter_name? local_parameter_name type_annotation? default_argument_clause?
- | 'var'   external_parameter_name? local_parameter_name type_annotation? default_argument_clause?
+ : 'let'?  external_parameter_name? local_parameter_name type_annotation default_argument_clause?
  | 'inout' external_parameter_name? local_parameter_name type_annotation
  |         external_parameter_name? local_parameter_name type_annotation range_operator
  ;

--- a/swift/Swift.g4
+++ b/swift/Swift.g4
@@ -613,7 +613,6 @@ in_out_expression : '&' identifier ;
 
 // GRAMMAR OF A TRY EXPRESSION
 
-try_operator : 'try' | 'try' '?' | 'try' '!' ;
 try_operator : 'try' '?' | 'try' '!' | 'try' ;
 
 // GRAMMAR OF A BINARY EXPRESSION

--- a/swift/Swift.g4
+++ b/swift/Swift.g4
@@ -29,7 +29,7 @@
  * Converted from Apple's doc, http://tinyurl.com/n8rkoue, to ANTLR's
  * meta-language.
  */
-grammar Swift; // 2.1
+grammar Swift; // 2.2
 
 top_level : statement* EOF ;
 
@@ -614,6 +614,7 @@ in_out_expression : '&' identifier ;
 // GRAMMAR OF A TRY EXPRESSION
 
 try_operator : 'try' | 'try' '?' | 'try' '!' ;
+try_operator : 'try' '?' | 'try' '!' | 'try' ;
 
 // GRAMMAR OF A BINARY EXPRESSION
 
@@ -738,6 +739,9 @@ postfix_expression
  | postfix_expression '.' Pure_decimal_digits                     # explicit_member_expression1
  | postfix_expression '.' identifier generic_argument_clause?     # explicit_member_expression2
  | postfix_expression '.' identifier '(' argument_names ')'       # explicit_member_expression3
+// This does't exist in the swift grammar, but this valid swift statement fails without it
+// self.addTarget(self, action: #selector(nameOfAction(_:)))
+ | postfix_expression '(' argument_names ')'                      # explicit_member_expression4
  | postfix_expression '.' 'self'                                  # postfix_self_expression
  | postfix_expression '.' 'dynamicType'                           # dynamic_type_expression
  | postfix_expression '[' expression_list ']'                     # subscript_expression


### PR DESCRIPTION
…sing `try! NSJSONSerialization.JSONObjectWithData(unwrappedData, options: .AllowFragments)` as a try with a prefix operator

- added definition to accommodate #selector actions