### PR TITLE
Add lexer support for multiline macros in C++

### DIFF
--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -1317,6 +1317,12 @@ noexceptspecification
 ;
 
 /*Preprocessing directives*/
+
+MultiLineMacro
+:
+    '#' (.*? '\\' [\r\n]+)+ (.*? ~[\r\n]*) -> skip
+;
+
 Directive
 :
 	'#' ~[\r\n]* -> skip

--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -1320,7 +1320,7 @@ noexceptspecification
 
 MultiLineMacro
 :
-    '#' (.*? '\\' [\r\n]+)+ (.*? ~[\r\n]*) -> skip
+    '#' (.*? '\\' [\r\n]+)+ ~[\r\n]+ -> skip
 ;
 
 Directive


### PR DESCRIPTION
The existing C++ grammar skips all pre-processor directives.  However, the grammar fails to handle multiline macros. These macros have to be skipped too, otherwise the parser will fail. This commit adds the necessary support.
