### PR TITLE
avoid that git converts line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# given the grammars context, avoid that git converts line endings
+* -crlf
+
 **/examples/* linguist-vendored
 _support/* linguist-vendored


### PR DESCRIPTION
Currently on Windows some grammars and/or their examples have issues because git converts line endings (with "_git config --global core.autocrlf **true**_").

Because this is about grammars (which could make a distinction between only a single LF or a CRLF combination) it could be preferable to try to avoid that git converts line endings.

Using "_git config --global core.autocrlf **false**_" could help, but it is a client configuration and can be inconvenient when using different git repositories that require a different configuration.

It is suggested to resolve this using a **.gitattributes** file.

see also
https://help.github.com/articles/dealing-with-line-endings/
http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/

Many thanks.