### PR TITLE
VBA - fix operator precedences

### DIFF
--- a/vba/examples/example2operators.bas
+++ b/vba/examples/example2operators.bas
@@ -1,0 +1,10 @@
+Public Sub Module()
+    X = 0
+    Y = 1
+    Z = 2
+    Test1 = X + Y * Z
+    Test2 = X - Y * Z
+    Test3 = Z + X * Y - Y * Z
+    Test4 = Z + X * Y Mod Z * 2 + 5 * Z
+    Test5 = Z + X ^ 3 * Y Mod Z * 2 + 5 * Z ^ X
+End Sub

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -533,15 +533,15 @@ valueStmt :
 	| valueStmt WS? NEQ WS? valueStmt 						# vsNeq
 	| valueStmt WS? EQ WS? valueStmt 						# vsEq
 
-	| valueStmt WS? AMPERSAND WS? valueStmt 					# vsAmp
+	| valueStmt WS? POW WS? valueStmt 						# vsPow
 	| MINUS WS? valueStmt 									# vsNegation
 	| PLUS WS? valueStmt 									# vsPlus
-	| valueStmt WS? PLUS WS? valueStmt 						# vsAdd
-	| valueStmt WS? MOD WS? valueStmt 						# vsMod
 	| valueStmt WS? DIV WS? valueStmt 						# vsDiv
 	| valueStmt WS? MULT WS? valueStmt 						# vsMult
+	| valueStmt WS? MOD WS? valueStmt 						# vsMod
+	| valueStmt WS? PLUS WS? valueStmt 						# vsAdd
 	| valueStmt WS? MINUS WS? valueStmt 					# vsMinus
-	| valueStmt WS? POW WS? valueStmt 						# vsPow
+	| valueStmt WS? AMPERSAND WS? valueStmt 					# vsAmp
 
 	| valueStmt WS? IMP WS? valueStmt 						# vsImp
 	| valueStmt WS? EQV WS? valueStmt 						# vsEqv


### PR DESCRIPTION
Many operators had incorrect precedences. Fixed to match the order described here: https://msdn.microsoft.com/en-us/library/fw84t893.aspx