### PR TITLE
Lua 5 3 updates

### DIFF
--- a/lua/Lua.g4
+++ b/lua/Lua.g4
@@ -41,9 +41,9 @@ This grammar file derived from:
     Lua 5.1 grammar written by Nicolai Mainiero
     http://www.antlr3.org/grammar/1178608849736/Lua.g
 
-I tested my grammar with Test suite for Lua 5.2 (http://www.lua.org/tests/5.2/)
+Tested by Kazunori Sakamoto with Test suite for Lua 5.2 (http://www.lua.org/tests/5.2/)
 
-Also tested with Test suite for Lua 5.3 http://www.lua.org/tests/lua-5.3.2-tests.tar.gz 
+Tested by Alexander Alexeev with Test suite for Lua 5.3 http://www.lua.org/tests/lua-5.3.2-tests.tar.gz 
 */
 
 grammar Lua;

--- a/lua/Lua.g4
+++ b/lua/Lua.g4
@@ -2,6 +2,7 @@
 BSD License
 
 Copyright (c) 2013, Kazunori Sakamoto
+Copyright (c) 2016, Alexander Alexeev
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -31,6 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This grammar file derived from:
 
+    Lua 5.3 Reference Manual
+    http://www.lua.org/manual/5.3/manual.html
+
     Lua 5.2 Reference Manual
     http://www.lua.org/manual/5.2/manual.html
 
@@ -38,6 +42,8 @@ This grammar file derived from:
     http://www.antlr3.org/grammar/1178608849736/Lua.g
 
 I tested my grammar with Test suite for Lua 5.2 (http://www.lua.org/tests/5.2/)
+
+Also tested with Test suite for Lua 5.3 http://www.lua.org/tests/lua-5.3.2-tests.tar.gz 
 */
 
 grammar Lua;

--- a/lua/Lua.g4
+++ b/lua/Lua.g4
@@ -93,23 +93,22 @@ explist
     ;
 
 exp
-    : 'nil' | 'false' | 'true' | number | string		
-	| '...'											
-	| functiondef								
-    | prefixexp										
-	| tableconstructor								
-	| <assoc=right> exp operatorPower exp			
-	| operatorUnary exp								
-	| exp operatorMulDivMod exp		
-	| exp operatorAddSub exp						
-	| <assoc=right> exp operatorStrcat exp			
-	| exp operatorComparison exp					
-	| exp operatorAnd exp							
-	| exp operatorOr exp	
-	;
-
-var
-    : (NAME | '(' exp ')' varSuffix) varSuffix*
+    : 'nil' | 'false' | 'true'
+    | number
+    | string
+    | '...'
+    | functiondef
+    | prefixexp
+    | tableconstructor
+    | <assoc=right> exp operatorPower exp
+    | operatorUnary exp
+    | exp operatorMulDivMod exp
+    | exp operatorAddSub exp
+    | <assoc=right> exp operatorStrcat exp
+    | exp operatorComparison exp
+    | exp operatorAnd exp
+    | exp operatorOr exp
+    | exp operatorBitwise exp
     ;
 
 prefixexp
@@ -124,12 +123,16 @@ varOrExp
     : var | '(' exp ')'
     ;
 
-nameAndArgs
-    : (':' NAME)? args
+var
+    : (NAME | '(' exp ')' varSuffix) varSuffix*
     ;
 
 varSuffix
     : nameAndArgs* ('[' exp ']' | '.' NAME)
+    ;
+
+nameAndArgs
+    : (':' NAME)? args
     ;
 
 /*
@@ -194,10 +197,13 @@ operatorAddSub
 	: '+' | '-';
 
 operatorMulDivMod
-	: '*' | '/' | '%';
+	: '*' | '/' | '%' | '//';
+
+operatorBitwise
+	: '&' | '|' | '~' | '<<' | '>>';
 
 operatorUnary
-    : 'not' | '#' | '-';
+    : 'not' | '#' | '-' | '~';
 
 operatorPower
     : '^';
@@ -270,6 +276,7 @@ EscapeSequence
     | '\\' '\r'? '\n'
     | DecimalEscape
     | HexEscape
+    | UtfEscape
     ;
     
 fragment
@@ -282,6 +289,11 @@ DecimalEscape
 fragment
 HexEscape
     : '\\' 'x' HexDigit HexDigit
+    ;
+
+fragment
+UtfEscape
+    : '\\' 'u{' HexDigit+ '}'
     ;
 
 fragment


### PR DESCRIPTION
Hello,

[Lua 5.3](https://www.lua.org/manual/5.3/) adds a little bit to language (such as bitwise ops and UTF-8 support) so current Lua.g4 fails on the [latest Lua test suite](https://www.lua.org/tests/). Here is Lua.g4 updated to 5.3 spec. Not sure if I correctly updated copyright info - please correct me if I'm wrong.

best regards,
Alexander Alexeev