### PR TITLE
Add support for negative integer and floating point literals in Java.g4.

### DIFF
--- a/java/Java.g4
+++ b/java/Java.g4
@@ -671,7 +671,7 @@ IntegerLiteral
 
 fragment
 DecimalIntegerLiteral
-    :   DecimalNumeral IntegerTypeSuffix?
+    :   Sign? DecimalNumeral IntegerTypeSuffix?
     ;
 
 fragment
@@ -799,10 +799,10 @@ FloatingPointLiteral
 
 fragment
 DecimalFloatingPointLiteral
-    :   Digits '.' Digits? ExponentPart? FloatTypeSuffix?
-    |   '.' Digits ExponentPart? FloatTypeSuffix?
-    |   Digits ExponentPart FloatTypeSuffix?
-    |   Digits FloatTypeSuffix
+    :   Sign? Digits '.' Digits? ExponentPart? FloatTypeSuffix?
+    |   Sign? '.' Digits ExponentPart? FloatTypeSuffix?
+    |   Sign? Digits ExponentPart FloatTypeSuffix?
+    |   Sign? Digits FloatTypeSuffix
     ;
 
 fragment


### PR DESCRIPTION
This PR will hopefully add support for negative integer and floating point literals to the Java.g4 grammar.

I am not an expert on Antlr4, but in my project when I imported this grammar I was not able to get it to parse negative/signed integer or floating point literals "-1" or "-1.5".

Please double-check that this makes sense before merging!

Many thanks!
Niall