### PR TITLE
JSON grammar fix: json can be any value

### DIFF
--- a/json/JSON.g4
+++ b/json/JSON.g4
@@ -5,8 +5,7 @@
 grammar JSON;
 
 json
-   : object
-   | array
+   : value
    ;
 
 object


### PR DESCRIPTION
The ECMA-404 standard says

> A JSON text is a sequence of tokens formed from Unicode code points
> that conforms to the JSON value grammar.

http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf

This corrects the JSON grammar so that it conforms to the spec, and will correctly parse any legal JSON value, instead of only objects and arrays.