### PR TITLE
Fix Token field access in the Python target of ECMAScript.

### DIFF
--- a/ecmascript/ECMAScript.PythonTarget.g4
+++ b/ecmascript/ECMAScript.PythonTarget.g4
@@ -738,11 +738,11 @@ futureReservedWord
  ;
 
 getter
- : {self._input.LT(1).getText() == "get"}? Identifier propertyName
+ : {self._input.LT(1).text == "get"}? Identifier propertyName
  ;
 
 setter
- : {self._input.LT(1).getText() == "set"}? Identifier propertyName
+ : {self._input.LT(1).text == "set"}? Identifier propertyName
  ;
 
 eos


### PR DESCRIPTION
The 'text' field of a Token is accessible via its 'text' property
in the Python runtime but it does not have a getText() getter
as it was used earlier. The patch fixes this issue.