### PR TITLE
Add skip #include to C grammar

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -924,3 +924,8 @@ LineComment
     :   '//' ~[\r\n]*
         -> skip
     ;
+
+IncludeStatement
+    :   '#include' ~[\r\n]*
+        -> skip
+    ;


### PR DESCRIPTION
The current C grammar will cause antlr generated classes to throw token recognition errors on `#include` statements