### PR TITLE
Fixing an issue with "insert" command

### DIFF
--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -145,8 +145,7 @@ delete_statement_from
 insert_statement
     : with_expression?
       INSERT (TOP '(' expression ')' PERCENT?)?
-      INTO? (ddl_object | rowset_function_limited)
-      insert_with_table_hints?
+      INTO? (ddl_object | rowset_function_limited insert_with_table_hints?)
       ('(' column_name_list ')')?
       output_clause?
       insert_statement_value


### PR DESCRIPTION
Table_hints are related to rowset_function_limited, not to the entire "INTO" clause.

Fixing rule as per documentation:
https://msdn.microsoft.com/en-us/library/ms174335.aspx