### PR TITLE
Corrections to Modelica grammar

### DIFF
--- a/modelica/examples/Complex.mo
+++ b/modelica/examples/Complex.mo
@@ -1,0 +1,274 @@
+within ;
+operator record Complex "Complex number with overloaded operators"
+//record Complex "Complex number with overloaded operators"
+  replaceable Real re "Real part of complex number" annotation(Dialog);
+  replaceable Real im "Imaginary part of complex number" annotation(Dialog);
+
+  encapsulated operator 'constructor' "Constructor"
+    function fromReal "Construct Complex from Real"
+      import Complex;
+      input Real re "Real part of complex number";
+      input Real im=0 "Imaginary part of complex number";
+      output Complex result(re=re, im=im) "Complex number";
+    algorithm
+
+      annotation(Inline=true, Documentation(info="<html>
+<p>This function returns a Complex number defined by real part <i>re</i> and optional imaginary part <i>im</i> (default=0).</p>
+</html>"));
+    end fromReal;
+    annotation (Documentation(info="<html>
+<p>Here the constructor operator(s) is/are defined.</p>
+</html>"), Icon(graphics={Rectangle(
+            lineColor={200,200,200},
+            fillColor={248,248,248},
+            fillPattern=FillPattern.HorizontalCylinder,
+            extent={{-100,-100},{100,100}},
+            radius=25.0), Rectangle(
+            lineColor={128,128,128},
+            fillPattern=FillPattern.None,
+            extent={{-100,-100},{100,100}},
+            radius=25.0)}));
+  end 'constructor';
+
+  encapsulated operator function '0' "Zero-element of addition (= Complex(0))"
+    import Complex;
+    output Complex result "Complex(0)";
+  algorithm
+    result := Complex(0);
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the zero-element of Complex, that is, Complex(0) = 0 + j*0.</p>
+</html>"));
+  end '0';
+
+  encapsulated operator '-' "Unary and binary minus"
+    function negate "Unary minus (multiply complex number by -1)"
+      import Complex;
+      input Complex c1 "Complex number";
+      output Complex c2 "= -c1";
+    algorithm
+      c2 := Complex(-c1.re, -c1.im);
+      annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the binary minus of the given Complex number.</p>
+</html>"));
+    end negate;
+
+    function subtract "Subtract two complex numbers"
+      import Complex;
+      input Complex c1 "Complex number 1";
+      input Complex c2 "Complex number 2";
+      output Complex c3 "= c1 - c2";
+    algorithm
+      c3 := Complex(c1.re - c2.re, c1.im - c2.im);
+      annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the difference of two given Complex numbers.</p>
+</html>"));
+    end subtract;
+    annotation (Documentation(info="<html>
+<p>Here the unary and binary minus operator(s) is/are defined.</p>
+</html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+              {100,100}}), graphics={
+          Rectangle(
+            lineColor={200,200,200},
+            fillColor={248,248,248},
+            fillPattern=FillPattern.HorizontalCylinder,
+            extent={{-100,-100},{100,100}},
+            radius=25.0),
+          Rectangle(
+            lineColor={128,128,128},
+            fillPattern=FillPattern.None,
+            extent={{-100,-100},{100,100}},
+            radius=25.0),
+          Line(
+            points={{-50,0},{50,0}},
+            color={0,0,0},
+            smooth=Smooth.None)}));
+  end '-';
+
+  encapsulated operator '*' "Multiplication"
+    function multiply "Multiply two complex numbers"
+      import Complex;
+      input Complex c1 "Complex number 1";
+      input Complex c2 "Complex number 2";
+      output Complex c3 "= c1*c2";
+    algorithm
+      c3 := Complex(c1.re*c2.re - c1.im*c2.im, c1.re*c2.im + c1.im*c2.re);
+
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the product of two given Complex numbers.</p>
+</html>"));
+    end multiply;
+
+    function scalarProduct "Scalar product c1*c2 of two complex vectors"
+      import Complex;
+      input Complex c1[:] "Vector of Complex numbers 1";
+      input Complex c2[size(c1,1)] "Vector of Complex numbers 2";
+      output Complex c3 "= c1*c2";
+    algorithm
+      c3 :=Complex(0);
+      for i in 1:size(c1,1) loop
+         c3 :=c3 + c1[i]*c2[i];
+         /*
+       c3 :=Complex(c3.re + c1[i].re*c2[i].re - c1[i].im*c2[i].im,
+                    c3.im + c1[i].re*c2[i].im + c1[i].im*c2[i].re);
+       */
+      end for;
+
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the scalar product of two given arrays of Complex numbers.</p>
+</html>"));
+    end scalarProduct;
+    annotation (
+      Documentation(info="<html>
+<p>Here the multiplication operator(s) is/are defined.</p>
+</html>"),
+      Icon(coordinateSystem(
+          preserveAspectRatio=false,
+          extent={{-100,-100},{100,100}}),
+          graphics={
+          Rectangle(
+            lineColor={200,200,200},
+            fillColor={248,248,248},
+            fillPattern=FillPattern.HorizontalCylinder,
+            extent={{-100,-100},{100,100}},
+            radius=25.0),
+          Rectangle(
+            lineColor={128,128,128},
+            fillPattern=FillPattern.None,
+            extent={{-100,-100},{100,100}},
+            radius=25.0),
+          Line(
+            points={{-42,36},{39,-34}},
+            color={0,0,0},
+            smooth=Smooth.None),
+          Line(
+            points={{-42,-35},{39,37}},
+            color={0,0,0},
+            smooth=Smooth.None),
+          Line(
+            points={{-55,1},{52,1}},
+            color={0,0,0},
+            smooth=Smooth.None),
+          Line(
+            points={{-1.5,55},{-2,-53}},
+            color={0,0,0},
+            smooth=Smooth.None)}));
+  end '*';
+
+  encapsulated operator function '+' "Add two complex numbers"
+    import Complex;
+    input Complex c1 "Complex number 1";
+    input Complex c2 "Complex number 2";
+    output Complex c3 "= c1 + c2";
+  algorithm
+    c3 := Complex(c1.re + c2.re, c1.im + c2.im);
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the sum of two given Complex numbers.</p>
+</html>"));
+  end '+';
+
+  encapsulated operator function '/' "Divide two complex numbers"
+    import Complex;
+    input Complex c1 "Complex number 1";
+    input Complex c2 "Complex number 2";
+    output Complex c3 "= c1/c2";
+  algorithm
+    c3 := Complex((+c1.re*c2.re + c1.im*c2.im)/(c2.re*c2.re + c2.im*c2.im),
+                  (-c1.re*c2.im + c1.im*c2.re)/(c2.re*c2.re + c2.im*c2.im));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the quotient of two given Complex numbers.</p>
+</html>"));
+  end '/';
+
+  encapsulated operator function '^' "Complex power of complex number"
+    import Complex;
+    input Complex c1 "Complex number";
+    input Complex c2 "Complex exponent";
+    output Complex c3 "= c1^c2";
+  protected
+    Real lnz=0.5*log(c1.re*c1.re + c1.im*c1.im);
+    Real phi=atan2(c1.im, c1.re);
+    Real re=lnz*c2.re - phi*c2.im;
+    Real im=lnz*c2.im + phi*c2.re;
+  algorithm
+    c3 := Complex(exp(re)*cos(im), exp(re)*sin(im));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the given Complex numbers c1 to the power of the Complex number c2.</p>
+</html>"));
+  end '^';
+
+  encapsulated operator function '=='
+    "Test whether two complex numbers are identical"
+    import Complex;
+    input Complex c1 "Complex number 1";
+    input Complex c2 "Complex number 2";
+    output Boolean result "c1 == c2";
+  algorithm
+    result := c1.re == c2.re and c1.im == c2.im;
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function tests whether two given Complex numbers are equal.</p>
+</html>"));
+  end '==';
+
+  encapsulated operator function '<>'
+    "Test whether two complex numbers are not identical"
+    import Complex;
+    input Complex c1 "Complex number 1";
+    input Complex c2 "Complex number 2";
+    output Boolean result "c1 <> c2";
+  algorithm
+    result := c1.re <> c2.re or c1.im <> c2.im;
+    annotation(Inline=true, Documentation(info="<html>
+    <p>This function tests whether two given Complex numbers are not equal.</p>
+</html>"));
+  end '<>';
+
+  encapsulated operator function 'String'
+    "Transform Complex number into a String representation"
+    import Complex;
+    input Complex c
+      "Complex number to be transformed in a String representation";
+    input String name="j"
+      "Name of variable representing sqrt(-1) in the string";
+    input Integer significantDigits=6
+      "Number of significant digits that are shown";
+    output String s="";
+  algorithm
+    s := String(c.re, significantDigits=significantDigits);
+    if c.im <> 0 then
+      if c.im > 0 then
+        s := s + " + ";
+      else
+        s := s + " - ";
+      end if;
+      s := s + String(abs(c.im), significantDigits=significantDigits) + "*" + name;
+    end if;
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function converts a given Complex number to String representation.</p>
+</html>"));
+  end 'String';
+
+
+annotation (Protection(access=Access.hide),
+version="3.2.2",
+versionBuild=0,
+versionDate="2016-01-15",
+dateModified = "2016-01-15 08:44:41Z",
+revisionId="$Id::                                       $",
+conversion(
+ noneFromVersion="3.2.1",
+ noneFromVersion="1.0",
+ noneFromVersion="1.1"),
+Documentation(info="<html>
+<p>Complex number defined as a record containing real and imaginary part, utilizing operator overloading.</p>
+</html>"),
+    Icon(graphics={Rectangle(
+          lineColor={160,160,164},
+          fillColor={160,160,164},
+          fillPattern=FillPattern.Solid,
+          extent={{-100,-100},{100,100}},
+          radius=25.0), Text(
+          lineColor={255,255,255},
+          extent={{-90,-50},{90,50}},
+          textString="C")}));
+
+end Complex;

--- a/modelica/examples/ComplexMath.mo
+++ b/modelica/examples/ComplexMath.mo
@@ -1,0 +1,667 @@
+within Modelica;
+package ComplexMath
+  "Library of complex mathematical functions (e.g., sin, cos) and of functions operating on complex vectors and matrices"
+  extends Modelica.Icons.Package;
+  final constant Complex j = Complex(0,1) "Imaginary unit";
+
+package Vectors "Library of functions operating on complex vectors"
+  extends Modelica.Icons.Package;
+
+function norm "Returns the p-norm of a complex vector"
+  extends Modelica.Icons.Function;
+  input Complex v[:] "Vector";
+  input Real p(min=1) = 2
+        "Type of p-norm (often used: 1, 2, or Modelica.Constants.inf)";
+  output Real result "p-norm of vector v";
+
+algorithm
+  if p == 2 then
+    result:= sqrt(sum(v[i].re^2 + v[i].im^2 for i in 1:size(v,1)));
+  elseif p == Modelica.Constants.inf then
+    result:= ComplexMath.'abs'(ComplexMath.'max'(v));
+  elseif p == 1 then
+    result:= sum(ComplexMath.'abs'(v[i]) for i in 1:size(v,1));
+  else
+    result:=(sum(ComplexMath.'abs'(v[i])^p for i in 1:size(v, 1)))^(1/p);
+  end if;
+
+  annotation (Documentation(info="<html>
+<h4>Syntax</h4>
+<blockquote><pre>
+Vectors.<b>norm</b>(v);
+Vectors.<b>norm</b>(v,p=2);   // 1 &le; p &le; &#8734;
+</pre></blockquote>
+
+<h4>Description</h4>
+<p>
+The function call \"<code>Vectors.<b>norm</b>(v)</code>\" returns the
+<b>Euclidean norm</b> \"<code>sqrt(v*v)</code>\" of vector v.
+With the optional
+second argument \"p\", any other p-norm can be computed:
+</p>
+<center>
+<IMG src=\"modelica://Modelica/Resources/Images/Math/Vectors/vectorNorm.png\" ALT=\"function Vectors.norm\">
+</center>
+<p>
+Besides the Euclidean norm (p=2), also the 1-norm and the
+infinity-norm are sometimes used:
+</p>
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><td><b>1-norm</b></td>
+      <td>= sum(abs(v))</td>
+      <td><b>norm</b>(v,1)</td>
+  </tr>
+  <tr><td><b>2-norm</b></td>
+      <td>= sqrt(v*v)</td>
+      <td><b>norm</b>(v) or <b>norm</b>(v,2)</td>
+  </tr>
+  <tr><td><b>infinity-norm</b></td>
+      <td>= max(abs(v))</td>
+      <td><b>norm</b>(v,Modelica.Constants.<b>inf</b>)</td>
+  </tr>
+</table>
+<p>
+Note, for any vector norm the following inequality holds:
+</p>
+<blockquote><pre>
+<b>norm</b>(v1+v2,p) &le; <b>norm</b>(v1,p) + <b>norm</b>(v2,p)
+</pre></blockquote>
+
+<h4>Example</h4>
+<blockquote><pre>
+  v = {2, -4, -2, -1};
+  <b>norm</b>(v,1);    // = 9
+  <b>norm</b>(v,2);    // = 5
+  <b>norm</b>(v);      // = 5
+  <b>norm</b>(v,10.5); // = 4.00052597412635
+  <b>norm</b>(v,Modelica.Constants.inf);  // = 4
+</pre></blockquote>
+
+<h4>See also</h4>
+<p>
+<a href=\"modelica://Modelica.Math.Matrices.norm\">Matrices.norm</a>
+</p>
+</html>"));
+end norm;
+
+function length "Return length of a complex vector"
+  extends Modelica.Icons.Function;
+  input Complex v[:] "Vector";
+  output Real result "Length of vector v";
+
+algorithm
+  result := sqrt(sum({v[i].re^2 + v[i].im^2 for i in 1:size(v,1)}));
+  annotation (Documentation(info="<html>
+<h4>Syntax</h4>
+<blockquote><pre>
+Vectors.<b>length</b>(v);
+</pre></blockquote>
+
+<h4>Description</h4>
+
+<p>
+The function call \"<code>Vectors.<b>length</b>(v)</code>\" returns the
+<b>Euclidean length</b> \"<code>sqrt(v*v)</code>\" of vector v.
+The function call is equivalent to Vectors.norm(v). The advantage of
+length(v) over norm(v)\"is that function length(..) is implemented
+in one statement and therefore the function is usually automatically
+inlined. Further symbolic processing is therefore possible, which is
+not the case with function norm(..).
+</p>
+
+<h4>Example</h4>
+<blockquote><pre>
+  v = {2, -4, -2, -1};
+  <b>length</b>(v);  // = 5
+</pre></blockquote>
+
+<h4>See also</h4>
+<p>
+<a href=\"modelica://Modelica.Math.Vectors.norm\">Vectors.norm</a>
+</p>
+</html>"));
+end length;
+
+function normalize
+      "Return normalized complex vector such that length = 1 and prevent zero-division for zero vector"
+  extends Modelica.Icons.Function;
+  input Complex v[:] "Vector";
+  input Real eps = 100*Modelica.Constants.eps "if |v| < eps then result = v";
+  output Complex result[size(v, 1)] "Input vector v normalized to length=1";
+
+    protected
+  Real length_v = length(v);
+algorithm
+  if length_v >= eps then
+     for i in 1:size(v,1) loop
+         result[i] :=v[i].re/length_v + (v[i].im/length_v)*j;
+     end for;
+  else
+     result :=v;
+  end if;
+
+  annotation (Documentation(info="<html>
+<h4>Syntax</h4>
+<blockquote><pre>
+Vectors.<b>normalize</b>(v);
+Vectors.<b>normalize</b>(v,eps=100*Modelica.Constants.eps);
+</pre></blockquote>
+
+<h4>Description</h4>
+<p>
+The function call \"<code>Vectors.<b>normalize</b>(v)</code>\" returns the
+<b>unit vector</b> \"<code>v/length(v)</code>\" of vector v.
+If length(v) is close to zero (more precisely, if length(v) &lt; eps),
+v is returned in order to avoid
+a division by zero. For many applications this is useful, because
+often the unit vector <b>e</b> = <b>v</b>/length(<b>v</b>) is used to compute
+a vector x*<b>e</b>, where the scalar x is in the order of length(<b>v</b>),
+i.e., x*<b>e</b> is small, when length(<b>v</b>) is small and then
+it is fine to replace <b>e</b> by <b>v</b> to avoid a division by zero.
+</p>
+<p>
+Since the function is implemented in one statement,
+it is usually inlined and therefore symbolic processing is
+possible.
+</p>
+
+<h4>Example</h4>
+<blockquote><pre>
+  <b>normalize</b>({1,2,3});  // = {0.267, 0.534, 0.802}
+  <b>normalize</b>({0,0,0});  // = {0,0,0}
+</pre></blockquote>
+
+<h4>See also</h4>
+<p>
+<a href=\"modelica://Modelica.Math.Vectors.length\">Vectors.length</a>
+</p>
+</html>"));
+end normalize;
+
+function reverse "Reverse vector elements (e.g., v[1] becomes last element)"
+extends Modelica.Icons.Function;
+
+  input Complex v[:] "Vector";
+  output Complex result[size(v, 1)] "Elements of vector v in reversed order";
+
+algorithm
+  result := {v[end-i+1] for i in 1:size(v,1)};
+annotation (Inline=true, Documentation(info="<html>
+<h4>Syntax</h4>
+<blockquote><pre>Vectors.<b>reverse</b>(v);</pre></blockquote>
+<h4>Description</h4>
+The function call &quot;<code>Vectors.<b>reverse</b>(v)</code>&quot; returns the complex vector elements in reverse order.
+<h4>Example</h4>
+<blockquote><pre>  <b>reverse</b>({1,2,3,4});  // = {4,3,2,1}</pre></blockquote>
+</html>"));
+end reverse;
+
+function sort "Sort elements of complex vector"
+  extends Modelica.Icons.Function;
+  input Complex v[:] "Vector to be sorted";
+  input Boolean ascending = true
+        "= true if ascending order, otherwise descending order";
+  input Boolean sortFrequency=true
+        "= true, if sorting is first for imaginary then for real value; = false, if sorting is for absolute value";
+  output Complex sorted_v[size(v,1)] = v "Sorted vector";
+  output Integer indices[size(v,1)] = 1:size(v,1) "sorted_v = v[indices]";
+
+  /* shellsort algorithm; should be improved later */
+    protected
+  Integer gap;
+  Integer i;
+  Integer j;
+  Complex wv;
+  Integer wi;
+  Integer nv = size(v,1);
+  Boolean swap;
+  Integer k1;
+  Integer k2;
+algorithm
+  gap := div(nv,2);
+
+  while gap > 0 loop
+     i := gap;
+     while i < nv loop
+        j := i-gap;
+        if j>=0 then
+           k1 := j+1;
+           k2 := j + gap + 1;
+           if sortFrequency then
+              if ascending then
+                 swap := abs(sorted_v[k1].im) >  abs(sorted_v[k2].im) or
+                         abs(sorted_v[k1].im) == abs(sorted_v[k2].im) and
+                         (sorted_v[k1].re  > sorted_v[k2].re or
+                          sorted_v[k1].re  == sorted_v[k2].re and sorted_v[k1].im < sorted_v[k2].im);
+              else
+                 swap := abs(sorted_v[k1].im) <  abs(sorted_v[k2].im) or
+                         abs(sorted_v[k1].im) == abs(sorted_v[k2].im) and
+                         (sorted_v[k1].re  < sorted_v[k2].re or
+                          sorted_v[k1].re  == sorted_v[k2].re and sorted_v[k1].im < sorted_v[k2].im);
+              end if;
+           else
+              if ascending then
+                 swap := ComplexMath.'abs'(sorted_v[k1]) > ComplexMath.'abs'(sorted_v[k2]);
+              else
+                 swap := ComplexMath.'abs'(sorted_v[k1]) < ComplexMath.'abs'(sorted_v[k2]);
+              end if;
+           end if;
+        else
+           swap := false;
+        end if;
+
+        while swap loop
+           wv := sorted_v[j+1];
+           wi := indices[j+1];
+           sorted_v[j+1] := sorted_v[j+gap+1];
+           sorted_v[j+gap+1] := wv;
+           indices[j+1] := indices[j+gap+1];
+           indices[j+gap+1] := wi;
+           j := j - gap;
+           if j >= 0 then
+              k1 := j+1;
+              k2 := j + gap + 1;
+              if sortFrequency then
+                 if ascending then
+                    swap := abs(sorted_v[k1].im) >  abs(sorted_v[k2].im) or
+                            abs(sorted_v[k1].im) == abs(sorted_v[k2].im) and
+                            (sorted_v[k1].re  > sorted_v[k2].re or
+                             sorted_v[k1].re  == sorted_v[k2].re and sorted_v[k1].im < sorted_v[k2].im);
+                 else
+                    swap := abs(sorted_v[k1].im) <  abs(sorted_v[k2].im) or
+                            abs(sorted_v[k1].im) == abs(sorted_v[k2].im) and
+                            (sorted_v[k1].re  < sorted_v[k2].re or
+                             sorted_v[k1].re  == sorted_v[k2].re and sorted_v[k1].im < sorted_v[k2].im);
+                 end if;
+              else
+                 if ascending then
+                    swap := ComplexMath.'abs'(sorted_v[k1]) > ComplexMath.'abs'(sorted_v[k2]);
+                 else
+                    swap := ComplexMath.'abs'(sorted_v[k1]) < ComplexMath.'abs'(sorted_v[k2]);
+                 end if;
+              end if;
+           else
+              swap := false;
+           end if;
+        end while;
+        i := i + 1;
+     end while;
+     gap := div(gap,2);
+  end while;
+
+  annotation (Documentation(info="<html>
+<h4>Syntax</h4>
+<blockquote><pre>
+           sorted_v = Vectors.<b>sort</b>(v);
+(sorted_v, indices) = Vectors.<b>sort</b>(v, ascending=true);
+</pre></blockquote>
+
+<h4>Description</h4>
+<p>
+Function <b>sort</b>(..) sorts a Real vector v
+in ascending order and returns the result in sorted_v.
+If the optional argument \"ascending\" is <b>false</b>, the vector
+is sorted in descending order. In the optional second
+output argument the indices of the sorted vector with respect
+to the original vector are given, such that sorted_v = v[indices].
+</p>
+
+<h4>Example</h4>
+<blockquote><pre>
+  (v2, i2) := Vectors.sort({-1, 8, 3, 6, 2});
+       -> v2 = {-1, 2, 3, 6, 8}
+          i2 = {1, 5, 3, 4, 2}
+</pre></blockquote>
+
+</html>"));
+end sort;
+
+  annotation(Documentation(info="<html>
+<p>
+This library provides functions operating on vectors
+of Complex numbers.
+</p>
+</html>"));
+end Vectors;
+
+  function sin "Sine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "sin(c1)";
+  algorithm
+     c2 := (exp(Complex(-c1.im, +c1.re)) - exp(Complex(+c1.im, -c1.re)))/Complex(0, 2);
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex sine of the Complex input.</p>
+</html>"));
+  end sin;
+
+  function cos "Cosine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= cos(c1)";
+  algorithm
+    c2 := (exp(Complex(-c1.im, +c1.re)) + exp(Complex(+c1.im, -c1.re)))/2;
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex cosine of the Complex input.</p>
+</html>"));
+  end cos;
+
+  function tan "Tangent of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= tan(c1)";
+  algorithm
+    c2 := sin(c1)/cos(c1);
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex tangent of the Complex input.</p>
+</html>"));
+  end tan;
+
+  function asin "Arc-sine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "arc_sin(c1)";
+  algorithm
+    c2 := -j*log(j*c1 + 'sqrt'(1 - c1*c1));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the inverse Complex sine of the Complex input.</p>
+</html>"));
+  end asin;
+
+  function acos "Arc-cosine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= arc_cos(c1)";
+  algorithm
+    c2 := -j*log(c1 + j*'sqrt'(1 - c1*c1));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the inverse Complex cosine of the Complex input.</p>
+</html>"));
+  end acos;
+
+  function atan "Arc-tangent of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= arc_tan(c1)";
+  algorithm
+    c2 := 0.5*j*log((j + c1)/(j - c1));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the inverse Complex tangent of the Complex input.</p>
+</html>"));
+  end atan;
+
+  function sinh "Hyperbolic-sine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "sinh(c1)";
+  algorithm
+    c2 := Complex(Math.sinh(c1.re)*Math.cos(c1.im), Math.cosh(c1.re)*Math.sin(c1.im));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex hyperbolic sine of the Complex input.</p>
+</html>"));
+  end sinh;
+
+  function cosh "Hyperbolic-cosine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= cosh(c1)";
+  algorithm
+    c2 := Complex(Math.cosh(c1.re)*Math.cos(c1.im), Math.sinh(c1.re)*Math.sin(c1.im));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex hyperbolic cosine of the Complex input.</p>
+</html>"));
+  end cosh;
+
+  function tanh "Hyperbolic-tangent of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= tanh(c1)";
+  algorithm
+    c2 := sinh(c1)/cosh(c1);
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex hyperbolic tangent of the Complex input.</p>
+</html>"));
+  end tanh;
+
+  function asinh "Area-hyperbolic-sine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "ar_sinh(c1)";
+  algorithm
+    c2 := log(c1 + 'sqrt'(c1*c1 + 1));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the inverse Complex hyperbolic sine of the Complex input.</p>
+</html>"));
+  end asinh;
+
+  function acosh "Area-hyperbolic-cosine of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= ar_cosh(c1)";
+  algorithm
+    c2 := log(c1 + (c1 + 1)*'sqrt'((c1 - 1)/(c1 + 1)));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the inverse Complex hyperbolic cosine of the Complex input.</p>
+</html>"));
+  end acosh;
+
+  function atanh "Area-hyperbolic-tangent of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= ar_tanh(c1)";
+  algorithm
+    c2 := 0.5*log((1 + c1)/(1 - c1));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the inverse Complex hyperbolic tangent of the Complex input.</p>
+</html>"));
+  end atanh;
+
+  function exp "Exponential of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= exp(c1)";
+  algorithm
+    c2 := Complex(Math.exp(c1.re)*Math.cos(c1.im), Math.exp(c1.re)*Math.sin(c1.im));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex natural exponential of the Complex input.</p>
+</html>"));
+  end exp;
+
+  function log "Logarithm of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= log(c1)";
+  algorithm
+    c2 := Complex(Modelica.Math.log('abs'(c1)), arg(c1));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex natural logarithm of the Complex input.</p>
+</html>"));
+  end log;
+
+  function 'abs' "Absolute value of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c "Complex number";
+    output Real result "= abs(c)";
+  algorithm
+    result := (c.re^2 + c.im^2)^0.5; //changed from sqrt
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Real absolute of the Complex input, i.e., its length.</p>
+</html>"));
+  end 'abs';
+
+  function arg "Phase angle of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c "Complex number";
+    input Modelica.SIunits.Angle phi0=0
+      "Phase angle phi shall be in the range: -pi < phi-phi0 < pi";
+    output Modelica.SIunits.Angle phi "= phase angle of c";
+  algorithm
+    phi := Modelica.Math.atan3(
+        c.im,
+        c.re,
+        phi0);
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Real argument of the Complex input, i.e., its angle.</p>
+</html>"));
+  end arg;
+
+  function conj "Conjugate of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= c1.re - j*c1.im";
+  algorithm
+    c2 := Complex(c1.re, -c1.im);
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex conjugate of the Complex input.</p>
+</html>"));
+  end conj;
+
+  function real "Real part of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c "Complex number";
+    output Real r "= c.re";
+  algorithm
+    r := c.re;
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the real part of the Complex input.</p>
+</html>"));
+  end real;
+
+  function imag "Imaginary part of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c "Complex number";
+    output Real r "= c.im";
+  algorithm
+    r := c.im;
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the imaginary part of the Complex input.</p>
+</html>"));
+  end imag;
+
+  function fromPolar "Complex from polar representation"
+    extends Modelica.Icons.Function;
+    input Real len "abs of complex";
+    input Modelica.SIunits.Angle phi "arg of complex";
+    output Complex c "= len*cos(phi) + j*len*sin(phi)";
+  algorithm
+    c := Complex(len*Modelica.Math.cos(phi), len*Modelica.Math.sin(phi));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function constructs a Complex number from its length (absolute) and angle (argument).</p>
+</html>"));
+  end fromPolar;
+
+  function 'sqrt' "Square root of complex number"
+    extends Modelica.Icons.Function;
+    input Complex c1 "Complex number";
+    output Complex c2 "= sqrt(c1)";
+  algorithm
+    c2 := Complex(sqrt('abs'(c1))*Math.cos(arg(c1)/2), sqrt('abs'(c1))*Math.sin(arg(c1)/2));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex square root (principal square root) of the Complex input.</p>
+</html>"));
+  end 'sqrt';
+
+  function 'max' "Return maximum element of complex vector"
+    extends Modelica.Icons.Function;
+    input Complex v[:] "Vector";
+    output Complex result "Element of v with largest absolute value";
+    output Integer index "v[index] has the largest absolute value";
+  protected
+    Real absv_i;
+    Real absres;
+  algorithm
+    if size(v,1) > 0 then
+      absres := 'abs'(v[1]);
+      index  := 1;
+      for i in 2:size(v,1) loop
+        absv_i := 'abs'(v[i]);
+        if absv_i > absres then
+          absres := absv_i;
+          index := i;
+        end if;
+      end for;
+      result :=v[index];
+    else
+      result := Complex(0);
+      index  := 0;
+    end if;
+    annotation(Documentation(info="<html>
+<p>This function returns the largest element of the Complex input vector, defined by the Complex absolute.</p>
+</html>"));
+  end 'max';
+
+  function 'min' "Return minimum element of complex vector"
+    extends Modelica.Icons.Function;
+    input Complex v[:] "Vector";
+    output Complex result "Element of v with smallest absolute value";
+    output Integer index "v[index] has the smallest absolute value";
+  protected
+    Real absv_i;
+    Real absres;
+  algorithm
+    if size(v,1) > 0 then
+      absres := 'abs'(v[1]);
+      index  := 1;
+      for i in 2:size(v,1) loop
+        absv_i := 'abs'(v[i]);
+        if absv_i < absres then
+          absres := absv_i;
+          index := i;
+        end if;
+      end for;
+      result :=v[index];
+    else
+      result := Complex(0);
+      index  := 0;
+    end if;
+    annotation(Documentation(info="<html>
+<p>This function returns the smallest element of the Complex input vector, defined by the Complex absolute.</p>
+</html>"));
+  end 'min';
+
+  function 'sum' "Return sum of complex vector"
+    extends Modelica.Icons.Function;
+    input Complex v[:] "Vector";
+    output Complex result "Complex sum of vector elements";
+  algorithm
+    result:=Complex(sum(v[:].re), sum(v[:].im));
+    annotation(Inline=true, Documentation(info="<html>
+<p>This function returns the Complex sum of the Complex input vector</p>
+</html>"));
+  end 'sum';
+
+  function 'product' "Return product of complex vector"
+    extends Modelica.Icons.Function;
+    input Complex v[:] "Vector";
+    output Complex result "Complex product of vector elements";
+  algorithm
+    result:=Complex(1);
+    for i in 1:size(v,1) loop
+      result:=result * v[i];
+    end for;
+    annotation(Documentation(info="<html>
+<p>This function returns the Complex product of the Complex input vector</p>
+</html>"));
+  end 'product';
+
+  annotation (Documentation(info="<html>
+<p>
+This package contains <b>basic mathematical functions</b>
+operating on complex numbers (such as sin(..)),
+as well as functions operating on vectors of complex numbers.
+</p>
+
+</html>"), Icon(coordinateSystem(extent={{-100,-100},{100,100}},
+          preserveAspectRatio=false), graphics={
+        Line(points={{32,-86},{32,88}}, color={175,175,175}),
+        Line(points={{-84,2},{88,2}}, color={175,175,175}),
+        Line(
+          points={{-50,75},{-5,30}}),
+        Line(
+          points={{-50,30},{-5,75}}),
+        Line(
+          points={{-50,-30},{-5,-75}}),
+        Line(
+          points={{-50,-75},{-5,-30}})}));
+
+end ComplexMath;

--- a/modelica/examples/Continuous.mo
+++ b/modelica/examples/Continuous.mo
@@ -1,0 +1,4644 @@
+within Modelica.Blocks;
+package Continuous "Library of continuous control blocks with internal states"
+
+  import Modelica.Blocks.Interfaces;
+  import Modelica.SIunits;
+  extends Modelica.Icons.Package;
+
+  block Integrator "Output the integral of the input signal"
+    import Modelica.Blocks.Types.Init;
+    parameter Real k(unit="1")=1 "Integrator gain";
+
+    /* InitialState is the default, because it was the default in Modelica 2.2
+     and therefore this setting is backward compatible
+  */
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.InitialState
+      "Type of initialization (1: no init, 2: steady state, 3,4: initial output)"
+                                                                                      annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real y_start=0 "Initial or guess value of output (= state)"
+      annotation (Dialog(group="Initialization"));
+    extends Interfaces.SISO(y(start=y_start));
+
+  initial equation
+    if initType == Init.SteadyState then
+       der(y) = 0;
+    elseif initType == Init.InitialState or
+           initType == Init.InitialOutput then
+      y = y_start;
+    end if;
+  equation
+    der(y) = k*u;
+    annotation (
+      Documentation(info="<html>
+<p>
+This blocks computes output <b>y</b> (element-wise) as
+<i>integral</i> of the input <b>u</b> multiplied with
+the gain <i>k</i>:
+</p>
+<pre>
+         k
+     y = - u
+         s
+</pre>
+
+<p>
+It might be difficult to initialize the integrator in steady state.
+This is discussed in the description of package
+<a href=\"modelica://Modelica.Blocks.Continuous#info\">Continuous</a>.
+</p>
+
+</html>"),   Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100.0,-100.0},{100.0,100.0}}),
+          graphics={
+            Line(
+              points={{-80.0,78.0},{-80.0,-90.0}},
+              color={192,192,192}),
+            Polygon(
+              lineColor={192,192,192},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              points={{-80.0,90.0},{-88.0,68.0},{-72.0,68.0},{-80.0,90.0}}),
+            Line(
+              points={{-90.0,-80.0},{82.0,-80.0}},
+              color={192,192,192}),
+            Polygon(
+              lineColor={192,192,192},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              points={{90.0,-80.0},{68.0,-72.0},{68.0,-88.0},{90.0,-80.0}}),
+            Text(
+              lineColor={192,192,192},
+              extent={{0.0,-70.0},{60.0,-10.0}},
+              textString="I"),
+            Text(
+              extent={{-150.0,-150.0},{150.0,-110.0}},
+              textString="k=%k"),
+            Line(
+              points={{-80.0,-80.0},{80.0,80.0}},
+              color={0,0,127})}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255}),
+          Text(
+            extent={{-36,60},{32,2}},
+            lineColor={0,0,0},
+            textString="k"),
+          Text(
+            extent={{-32,0},{36,-58}},
+            lineColor={0,0,0},
+            textString="s"),
+          Line(points={{-46,0},{46,0}})}));
+  end Integrator;
+
+  block LimIntegrator "Integrator with limited value of the output"
+    import Modelica.Blocks.Types.Init;
+    parameter Real k(unit="1")=1 "Integrator gain";
+    parameter Real outMax(start=1) "Upper limit of output";
+    parameter Real outMin=-outMax "Lower limit of output";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.InitialState
+      "Type of initialization (1: no init, 2: steady state, 3/4: initial output)"
+      annotation(Evaluate=true, Dialog(group="Initialization"));
+    parameter Boolean limitsAtInit = true
+      "= false, if limits are ignored during initialization (i.e., der(y)=k*u)"
+      annotation(Evaluate=true, Dialog(group="Initialization"));
+    parameter Real y_start=0
+      "Initial or guess value of output (must be in the limits outMin .. outMax)"
+      annotation (Dialog(group="Initialization"));
+    parameter Boolean strict=false "= true, if strict limits with noEvent(..)"
+      annotation (Evaluate=true, choices(checkBox=true), Dialog(tab="Advanced"));
+    extends Interfaces.SISO(y(start=y_start));
+
+  initial equation
+    if initType == Init.SteadyState then
+       der(y) = 0;
+    elseif initType == Init.InitialState or
+           initType == Init.InitialOutput then
+      y = y_start;
+    end if;
+  equation
+    if initial() and not limitsAtInit then
+       der(y) = k*u;
+       assert(y >= outMin - 0.001*abs(outMax-outMin) and y <= outMax + 0.001*abs(outMax-outMin),
+            "LimIntegrator: During initialization the limits have been ignored.\n"
+          + "However, the result is that the output y is not within the required limits:\n"
+          + "  y = " + String(y) + ", outMin = " + String(outMin) + ", outMax = " + String(outMax));
+    elseif strict then
+       der(y) = noEvent(if y < outMin and k*u < 0 or y > outMax and k*u > 0 then 0 else k*u);
+    else
+       der(y) = if y < outMin and k*u < 0 or y > outMax and k*u > 0 then 0 else k*u;
+    end if;
+    annotation (
+      Documentation(info="<html>
+<p>
+This blocks computes <b>y</b> (element-wise) as <i>integral</i>
+of the input <b>u</b> multiplied with the gain <i>k</i>. If the
+integral reaches a given upper or lower <i>limit</i> and the
+input will drive the integral outside of this bound, the
+integration is halted and only restarted if the input drives
+the integral away from the bounds.
+</p>
+
+<p>
+It might be difficult to initialize the integrator in steady state.
+This is discussed in the description of package
+<a href=\"modelica://Modelica.Blocks.Continuous#info\">Continuous</a>.
+</p>
+
+<p>
+If parameter <b>limitAtInit</b> = <b>false</b>, the limits of the
+integrator are removed from the initialization problem which
+leads to a much simpler equation system. After initialization has been
+performed, it is checked via an assert whether the output is in the
+defined limits. For backward compatibility reasons
+<b>limitAtInit</b> = <b>true</b>. In most cases it is best
+to use <b>limitAtInit</b> = <b>false</b>.
+</p>
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(points={{-80,78},{-80,-90}}, color={192,192,192}),
+          Polygon(
+            points={{-80,90},{-88,68},{-72,68},{-80,90}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-90,-80},{82,-80}}, color={192,192,192}),
+          Polygon(
+            points={{90,-80},{68,-72},{68,-88},{90,-80}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-80,-80},{20,20},{80,20}}, color={0,0,127}),
+          Text(
+            extent={{0,-10},{60,-70}},
+            lineColor={192,192,192},
+            textString="I"),
+          Text(
+            extent={{-150,-150},{150,-110}},
+            lineColor={0,0,0},
+            textString="k=%k"),
+          Line(
+            visible=strict,
+            points={{20,20},{80,20}},
+            color={255,0,0})}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Text(
+            extent={{-54,46},{-4,-48}},
+            lineColor={0,0,0},
+            textString="lim"),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255}),
+          Text(
+            extent={{-8,60},{60,2}},
+            lineColor={0,0,0},
+            textString="k"),
+          Text(
+            extent={{-8,-2},{60,-60}},
+            lineColor={0,0,0},
+            textString="s"),
+          Line(points={{4,0},{46,0}})}));
+  end LimIntegrator;
+
+  block Derivative "Approximated derivative block"
+    import Modelica.Blocks.Types.Init;
+    parameter Real k(unit="1")=1 "Gains";
+    parameter SIunits.Time T(min=Modelica.Constants.small) = 0.01
+      "Time constants (T>0 required; T=0 is ideal derivative block)";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                                                                      annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real x_start=0 "Initial or guess value of state"
+      annotation (Dialog(group="Initialization"));
+    parameter Real y_start=0 "Initial value of output (= state)"
+      annotation(Dialog(enable=initType == Init.InitialOutput, group=
+            "Initialization"));
+    extends Interfaces.SISO;
+
+    output Real x(start=x_start) "State of block";
+
+  protected
+    parameter Boolean zeroGain = abs(k) < Modelica.Constants.eps;
+  initial equation
+    if initType == Init.SteadyState then
+      der(x) = 0;
+    elseif initType == Init.InitialState then
+      x = x_start;
+    elseif initType == Init.InitialOutput then
+      if zeroGain then
+         x = u;
+      else
+         y = y_start;
+      end if;
+    end if;
+  equation
+    der(x) = if zeroGain then 0 else (u - x)/T;
+    y = if zeroGain then 0 else (k/T)*(u - x);
+    annotation (
+      Documentation(info="<html>
+<p>
+This blocks defines the transfer function between the
+input u and the output y
+(element-wise) as <i>approximated derivative</i>:
+</p>
+<pre>
+             k * s
+     y = ------------ * u
+            T * s + 1
+</pre>
+<p>
+If you would like to be able to change easily between different
+transfer functions (FirstOrder, SecondOrder, ... ) by changing
+parameters, use the general block <b>TransferFunction</b> instead
+and model a derivative block with parameters<br>
+b = {k,0}, a = {T, 1}.
+</p>
+
+<p>
+If k=0, the block reduces to y=0.
+</p>
+</html>"),   Icon(
+      coordinateSystem(preserveAspectRatio=true,
+          extent={{-100.0,-100.0},{100.0,100.0}}),
+        graphics={
+      Line(points={{-80.0,78.0},{-80.0,-90.0}},
+        color={192,192,192}),
+    Polygon(lineColor={192,192,192},
+      fillColor={192,192,192},
+      fillPattern=FillPattern.Solid,
+      points={{-80.0,90.0},{-88.0,68.0},{-72.0,68.0},{-80.0,90.0}}),
+    Line(points={{-90.0,-80.0},{82.0,-80.0}},
+      color={192,192,192}),
+    Polygon(lineColor={192,192,192},
+      fillColor={192,192,192},
+      fillPattern=FillPattern.Solid,
+      points={{90.0,-80.0},{68.0,-72.0},{68.0,-88.0},{90.0,-80.0}}),
+    Line(origin = {-24.667,-27.333},
+      points = {{-55.333,87.333},{-19.333,-40.667},{86.667,-52.667}},
+      color = {0,0,127},
+      smooth = Smooth.Bezier),
+    Text(lineColor={192,192,192},
+      extent={{-30.0,14.0},{86.0,60.0}},
+      textString="DT1"),
+    Text(extent={{-150.0,-150.0},{150.0,-110.0}},
+      textString="k=%k")}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Text(
+            extent={{-54,52},{50,10}},
+            lineColor={0,0,0},
+            textString="k s"),
+          Text(
+            extent={{-54,-6},{52,-52}},
+            lineColor={0,0,0},
+            textString="T s + 1"),
+          Line(points={{-50,0},{50,0}}),
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255})}));
+  end Derivative;
+
+  block FirstOrder "First order transfer function block (= 1 pole)"
+    import Modelica.Blocks.Types.Init;
+    parameter Real k(unit="1")=1 "Gain";
+    parameter SIunits.Time T(start=1) "Time Constant";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3/4: initial output)"
+                                                                                      annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real y_start=0 "Initial or guess value of output (= state)"
+      annotation (Dialog(group="Initialization"));
+
+    extends Interfaces.SISO(y(start=y_start));
+
+  initial equation
+    if initType == Init.SteadyState then
+      der(y) = 0;
+    elseif initType == Init.InitialState or initType == Init.InitialOutput then
+      y = y_start;
+    end if;
+  equation
+    der(y) = (k*u - y)/T;
+    annotation (
+      Documentation(info="<html>
+<p>
+This blocks defines the transfer function between the input u
+and the output y (element-wise) as <i>first order</i> system:
+</p>
+<pre>
+               k
+     y = ------------ * u
+            T * s + 1
+</pre>
+<p>
+If you would like to be able to change easily between different
+transfer functions (FirstOrder, SecondOrder, ... ) by changing
+parameters, use the general block <b>TransferFunction</b> instead
+and model a first order SISO system with parameters<br>
+b = {k}, a = {T, 1}.
+</p>
+<pre>
+Example:
+   parameter: k = 0.3, T = 0.4
+   results in:
+             0.3
+      y = ----------- * u
+          0.4 s + 1.0
+</pre>
+
+</html>"),   Icon(
+    coordinateSystem(preserveAspectRatio=true,
+        extent={{-100.0,-100.0},{100.0,100.0}}),
+      graphics={
+    Line(points={{-80.0,78.0},{-80.0,-90.0}},
+      color={192,192,192}),
+    Polygon(lineColor={192,192,192},
+      fillColor={192,192,192},
+      fillPattern=FillPattern.Solid,
+      points={{-80.0,90.0},{-88.0,68.0},{-72.0,68.0},{-80.0,90.0}}),
+    Line(points={{-90.0,-80.0},{82.0,-80.0}},
+      color={192,192,192}),
+    Polygon(lineColor={192,192,192},
+      fillColor={192,192,192},
+      fillPattern=FillPattern.Solid,
+      points={{90.0,-80.0},{68.0,-72.0},{68.0,-88.0},{90.0,-80.0}}),
+    Line(origin = {-26.667,6.667},
+        points = {{106.667,43.333},{-13.333,29.333},{-53.333,-86.667}},
+        color = {0,0,127},
+        smooth = Smooth.Bezier),
+    Text(lineColor={192,192,192},
+      extent={{0.0,-60.0},{60.0,0.0}},
+      textString="PT1"),
+    Text(extent={{-150.0,-150.0},{150.0,-110.0}},
+      textString="T=%T")}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Text(
+            extent={{-48,52},{50,8}},
+            lineColor={0,0,0},
+            textString="k"),
+          Text(
+            extent={{-54,-6},{56,-56}},
+            lineColor={0,0,0},
+            textString="T s + 1"),
+          Line(points={{-50,0},{50,0}}),
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255})}));
+  end FirstOrder;
+
+  block SecondOrder "Second order transfer function block (= 2 poles)"
+    import Modelica.Blocks.Types.Init;
+    parameter Real k(unit="1")=1 "Gain";
+    parameter Real w(start=1) "Angular frequency";
+    parameter Real D(start=1) "Damping";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3/4: initial output)"
+                                                                                      annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real y_start=0 "Initial or guess value of output (= state)"
+      annotation (Dialog(group="Initialization"));
+    parameter Real yd_start=0
+      "Initial or guess value of derivative of output (= state)"
+      annotation (Dialog(group="Initialization"));
+
+    extends Interfaces.SISO(y(start=y_start));
+    output Real yd(start=yd_start) "Derivative of y";
+
+  initial equation
+    if initType == Init.SteadyState then
+      der(y) = 0;
+      der(yd) = 0;
+    elseif initType == Init.InitialState or initType == Init.InitialOutput then
+      y = y_start;
+      yd = yd_start;
+    end if;
+  equation
+    der(y) = yd;
+    der(yd) = w*(w*(k*u - y) - 2*D*yd);
+    annotation (
+      Documentation(info="<html>
+<p>
+This blocks defines the transfer function between the input u and
+the output y (element-wise) as <i>second order</i> system:
+</p>
+<pre>
+                             k
+     y = ---------------------------------------- * u
+            ( s / w )^2 + 2*D*( s / w ) + 1
+</pre>
+<p>
+If you would like to be able to change easily between different
+transfer functions (FirstOrder, SecondOrder, ... ) by changing
+parameters, use the general model class <b>TransferFunction</b>
+instead and model a second order SISO system with parameters<br>
+b = {k}, a = {1/w^2, 2*D/w, 1}.
+</p>
+<pre>
+Example:
+
+   parameter: k =  0.3,  w = 0.5,  D = 0.4
+   results in:
+                  0.3
+      y = ------------------- * u
+          4.0 s^2 + 1.6 s + 1
+</pre>
+
+</html>"),   Icon(
+        coordinateSystem(preserveAspectRatio=true,
+              extent={{-100.0,-100.0},{100.0,100.0}}),
+            graphics={
+        Line(points={{-80.0,78.0},{-80.0,-90.0}},
+            color={192,192,192}),
+      Polygon(lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid,
+          points={{-80.0,90.0},{-88.0,68.0},{-72.0,68.0},{-80.0,90.0}}),
+      Line(points={{-90.0,-80.0},{82.0,-80.0}},
+          color={192,192,192}),
+      Polygon(lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid,
+          points={{90.0,-80.0},{68.0,-72.0},{68.0,-88.0},{90.0,-80.0}}),
+      Line(origin = {-1.939,-1.816},
+          points = {{81.939,36.056},{65.362,36.056},{14.39,-26.199},{-29.966,113.485},{-65.374,-61.217},{-78.061,-78.184}},
+          color = {0,0,127},
+          smooth = Smooth.Bezier),
+      Text(lineColor={192,192,192},
+          extent={{0.0,-70.0},{60.0,-10.0}},
+          textString="PT2"),
+      Text(extent={{-150.0,-150.0},{150.0,-110.0}},
+          textString="w=%w")}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Text(
+            extent={{-60,60},{60,14}},
+            lineColor={0,0,0},
+            textString="k"),
+          Text(
+            extent={{-60,8},{-32,-20}},
+            lineColor={0,0,0},
+            textString="s"),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255}),
+          Line(points={{-50,14},{50,14}}),
+          Line(points={{-54,-20},{-38,-20}}),
+          Text(
+            extent={{-52,-26},{-36,-48}},
+            lineColor={0,0,0},
+            textString="w"),
+          Line(points={{-50,2},{-56,-8},{-56,-28},{-52,-46}}),
+          Line(points={{-40,2},{-34,-10},{-34,-30},{-38,-46}}),
+          Text(
+            extent={{-34,8},{-22,-10}},
+            lineColor={0,0,0},
+            textString="2"),
+          Text(
+            extent={{-34,-6},{6,-36}},
+            lineColor={0,0,0},
+            textString="+2D"),
+          Text(
+            extent={{2,8},{30,-20}},
+            lineColor={0,0,0},
+            textString="s"),
+          Line(points={{8,-20},{24,-20}}),
+          Text(
+            extent={{10,-26},{26,-48}},
+            lineColor={0,0,0},
+            textString="w"),
+          Line(points={{12,2},{6,-8},{6,-28},{10,-46}}),
+          Line(points={{22,2},{28,-10},{28,-30},{24,-46}}),
+          Text(
+            extent={{30,2},{58,-42}},
+            lineColor={0,0,0},
+            textString="+1")}));
+  end SecondOrder;
+
+  block PI "Proportional-Integral controller"
+    import Modelica.Blocks.Types.Init;
+    parameter Real k(unit="1")=1 "Gain";
+    parameter SIunits.Time T(start=1,min=Modelica.Constants.small)
+      "Time Constant (T>0 required)";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                                                              annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real x_start=0 "Initial or guess value of state"
+      annotation (Dialog(group="Initialization"));
+    parameter Real y_start=0 "Initial value of output"
+      annotation(Dialog(enable=initType == Init.SteadyState or initType == Init.InitialOutput, group=
+            "Initialization"));
+
+    extends Interfaces.SISO;
+    output Real x(start=x_start) "State of block";
+
+  initial equation
+    if initType == Init.SteadyState then
+      der(x) = 0;
+    elseif initType == Init.InitialState then
+      x = x_start;
+    elseif initType == Init.InitialOutput then
+      y = y_start;
+    end if;
+  equation
+    der(x) = u/T;
+    y = k*(x + u);
+    annotation (defaultComponentName="PI",
+      Documentation(info="<html>
+<p>
+This blocks defines the transfer function between the input u and
+the output y (element-wise) as <i>PI</i> system:
+</p>
+<pre>
+                 1
+   y = k * (1 + ---) * u
+                T*s
+           T*s + 1
+     = k * ------- * u
+             T*s
+</pre>
+<p>
+If you would like to be able to change easily between different
+transfer functions (FirstOrder, SecondOrder, ... ) by changing
+parameters, use the general model class <b>TransferFunction</b>
+instead and model a PI SISO system with parameters<br>
+b = {k*T, k}, a = {T, 0}.
+</p>
+<pre>
+Example:
+
+   parameter: k = 0.3,  T = 0.4
+
+   results in:
+               0.4 s + 1
+      y = 0.3 ----------- * u
+                 0.4 s
+</pre>
+
+<p>
+It might be difficult to initialize the PI component in steady state
+due to the integrator part.
+This is discussed in the description of package
+<a href=\"modelica://Modelica.Blocks.Continuous#info\">Continuous</a>.
+</p>
+
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(points={{-80,78},{-80,-90}}, color={192,192,192}),
+          Polygon(
+            points={{-80,90},{-88,68},{-72,68},{-80,90}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-90,-80},{82,-80}}, color={192,192,192}),
+          Polygon(
+            points={{90,-80},{68,-72},{68,-88},{90,-80}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(points = {{-80.0,-80.0},{-80.0,-20.0},{60.0,80.0}}, color = {0,0,127}),
+          Text(
+            extent={{0,6},{60,-56}},
+            lineColor={192,192,192},
+            textString="PI"),
+          Text(
+            extent={{-150,-150},{150,-110}},
+            lineColor={0,0,0},
+            textString="T=%T")}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Text(
+            extent={{-68,24},{-24,-18}},
+            lineColor={0,0,0},
+            textString="k"),
+          Text(
+            extent={{-32,48},{60,0}},
+            lineColor={0,0,0},
+            textString="T s + 1"),
+          Text(
+            extent={{-30,-8},{52,-40}},
+            lineColor={0,0,0},
+            textString="T s"),
+          Line(points={{-24,0},{54,0}}),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{62,0},{100,0}}, color={0,0,255})}));
+  end PI;
+
+  block PID "PID-controller in additive description form"
+    import Modelica.Blocks.Types.InitPID;
+    import Modelica.Blocks.Types.Init;
+    extends Interfaces.SISO;
+
+    parameter Real k(unit="1")=1 "Gain";
+    parameter SIunits.Time Ti(min=Modelica.Constants.small, start=0.5)
+      "Time Constant of Integrator";
+    parameter SIunits.Time Td(min=0, start=0.1)
+      "Time Constant of Derivative block";
+    parameter Real Nd(min=Modelica.Constants.small) = 10
+      "The higher Nd, the more ideal the derivative block";
+    parameter Modelica.Blocks.Types.InitPID initType= Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                       annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real xi_start=0
+      "Initial or guess value value for integrator output (= integrator state)"
+      annotation (Dialog(group="Initialization"));
+    parameter Real xd_start=0
+      "Initial or guess value for state of derivative block"
+      annotation (Dialog(group="Initialization"));
+    parameter Real y_start=0 "Initial value of output"
+      annotation(Dialog(enable=initType == InitPID.InitialOutput, group=
+            "Initialization"));
+    constant SI.Time unitTime=1  annotation(HideResult=true);
+
+    Blocks.Math.Gain P(k=1) "Proportional part of PID controller"
+      annotation (Placement(transformation(extent={{-60,60},{-20,100}})));
+    Blocks.Continuous.Integrator I(k=unitTime/Ti, y_start=xi_start,
+      initType=if initType==InitPID.SteadyState then
+                  Init.SteadyState else
+               if initType==InitPID.InitialState or
+                  initType==InitPID.DoNotUse_InitialIntegratorState then
+                  Init.InitialState else Init.NoInit)
+      "Integral part of PID controller"
+      annotation (Placement(transformation(extent={{-60,-20},{-20,20}})));
+    Blocks.Continuous.Derivative D(k=Td/unitTime, T=max([Td/Nd, 100*Modelica.
+          Constants.eps]), x_start=xd_start,
+      initType=if initType==InitPID.SteadyState or
+                  initType==InitPID.InitialOutput then Init.SteadyState else
+               if initType==InitPID.InitialState then Init.InitialState else
+                  Init.NoInit) "Derivative part of PID controller"
+      annotation (Placement(transformation(extent={{-60,-100},{-20,-60}})));
+    Blocks.Math.Gain Gain(k=k) "Gain of PID controller"
+      annotation (Placement(transformation(extent={{60,-10},{80,10}})));
+    Blocks.Math.Add3 Add annotation (Placement(transformation(extent={{20,-10},
+              {40,10}})));
+  initial equation
+    if initType==InitPID.InitialOutput then
+       y = y_start;
+    end if;
+
+  equation
+    connect(u, P.u) annotation (Line(points={{-120,0},{-80,0},{-80,80},{-64,80}},
+          color={0,0,127}));
+    connect(u, I.u)
+      annotation (Line(points={{-120,0},{-64,0}}, color={0,0,127}));
+    connect(u, D.u) annotation (Line(points={{-120,0},{-80,0},{-80,-80},{-64,
+            -80}}, color={0,0,127}));
+    connect(P.y, Add.u1) annotation (Line(points={{-18,80},{0,80},{0,8},{18,8}},
+          color={0,0,127}));
+    connect(I.y, Add.u2)
+      annotation (Line(points={{-18,0},{18,0}}, color={0,0,127}));
+    connect(D.y, Add.u3) annotation (Line(points={{-18,-80},{0,-80},{0,-8},{18,
+            -8}}, color={0,0,127}));
+    connect(Add.y, Gain.u)
+      annotation (Line(points={{41,0},{58,0}}, color={0,0,127}));
+    connect(Gain.y, y)
+      annotation (Line(points={{81,0},{110,0}}, color={0,0,127}));
+    annotation (defaultComponentName="PID",
+      Icon(
+          coordinateSystem(preserveAspectRatio=true,
+              extent={{-100.0,-100.0},{100.0,100.0}}),
+              graphics={
+          Line(points={{-80.0,78.0},{-80.0,-90.0}},
+              color={192,192,192}),
+        Polygon(lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid,
+            points={{-80.0,90.0},{-88.0,68.0},{-72.0,68.0},{-80.0,90.0}}),
+        Line(points={{-90.0,-80.0},{82.0,-80.0}},
+            color={192,192,192}),
+        Polygon(lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid,
+            points={{90.0,-80.0},{68.0,-72.0},{68.0,-88.0},{90.0,-80.0}}),
+        Line(points = {{-80,-80},{-80,-20},{60,80}}, color = {0,0,127}),
+        Text(lineColor={192,192,192},
+            extent={{-20.0,-60.0},{80.0,-20.0}},
+            textString="PID"),
+        Text(extent={{-150.0,-150.0},{150.0,-110.0}},
+            textString="Ti=%Ti")}),
+      Documentation(info="<html>
+<p>
+This is the text-book version of a PID-controller.
+For a more practically useful PID-controller, use
+block LimPID.
+</p>
+
+<p>
+The PID block can be initialized in different
+ways controlled by parameter <b>initType</b>. The possible
+values of initType are defined in
+<a href=\"modelica://Modelica.Blocks.Types.InitPID\">Modelica.Blocks.Types.InitPID</a>.
+This type is identical to
+<a href=\"modelica://Modelica.Blocks.Types.Init\">Types.Init</a>,
+with the only exception that the additional option
+<b>DoNotUse_InitialIntegratorState</b> is added for
+backward compatibility reasons (= integrator is initialized with
+InitialState whereas differential part is initialized with
+NoInit which was the initialization in version 2.2 of the Modelica
+standard library).
+</p>
+
+<p>
+Based on the setting of initType, the integrator (I) and derivative (D)
+blocks inside the PID controller are initialized according to the following table:
+</p>
+
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><td valign=\"top\"><b>initType</b></td>
+      <td valign=\"top\"><b>I.initType</b></td>
+      <td valign=\"top\"><b>D.initType</b></td></tr>
+
+  <tr><td valign=\"top\"><b>NoInit</b></td>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">NoInit</td></tr>
+
+  <tr><td valign=\"top\"><b>SteadyState</b></td>
+      <td valign=\"top\">SteadyState</td>
+      <td valign=\"top\">SteadyState</td></tr>
+
+  <tr><td valign=\"top\"><b>InitialState</b></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">InitialState</td></tr>
+
+  <tr><td valign=\"top\"><b>InitialOutput</b><br>
+          and initial equation: y = y_start</td>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">SteadyState</td></tr>
+
+  <tr><td valign=\"top\"><b>DoNotUse_InitialIntegratorState</b></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">NoInit</td></tr>
+</table>
+
+<p>
+In many cases, the most useful initial condition is
+<b>SteadyState</b> because initial transients are then no longer
+present. If initType = InitPID.SteadyState, then in some
+cases difficulties might occur. The reason is the
+equation of the integrator:
+</p>
+
+<pre>
+   <b>der</b>(y) = k*u;
+</pre>
+
+<p>
+The steady state equation \"der(x)=0\" leads to the condition that the input u to the
+integrator is zero. If the input u is already (directly or indirectly) defined
+by another initial condition, then the initialization problem is <b>singular</b>
+(has none or infinitely many solutions). This situation occurs often
+for mechanical systems, where, e.g., u = desiredSpeed - measuredSpeed and
+since speed is both a state and a derivative, it is natural to
+initialize it with zero. As sketched this is, however, not possible.
+The solution is to not initialize u or the variable that is used
+to compute u by an algebraic equation.
+</p>
+
+</html>"));
+  end PID;
+
+  block LimPID
+    "P, PI, PD, and PID controller with limited output, anti-windup compensation and setpoint weighting"
+    import Modelica.Blocks.Types.InitPID;
+    import Modelica.Blocks.Types.Init;
+    import Modelica.Blocks.Types.SimpleController;
+    extends Interfaces.SVcontrol;
+    output Real controlError = u_s - u_m
+      "Control error (set point - measurement)";
+
+    parameter .Modelica.Blocks.Types.SimpleController controllerType=
+           .Modelica.Blocks.Types.SimpleController.PID "Type of controller";
+    parameter Real k(min=0, unit="1") = 1 "Gain of controller";
+    parameter SIunits.Time Ti(min=Modelica.Constants.small)=0.5
+      "Time constant of Integrator block"
+       annotation(Dialog(enable=controllerType==.Modelica.Blocks.Types.SimpleController.PI or
+                                controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+    parameter SIunits.Time Td(min=0)= 0.1 "Time constant of Derivative block"
+         annotation(Dialog(enable=controllerType==.Modelica.Blocks.Types.SimpleController.PD or
+                                  controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+    parameter Real yMax(start=1) "Upper limit of output";
+    parameter Real yMin=-yMax "Lower limit of output";
+    parameter Real wp(min=0) = 1
+      "Set-point weight for Proportional block (0..1)";
+    parameter Real wd(min=0) = 0 "Set-point weight for Derivative block (0..1)"
+         annotation(Dialog(enable=controllerType==.Modelica.Blocks.Types.SimpleController.PD or
+                                  controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+    parameter Real Ni(min=100*Modelica.Constants.eps) = 0.9
+      "Ni*Ti is time constant of anti-windup compensation"
+       annotation(Dialog(enable=controllerType==.Modelica.Blocks.Types.SimpleController.PI or
+                                controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+    parameter Real Nd(min=100*Modelica.Constants.eps) = 10
+      "The higher Nd, the more ideal the derivative block"
+         annotation(Dialog(enable=controllerType==.Modelica.Blocks.Types.SimpleController.PD or
+                                  controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+    parameter .Modelica.Blocks.Types.InitPID initType= .Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                       annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Boolean limitsAtInit = true
+      "= false, if limits are ignored during initialization"
+      annotation(Evaluate=true, Dialog(group="Initialization"));
+    parameter Real xi_start=0
+      "Initial or guess value value for integrator output (= integrator state)"
+      annotation (Dialog(group="Initialization",
+                  enable=controllerType==.Modelica.Blocks.Types.SimpleController.PI or
+                         controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+    parameter Real xd_start=0
+      "Initial or guess value for state of derivative block"
+      annotation (Dialog(group="Initialization",
+                           enable=controllerType==.Modelica.Blocks.Types.SimpleController.PD or
+                                  controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+    parameter Real y_start=0 "Initial value of output"
+      annotation(Dialog(enable=initType == .Modelica.Blocks.Types.InitPID.InitialOutput, group=
+            "Initialization"));
+    parameter Boolean strict=false "= true, if strict limits with noEvent(..)"
+      annotation (Evaluate=true, choices(checkBox=true), Dialog(tab="Advanced"));
+    constant SI.Time unitTime=1  annotation(HideResult=true);
+    Blocks.Math.Add addP(k1=wp, k2=-1)
+      annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
+    Blocks.Math.Add addD(k1=wd, k2=-1) if with_D
+      annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
+    Blocks.Math.Gain P(k=1)
+                       annotation (Placement(transformation(extent={{-40,40},{
+              -20,60}})));
+    Blocks.Continuous.Integrator I(k=unitTime/Ti, y_start=xi_start,
+      initType=if initType==InitPID.SteadyState then
+                  Init.SteadyState else
+               if initType==InitPID.InitialState or
+                  initType==InitPID.DoNotUse_InitialIntegratorState then
+                  Init.InitialState else Init.NoInit) if with_I
+      annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
+    Blocks.Continuous.Derivative D(k=Td/unitTime, T=max([Td/Nd, 1.e-14]), x_start=xd_start,
+      initType=if initType==InitPID.SteadyState or
+                  initType==InitPID.InitialOutput then Init.SteadyState else
+               if initType==InitPID.InitialState then Init.InitialState else
+                  Init.NoInit) if with_D
+      annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+    Blocks.Math.Gain gainPID(k=k) annotation (Placement(transformation(extent={
+              {30,-10},{50,10}})));
+    Blocks.Math.Add3 addPID annotation (Placement(transformation(
+            extent={{0,-10},{20,10}})));
+    Blocks.Math.Add3 addI(k2=-1) if with_I annotation (Placement(
+          transformation(extent={{-80,-60},{-60,-40}})));
+    Blocks.Math.Add addSat(k1=+1, k2=-1) if
+                                     with_I
+      annotation (Placement(transformation(
+          origin={80,-50},
+          extent={{-10,-10},{10,10}},
+          rotation=270)));
+    Blocks.Math.Gain gainTrack(k=1/(k*Ni)) if with_I
+      annotation (Placement(transformation(extent={{40,-80},{20,-60}})));
+    Blocks.Nonlinear.Limiter limiter(uMax=yMax, uMin=yMin, strict=strict, limitsAtInit=limitsAtInit)
+      annotation (Placement(transformation(extent={{70,-10},{90,10}})));
+  protected
+    parameter Boolean with_I = controllerType==SimpleController.PI or
+                               controllerType==SimpleController.PID annotation(Evaluate=true, HideResult=true);
+    parameter Boolean with_D = controllerType==SimpleController.PD or
+                               controllerType==SimpleController.PID annotation(Evaluate=true, HideResult=true);
+  public
+    Sources.Constant Dzero(k=0) if not with_D
+      annotation (Placement(transformation(extent={{-30,20},{-20,30}})));
+    Sources.Constant Izero(k=0) if not with_I
+      annotation (Placement(transformation(extent={{10,-55},{0,-45}})));
+  initial equation
+    if initType==InitPID.InitialOutput then
+       gainPID.y = y_start;
+    end if;
+  equation
+    if initType == InitPID.InitialOutput and (y_start < yMin or y_start > yMax) then
+        Modelica.Utilities.Streams.error("LimPID: Start value y_start (=" + String(y_start) +
+           ") is outside of the limits of yMin (=" + String(yMin) +") and yMax (=" + String(yMax) + ")");
+    end if;
+
+    connect(u_s, addP.u1) annotation (Line(points={{-120,0},{-96,0},{-96,56},{
+            -82,56}}, color={0,0,127}));
+    connect(u_s, addD.u1) annotation (Line(points={{-120,0},{-96,0},{-96,6},{
+            -82,6}}, color={0,0,127}));
+    connect(u_s, addI.u1) annotation (Line(points={{-120,0},{-96,0},{-96,-42},{
+            -82,-42}}, color={0,0,127}));
+    connect(addP.y, P.u) annotation (Line(points={{-59,50},{-42,50}}, color={0,
+            0,127}));
+    connect(addD.y, D.u)
+      annotation (Line(points={{-59,0},{-42,0}}, color={0,0,127}));
+    connect(addI.y, I.u) annotation (Line(points={{-59,-50},{-42,-50}}, color={
+            0,0,127}));
+    connect(P.y, addPID.u1) annotation (Line(points={{-19,50},{-10,50},{-10,8},
+            {-2,8}}, color={0,0,127}));
+    connect(D.y, addPID.u2)
+      annotation (Line(points={{-19,0},{-2,0}}, color={0,0,127}));
+    connect(I.y, addPID.u3) annotation (Line(points={{-19,-50},{-10,-50},{-10,
+            -8},{-2,-8}}, color={0,0,127}));
+    connect(addPID.y, gainPID.u)
+      annotation (Line(points={{21,0},{28,0}}, color={0,0,127}));
+    connect(gainPID.y, addSat.u2) annotation (Line(points={{51,0},{60,0},{60,
+            -20},{74,-20},{74,-38}}, color={0,0,127}));
+    connect(gainPID.y, limiter.u)
+      annotation (Line(points={{51,0},{68,0}}, color={0,0,127}));
+    connect(limiter.y, addSat.u1) annotation (Line(points={{91,0},{94,0},{94,
+            -20},{86,-20},{86,-38}}, color={0,0,127}));
+    connect(limiter.y, y)
+      annotation (Line(points={{91,0},{110,0}}, color={0,0,127}));
+    connect(addSat.y, gainTrack.u) annotation (Line(points={{80,-61},{80,-70},{
+            42,-70}}, color={0,0,127}));
+    connect(gainTrack.y, addI.u3) annotation (Line(points={{19,-70},{-88,-70},{
+            -88,-58},{-82,-58}}, color={0,0,127}));
+    connect(u_m, addP.u2) annotation (Line(
+        points={{0,-120},{0,-92},{-92,-92},{-92,44},{-82,44}},
+        color={0,0,127},
+        thickness=0.5));
+    connect(u_m, addD.u2) annotation (Line(
+        points={{0,-120},{0,-92},{-92,-92},{-92,-6},{-82,-6}},
+        color={0,0,127},
+        thickness=0.5));
+    connect(u_m, addI.u2) annotation (Line(
+        points={{0,-120},{0,-92},{-92,-92},{-92,-50},{-82,-50}},
+        color={0,0,127},
+        thickness=0.5));
+    connect(Dzero.y, addPID.u2) annotation (Line(points={{-19.5,25},{-14,25},{
+            -14,0},{-2,0}}, color={0,0,127}));
+    connect(Izero.y, addPID.u3) annotation (Line(points={{-0.5,-50},{-10,-50},{
+            -10,-8},{-2,-8}}, color={0,0,127}));
+    annotation (defaultComponentName="PID",
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(points={{-80,78},{-80,-90}}, color={192,192,192}),
+          Polygon(
+            points={{-80,90},{-88,68},{-72,68},{-80,90}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-90,-80},{82,-80}}, color={192,192,192}),
+          Polygon(
+            points={{90,-80},{68,-72},{68,-88},{90,-80}},
+            lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-80,-80},{-80,-20},{30,60},{80,60}}, color={0,0,127}),
+          Text(
+            extent={{-20,-20},{80,-60}},
+            lineColor={192,192,192},
+            textString="%controllerType"),
+          Line(
+            visible=strict,
+            points={{30,60},{81,60}},
+            color={255,0,0})}),
+      Documentation(info="<html>
+<p>
+Via parameter <b>controllerType</b> either <b>P</b>, <b>PI</b>, <b>PD</b>,
+or <b>PID</b> can be selected. If, e.g., PI is selected, all components belonging to the
+D-part are removed from the block (via conditional declarations).
+The example model
+<a href=\"modelica://Modelica.Blocks.Examples.PID_Controller\">Modelica.Blocks.Examples.PID_Controller</a>
+demonstrates the usage of this controller.
+Several practical aspects of PID controller design are incorporated
+according to chapter 3 of the book:
+</p>
+
+<dl>
+<dt>&Aring;str&ouml;m K.J., and H&auml;gglund T.:</dt>
+<dd> <b>PID Controllers: Theory, Design, and Tuning</b>.
+     Instrument Society of America, 2nd edition, 1995.
+</dd>
+</dl>
+
+<p>
+Besides the additive <b>proportional, integral</b> and <b>derivative</b>
+part of this controller, the following features are present:
+</p>
+<ul>
+<li> The output of this controller is limited. If the controller is
+     in its limits, anti-windup compensation is activated to drive
+     the integrator state to zero. </li>
+<li> The high-frequency gain of the derivative part is limited
+     to avoid excessive amplification of measurement noise.</li>
+<li> Setpoint weighting is present, which allows to weight
+     the setpoint in the proportional and the derivative part
+     independently from the measurement. The controller will respond
+     to load disturbances and measurement noise independently of this setting
+     (parameters wp, wd). However, setpoint changes will depend on this
+     setting. For example, it is useful to set the setpoint weight wd
+     for the derivative part to zero, if steps may occur in the
+     setpoint signal.</li>
+</ul>
+
+<p>
+The parameters of the controller can be manually adjusted by performing
+simulations of the closed loop system (= controller + plant connected
+together) and using the following strategy:
+</p>
+
+<ol>
+<li> Set very large limits, e.g., yMax = Modelica.Constants.inf</li>
+<li> Select a <b>P</b>-controller and manually enlarge parameter <b>k</b>
+     (the total gain of the controller) until the closed-loop response
+     cannot be improved any more.</li>
+<li> Select a <b>PI</b>-controller and manually adjust parameters
+     <b>k</b> and <b>Ti</b> (the time constant of the integrator).
+     The first value of Ti can be selected, such that it is in the
+     order of the time constant of the oscillations occurring with
+     the P-controller. If, e.g., vibrations in the order of T=10 ms
+     occur in the previous step, start with Ti=0.01 s.</li>
+<li> If you want to make the reaction of the control loop faster
+     (but probably less robust against disturbances and measurement noise)
+     select a <b>PID</b>-Controller and manually adjust parameters
+     <b>k</b>, <b>Ti</b>, <b>Td</b> (time constant of derivative block).</li>
+<li> Set the limits yMax and yMin according to your specification.</li>
+<li> Perform simulations such that the output of the PID controller
+     goes in its limits. Tune <b>Ni</b> (Ni*Ti is the time constant of
+     the anti-windup compensation) such that the input to the limiter
+     block (= limiter.u) goes quickly enough back to its limits.
+     If Ni is decreased, this happens faster. If Ni=infinity, the
+     anti-windup compensation is switched off and the controller works bad.</li>
+</ol>
+
+<p>
+<b>Initialization</b>
+</p>
+
+<p>
+This block can be initialized in different
+ways controlled by parameter <b>initType</b>. The possible
+values of initType are defined in
+<a href=\"modelica://Modelica.Blocks.Types.InitPID\">Modelica.Blocks.Types.InitPID</a>.
+This type is identical to
+<a href=\"modelica://Modelica.Blocks.Types.Init\">Types.Init</a>,
+with the only exception that the additional option
+<b>DoNotUse_InitialIntegratorState</b> is added for
+backward compatibility reasons (= integrator is initialized with
+InitialState whereas differential part is initialized with
+NoInit which was the initialization in version 2.2 of the Modelica
+standard library).
+</p>
+
+<p>
+Based on the setting of initType, the integrator (I) and derivative (D)
+blocks inside the PID controller are initialized according to the following table:
+</p>
+
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><td valign=\"top\"><b>initType</b></td>
+      <td valign=\"top\"><b>I.initType</b></td>
+      <td valign=\"top\"><b>D.initType</b></td></tr>
+
+  <tr><td valign=\"top\"><b>NoInit</b></td>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">NoInit</td></tr>
+
+  <tr><td valign=\"top\"><b>SteadyState</b></td>
+      <td valign=\"top\">SteadyState</td>
+      <td valign=\"top\">SteadyState</td></tr>
+
+  <tr><td valign=\"top\"><b>InitialState</b></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">InitialState</td></tr>
+
+  <tr><td valign=\"top\"><b>InitialOutput</b><br>
+          and initial equation: y = y_start</td>
+      <td valign=\"top\">NoInit</td>
+      <td valign=\"top\">SteadyState</td></tr>
+
+  <tr><td valign=\"top\"><b>DoNotUse_InitialIntegratorState</b></td>
+      <td valign=\"top\">InitialState</td>
+      <td valign=\"top\">NoInit</td></tr>
+</table>
+
+<p>
+In many cases, the most useful initial condition is
+<b>SteadyState</b> because initial transients are then no longer
+present. If initType = InitPID.SteadyState, then in some
+cases difficulties might occur. The reason is the
+equation of the integrator:
+</p>
+
+<pre>
+   <b>der</b>(y) = k*u;
+</pre>
+
+<p>
+The steady state equation \"der(x)=0\" leads to the condition that the input u to the
+integrator is zero. If the input u is already (directly or indirectly) defined
+by another initial condition, then the initialization problem is <b>singular</b>
+(has none or infinitely many solutions). This situation occurs often
+for mechanical systems, where, e.g., u = desiredSpeed - measuredSpeed and
+since speed is both a state and a derivative, it is natural to
+initialize it with zero. As sketched this is, however, not possible.
+The solution is to not initialize u_m or the variable that is used
+to compute u_m by an algebraic equation.
+</p>
+
+<p>
+If parameter <b>limitAtInit</b> = <b>false</b>, the limits at the
+output of this controller block are removed from the initialization problem which
+leads to a much simpler equation system. After initialization has been
+performed, it is checked via an assert whether the output is in the
+defined limits. For backward compatibility reasons
+<b>limitAtInit</b> = <b>true</b>. In most cases it is best
+to use <b>limitAtInit</b> = <b>false</b>.
+</p>
+</html>"));
+  end LimPID;
+
+  block TransferFunction "Linear transfer function"
+    import Modelica.Blocks.Types.Init;
+    extends Interfaces.SISO;
+
+    parameter Real b[:]={1}
+      "Numerator coefficients of transfer function (e.g., 2*s+3 is specified as {2,3})";
+    parameter Real a[:]={1}
+      "Denominator coefficients of transfer function (e.g., 5*s+6 is specified as {5,6})";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                       annotation(Evaluate=true, Dialog(group=
+            "Initialization"));
+    parameter Real x_start[size(a, 1) - 1]=zeros(nx)
+      "Initial or guess values of states"
+      annotation (Dialog(group="Initialization"));
+    parameter Real y_start=0
+      "Initial value of output (derivatives of y are zero up to nx-1-th derivative)"
+      annotation(Dialog(enable=initType == Init.InitialOutput, group=
+            "Initialization"));
+    output Real x[size(a, 1) - 1](start=x_start)
+      "State of transfer function from controller canonical form";
+  protected
+    parameter Integer na=size(a, 1) "Size of Denominator of transfer function.";
+    parameter Integer nb=size(b, 1) "Size of Numerator of transfer function.";
+    parameter Integer nx=size(a, 1) - 1;
+    parameter Real bb[:] = vector([zeros(max(0,na-nb),1);b]);
+    parameter Real d = bb[1]/a[1];
+    parameter Real a_end = if a[end] > 100*Modelica.Constants.eps*sqrt(a*a) then a[end] else 1.0;
+    Real x_scaled[size(x,1)] "Scaled vector x";
+
+  initial equation
+    if initType == Init.SteadyState then
+      der(x_scaled) = zeros(nx);
+    elseif initType == Init.InitialState then
+      x_scaled = x_start*a_end;
+    elseif initType == Init.InitialOutput then
+      y = y_start;
+      der(x_scaled[2:nx]) = zeros(nx-1);
+    end if;
+  equation
+    assert(size(b,1) <= size(a,1), "Transfer function is not proper");
+    if nx == 0 then
+       y = d*u;
+    else
+       der(x_scaled[1])    = (-a[2:na]*x_scaled + a_end*u)/a[1];
+       der(x_scaled[2:nx]) = x_scaled[1:nx-1];
+       y = ((bb[2:na] - d*a[2:na])*x_scaled)/a_end + d*u;
+       x = x_scaled/a_end;
+    end if;
+    annotation (
+      Documentation(info="<html>
+<p>
+This block defines the transfer function between the input
+u and the output y
+as (nb = dimension of b, na = dimension of a):
+</p>
+<pre>
+           b[1]*s^[nb-1] + b[2]*s^[nb-2] + ... + b[nb]
+   y(s) = --------------------------------------------- * u(s)
+           a[1]*s^[na-1] + a[2]*s^[na-2] + ... + a[na]
+</pre>
+<p>
+State variables <b>x</b> are defined according to <b>controller canonical</b>
+form. Internally, vector <b>x</b> is scaled to improve the numerics (the states in versions before version 3.0 of the Modelica Standard Library have been not scaled). This scaling is
+not visible from the outside of this block because the non-scaled vector <b>x</b>
+is provided as output signal and the start value is with respect to the non-scaled
+vector <b>x</b>.
+Initial values of the states <b>x</b> can be set via parameter <b>x_start</b>.
+</p>
+
+<p>
+Example:
+</p>
+<pre>
+     TransferFunction g(b = {2,4}, a = {1,3});
+</pre>
+<p>
+results in the following transfer function:
+</p>
+<pre>
+        2*s + 4
+   y = --------- * u
+         s + 3
+</pre>
+</html>"),
+      Icon(
+          coordinateSystem(preserveAspectRatio=true,
+            extent={{-100.0,-100.0},{100.0,100.0}}),
+            graphics={
+          Line(points={{-80.0,0.0},{80.0,0.0}},
+            color={0,0,127}),
+        Text(lineColor={0,0,127},
+          extent={{-90.0,10.0},{90.0,90.0}},
+          textString="b(s)"),
+        Text(lineColor={0,0,127},
+          extent={{-90.0,-90.0},{90.0,-10.0}},
+          textString="a(s)")}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(points={{40,0},{-40,0}}),
+          Text(
+            extent={{-55,55},{55,5}},
+            lineColor={0,0,0},
+            textString="b(s)"),
+          Text(
+            extent={{-55,-5},{55,-55}},
+            lineColor={0,0,0},
+            textString="a(s)"),
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255})}));
+  end TransferFunction;
+
+  block StateSpace "Linear state space system"
+    import Modelica.Blocks.Types.Init;
+    parameter Real A[:, size(A, 1)]=[1, 0; 0, 1]
+      "Matrix A of state space model (e.g., A=[1, 0; 0, 1])";
+    parameter Real B[size(A, 1), :]=[1; 1]
+      "Matrix B of state space model (e.g., B=[1; 1])";
+    parameter Real C[:, size(A, 1)]=[1, 1]
+      "Matrix C of state space model (e.g., C=[1, 1])";
+    parameter Real D[size(C, 1), size(B, 2)]=zeros(size(C, 1), size(B, 2))
+      "Matrix D of state space model";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                                                                      annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real x_start[nx]=zeros(nx) "Initial or guess values of states"
+      annotation (Dialog(group="Initialization"));
+    parameter Real y_start[ny]=zeros(ny)
+      "Initial values of outputs (remaining states are in steady state if possible)"
+      annotation(Dialog(enable=initType == Init.InitialOutput, group=
+            "Initialization"));
+
+    extends Interfaces.MIMO(final nin=size(B, 2), final nout=size(C, 1));
+    output Real x[size(A, 1)](start=x_start) "State vector";
+
+  protected
+    parameter Integer nx = size(A, 1) "number of states";
+    parameter Integer ny = size(C, 1) "number of outputs";
+  initial equation
+    if initType == Init.SteadyState then
+      der(x) = zeros(nx);
+    elseif initType == Init.InitialState then
+      x = x_start;
+    elseif initType == Init.InitialOutput then
+      x = Modelica.Math.Matrices.equalityLeastSquares(A, -B*u, C, y_start - D*u);
+    end if;
+  equation
+    der(x) = A*x + B*u;
+    y = C*x + D*u;
+    annotation (
+      Documentation(info="<html>
+<p>
+The State Space block defines the relation
+between the input u and the output
+y in state space form:
+</p>
+<pre>
+
+    der(x) = A * x + B * u
+        y  = C * x + D * u
+</pre>
+<p>
+The input is a vector of length nu, the output is a vector
+of length ny and nx is the number of states. Accordingly
+</p>
+<pre>
+        A has the dimension: A(nx,nx),
+        B has the dimension: B(nx,nu),
+        C has the dimension: C(ny,nx),
+        D has the dimension: D(ny,nu)
+</pre>
+<p>
+Example:
+</p>
+<pre>
+     parameter: A = [0.12, 2;3, 1.5]
+     parameter: B = [2, 7;3, 1]
+     parameter: C = [0.1, 2]
+     parameter: D = zeros(ny,nu)
+results in the following equations:
+  [der(x[1])]   [0.12  2.00] [x[1]]   [2.0  7.0] [u[1]]
+  [         ] = [          ]*[    ] + [        ]*[    ]
+  [der(x[2])]   [3.00  1.50] [x[2]]   [0.1  2.0] [u[2]]
+                             [x[1]]            [u[1]]
+       y[1]   = [0.1  2.0] * [    ] + [0  0] * [    ]
+                             [x[2]]            [u[2]]
+</pre>
+</html>"),   Icon(
+      coordinateSystem(preserveAspectRatio=true,
+        extent={{-100,-100},{100,100}}),
+        graphics={
+      Text(extent={{-90,10},{-10,90}},
+        textString="A",
+        lineColor={0,0,127}),
+      Text(extent={{10,10},{90,90}},
+        textString="B",
+        lineColor={0,0,127}),
+      Text(extent={{-90,-10},{-10,-90}},
+        textString="C",
+        lineColor={0,0,127}),
+      Text(extent={{10,-10},{90,-90}},
+        textString="D",
+        lineColor={0,0,127}),
+      Line(points={{0,-90},{0,90}},
+        color={192,192,192}),
+      Line(points={{-90,0},{90,0}},
+        color={192,192,192})}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Text(
+            extent={{-60,40},{60,0}},
+            lineColor={0,0,0},
+            textString="sx=Ax+Bu"),
+          Text(
+            extent={{-60,0},{60,-40}},
+            lineColor={0,0,0},
+            textString=" y=Cx+Du"),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255})}));
+  end StateSpace;
+
+  block Der "Derivative of input (= analytic differentiations)"
+      extends Interfaces.SISO;
+
+  equation
+    y = der(u);
+      annotation (defaultComponentName="der1",
+   Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}),
+          graphics={Text(
+            extent={{-96,28},{94,-24}},
+            textString="der()",
+            lineColor={0,0,127})}),
+          Documentation(info="<html>
+<p>
+Defines that the output y is the <i>derivative</i>
+of the input u. Note, that Modelica.Blocks.Continuous.Derivative
+computes the derivative in an approximate sense, where as this block computes
+the derivative exactly. This requires that the input u is differentiated
+by the Modelica translator, if this derivative is not yet present in
+the model.
+</p>
+</html>"));
+  end Der;
+
+  block LowpassButterworth
+    "Output the input signal filtered with a low pass Butterworth filter of any order"
+
+    import Modelica.Blocks.Types.Init;
+    import Modelica.Constants.pi;
+
+    extends Modelica.Blocks.Interfaces.SISO;
+
+    parameter Integer n(min=1) = 2 "Order of filter";
+    parameter SI.Frequency f(start=1) "Cut-off frequency";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                                                                      annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real x1_start[m]=zeros(m)
+      "Initial or guess values of states 1 (der(x1)=x2)"
+      annotation (Dialog(group="Initialization"));
+    parameter Real x2_start[m]=zeros(m) "Initial or guess values of states 2"
+      annotation (Dialog(group="Initialization"));
+    parameter Real xr_start=0.0
+      "Initial or guess value of real pole for uneven order otherwise dummy"
+      annotation (Dialog(group="Initialization"));
+    parameter Real y_start=0.0
+      "Initial value of output (states are initialized in steady state if possible)"
+       annotation(Dialog(enable=initType == Init.InitialOutput, group=
+            "Initialization"));
+
+    output Real x1[m](start=x1_start)
+      "states 1 of second order filters (der(x1) = x2)";
+    output Real x2[m](start=x2_start) "states 2 of second order filters";
+    output Real xr(start=xr_start)
+      "state of real pole for uneven order otherwise dummy";
+  protected
+    parameter Integer m=integer(n/2);
+    parameter Boolean evenOrder = 2*m == n;
+    parameter Real w=2*pi*f;
+    Real z[m + 1];
+    Real polereal[m];
+    Real poleimag[m];
+    Real realpol;
+    Real k2[m];
+    Real D[m];
+    Real w0[m];
+    Real k1;
+    Real T;
+  initial equation
+    if initType == Init.SteadyState then
+      der(x1) = zeros(m);
+      der(x2) = zeros(m);
+      if not evenOrder then
+        der(xr) = 0.0;
+      end if;
+    elseif initType == Init.InitialState then
+      x1 = x1_start;
+      x2 = x2_start;
+      if not evenOrder then
+        xr = xr_start;
+      end if;
+    elseif initType == Init.InitialOutput then
+      y = y_start;
+      der(x1) = zeros(m);
+      if evenOrder then
+        if m > 1 then
+          der(x2[1:m-1]) = zeros(m-1);
+        end if;
+      else
+        der(x1) = zeros(m);
+      end if;
+    end if;
+  equation
+    k2 = ones(m);
+    k1 = 1;
+    z[1] = u;
+
+    // calculate filter parameters
+    for i in 1:m loop
+      // poles of prototype lowpass
+      polereal[i] = cos(pi/2 + pi/n*(i - 0.5));
+      poleimag[i] = sin(pi/2 + pi/n*(i - 0.5));
+      // scaling and calculation of second order filter coefficients
+      w0[i] = (polereal[i]^2 + poleimag[i]^2)*w;
+      D[i] = -polereal[i]/w0[i]*w;
+    end for;
+    realpol = 1*w;
+    T = 1/realpol;
+
+    // calculate second order filters
+    for i in 1:m loop
+      der(x1[i]) = x2[i];
+      der(x2[i]) = k2[i]*w0[i]^2*z[i] - 2*D[i]*w0[i]*x2[i] - w0[i]^2*x1[i];
+      z[i + 1] = x1[i];
+    end for;
+
+    // calculate first order filter if necessary
+    if evenOrder then
+      // even order
+      xr = 0;
+      y = z[m + 1];
+    else
+      // uneven order
+      der(xr) = (k1*z[m + 1] - xr)/T;
+      y = xr;
+    end if;
+    annotation (
+      Icon(
+          coordinateSystem(preserveAspectRatio=true,
+              extent={{-100.0,-100.0},{100.0,100.0}}),
+              graphics={
+          Line(points={{-80.0,78.0},{-80.0,-90.0}},
+              color={192,192,192}),
+          Polygon(lineColor={192,192,192},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              points={{-79.5584,91.817},{-87.5584,69.817},{-71.5584,69.817},{-79.5584,91.817}}),
+          Line(origin = {-1.939,-1.816},
+              points = {{81.939,36.056},{65.362,36.056},{14.39,-26.199},{-29.966,113.485},{-65.374,-61.217},{-78.061,-78.184}},
+              color = {0,0,127},
+              smooth = Smooth.Bezier),
+          Line(points={{-90.9779,-80.7697},{81.0221,-80.7697}},
+              color={192,192,192}),
+          Polygon(lineColor={192,192,192},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              points={{91.3375,-79.8233},{69.3375,-71.8233},{69.3375,-87.8233},{91.3375,-79.8233}}),
+          Text(lineColor={192,192,192},
+              extent={{-45.1735,-68.0},{92.0,-11.47}},
+              textString="LowpassButterworthFilter"),
+          Text(extent={{8.0,-146.0},{8.0,-106.0}},
+              textString="f=%f"),
+          Text(lineColor={192,192,192},
+              extent={{-2.0,48.0},{94.0,94.0}},
+              textString="%n")}),
+      Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
+              100,100}}), graphics={
+          Line(points={{40,0},{-40,0}}),
+          Text(
+            extent={{-55,55},{55,5}},
+            lineColor={0,0,0},
+            textString="1"),
+          Text(
+            extent={{-55,-5},{55,-55}},
+            lineColor={0,0,0},
+            textString="a(s)"),
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255})}),
+      Documentation(info="<html>
+<p>
+This block defines the transfer function between the input u
+and the output y as an n-th order low pass filter with <i>Butterworth</i>
+characteristics and cut-off frequency f. It is implemented as
+a series of second order filters and a first order filter.
+Butterworth filters have the feature that the amplitude at the
+cut-off frequency f is 1/sqrt(2) (= 3 dB), i.e., they are
+always \"normalized\". Step responses of the Butterworth filter of
+different orders are shown in the next figure:
+</p>
+
+<p>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/Butterworth.png\"
+     alt=\"Butterworth.png\">
+</p>
+
+<p>
+If transients at the simulation start shall be avoided, the filter
+should be initialized in steady state (e.g., using option
+initType=Modelica.Blocks.Types.Init.SteadyState).
+</p>
+
+</html>"));
+  end LowpassButterworth;
+
+  block CriticalDamping
+    "Output the input signal filtered with an n-th order filter with critical damping"
+
+    import Modelica.Blocks.Types.Init;
+    extends Modelica.Blocks.Interfaces.SISO;
+
+    parameter Integer n=2 "Order of filter";
+    parameter Modelica.SIunits.Frequency f(start=1) "Cut-off frequency";
+    parameter Boolean normalized = true
+      "= true, if amplitude at f_cut is 3 dB, otherwise unmodified filter";
+    parameter Modelica.Blocks.Types.Init initType=Modelica.Blocks.Types.Init.NoInit
+      "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
+                                                                                      annotation(Evaluate=true,
+        Dialog(group="Initialization"));
+    parameter Real x_start[n]=zeros(n) "Initial or guess values of states"
+      annotation (Dialog(group="Initialization"));
+    parameter Real y_start=0.0
+      "Initial value of output (remaining states are in steady state)"
+      annotation(Dialog(enable=initType == Init.InitialOutput, group=
+            "Initialization"));
+
+    output Real x[n](start=x_start) "Filter states";
+  protected
+    parameter Real alpha=if normalized then sqrt(2^(1/n) - 1) else 1.0
+      "Frequency correction factor for normalized filter";
+    parameter Real w=2*Modelica.Constants.pi*f/alpha;
+  initial equation
+    if initType == Init.SteadyState then
+      der(x) = zeros(n);
+    elseif initType == Init.InitialState then
+      x = x_start;
+    elseif initType == Init.InitialOutput then
+      y = y_start;
+      der(x[1:n-1]) = zeros(n-1);
+    end if;
+  equation
+    der(x[1]) = (u - x[1])*w;
+    for i in 2:n loop
+      der(x[i]) = (x[i - 1] - x[i])*w;
+    end for;
+    y = x[n];
+    annotation (
+      Icon(
+          coordinateSystem(preserveAspectRatio=true,
+            extent={{-100.0,-100.0},{100.0,100.0}}),
+            graphics={
+          Line(points={{-80.6897,77.6256},{-80.6897,-90.3744}},
+            color={192,192,192}),
+          Polygon(lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid,
+            points={{-79.7044,90.6305},{-87.7044,68.6305},{-71.7044,68.6305},{-79.7044,90.6305}}),
+          Line(points={{-90.0,-80.0},{82.0,-80.0}},
+            color={192,192,192}),
+          Polygon(lineColor={192,192,192},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid,
+            points={{90.0,-80.0},{68.0,-72.0},{68.0,-88.0},{90.0,-80.0}}),
+          Text(lineColor={192,192,192},
+            extent={{0.0,-60.0},{60.0,0.0}},
+            textString="PTn"),
+          Line(origin = {-17.976,-6.521},
+            points = {{96.962,55.158},{16.42,50.489},{-18.988,18.583},{-32.024,-53.479},{-62.024,-73.479}},
+            color = {0,0,127},
+            smooth = Smooth.Bezier),
+          Text(lineColor={192,192,192},
+            extent={{-70.0,48.0},{26.0,94.0}},
+            textString="%n"),
+          Text(extent={{8.0,-146.0},{8.0,-106.0}},
+            textString="f=%f")}),
+      Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
+              100,100}}), graphics={
+          Line(points={{40,0},{-40,0}}),
+          Text(
+            extent={{-55,55},{55,5}},
+            lineColor={0,0,0},
+            textString="1"),
+          Rectangle(extent={{-60,60},{60,-60}}, lineColor={0,0,255}),
+          Line(points={{-100,0},{-60,0}}, color={0,0,255}),
+          Line(points={{60,0},{100,0}}, color={0,0,255}),
+          Text(
+            extent={{-54,-6},{44,-56}},
+            lineColor={0,0,0},
+            textString="(s/w + 1)"),
+          Text(
+            extent={{38,-10},{58,-30}},
+            lineColor={0,0,0},
+            textString="n")}),
+      Documentation(info="<html>
+<p>This block defines the transfer function between the
+input u and the output y
+as an n-th order filter with <i>critical damping</i>
+characteristics and cut-off frequency f. It is
+implemented as a series of first order filters.
+This filter type is especially useful to filter the input of an
+inverse model, since the filter does not introduce any transients.
+</p>
+
+<p>
+If parameter <b>normalized</b> = <b>true</b> (default), the filter
+is normalized such that the amplitude of the filter transfer function
+at the cut-off frequency f is 1/sqrt(2) (= 3 dB). Otherwise, the filter
+is not normalized, i.e., it is unmodified. A normalized filter is usually
+much better for applications, since filters of different orders are
+\"comparable\", whereas non-normalized filters usually require to adapt the
+cut-off frequency, when the order of the filter is changed.
+Figures of the filter step responses are shown below.
+Note, in versions before version 3.0 of the Modelica Standard library,
+the CriticalDamping filter was provided only in non-normalized form.
+</p>
+
+<p>If transients at the simulation start shall be avoided, the filter
+should be initialized in steady state (e.g., using option
+initType=Modelica.Blocks.Types.Init.SteadyState).
+</p>
+
+<p>
+The critical damping filter is defined as
+</p>
+
+<pre>
+    &alpha; = <b>if</b> normalized <b>then</b> <b>sqrt</b>(2^(1/n) - 1) <b>else</b> 1 // frequency correction factor
+    &omega; = 2*&pi;*f/&alpha;
+              1
+    y = ------------- * u
+         (s/w + 1)^n
+
+</pre>
+
+<p>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/CriticalDampingNormalized.png\"
+     alt=\"CriticalDampingNormalized.png\">
+</p>
+
+<p>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/CriticalDampingNonNormalized.png\"
+     alt=\"CriticalDampingNonNormalized.png\">
+</p>
+
+</html>"));
+  end CriticalDamping;
+
+  block Filter
+    "Continuous low pass, high pass, band pass or band stop IIR-filter of type CriticalDamping, Bessel, Butterworth or ChebyshevI"
+    import Modelica.Blocks.Continuous.Internal;
+
+    extends Modelica.Blocks.Interfaces.SISO;
+
+    parameter Modelica.Blocks.Types.AnalogFilter analogFilter=Modelica.Blocks.Types.AnalogFilter.CriticalDamping
+      "Analog filter characteristics (CriticalDamping/Bessel/Butterworth/ChebyshevI)";
+    parameter Modelica.Blocks.Types.FilterType filterType=Modelica.Blocks.Types.FilterType.LowPass
+      "Type of filter (LowPass/HighPass/BandPass/BandStop)";
+    parameter Integer order(min=1) = 2 "Order of filter";
+    parameter Modelica.SIunits.Frequency f_cut "Cut-off frequency";
+    parameter Real gain=1.0
+      "Gain (= amplitude of frequency response at zero frequency)";
+    parameter Real A_ripple(unit="dB") = 0.5
+      "Pass band ripple for Chebyshev filter (otherwise not used); > 0 required"
+      annotation(Dialog(enable=analogFilter==Modelica.Blocks.Types.AnalogFilter.ChebyshevI));
+    parameter Modelica.SIunits.Frequency f_min=0
+      "Band of band pass/stop filter is f_min (A=-3db*gain) .. f_cut (A=-3db*gain)"
+      annotation(Dialog(enable=filterType == Modelica.Blocks.Types.FilterType.BandPass or
+                               filterType == Modelica.Blocks.Types.FilterType.BandStop));
+    parameter Boolean normalized=true
+      "= true, if amplitude at f_cut = -3db, otherwise unmodified filter";
+    parameter Modelica.Blocks.Types.Init init=Modelica.Blocks.Types.Init.SteadyState
+      "Type of initialization (no init/steady state/initial state/initial output)"
+      annotation(Evaluate=true, Dialog(tab="Advanced"));
+    final parameter Integer nx = if filterType == Modelica.Blocks.Types.FilterType.LowPass or
+                                    filterType == Modelica.Blocks.Types.FilterType.HighPass then
+                                    order else 2*order;
+    parameter Real x_start[nx] = zeros(nx) "Initial or guess values of states"
+      annotation(Dialog(tab="Advanced"));
+    parameter Real y_start = 0 "Initial value of output"
+      annotation(Dialog(tab="Advanced"));
+    parameter Real u_nominal = 1.0
+      "Nominal value of input (used for scaling the states)"
+    annotation(Dialog(tab="Advanced"));
+    Modelica.Blocks.Interfaces.RealOutput x[nx] "Filter states";
+
+  protected
+    parameter Integer ncr = if analogFilter == Modelica.Blocks.Types.AnalogFilter.CriticalDamping then
+                               order else mod(order,2);
+    parameter Integer nc0 = if analogFilter == Modelica.Blocks.Types.AnalogFilter.CriticalDamping then
+                               0 else integer(order/2);
+    parameter Integer na = if filterType == Modelica.Blocks.Types.FilterType.BandPass or
+                              filterType == Modelica.Blocks.Types.FilterType.BandStop then order else
+                           if analogFilter == Modelica.Blocks.Types.AnalogFilter.CriticalDamping then
+                              0 else integer(order/2);
+    parameter Integer nr = if filterType == Modelica.Blocks.Types.FilterType.BandPass or
+                              filterType == Modelica.Blocks.Types.FilterType.BandStop then 0 else
+                           if analogFilter == Modelica.Blocks.Types.AnalogFilter.CriticalDamping then
+                              order else mod(order,2);
+
+    // Coefficients of prototype base filter (low pass filter with w_cut = 1 rad/s)
+    parameter Real cr[ncr](each fixed=false);
+    parameter Real c0[nc0](each fixed=false);
+    parameter Real c1[nc0](each fixed=false);
+
+    // Coefficients for differential equations.
+    parameter Real r[nr](each fixed=false);
+    parameter Real a[na](each fixed=false);
+    parameter Real b[na](each fixed=false);
+    parameter Real ku[na](each fixed=false);
+    parameter Real k1[if filterType == Modelica.Blocks.Types.FilterType.LowPass then 0 else na](
+                   each fixed = false);
+    parameter Real k2[if filterType == Modelica.Blocks.Types.FilterType.LowPass then 0 else na](
+                   each fixed = false);
+
+    // Auxiliary variables
+    Real uu[na+nr+1];
+
+  initial equation
+     if analogFilter == Modelica.Blocks.Types.AnalogFilter.CriticalDamping then
+        cr = Internal.Filter.base.CriticalDamping(order, normalized);
+     elseif analogFilter == Modelica.Blocks.Types.AnalogFilter.Bessel then
+        (cr,c0,c1) = Internal.Filter.base.Bessel(order, normalized);
+     elseif analogFilter == Modelica.Blocks.Types.AnalogFilter.Butterworth then
+        (cr,c0,c1) = Internal.Filter.base.Butterworth(order, normalized);
+     elseif analogFilter == Modelica.Blocks.Types.AnalogFilter.ChebyshevI then
+        (cr,c0,c1) = Internal.Filter.base.ChebyshevI(order, A_ripple, normalized);
+     end if;
+
+     if filterType == Modelica.Blocks.Types.FilterType.LowPass then
+        (r,a,b,ku) = Internal.Filter.roots.lowPass(cr,c0,c1,f_cut);
+     elseif filterType == Modelica.Blocks.Types.FilterType.HighPass then
+        (r,a,b,ku,k1,k2) = Internal.Filter.roots.highPass(cr,c0,c1,f_cut);
+     elseif filterType == Modelica.Blocks.Types.FilterType.BandPass then
+        (a,b,ku,k1,k2) = Internal.Filter.roots.bandPass(cr,c0,c1,f_min,f_cut);
+     elseif filterType == Modelica.Blocks.Types.FilterType.BandStop then
+        (a,b,ku,k1,k2) = Internal.Filter.roots.bandStop(cr,c0,c1,f_min,f_cut);
+     end if;
+
+     if init == Modelica.Blocks.Types.Init.InitialState then
+        x = x_start;
+     elseif init == Modelica.Blocks.Types.Init.SteadyState then
+        der(x) = zeros(nx);
+     elseif init == Modelica.Blocks.Types.Init.InitialOutput then
+        y = y_start;
+        if nx > 1 then
+           der(x[1:nx-1]) = zeros(nx-1);
+        end if;
+     end if;
+
+  equation
+     assert(u_nominal > 0, "u_nominal > 0 required");
+     assert(filterType == Modelica.Blocks.Types.FilterType.LowPass or
+            filterType == Modelica.Blocks.Types.FilterType.HighPass or
+            f_min > 0, "f_min > 0 required for band pass and band stop filter");
+     assert(A_ripple > 0, "A_ripple > 0 required");
+     assert(f_cut > 0, "f_cut > 0 required");
+
+     /* All filters have the same basic differential equations:
+        Real poles:
+           der(x) = r*x - r*u
+        Complex conjugate poles:
+           der(x1) = a*x1 - b*x2 + ku*u;
+           der(x2) = b*x1 + a*x2;
+   */
+     uu[1] = u/u_nominal;
+     for i in 1:nr loop
+        der(x[i]) = r[i]*(x[i] - uu[i]);
+     end for;
+     for i in 1:na loop
+        der(x[nr+2*i-1]) = a[i]*x[nr+2*i-1] - b[i]*x[nr+2*i] + ku[i]*uu[nr+i];
+        der(x[nr+2*i])   = b[i]*x[nr+2*i-1] + a[i]*x[nr+2*i];
+     end for;
+
+     // The output equation is different for the different filter types
+     if filterType == Modelica.Blocks.Types.FilterType.LowPass then
+        /* Low pass filter
+           Real poles             :  y = x
+           Complex conjugate poles:  y = x2
+      */
+        for i in 1:nr loop
+           uu[i+1] = x[i];
+        end for;
+        for i in 1:na loop
+           uu[nr+i+1] = x[nr+2*i];
+        end for;
+
+     elseif filterType == Modelica.Blocks.Types.FilterType.HighPass then
+        /* High pass filter
+           Real poles             :  y = -x + u;
+           Complex conjugate poles:  y = k1*x1 + k2*x2 + u;
+      */
+        for i in 1:nr loop
+           uu[i+1] = -x[i] + uu[i];
+        end for;
+        for i in 1:na loop
+           uu[nr+i+1] = k1[i]*x[nr+2*i-1] + k2[i]*x[nr+2*i] + uu[nr+i];
+        end for;
+
+     elseif filterType == Modelica.Blocks.Types.FilterType.BandPass then
+        /* Band pass filter
+           Complex conjugate poles:  y = k1*x1 + k2*x2;
+      */
+        for i in 1:na loop
+           uu[nr+i+1] = k1[i]*x[nr+2*i-1] + k2[i]*x[nr+2*i];
+        end for;
+
+     elseif filterType == Modelica.Blocks.Types.FilterType.BandStop then
+        /* Band pass filter
+           Complex conjugate poles:  y = k1*x1 + k2*x2 + u;
+      */
+        for i in 1:na loop
+           uu[nr+i+1] = k1[i]*x[nr+2*i-1] + k2[i]*x[nr+2*i] + uu[nr+i];
+        end for;
+
+     else
+        assert(false, "filterType (= " + String(filterType) + ") is unknown");
+        uu = zeros(na+nr+1);
+     end if;
+
+     y = (gain*u_nominal)*uu[nr+na+1];
+
+    annotation (
+      Icon(
+        coordinateSystem(preserveAspectRatio=true,
+          extent={{-100.0,-100.0},{100.0,100.0}}),
+          graphics={
+        Line(points={{-80.0,80.0},{-80.0,-88.0}},
+          color={192,192,192}),
+        Polygon(lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid,
+          points={{-80.0,92.0},{-88.0,70.0},{-72.0,70.0},{-80.0,92.0}}),
+        Line(points={{-90.0,-78.0},{82.0,-78.0}},
+          color={192,192,192}),
+        Polygon(lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid,
+          points={{90.0,-78.0},{68.0,-70.0},{68.0,-86.0},{90.0,-78.0}}),
+        Text(lineColor={192,192,192},
+          extent={{-66.0,52.0},{88.0,90.0}},
+          textString="%order"),
+        Text(fillPattern=FillPattern.Solid,
+          extent={{-138.0,-140.0},{162.0,-110.0}},
+          textString="f_cut=%f_cut"),
+        Rectangle(lineColor={160,160,164},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Backward,
+          extent={{-80.0,-78.0},{22.0,10.0}}),
+        Line(origin = {3.333,-6.667}, points = {{-83.333,34.667},{24.667,34.667},{42.667,-71.333}}, color = {0,0,127}, smooth = Smooth.Bezier)}),
+      Documentation(info="<html>
+
+<p>
+This blocks models various types of filters:
+</p>
+
+<blockquote>
+<b>low pass, high pass, band pass, and band stop filters</b>
+</blockquote>
+
+<p>
+using various filter characteristics:
+</p>
+
+<blockquote>
+<b>CriticalDamping, Bessel, Butterworth, Chebyshev Type I filters</b>
+</blockquote>
+
+<p>
+By default, a filter block is initialized in <b>steady-state</b>, in order to
+avoid unwanted oscillations at the beginning. In special cases, it might be
+useful to select one of the other initialization options under tab
+\"Advanced\".
+</p>
+
+<p>
+Typical frequency responses for the 4 supported low pass filter types
+are shown in the next figure:
+</p>
+
+<blockquote>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/LowPassOrder4Filters.png\"
+     alt=\"LowPassOrder4Filters.png\">
+</blockquote>
+
+<p>
+The step responses of the same low pass filters are shown in the next figure,
+starting from a steady state initial filter with initial input = 0.2:
+</p>
+
+<blockquote>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/LowPassOrder4FiltersStepResponse.png\"
+     alt=\"LowPassOrder4FiltersStepResponse.png\">
+</blockquote>
+
+<p>
+Obviously, the frequency responses give a somewhat wrong impression
+of the filter characteristics: Although Butterworth and Chebyshev
+filters have a significantly steeper magnitude as the
+CriticalDamping and Bessel filters, the step responses of
+the latter ones are much better. This means for example, that
+a CriticalDamping or a Bessel filter should be selected,
+if a filter is mainly used to make a non-linear inverse model
+realizable.
+</p>
+
+<p>
+Typical frequency responses for the 4 supported high pass filter types
+are shown in the next figure:
+</p>
+
+<blockquote>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/HighPassOrder4Filters.png\"
+     alt=\"HighPassOrder4Filters.png\">
+</blockquote>
+
+<p>
+The corresponding step responses of these high pass filters are
+shown in the next figure:
+</p>
+<blockquote>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/HighPassOrder4FiltersStepResponse.png\"
+     alt=\"HighPassOrder4FiltersStepResponse.png\">
+</blockquote>
+
+<p>
+All filters are available in <b>normalized</b> (default) and non-normalized form.
+In the normalized form, the amplitude of the filter transfer function
+at the cut-off frequency f_cut is -3 dB (= 10^(-3/20) = 0.70794..).
+Note, when comparing the filters of this function with other software systems,
+the setting of \"normalized\" has to be selected appropriately. For example, the signal processing
+toolbox of MATLAB provides the filters in non-normalized form and
+therefore a comparison makes only sense, if normalized = <b>false</b>
+is set. A normalized filter is usually better suited for applications,
+since filters of different orders are \"comparable\",
+whereas non-normalized filters usually require to adapt the
+cut-off frequency, when the order of the filter is changed.
+See a comparison of \"normalized\" and \"non-normalized\" filters at hand of
+CriticalDamping filters of order 1,2,3:
+</p>
+
+<blockquote>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/CriticalDampingNormalized.png\"
+     alt=\"CriticalDampingNormalized.png\">
+</blockquote>
+
+<blockquote>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/CriticalDampingNonNormalized.png\"
+     alt=\"CriticalDampingNonNormalized.png\">
+</blockquote>
+
+<h4>Implementation</h4>
+
+<p>
+The filters are implemented in the following, reliable way:
+</p>
+
+<ol>
+<li> A prototype low pass filter with a cut-off angular frequency of 1 rad/s is constructed
+     from the desired analogFilter and the desired normalization.</li>
+
+<li> This prototype low pass filter is transformed to the desired filterType and the
+     desired cut-off frequency f_cut using a transformation on the Laplace variable \"s\".</li>
+
+<li> The resulting first and second order transfer functions are implemented in
+     state space form, using the \"eigen value\" representation of a transfer function:
+     <pre>
+
+  // second order block with eigen values: a +/- jb
+  <b>der</b>(x1) = a*x1 - b*x2 + (a^2 + b^2)/b*u;
+  <b>der</b>(x2) = b*x1 + a*x2;
+       y  = x2;
+     </pre>
+     The dc-gain from the input to the output of this block is one and the selected
+     states are in the order of the input (if \"u\" is in the order of \"one\", then the
+     states are also in the order of \"one\"). In the \"Advanced\" tab, a \"nominal\" value for
+     the input \"u\" can be given. If appropriately selected, the states are in the order of \"one\" and
+     then step-size control is always appropriate.</li>
+</ol>
+
+<h4>References</h4>
+
+<dl>
+<dt>Tietze U., and Schenk C. (2002):</dt>
+<dd> <b>Halbleiter-Schaltungstechnik</b>.
+     Springer Verlag, 12. Auflage, pp. 815-852.</dd>
+</dl>
+
+</html>", revisions="<html>
+<dl>
+  <dt><b>Main Author:</b></dt>
+  <dd><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a>,
+      DLR Oberpfaffenhofen.</dd>
+</dl>
+
+<h4>Acknowledgement</h4>
+
+<p>
+The development of this block was partially funded by BMBF within the
+     <a href=\"http://www.eurosyslib.com/\">ITEA2 EUROSYSLIB</a>
+      project.
+</p>
+
+</html>"));
+  end Filter;
+
+  package Internal
+    "Internal utility functions and blocks that should not be directly utilized by the user"
+      extends Modelica.Icons.InternalPackage;
+    package Filter
+      "Internal utility functions for filters that should not be directly used"
+        extends Modelica.Icons.InternalPackage;
+      package base
+        "Prototype low pass filters with cut-off frequency of 1 rad/s (other filters are derived by transformation from these base filters)"
+          extends Modelica.Icons.InternalPackage;
+      function CriticalDamping
+          "Return base filter coefficients of CriticalDamping filter (= low pass filter with w_cut = 1 rad/s)"
+        extends Modelica.Icons.Function;
+
+        input Integer order(min=1) "Order of filter";
+        input Boolean normalized=true
+            "= true, if amplitude at f_cut = -3db, otherwise unmodified filter";
+
+        output Real cr[order] "Coefficients of real poles";
+        protected
+        Real alpha=1.0 "Frequency correction factor";
+        Real alpha2 "= alpha*alpha";
+        Real den1[order]
+            "[p] coefficients of denominator first order polynomials (a*p + 1)";
+        Real den2[0,2]
+            "[p^2, p] coefficients of denominator second order polynomials (b*p^2 + a*p + 1)";
+        Real c0[0] "Coefficients of s^0 term if conjugate complex pole";
+        Real c1[0] "Coefficients of s^1 term if conjugate complex pole";
+      algorithm
+        if normalized then
+           // alpha := sqrt(2^(1/order) - 1);
+           alpha := sqrt(10^(3/10/order)-1);
+        else
+           alpha := 1.0;
+        end if;
+
+        for i in 1:order loop
+           den1[i] := alpha;
+        end for;
+
+        // Determine polynomials with highest power of s equal to one
+          (cr,c0,c1) :=
+            Modelica.Blocks.Continuous.Internal.Filter.Utilities.toHighestPowerOne(
+            den1, den2);
+      end CriticalDamping;
+
+      function Bessel
+          "Return base filter coefficients of Bessel filter (= low pass filter with w_cut = 1 rad/s)"
+        extends Modelica.Icons.Function;
+
+        input Integer order(min=1) "Order of filter";
+        input Boolean normalized=true
+            "= true, if amplitude at f_cut = -3db, otherwise unmodified filter";
+
+        output Real cr[mod(order, 2)] "Coefficient of real pole";
+        output Real c0[integer(order/2)]
+            "Coefficients of s^0 term if conjugate complex pole";
+        output Real c1[integer(order/2)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        protected
+        Real alpha=1.0 "Frequency correction factor";
+        Real alpha2 "= alpha*alpha";
+        Real den1[size(cr,1)]
+            "[p] coefficients of denominator first order polynomials (a*p + 1)";
+        Real den2[size(c0, 1),2]
+            "[p^2, p] coefficients of denominator second order polynomials (b*p^2 + a*p + 1)";
+      algorithm
+          (den1,den2,alpha) :=
+            Modelica.Blocks.Continuous.Internal.Filter.Utilities.BesselBaseCoefficients(
+            order);
+        if not normalized then
+           alpha2 := alpha*alpha;
+           for i in 1:size(c0, 1) loop
+             den2[i, 1] := den2[i, 1]*alpha2;
+             den2[i, 2] := den2[i, 2]*alpha;
+           end for;
+           if size(cr,1) == 1 then
+             den1[1] := den1[1]*alpha;
+           end if;
+           end if;
+
+        // Determine polynomials with highest power of s equal to one
+          (cr,c0,c1) :=
+            Modelica.Blocks.Continuous.Internal.Filter.Utilities.toHighestPowerOne(
+            den1, den2);
+      end Bessel;
+
+      function Butterworth
+          "Return base filter coefficients of Butterworth filter (= low pass filter with w_cut = 1 rad/s)"
+        import Modelica.Constants.pi;
+        extends Modelica.Icons.Function;
+
+        input Integer order(min=1) "Order of filter";
+        input Boolean normalized=true
+            "= true, if amplitude at f_cut = -3db, otherwise unmodified filter";
+
+        output Real cr[mod(order, 2)] "Coefficient of real pole";
+        output Real c0[integer(order/2)]
+            "Coefficients of s^0 term if conjugate complex pole";
+        output Real c1[integer(order/2)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        protected
+        Real alpha=1.0 "Frequency correction factor";
+        Real alpha2 "= alpha*alpha";
+        Real den1[size(cr,1)]
+            "[p] coefficients of denominator first order polynomials (a*p + 1)";
+        Real den2[size(c0, 1),2]
+            "[p^2, p] coefficients of denominator second order polynomials (b*p^2 + a*p + 1)";
+      algorithm
+        for i in 1:size(c0, 1) loop
+          den2[i, 1] := 1.0;
+          den2[i, 2] := -2*Modelica.Math.cos(pi*(0.5 + (i - 0.5)/order));
+        end for;
+        if size(cr,1) == 1 then
+          den1[1] := 1.0;
+        end if;
+
+        /* Transformation of filter transfer function with "new(p) = alpha*p"
+     in order that the filter transfer function has an amplitude of
+     -3 db at the cutoff frequency
+  */
+        /*
+    if normalized then
+      alpha := Internal.normalizationFactor(den1, den2);
+      alpha2 := alpha*alpha;
+      for i in 1:size(c0, 1) loop
+        den2[i, 1] := den2[i, 1]*alpha2;
+        den2[i, 2] := den2[i, 2]*alpha;
+      end for;
+      if size(cr,1) == 1 then
+        den1[1] := den1[1]*alpha;
+      end if;
+    end if;
+  */
+
+        // Determine polynomials with highest power of s equal to one
+          (cr,c0,c1) :=
+            Modelica.Blocks.Continuous.Internal.Filter.Utilities.toHighestPowerOne(
+            den1, den2);
+      end Butterworth;
+
+      function ChebyshevI
+          "Return base filter coefficients of Chebyshev I filter (= low pass filter with w_cut = 1 rad/s)"
+        import Modelica.Math.asinh;
+        import Modelica.Constants.pi;
+
+        extends Modelica.Icons.Function;
+
+        input Integer order(min=1) "Order of filter";
+        input Real A_ripple = 0.5 "Pass band ripple in [dB]";
+        input Boolean normalized=true
+            "= true, if amplitude at f_cut = -3db, otherwise unmodified filter";
+
+        output Real cr[mod(order, 2)] "Coefficient of real pole";
+        output Real c0[integer(order/2)]
+            "Coefficients of s^0 term if conjugate complex pole";
+        output Real c1[integer(order/2)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        protected
+        Real epsilon;
+        Real fac;
+        Real alpha=1.0 "Frequency correction factor";
+        Real alpha2 "= alpha*alpha";
+        Real den1[size(cr,1)]
+            "[p] coefficients of denominator first order polynomials (a*p + 1)";
+        Real den2[size(c0, 1),2]
+            "[p^2, p] coefficients of denominator second order polynomials (b*p^2 + a*p + 1)";
+      algorithm
+          epsilon := sqrt(10^(A_ripple/10) - 1);
+          fac := asinh(1/epsilon)/order;
+
+          den1 := fill(1/sinh(fac),size(den1,1));
+          if size(cr,1) == 0 then
+             for i in 1:size(c0, 1) loop
+                den2[i,1] :=1/(cosh(fac)^2 - cos((2*i - 1)*pi/(2*order))^2);
+                den2[i,2] :=2*den2[i, 1]*sinh(fac)*cos((2*i - 1)*pi/(2*order));
+             end for;
+          else
+             for i in 1:size(c0, 1) loop
+                den2[i,1] :=1/(cosh(fac)^2 - cos(i*pi/order)^2);
+                den2[i,2] :=2*den2[i, 1]*sinh(fac)*cos(i*pi/order);
+             end for;
+          end if;
+
+          /* Transformation of filter transfer function with "new(p) = alpha*p"
+       in order that the filter transfer function has an amplitude of
+       -3 db at the cutoff frequency
+    */
+          if normalized then
+            alpha :=
+              Modelica.Blocks.Continuous.Internal.Filter.Utilities.normalizationFactor(
+              den1, den2);
+            alpha2 := alpha*alpha;
+            for i in 1:size(c0, 1) loop
+              den2[i, 1] := den2[i, 1]*alpha2;
+              den2[i, 2] := den2[i, 2]*alpha;
+            end for;
+            den1 := den1*alpha;
+          end if;
+
+        // Determine polynomials with highest power of s equal to one
+          (cr,c0,c1) :=
+            Modelica.Blocks.Continuous.Internal.Filter.Utilities.toHighestPowerOne(
+            den1, den2);
+      end ChebyshevI;
+      end base;
+
+      package coefficients "Filter coefficients"
+          extends Modelica.Icons.InternalPackage;
+      function lowPass
+          "Return low pass filter coefficients at given cut-off frequency"
+        import Modelica.Constants.pi;
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles";
+        input Real c0_in[:]
+            "Coefficients of s^0 term if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_cut "Cut-off frequency";
+
+        output Real cr[size(cr_in,1)] "Coefficient of real pole";
+        output Real c0[size(c0_in,1)]
+            "Coefficients of s^0 term if conjugate complex pole";
+        output Real c1[size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+
+        protected
+        Modelica.SIunits.AngularVelocity w_cut=2*pi*f_cut
+            "Cut-off angular frequency";
+        Real w_cut2=w_cut*w_cut;
+
+      algorithm
+        assert(f_cut > 0, "Cut-off frequency f_cut must be positive");
+
+        /* Change filter coefficients according to transformation new(s) = s/w_cut
+     s + cr           -> (s/w) + cr              = (s + w*cr)/w
+     s^2 + c1*s + c0  -> (s/w)^2 + c1*(s/w) + c0 = (s^2 + (c1*w)*s + (c0*w^2))/w^2
+  */
+        cr := w_cut*cr_in;
+        c1 := w_cut*c1_in;
+        c0 := w_cut2*c0_in;
+
+      end lowPass;
+
+      function highPass
+          "Return high pass filter coefficients at given cut-off frequency"
+        import Modelica.Constants.pi;
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles";
+        input Real c0_in[:]
+            "Coefficients of s^0 term if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_cut "Cut-off frequency";
+
+        output Real cr[size(cr_in,1)] "Coefficient of real pole";
+        output Real c0[size(c0_in,1)]
+            "Coefficients of s^0 term if conjugate complex pole";
+        output Real c1[size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+
+        protected
+        Modelica.SIunits.AngularVelocity w_cut=2*pi*f_cut
+            "Cut-off angular frequency";
+        Real w_cut2=w_cut*w_cut;
+
+      algorithm
+        assert(f_cut > 0, "Cut-off frequency f_cut must be positive");
+
+        /* Change filter coefficients according to transformation: new(s) = 1/s
+        1/(s + cr)          -> 1/(1/s + cr)                = (1/cr)*s / (s + (1/cr))
+        1/(s^2 + c1*s + c0) -> 1/((1/s)^2 + c1*(1/s) + c0) = (1/c0)*s^2 / (s^2 + (c1/c0)*s + 1/c0)
+
+     Check whether transformed roots are also conjugate complex:
+        c0 - c1^2/4 > 0  -> (1/c0) - (c1/c0)^2 / 4
+                            = (c0 - c1^2/4) / c0^2 > 0
+        It is therefore guaranteed that the roots remain conjugate complex
+
+     Change filter coefficients according to transformation new(s) = s/w_cut
+        s + 1/cr                -> (s/w) + 1/cr                   = (s + w/cr)/w
+        s^2 + (c1/c0)*s + 1/c0  -> (s/w)^2 + (c1/c0)*(s/w) + 1/c0 = (s^2 + (w*c1/c0)*s + (w^2/c0))/w^2
+  */
+        for i in 1:size(cr_in,1) loop
+           cr[i] := w_cut/cr_in[i];
+        end for;
+
+        for i in 1:size(c0_in,1) loop
+           c0[i] := w_cut2/c0_in[i];
+           c1[i] := w_cut*c1_in[i]/c0_in[i];
+        end for;
+
+      end highPass;
+
+      function bandPass
+          "Return band pass filter coefficients at given cut-off frequency"
+        import Modelica.Constants.pi;
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles";
+        input Real c0_in[:]
+            "Coefficients of s^0 term if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_min
+            "Band of band pass filter is f_min (A=-3db) .. f_max (A=-3db)";
+        input Modelica.SIunits.Frequency f_max "Upper band frequency";
+
+        output Real cr[0] "Coefficient of real pole";
+        output Real c0[size(cr_in,1) + 2*size(c0_in,1)]
+            "Coefficients of s^0 term if conjugate complex pole";
+        output Real c1[size(cr_in,1) + 2*size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        output Real cn "Numerator coefficient of the PT2 terms";
+        protected
+        Modelica.SIunits.Frequency f0 = sqrt(f_min*f_max);
+        Modelica.SIunits.AngularVelocity w_cut=2*pi*f0
+            "Cut-off angular frequency";
+        Real w_band = (f_max - f_min) / f0;
+        Real w_cut2=w_cut*w_cut;
+        Real c;
+        Real alpha;
+        Integer j;
+      algorithm
+        assert(f_min > 0 and f_min < f_max, "Band frequencies f_min and f_max are wrong");
+
+          /* The band pass filter is derived from the low pass filter by
+       the transformation new(s) = (s + 1/s)/w   (w = w_band = (f_max - f_min)/sqrt(f_max*f_min) )
+
+       1/(s + cr)         -> 1/((s/w + 1/s/w) + cr)
+                             = w*s / (s^2 + cr*w*s + 1)
+
+       1/(s^2 + c1*s + c0) -> 1/( (s+1/s)^2/w^2 + c1*(s + 1/s)/w + c0 )
+                              = 1 /( ( s^2 + 1/s^2 + 2)/w^2 + (s + 1/s)*c1/w + c0 )
+                              = w^2*s^2 / (s^4 + 2*s^2 + 1 + (s^3 + s)*c1*w + c0*w^2*s^2)
+                              = w^2*s^2 / (s^4 + c1*w*s^3 + (2+c0*w^2)*s^2 + c1*w*s + 1)
+
+                              Assume the following description with PT2:
+                              = w^2*s^2 /( (s^2 + s*(c/alpha) + 1/alpha^2)*
+                                           (s^2 + s*(c*alpha) + alpha^2) )
+                              = w^2*s^2 / ( s^4 + c*(alpha + 1/alpha)*s^3
+                                                + (alpha^2 + 1/alpha^2 + c^2)*s^2
+                                                + c*(alpha + 1/alpha)*s + 1 )
+
+                              and therefore:
+                                c*(alpha + 1/alpha) = c1*w       -> c = c1*w / (alpha + 1/alpha)
+                                                                      = c1*w*alpha/(1+alpha^2)
+                                alpha^2 + 1/alpha^2 + c^2 = 2+c0*w^2 -> equation to determine alpha
+                                alpha^4 + 1 + c1^2*w^2*alpha^4/(1+alpha^2)^2 = (2+c0*w^2)*alpha^2
+                                or z = alpha^2
+                                z^2 + c^1^2*w^2*z^2/(1+z)^2 - (2+c0*w^2)*z + 1 = 0
+
+     Check whether roots remain conjugate complex
+        c0 - (c1/2)^2 > 0:    1/alpha^2 - (c/alpha)^2/4
+                              = 1/alpha^2*(1 - c^2/4)    -> not possible to figure this out
+
+     Afterwards, change filter coefficients according to transformation new(s) = s/w_cut
+        w_band*s/(s^2 + c1*s + c0)  -> w_band*(s/w)/((s/w)^2 + c1*(s/w) + c0 =
+                                       (w_band/w)*s/(s^2 + (c1*w)*s + (c0*w^2))/w^2) =
+                                       (w_band*w)*s/(s^2 + (c1*w)*s + (c0*w^2))
+    */
+          for i in 1:size(cr_in,1) loop
+             c1[i] := w_cut*cr_in[i]*w_band;
+             c0[i] := w_cut2;
+          end for;
+
+          for i in 1:size(c1_in,1) loop
+            alpha :=
+              Modelica.Blocks.Continuous.Internal.Filter.Utilities.bandPassAlpha(
+                    c1_in[i],
+                    c0_in[i],
+                    w_band);
+             c       := c1_in[i]*w_band / (alpha + 1/alpha);
+             j       := size(cr_in,1) + 2*i - 1;
+             c1[j]   := w_cut*c/alpha;
+             c1[j+1] := w_cut*c*alpha;
+             c0[j]   := w_cut2/alpha^2;
+             c0[j+1] := w_cut2*alpha^2;
+          end for;
+
+          cn :=w_band*w_cut;
+
+      end bandPass;
+
+      function bandStop
+          "Return band stop filter coefficients at given cut-off frequency"
+        import Modelica.Constants.pi;
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles";
+        input Real c0_in[:]
+            "Coefficients of s^0 term if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_min
+            "Band of band stop filter is f_min (A=-3db) .. f_max (A=-3db)";
+        input Modelica.SIunits.Frequency f_max "Upper band frequency";
+
+        output Real cr[0] "Coefficient of real pole";
+        output Real c0[size(cr_in,1) + 2*size(c0_in,1)]
+            "Coefficients of s^0 term if conjugate complex pole";
+        output Real c1[size(cr_in,1) + 2*size(c0_in,1)]
+            "Coefficients of s^1 term if conjugate complex pole";
+        protected
+        Modelica.SIunits.Frequency f0 = sqrt(f_min*f_max);
+        Modelica.SIunits.AngularVelocity w_cut=2*pi*f0
+            "Cut-off angular frequency";
+        Real w_band = (f_max - f_min) / f0;
+        Real w_cut2=w_cut*w_cut;
+        Real c;
+        Real ww;
+        Real alpha;
+        Integer j;
+      algorithm
+        assert(f_min > 0 and f_min < f_max, "Band frequencies f_min and f_max are wrong");
+
+          /* The band pass filter is derived from the low pass filter by
+       the transformation new(s) = (s + 1/s)/w   (w = w_band = (f_max - f_min)/sqrt(f_max*f_min) )
+
+       1/(s + cr)         -> 1/((s/w + 1/s/w) + cr)
+                             = w*s / (s^2 + cr*w*s + 1)
+
+       1/(s^2 + c1*s + c0) -> 1/( (s+1/s)^2/w^2 + c1*(s + 1/s)/w + c0 )
+                              = 1 /( ( s^2 + 1/s^2 + 2)/w^2 + (s + 1/s)*c1/w + c0 )
+                              = w^2*s^2 / (s^4 + 2*s^2 + 1 + (s^3 + s)*c1*w + c0*w^2*s^2)
+                              = w^2*s^2 / (s^4 + c1*w*s^3 + (2+c0*w^2)*s^2 + c1*w*s + 1)
+
+                              Assume the following description with PT2:
+                              = w^2*s^2 /( (s^2 + s*(c/alpha) + 1/alpha^2)*
+                                           (s^2 + s*(c*alpha) + alpha^2) )
+                              = w^2*s^2 / ( s^4 + c*(alpha + 1/alpha)*s^3
+                                                + (alpha^2 + 1/alpha^2 + c^2)*s^2
+                                                + c*(alpha + 1/alpha)*s + 1 )
+
+                              and therefore:
+                                c*(alpha + 1/alpha) = c1*w       -> c = c1*w / (alpha + 1/alpha)
+                                                                      = c1*w*alpha/(1+alpha^2)
+                                alpha^2 + 1/alpha^2 + c^2 = 2+c0*w^2 -> equation to determine alpha
+                                alpha^4 + 1 + c1^2*w^2*alpha^4/(1+alpha^2)^2 = (2+c0*w^2)*alpha^2
+                                or z = alpha^2
+                                z^2 + c^1^2*w^2*z^2/(1+z)^2 - (2+c0*w^2)*z + 1 = 0
+
+       The band stop filter is derived from the low pass filter by
+       the transformation new(s) = w/( (s + 1/s) )   (w = w_band = (f_max - f_min)/sqrt(f_max*f_min) )
+
+       cr/(s + cr)         -> 1/(( w/(s + 1/s) ) + cr)
+                              = (s^2 + 1) / (s^2 + (w/cr)*s + 1)
+
+       c0/(s^2 + c1*s + c0) -> c0/( w^2/(s + 1/s)^2 + c1*w/(s + 1/s) + c0 )
+                               = c0*(s^2 + 1)^2 / (s^4 + c1*w*s^3/c0 + (2+w^2/b)*s^2 + c1*w*s/c0 + 1)
+
+                               Assume the following description with PT2:
+                               = c0*(s^2 + 1)^2 / ( (s^2 + s*(c/alpha) + 1/alpha^2)*
+                                                    (s^2 + s*(c*alpha) + alpha^2) )
+                               = c0*(s^2 + 1)^2 / (  s^4 + c*(alpha + 1/alpha)*s^3
+                                                         + (alpha^2 + 1/alpha^2 + c^2)*s^2
+                                                         + c*(alpha + 1/alpha)*p + 1 )
+
+                            and therefore:
+                              c*(alpha + 1/alpha) = c1*w/b         -> c = c1*w/(c0*(alpha + 1/alpha))
+                              alpha^2 + 1/alpha^2 + c^2 = 2+w^2/c0 -> equation to determine alpha
+                              alpha^4 + 1 + (c1*w/c0*alpha^2)^2/(1+alpha^2)^2 = (2+w^2/c0)*alpha^2
+                              or z = alpha^2
+                              z^2 + (c1*w/c0*z)^2/(1+z)^2 - (2+w^2/c0)*z + 1 = 0
+
+                            same as:  ww = w/c0
+                              z^2 + (c1*ww*z)^2/(1+z)^2 - (2+c0*ww)*z + 1 = 0  -> same equation as for BandPass
+
+     Afterwards, change filter coefficients according to transformation new(s) = s/w_cut
+        c0*(s^2+1)(s^2 + c1*s + c0)  -> c0*((s/w)^2 + 1) / ((s/w)^2 + c1*(s/w) + c0 =
+                                        c0/w^2*(s^2 + w^2) / (s^2 + (c1*w)*s + (c0*w^2))/w^2) =
+                                        (s^2 + c0*w^2) / (s^2 + (c1*w)*s + (c0*w^2))
+    */
+          for i in 1:size(cr_in,1) loop
+             c1[i] := w_cut*w_band/cr_in[i];
+             c0[i] := w_cut2;
+          end for;
+
+          for i in 1:size(c1_in,1) loop
+             ww      := w_band/c0_in[i];
+            alpha :=
+              Modelica.Blocks.Continuous.Internal.Filter.Utilities.bandPassAlpha(
+                    c1_in[i],
+                    c0_in[i],
+                    ww);
+             c       := c1_in[i]*ww / (alpha + 1/alpha);
+             j       := size(cr_in,1) + 2*i - 1;
+             c1[j]   := w_cut*c/alpha;
+             c1[j+1] := w_cut*c*alpha;
+             c0[j]   := w_cut2/alpha^2;
+             c0[j+1] := w_cut2*alpha^2;
+          end for;
+
+      end bandStop;
+      end coefficients;
+
+      package roots "Filter roots and gain as needed for block implementations"
+          extends Modelica.Icons.InternalPackage;
+      function lowPass
+          "Return low pass filter roots as needed for block for given cut-off frequency"
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles of base filter";
+        input Real c0_in[:]
+            "Coefficients of s^0 term of base filter if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term of base filter if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_cut "Cut-off frequency";
+
+        output Real r[size(cr_in,1)] "Real eigenvalues";
+        output Real a[size(c0_in,1)]
+            "Real parts of complex conjugate eigenvalues";
+        output Real b[size(c0_in,1)]
+            "Imaginary parts of complex conjugate eigenvalues";
+        output Real ku[size(c0_in,1)] "Input gain";
+        protected
+        Real c0[size(c0_in,1)];
+        Real c1[size(c0_in,1)];
+        Real cr[size(cr_in,1)];
+      algorithm
+        // Get coefficients of low pass filter at f_cut
+        (cr, c0, c1) :=coefficients.lowPass(cr_in, c0_in, c1_in, f_cut);
+
+        // Transform coefficients in to root
+        for i in 1:size(cr_in,1) loop
+          r[i] :=-cr[i];
+        end for;
+
+        for i in 1:size(c0_in,1) loop
+          a [i] :=-c1[i]/2;
+          b [i] :=sqrt(c0[i] - a[i]*a[i]);
+          ku[i] :=c0[i]/b[i];
+        end for;
+
+        annotation (Documentation(info="<html>
+
+<p>
+The goal is to implement the filter in the following form:
+</p>
+
+<pre>
+  // real pole:
+   der(x) = r*x - r*u
+       y  = x
+
+  // complex conjugate poles:
+  der(x1) = a*x1 - b*x2 + ku*u;
+  der(x2) = b*x1 + a*x2;
+       y  = x2;
+
+            ku = (a^2 + b^2)/b
+</pre>
+<p>
+This representation has the following transfer function:
+</p>
+<pre>
+// real pole:
+    s*y = r*y - r*u
+  or
+    (s-r)*y = -r*u
+  or
+    y = -r/(s-r)*u
+
+  comparing coefficients with
+    y = cr/(s + cr)*u  ->  r = -cr      // r is the real eigenvalue
+
+// complex conjugate poles
+    s*x2 =  a*x2 + b*x1
+    s*x1 = -b*x2 + a*x1 + ku*u
+  or
+    (s-a)*x2               = b*x1  ->  x2 = b/(s-a)*x1
+    (s + b^2/(s-a) - a)*x1 = ku*u  ->  (s(s-a) + b^2 - a*(s-a))*x1  = ku*(s-a)*u
+                                   ->  (s^2 - 2*a*s + a^2 + b^2)*x1 = ku*(s-a)*u
+  or
+    x1 = ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+    x2 = b/(s-a)*ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+       = b*ku/(s^2 - 2*a*s + a^2 + b^2)*u
+    y  = x2
+
+  comparing coefficients with
+    y = c0/(s^2 + c1*s + c0)*u  ->  a  = -c1/2
+                                    b  = sqrt(c0 - a^2)
+                                    ku = c0/b
+                                       = (a^2 + b^2)/b
+
+  comparing with eigenvalue representation:
+    (s - (a+jb))*(s - (a-jb)) = s^2 -2*a*s + a^2 + b^2
+  shows that:
+    a: real part of eigenvalue
+    b: imaginary part of eigenvalue
+
+  time -> infinity:
+    y(s=0) = x2(s=0) = 1
+             x1(s=0) = -ku*a/(a^2 + b^2)*u
+                     = -(a/b)*u
+</pre>
+
+</html>"));
+      end lowPass;
+
+      function highPass
+          "Return high pass filter roots as needed for block for given cut-off frequency"
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles of base filter";
+        input Real c0_in[:]
+            "Coefficients of s^0 term of base filter if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term of base filter if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_cut "Cut-off frequency";
+
+        output Real r[size(cr_in,1)] "Real eigenvalues";
+        output Real a[size(c0_in,1)]
+            "Real parts of complex conjugate eigenvalues";
+        output Real b[size(c0_in,1)]
+            "Imaginary parts of complex conjugate eigenvalues";
+        output Real ku[size(c0_in,1)] "Gains of input terms";
+        output Real k1[size(c0_in,1)] "Gains of y = k1*x1 + k2*x + u";
+        output Real k2[size(c0_in,1)] "Gains of y = k1*x1 + k2*x + u";
+        protected
+        Real c0[size(c0_in,1)];
+        Real c1[size(c0_in,1)];
+        Real cr[size(cr_in,1)];
+        Real ba2;
+      algorithm
+        // Get coefficients of high pass filter at f_cut
+        (cr, c0, c1) :=coefficients.highPass(cr_in, c0_in, c1_in, f_cut);
+
+        // Transform coefficients in to roots
+        for i in 1:size(cr_in,1) loop
+          r[i] :=-cr[i];
+        end for;
+
+        for i in 1:size(c0_in,1) loop
+          a[i]  := -c1[i]/2;
+          b[i]  := sqrt(c0[i] - a[i]*a[i]);
+          ku[i] := c0[i]/b[i];
+          k1[i] := 2*a[i]/ku[i];
+          ba2   := (b[i]/a[i])^2;
+          k2[i] := (1-ba2)/(1+ba2);
+        end for;
+
+        annotation (Documentation(info="<html>
+
+<p>
+The goal is to implement the filter in the following form:
+</p>
+
+<pre>
+  // real pole:
+   der(x) = r*x - r*u
+       y  = -x + u
+
+  // complex conjugate poles:
+  der(x1) = a*x1 - b*x2 + ku*u;
+  der(x2) = b*x1 + a*x2;
+       y  = k1*x1 + k2*x2 + u;
+
+            ku = (a^2 + b^2)/b
+            k1 = 2*a/ku
+            k2 = (a^2 - b^2) / (b*ku)
+               = (a^2 - b^2) / (a^2 + b^2)
+               = (1 - (b/a)^2) / (1 + (b/a)^2)
+
+</pre>
+<p>
+This representation has the following transfer function:
+</p>
+<pre>
+// real pole:
+    s*x = r*x - r*u
+  or
+    (s-r)*x = -r*u   -> x = -r/(s-r)*u
+  or
+    y = r/(s-r)*u + (s-r)/(s-r)*u
+      = (r+s-r)/(s-r)*u
+      = s/(s-r)*u
+
+  comparing coefficients with
+    y = s/(s + cr)*u  ->  r = -cr      // r is the real eigenvalue
+
+// complex conjugate poles
+    s*x2 =  a*x2 + b*x1
+    s*x1 = -b*x2 + a*x1 + ku*u
+  or
+    (s-a)*x2               = b*x1  ->  x2 = b/(s-a)*x1
+    (s + b^2/(s-a) - a)*x1 = ku*u  ->  (s(s-a) + b^2 - a*(s-a))*x1  = ku*(s-a)*u
+                                   ->  (s^2 - 2*a*s + a^2 + b^2)*x1 = ku*(s-a)*u
+  or
+    x1 = ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+    x2 = b/(s-a)*ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+       = b*ku/(s^2 - 2*a*s + a^2 + b^2)*u
+    y  = k1*x1 + k2*x2 + u
+       = (k1*ku*(s-a) + k2*b*ku +  s^2 - 2*a*s + a^2 + b^2) /
+         (s^2 - 2*a*s + a^2 + b^2)*u
+       = (s^2 + (k1*ku - 2*a)*s + k2*b*ku - k1*ku*a + a^2 + b^2) /
+         (s^2 - 2*a*s + a^2 + b^2)*u
+       = (s^2 + (2*a-2*a)*s + a^2 - b^2 - 2*a^2 + a^2 + b^2) /
+         (s^2 - 2*a*s + a^2 + b^2)*u
+       = s^2 / (s^2 - 2*a*s + a^2 + b^2)*u
+
+  comparing coefficients with
+    y = s^2/(s^2 + c1*s + c0)*u  ->  a = -c1/2
+                                     b = sqrt(c0 - a^2)
+
+  comparing with eigenvalue representation:
+    (s - (a+jb))*(s - (a-jb)) = s^2 -2*a*s + a^2 + b^2
+  shows that:
+    a: real part of eigenvalue
+    b: imaginary part of eigenvalue
+</pre>
+
+</html>"));
+      end highPass;
+
+      function bandPass
+          "Return band pass filter roots as needed for block for given cut-off frequency"
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles of base filter";
+        input Real c0_in[:]
+            "Coefficients of s^0 term of base filter if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term of base filter if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_min
+            "Band of band pass filter is f_min (A=-3db) .. f_max (A=-3db)";
+        input Modelica.SIunits.Frequency f_max "Upper band frequency";
+
+        output Real a[size(cr_in,1) + 2*size(c0_in,1)]
+            "Real parts of complex conjugate eigenvalues";
+        output Real b[size(cr_in,1) + 2*size(c0_in,1)]
+            "Imaginary parts of complex conjugate eigenvalues";
+        output Real ku[size(cr_in,1) + 2*size(c0_in,1)] "Gains of input terms";
+        output Real k1[size(cr_in,1) + 2*size(c0_in,1)]
+            "Gains of y = k1*x1 + k2*x";
+        output Real k2[size(cr_in,1) + 2*size(c0_in,1)]
+            "Gains of y = k1*x1 + k2*x";
+        protected
+        Real cr[0];
+        Real c0[size(a,1)];
+        Real c1[size(a,1)];
+        Real cn;
+        Real bb;
+      algorithm
+        // Get coefficients of band pass filter at f_cut
+        (cr, c0, c1, cn) :=coefficients.bandPass(cr_in, c0_in, c1_in, f_min, f_max);
+
+        // Transform coefficients in to roots
+        for i in 1:size(a,1) loop
+          a[i]  := -c1[i]/2;
+          bb    := c0[i] - a[i]*a[i];
+          assert(bb >= 0, "\nNot possible to use band pass filter, since transformation results in\n"+
+                          "system that does not have conjugate complex poles.\n" +
+                          "Try to use another analog filter for the band pass.\n");
+          b[i]  := sqrt(bb);
+          ku[i] := c0[i]/b[i];
+          k1[i] := cn/ku[i];
+          k2[i] := cn*a[i]/(b[i]*ku[i]);
+        end for;
+
+        annotation (Documentation(info="<html>
+
+<p>
+The goal is to implement the filter in the following form:
+</p>
+
+<pre>
+  // complex conjugate poles:
+  der(x1) = a*x1 - b*x2 + ku*u;
+  der(x2) = b*x1 + a*x2;
+       y  = k1*x1 + k2*x2;
+
+            ku = (a^2 + b^2)/b
+            k1 = cn/ku
+            k2 = cn*a/(b*ku)
+</pre>
+<p>
+This representation has the following transfer function:
+</p>
+<pre>
+// complex conjugate poles
+    s*x2 =  a*x2 + b*x1
+    s*x1 = -b*x2 + a*x1 + ku*u
+  or
+    (s-a)*x2               = b*x1  ->  x2 = b/(s-a)*x1
+    (s + b^2/(s-a) - a)*x1 = ku*u  ->  (s(s-a) + b^2 - a*(s-a))*x1  = ku*(s-a)*u
+                                   ->  (s^2 - 2*a*s + a^2 + b^2)*x1 = ku*(s-a)*u
+  or
+    x1 = ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+    x2 = b/(s-a)*ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+       = b*ku/(s^2 - 2*a*s + a^2 + b^2)*u
+    y  = k1*x1 + k2*x2
+       = (k1*ku*(s-a) + k2*b*ku) / (s^2 - 2*a*s + a^2 + b^2)*u
+       = (k1*ku*s + k2*b*ku - k1*ku*a) / (s^2 - 2*a*s + a^2 + b^2)*u
+       = (cn*s + cn*a - cn*a) / (s^2 - 2*a*s + a^2 + b^2)*u
+       = cn*s / (s^2 - 2*a*s + a^2 + b^2)*u
+
+  comparing coefficients with
+    y = cn*s / (s^2 + c1*s + c0)*u  ->  a = -c1/2
+                                        b = sqrt(c0 - a^2)
+
+  comparing with eigenvalue representation:
+    (s - (a+jb))*(s - (a-jb)) = s^2 -2*a*s + a^2 + b^2
+  shows that:
+    a: real part of eigenvalue
+    b: imaginary part of eigenvalue
+</pre>
+
+</html>"));
+      end bandPass;
+
+      function bandStop
+          "Return band stop filter roots as needed for block for given cut-off frequency"
+        extends Modelica.Icons.Function;
+
+        input Real cr_in[:] "Coefficients of real poles of base filter";
+        input Real c0_in[:]
+            "Coefficients of s^0 term of base filter if conjugate complex pole";
+        input Real c1_in[size(c0_in,1)]
+            "Coefficients of s^1 term of base filter if conjugate complex pole";
+        input Modelica.SIunits.Frequency f_min
+            "Band of band stop filter is f_min (A=-3db) .. f_max (A=-3db)";
+        input Modelica.SIunits.Frequency f_max "Upper band frequency";
+
+        output Real a[size(cr_in,1) + 2*size(c0_in,1)]
+            "Real parts of complex conjugate eigenvalues";
+        output Real b[size(cr_in,1) + 2*size(c0_in,1)]
+            "Imaginary parts of complex conjugate eigenvalues";
+        output Real ku[size(cr_in,1) + 2*size(c0_in,1)] "Gains of input terms";
+        output Real k1[size(cr_in,1) + 2*size(c0_in,1)]
+            "Gains of y = k1*x1 + k2*x";
+        output Real k2[size(cr_in,1) + 2*size(c0_in,1)]
+            "Gains of y = k1*x1 + k2*x";
+        protected
+        Real cr[0];
+        Real c0[size(a,1)];
+        Real c1[size(a,1)];
+        Real cn;
+        Real bb;
+      algorithm
+        // Get coefficients of band stop filter at f_cut
+        (cr, c0, c1) :=coefficients.bandStop(cr_in, c0_in, c1_in, f_min, f_max);
+
+        // Transform coefficients in to roots
+        for i in 1:size(a,1) loop
+          a[i]  := -c1[i]/2;
+          bb    := c0[i] - a[i]*a[i];
+          assert(bb >= 0, "\nNot possible to use band stop filter, since transformation results in\n"+
+                          "system that does not have conjugate complex poles.\n" +
+                          "Try to use another analog filter for the band stop filter.\n");
+          b[i]  := sqrt(bb);
+          ku[i] := c0[i]/b[i];
+          k1[i] := 2*a[i]/ku[i];
+          k2[i] := (c0[i] + a[i]^2 - b[i]^2)/(b[i]*ku[i]);
+        end for;
+
+        annotation (Documentation(info="<html>
+
+<p>
+The goal is to implement the filter in the following form:
+</p>
+
+<pre>
+  // complex conjugate poles:
+  der(x1) = a*x1 - b*x2 + ku*u;
+  der(x2) = b*x1 + a*x2;
+       y  = k1*x1 + k2*x2 + u;
+
+            ku = (a^2 + b^2)/b
+            k1 = 2*a/ku
+            k2 = (c0 + a^2 - b^2)/(b*ku)
+</pre>
+<p>
+This representation has the following transfer function:
+</p>
+<pre>
+// complex conjugate poles
+    s*x2 =  a*x2 + b*x1
+    s*x1 = -b*x2 + a*x1 + ku*u
+  or
+    (s-a)*x2               = b*x1  ->  x2 = b/(s-a)*x1
+    (s + b^2/(s-a) - a)*x1 = ku*u  ->  (s(s-a) + b^2 - a*(s-a))*x1  = ku*(s-a)*u
+                                   ->  (s^2 - 2*a*s + a^2 + b^2)*x1 = ku*(s-a)*u
+  or
+    x1 = ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+    x2 = b/(s-a)*ku*(s-a)/(s^2 - 2*a*s + a^2 + b^2)*u
+       = b*ku/(s^2 - 2*a*s + a^2 + b^2)*u
+    y  = k1*x1 + k2*x2 + u
+       = (k1*ku*(s-a) + k2*b*ku + s^2 - 2*a*s + a^2 + b^2) / (s^2 - 2*a*s + a^2 + b^2)*u
+       = (s^2 + (k1*ku-2*a)*s + k2*b*ku - k1*ku*a + a^2 + b^2) / (s^2 - 2*a*s + a^2 + b^2)*u
+       = (s^2 + c0 + a^2 - b^2 - 2*a^2 + a^2 + b^2) / (s^2 - 2*a*s + a^2 + b^2)*u
+       = (s^2 + c0) / (s^2 - 2*a*s + a^2 + b^2)*u
+
+  comparing coefficients with
+    y = (s^2 + c0) / (s^2 + c1*s + c0)*u  ->  a = -c1/2
+                                              b = sqrt(c0 - a^2)
+
+  comparing with eigenvalue representation:
+    (s - (a+jb))*(s - (a-jb)) = s^2 -2*a*s + a^2 + b^2
+  shows that:
+    a: real part of eigenvalue
+    b: imaginary part of eigenvalue
+</pre>
+
+</html>"));
+      end bandStop;
+      end roots;
+
+      package Utilities "Utility functions for filter computations"
+          extends Modelica.Icons.InternalPackage;
+        function BesselBaseCoefficients
+          "Return coefficients of normalized low pass Bessel filter (= gain at cut-off frequency 1 rad/s is decreased 3dB)"
+          extends Modelica.Icons.Function;
+
+          import Modelica.Utilities.Streams;
+          input Integer order "Order of filter in the range 1..41";
+          output Real c1[mod(order, 2)]
+            "[p] coefficients of Bessel denominator polynomials (a*p + 1)";
+          output Real c2[integer(order/2),2]
+            "[p^2, p] coefficients of Bessel denominator polynomials (b2*p^2 + b1*p + 1)";
+          output Real alpha "Normalization factor";
+        algorithm
+          if order == 1 then
+            alpha := 1.002377293007601;
+            c1[1] := 0.9976283451109835;
+          elseif order == 2 then
+            alpha := 0.7356641785819585;
+            c2[1, 1] := 0.6159132201783791;
+            c2[1, 2] := 1.359315879600889;
+          elseif order == 3 then
+            alpha := 0.5704770156982642;
+            c1[1] := 0.7548574865985343;
+            c2[1, 1] := 0.4756958028827457;
+            c2[1, 2] := 0.9980615136104388;
+          elseif order == 4 then
+            alpha := 0.4737978580281427;
+            c2[1, 1] := 0.4873729247240677;
+            c2[1, 2] := 1.337564170455762;
+            c2[2, 1] := 0.3877724315741958;
+            c2[2, 2] := 0.7730405590839861;
+          elseif order == 5 then
+            alpha := 0.4126226974763408;
+            c1[1] := 0.6645723262620757;
+            c2[1, 1] := 0.4115231900614016;
+            c2[1, 2] := 1.138349926728708;
+            c2[2, 1] := 0.3234938702877912;
+            c2[2, 2] := 0.6205992985771313;
+          elseif order == 6 then
+            alpha := 0.3705098000736233;
+            c2[1, 1] := 0.3874508649098960;
+            c2[1, 2] := 1.219740879520741;
+            c2[2, 1] := 0.3493298843155746;
+            c2[2, 2] := 0.9670265529381365;
+            c2[3, 1] := 0.2747419229514599;
+            c2[3, 2] := 0.5122165075105700;
+          elseif order == 7 then
+            alpha := 0.3393452623586350;
+            c1[1] := 0.5927147125821412;
+            c2[1, 1] := 0.3383379423919174;
+            c2[1, 2] := 1.092630816438030;
+            c2[2, 1] := 0.3001025788696046;
+            c2[2, 2] := 0.8289928256598656;
+            c2[3, 1] := 0.2372867471539579;
+            c2[3, 2] := 0.4325128641920154;
+          elseif order == 8 then
+            alpha := 0.3150267393795002;
+            c2[1, 1] := 0.3151115975207653;
+            c2[1, 2] := 1.109403015460190;
+            c2[2, 1] := 0.2969344839572762;
+            c2[2, 2] := 0.9737455812222699;
+            c2[3, 1] := 0.2612545921889538;
+            c2[3, 2] := 0.7190394712068573;
+            c2[4, 1] := 0.2080523342974281;
+            c2[4, 2] := 0.3721456473047434;
+          elseif order == 9 then
+            alpha := 0.2953310177184124;
+            c1[1] := 0.5377196679501422;
+            c2[1, 1] := 0.2824689124281034;
+            c2[1, 2] := 1.022646191567475;
+            c2[2, 1] := 0.2626824161383468;
+            c2[2, 2] := 0.8695626454762596;
+            c2[3, 1] := 0.2302781917677917;
+            c2[3, 2] := 0.6309047553448520;
+            c2[4, 1] := 0.1847991729757028;
+            c2[4, 2] := 0.3251978031287202;
+          elseif order == 10 then
+            alpha := 0.2789426890619463;
+            c2[1, 1] := 0.2640769908255582;
+            c2[1, 2] := 1.019788132875305;
+            c2[2, 1] := 0.2540802639216947;
+            c2[2, 2] := 0.9377020417760623;
+            c2[3, 1] := 0.2343577229427963;
+            c2[3, 2] := 0.7802229808216112;
+            c2[4, 1] := 0.2052193139338624;
+            c2[4, 2] := 0.5594176813008133;
+            c2[5, 1] := 0.1659546953748916;
+            c2[5, 2] := 0.2878349616233292;
+          elseif order == 11 then
+            alpha := 0.2650227766037203;
+            c1[1] := 0.4950265498954191;
+            c2[1, 1] := 0.2411858478546218;
+            c2[1, 2] := 0.9567800996387417;
+            c2[2, 1] := 0.2296849355380925;
+            c2[2, 2] := 0.8592523717113126;
+            c2[3, 1] := 0.2107851705677406;
+            c2[3, 2] := 0.7040216048898129;
+            c2[4, 1] := 0.1846461385164021;
+            c2[4, 2] := 0.5006729207276717;
+            c2[5, 1] := 0.1504217970817433;
+            c2[5, 2] := 0.2575070491320295;
+          elseif order == 12 then
+            alpha := 0.2530051198547209;
+            c2[1, 1] := 0.2268294941204543;
+            c2[1, 2] := 0.9473116570034053;
+            c2[2, 1] := 0.2207657387793729;
+            c2[2, 2] := 0.8933728946287606;
+            c2[3, 1] := 0.2087600700376653;
+            c2[3, 2] := 0.7886236252756229;
+            c2[4, 1] := 0.1909959101492760;
+            c2[4, 2] := 0.6389263649257017;
+            c2[5, 1] := 0.1675208146048472;
+            c2[5, 2] := 0.4517847275162215;
+            c2[6, 1] := 0.1374257286372761;
+            c2[6, 2] := 0.2324699157474680;
+          elseif order == 13 then
+            alpha := 0.2424910397561007;
+            c1[1] := 0.4608848369928040;
+            c2[1, 1] := 0.2099813050274780;
+            c2[1, 2] := 0.8992478823790660;
+            c2[2, 1] := 0.2027250423101359;
+            c2[2, 2] := 0.8328117484224146;
+            c2[3, 1] := 0.1907635894058731;
+            c2[3, 2] := 0.7257379204691213;
+            c2[4, 1] := 0.1742280397887686;
+            c2[4, 2] := 0.5830640944868014;
+            c2[5, 1] := 0.1530858190490478;
+            c2[5, 2] := 0.4106192089751885;
+            c2[6, 1] := 0.1264090712880446;
+            c2[6, 2] := 0.2114980230156001;
+          elseif order == 14 then
+            alpha := 0.2331902368695848;
+            c2[1, 1] := 0.1986162311411235;
+            c2[1, 2] := 0.8876961808055535;
+            c2[2, 1] := 0.1946683341271615;
+            c2[2, 2] := 0.8500754229171967;
+            c2[3, 1] := 0.1868331332895056;
+            c2[3, 2] := 0.7764629313723603;
+            c2[4, 1] := 0.1752118757862992;
+            c2[4, 2] := 0.6699720402924552;
+            c2[5, 1] := 0.1598906457908402;
+            c2[5, 2] := 0.5348446712848934;
+            c2[6, 1] := 0.1407810153019944;
+            c2[6, 2] := 0.3755841316563539;
+            c2[7, 1] := 0.1169627966707339;
+            c2[7, 2] := 0.1937088226304455;
+          elseif order == 15 then
+            alpha := 0.2248854870552422;
+            c1[1] := 0.4328492272335646;
+            c2[1, 1] := 0.1857292591004588;
+            c2[1, 2] := 0.8496337061962563;
+            c2[2, 1] := 0.1808644178280136;
+            c2[2, 2] := 0.8020517898136011;
+            c2[3, 1] := 0.1728264404199081;
+            c2[3, 2] := 0.7247449729331105;
+            c2[4, 1] := 0.1616970125901954;
+            c2[4, 2] := 0.6205369315943097;
+            c2[5, 1] := 0.1475257264578426;
+            c2[5, 2] := 0.4929612162355906;
+            c2[6, 1] := 0.1301861023357119;
+            c2[6, 2] := 0.3454770708040735;
+            c2[7, 1] := 0.1087810777120188;
+            c2[7, 2] := 0.1784526655428406;
+          elseif order == 16 then
+            alpha := 0.2174105053474761;
+            c2[1, 1] := 0.1765637967473151;
+            c2[1, 2] := 0.8377453068635511;
+            c2[2, 1] := 0.1738525357503125;
+            c2[2, 2] := 0.8102988957433199;
+            c2[3, 1] := 0.1684627004613343;
+            c2[3, 2] := 0.7563265923413258;
+            c2[4, 1] := 0.1604519074815815;
+            c2[4, 2] := 0.6776082294687619;
+            c2[5, 1] := 0.1498828607802206;
+            c2[5, 2] := 0.5766417034027680;
+            c2[6, 1] := 0.1367764717792823;
+            c2[6, 2] := 0.4563528264410489;
+            c2[7, 1] := 0.1209810465419295;
+            c2[7, 2] := 0.3193782657322374;
+            c2[8, 1] := 0.1016312648007554;
+            c2[8, 2] := 0.1652419227369036;
+          elseif order == 17 then
+            alpha := 0.2106355148193306;
+            c1[1] := 0.4093223608497299;
+            c2[1, 1] := 0.1664014345826274;
+            c2[1, 2] := 0.8067173752345952;
+            c2[2, 1] := 0.1629839591538256;
+            c2[2, 2] := 0.7712924931447541;
+            c2[3, 1] := 0.1573277802512491;
+            c2[3, 2] := 0.7134213666303411;
+            c2[4, 1] := 0.1494828185148637;
+            c2[4, 2] := 0.6347841731714884;
+            c2[5, 1] := 0.1394948812681826;
+            c2[5, 2] := 0.5375594414619047;
+            c2[6, 1] := 0.1273627583380806;
+            c2[6, 2] := 0.4241608926375478;
+            c2[7, 1] := 0.1129187258461290;
+            c2[7, 2] := 0.2965752009703245;
+            c2[8, 1] := 0.9533357359908857e-1;
+            c2[8, 2] := 0.1537041700889585;
+          elseif order == 18 then
+            alpha := 0.2044575288651841;
+            c2[1, 1] := 0.1588768571976356;
+            c2[1, 2] := 0.7951914263212913;
+            c2[2, 1] := 0.1569357024981854;
+            c2[2, 2] := 0.7744529690772538;
+            c2[3, 1] := 0.1530722206358810;
+            c2[3, 2] := 0.7335304425992080;
+            c2[4, 1] := 0.1473206710524167;
+            c2[4, 2] := 0.6735038935387268;
+            c2[5, 1] := 0.1397225420331520;
+            c2[5, 2] := 0.5959151542621590;
+            c2[6, 1] := 0.1303092459809849;
+            c2[6, 2] := 0.5026483447894845;
+            c2[7, 1] := 0.1190627367060072;
+            c2[7, 2] := 0.3956893824587150;
+            c2[8, 1] := 0.1058058030798994;
+            c2[8, 2] := 0.2765091830730650;
+            c2[9, 1] := 0.8974708108800873e-1;
+            c2[9, 2] := 0.1435505288284833;
+          elseif order == 19 then
+            alpha := 0.1987936248083529;
+            c1[1] := 0.3892259966869526;
+            c2[1, 1] := 0.1506640012172225;
+            c2[1, 2] := 0.7693121733774260;
+            c2[2, 1] := 0.1481728062796673;
+            c2[2, 2] := 0.7421133586741549;
+            c2[3, 1] := 0.1440444668388838;
+            c2[3, 2] := 0.6975075386214800;
+            c2[4, 1] := 0.1383101628540374;
+            c2[4, 2] := 0.6365464378910025;
+            c2[5, 1] := 0.1310032283190998;
+            c2[5, 2] := 0.5606211948462122;
+            c2[6, 1] := 0.1221431166405330;
+            c2[6, 2] := 0.4713530424221445;
+            c2[7, 1] := 0.1116991161103884;
+            c2[7, 2] := 0.3703717538617073;
+            c2[8, 1] := 0.9948917351196349e-1;
+            c2[8, 2] := 0.2587371155559744;
+            c2[9, 1] := 0.8475989238107367e-1;
+            c2[9, 2] := 0.1345537894555993;
+          elseif order == 20 then
+            alpha := 0.1935761760416219;
+            c2[1, 1] := 0.1443871348337404;
+            c2[1, 2] := 0.7584165598446141;
+            c2[2, 1] := 0.1429501891353184;
+            c2[2, 2] := 0.7423000962318863;
+            c2[3, 1] := 0.1400877384920004;
+            c2[3, 2] := 0.7104185332215555;
+            c2[4, 1] := 0.1358210369491446;
+            c2[4, 2] := 0.6634599783272630;
+            c2[5, 1] := 0.1301773703034290;
+            c2[5, 2] := 0.6024175491895959;
+            c2[6, 1] := 0.1231826501439148;
+            c2[6, 2] := 0.5285332736326852;
+            c2[7, 1] := 0.1148465498575254;
+            c2[7, 2] := 0.4431977385498628;
+            c2[8, 1] := 0.1051289462376788;
+            c2[8, 2] := 0.3477444062821162;
+            c2[9, 1] := 0.9384622797485121e-1;
+            c2[9, 2] := 0.2429038300327729;
+            c2[10, 1] := 0.8028211612831444e-1;
+            c2[10, 2] := 0.1265329974009533;
+          elseif order == 21 then
+            alpha := 0.1887494014766075;
+            c1[1] := 0.3718070668941645;
+            c2[1, 1] := 0.1376151928386445;
+            c2[1, 2] := 0.7364290859445481;
+            c2[2, 1] := 0.1357438914390695;
+            c2[2, 2] := 0.7150167318935022;
+            c2[3, 1] := 0.1326398453462415;
+            c2[3, 2] := 0.6798001808470175;
+            c2[4, 1] := 0.1283231214897678;
+            c2[4, 2] := 0.6314663440439816;
+            c2[5, 1] := 0.1228169159777534;
+            c2[5, 2] := 0.5709353626166905;
+            c2[6, 1] := 0.1161406100773184;
+            c2[6, 2] := 0.4993087153571335;
+            c2[7, 1] := 0.1082959649233524;
+            c2[7, 2] := 0.4177766148584385;
+            c2[8, 1] := 0.9923596957485723e-1;
+            c2[8, 2] := 0.3274257287232124;
+            c2[9, 1] := 0.8877776108724853e-1;
+            c2[9, 2] := 0.2287218166767916;
+            c2[10, 1] := 0.7624076527736326e-1;
+            c2[10, 2] := 0.1193423971506988;
+          elseif order == 22 then
+            alpha := 0.1842668221199706;
+            c2[1, 1] := 0.1323053462701543;
+            c2[1, 2] := 0.7262446126765204;
+            c2[2, 1] := 0.1312121721769772;
+            c2[2, 2] := 0.7134286088450949;
+            c2[3, 1] := 0.1290330911166814;
+            c2[3, 2] := 0.6880287870435514;
+            c2[4, 1] := 0.1257817990372067;
+            c2[4, 2] := 0.6505015800059301;
+            c2[5, 1] := 0.1214765261983008;
+            c2[5, 2] := 0.6015107185211451;
+            c2[6, 1] := 0.1161365140967959;
+            c2[6, 2] := 0.5418983553698413;
+            c2[7, 1] := 0.1097755171533100;
+            c2[7, 2] := 0.4726370779831614;
+            c2[8, 1] := 0.1023889478519956;
+            c2[8, 2] := 0.3947439506537486;
+            c2[9, 1] := 0.9392485861253800e-1;
+            c2[9, 2] := 0.3090996703083202;
+            c2[10, 1] := 0.8420273775456455e-1;
+            c2[10, 2] := 0.2159561978556017;
+            c2[11, 1] := 0.7257600023938262e-1;
+            c2[11, 2] := 0.1128633732721116;
+          elseif order == 23 then
+            alpha := 0.1800893554453722;
+            c1[1] := 0.3565232673929280;
+            c2[1, 1] := 0.1266275171652706;
+            c2[1, 2] := 0.7072778066734162;
+            c2[2, 1] := 0.1251865227648538;
+            c2[2, 2] := 0.6900676345785905;
+            c2[3, 1] := 0.1227944815236645;
+            c2[3, 2] := 0.6617011100576023;
+            c2[4, 1] := 0.1194647013077667;
+            c2[4, 2] := 0.6226432315773119;
+            c2[5, 1] := 0.1152132989252356;
+            c2[5, 2] := 0.5735222810625359;
+            c2[6, 1] := 0.1100558598478487;
+            c2[6, 2] := 0.5151027978024605;
+            c2[7, 1] := 0.1040013558214886;
+            c2[7, 2] := 0.4482410942032739;
+            c2[8, 1] := 0.9704014176512626e-1;
+            c2[8, 2] := 0.3738049984631116;
+            c2[9, 1] := 0.8911683905758054e-1;
+            c2[9, 2] := 0.2925028692588410;
+            c2[10, 1] := 0.8005438265072295e-1;
+            c2[10, 2] := 0.2044134600278901;
+            c2[11, 1] := 0.6923832296800832e-1;
+            c2[11, 2] := 0.1069984887283394;
+          elseif order == 24 then
+            alpha := 0.1761838665838427;
+            c2[1, 1] := 0.1220804912720132;
+            c2[1, 2] := 0.6978026874156063;
+            c2[2, 1] := 0.1212296762358897;
+            c2[2, 2] := 0.6874139794926736;
+            c2[3, 1] := 0.1195328372961027;
+            c2[3, 2] := 0.6667954259551859;
+            c2[4, 1] := 0.1169990987333593;
+            c2[4, 2] := 0.6362602049901176;
+            c2[5, 1] := 0.1136409040480130;
+            c2[5, 2] := 0.5962662188435553;
+            c2[6, 1] := 0.1094722001757955;
+            c2[6, 2] := 0.5474001634109253;
+            c2[7, 1] := 0.1045052832229087;
+            c2[7, 2] := 0.4903523180249535;
+            c2[8, 1] := 0.9874509806025907e-1;
+            c2[8, 2] := 0.4258751523524645;
+            c2[9, 1] := 0.9217799943472177e-1;
+            c2[9, 2] := 0.3547079765396403;
+            c2[10, 1] := 0.8474633796250476e-1;
+            c2[10, 2] := 0.2774145482392767;
+            c2[11, 1] := 0.7627722381240495e-1;
+            c2[11, 2] := 0.1939329108084139;
+            c2[12, 1] := 0.6618645465422745e-1;
+            c2[12, 2] := 0.1016670147947242;
+          elseif order == 25 then
+            alpha := 0.1725220521949266;
+            c1[1] := 0.3429735385896000;
+            c2[1, 1] := 0.1172525033170618;
+            c2[1, 2] := 0.6812327932576614;
+            c2[2, 1] := 0.1161194585333535;
+            c2[2, 2] := 0.6671566071153211;
+            c2[3, 1] := 0.1142375145794466;
+            c2[3, 2] := 0.6439167855053158;
+            c2[4, 1] := 0.1116157454252308;
+            c2[4, 2] := 0.6118378416180135;
+            c2[5, 1] := 0.1082654809459177;
+            c2[5, 2] := 0.5713609763370088;
+            c2[6, 1] := 0.1041985674230918;
+            c2[6, 2] := 0.5230289949762722;
+            c2[7, 1] := 0.9942439308123559e-1;
+            c2[7, 2] := 0.4674627926041906;
+            c2[8, 1] := 0.9394453593830893e-1;
+            c2[8, 2] := 0.4053226688298811;
+            c2[9, 1] := 0.8774221237222533e-1;
+            c2[9, 2] := 0.3372372276379071;
+            c2[10, 1] := 0.8075839512216483e-1;
+            c2[10, 2] := 0.2636485508005428;
+            c2[11, 1] := 0.7282483286646764e-1;
+            c2[11, 2] := 0.1843801345273085;
+            c2[12, 1] := 0.6338571166846652e-1;
+            c2[12, 2] := 0.9680153764737715e-1;
+          elseif order == 26 then
+            alpha := 0.1690795702796737;
+            c2[1, 1] := 0.1133168695796030;
+            c2[1, 2] := 0.6724297955493932;
+            c2[2, 1] := 0.1126417845769961;
+            c2[2, 2] := 0.6638709519790540;
+            c2[3, 1] := 0.1112948749545606;
+            c2[3, 2] := 0.6468652038763624;
+            c2[4, 1] := 0.1092823986944244;
+            c2[4, 2] := 0.6216337070799265;
+            c2[5, 1] := 0.1066130386697976;
+            c2[5, 2] := 0.5885011413992190;
+            c2[6, 1] := 0.1032969057045413;
+            c2[6, 2] := 0.5478864278297548;
+            c2[7, 1] := 0.9934388184210715e-1;
+            c2[7, 2] := 0.5002885306054287;
+            c2[8, 1] := 0.9476081523436283e-1;
+            c2[8, 2] := 0.4462644847551711;
+            c2[9, 1] := 0.8954648464575577e-1;
+            c2[9, 2] := 0.3863930785049522;
+            c2[10, 1] := 0.8368166847159917e-1;
+            c2[10, 2] := 0.3212074592527143;
+            c2[11, 1] := 0.7710664731701103e-1;
+            c2[11, 2] := 0.2510470347119383;
+            c2[12, 1] := 0.6965807988411425e-1;
+            c2[12, 2] := 0.1756419294111342;
+            c2[13, 1] := 0.6080674930548766e-1;
+            c2[13, 2] := 0.9234535279274277e-1;
+          elseif order == 27 then
+            alpha := 0.1658353543067995;
+            c1[1] := 0.3308543720638957;
+            c2[1, 1] := 0.1091618578712746;
+            c2[1, 2] := 0.6577977071169651;
+            c2[2, 1] := 0.1082549561495043;
+            c2[2, 2] := 0.6461121666520275;
+            c2[3, 1] := 0.1067479247890451;
+            c2[3, 2] := 0.6267937760991321;
+            c2[4, 1] := 0.1046471079537577;
+            c2[4, 2] := 0.6000750116745808;
+            c2[5, 1] := 0.1019605976654259;
+            c2[5, 2] := 0.5662734183049320;
+            c2[6, 1] := 0.9869726954433709e-1;
+            c2[6, 2] := 0.5257827234948534;
+            c2[7, 1] := 0.9486520934132483e-1;
+            c2[7, 2] := 0.4790595019077763;
+            c2[8, 1] := 0.9046906518775348e-1;
+            c2[8, 2] := 0.4266025862147336;
+            c2[9, 1] := 0.8550529998276152e-1;
+            c2[9, 2] := 0.3689188223512328;
+            c2[10, 1] := 0.7995282239306020e-1;
+            c2[10, 2] := 0.3064589322702932;
+            c2[11, 1] := 0.7375174596252882e-1;
+            c2[11, 2] := 0.2394754504667310;
+            c2[12, 1] := 0.6674377263329041e-1;
+            c2[12, 2] := 0.1676223546666024;
+            c2[13, 1] := 0.5842458027529246e-1;
+            c2[13, 2] := 0.8825044329219431e-1;
+          elseif order == 28 then
+            alpha := 0.1627710671942929;
+            c2[1, 1] := 0.1057232656113488;
+            c2[1, 2] := 0.6496161226860832;
+            c2[2, 1] := 0.1051786825724864;
+            c2[2, 2] := 0.6424661279909941;
+            c2[3, 1] := 0.1040917964935006;
+            c2[3, 2] := 0.6282470268918791;
+            c2[4, 1] := 0.1024670101953951;
+            c2[4, 2] := 0.6071189030701136;
+            c2[5, 1] := 0.1003105109519892;
+            c2[5, 2] := 0.5793175191747016;
+            c2[6, 1] := 0.9762969425430802e-1;
+            c2[6, 2] := 0.5451486608855443;
+            c2[7, 1] := 0.9443223803058400e-1;
+            c2[7, 2] := 0.5049796971628137;
+            c2[8, 1] := 0.9072460982036488e-1;
+            c2[8, 2] := 0.4592270546572523;
+            c2[9, 1] := 0.8650956423253280e-1;
+            c2[9, 2] := 0.4083368605952977;
+            c2[10, 1] := 0.8178165740374893e-1;
+            c2[10, 2] := 0.3527525188880655;
+            c2[11, 1] := 0.7651838885868020e-1;
+            c2[11, 2] := 0.2928534570013572;
+            c2[12, 1] := 0.7066010532447490e-1;
+            c2[12, 2] := 0.2288185204390681;
+            c2[13, 1] := 0.6405358596145789e-1;
+            c2[13, 2] := 0.1602396172588190;
+            c2[14, 1] := 0.5621780070227172e-1;
+            c2[14, 2] := 0.8447589564915071e-1;
+          elseif order == 29 then
+            alpha := 0.1598706626277596;
+            c1[1] := 0.3199314513011623;
+            c2[1, 1] := 0.1021101032532951;
+            c2[1, 2] := 0.6365758882240111;
+            c2[2, 1] := 0.1013729819392774;
+            c2[2, 2] := 0.6267495975736321;
+            c2[3, 1] := 0.1001476175660628;
+            c2[3, 2] := 0.6104876178266819;
+            c2[4, 1] := 0.9843854640428316e-1;
+            c2[4, 2] := 0.5879603139195113;
+            c2[5, 1] := 0.9625164534591696e-1;
+            c2[5, 2] := 0.5594012291050210;
+            c2[6, 1] := 0.9359356960417668e-1;
+            c2[6, 2] := 0.5251016150410664;
+            c2[7, 1] := 0.9047086748649986e-1;
+            c2[7, 2] := 0.4854024475590397;
+            c2[8, 1] := 0.8688856407189167e-1;
+            c2[8, 2] := 0.4406826457109709;
+            c2[9, 1] := 0.8284779224069856e-1;
+            c2[9, 2] := 0.3913408089298914;
+            c2[10, 1] := 0.7834154620997181e-1;
+            c2[10, 2] := 0.3377643999400627;
+            c2[11, 1] := 0.7334628941928766e-1;
+            c2[11, 2] := 0.2802710651919946;
+            c2[12, 1] := 0.6780290487362146e-1;
+            c2[12, 2] := 0.2189770008083379;
+            c2[13, 1] := 0.6156321231528423e-1;
+            c2[13, 2] := 0.1534235999306070;
+            c2[14, 1] := 0.5416797446761512e-1;
+            c2[14, 2] := 0.8098664736760292e-1;
+          elseif order == 30 then
+            alpha := 0.1571200296252450;
+            c2[1, 1] := 0.9908074847842124e-1;
+            c2[1, 2] := 0.6289618807831557;
+            c2[2, 1] := 0.9863509708328196e-1;
+            c2[2, 2] := 0.6229164525571278;
+            c2[3, 1] := 0.9774542692037148e-1;
+            c2[3, 2] := 0.6108853364240036;
+            c2[4, 1] := 0.9641490581986484e-1;
+            c2[4, 2] := 0.5929869253412513;
+            c2[5, 1] := 0.9464802912225441e-1;
+            c2[5, 2] := 0.5693960175547550;
+            c2[6, 1] := 0.9245027206218041e-1;
+            c2[6, 2] := 0.5403402396359503;
+            c2[7, 1] := 0.8982754584112941e-1;
+            c2[7, 2] := 0.5060948065875106;
+            c2[8, 1] := 0.8678535291732599e-1;
+            c2[8, 2] := 0.4669749797983789;
+            c2[9, 1] := 0.8332744242052199e-1;
+            c2[9, 2] := 0.4233249626334694;
+            c2[10, 1] := 0.7945356393775309e-1;
+            c2[10, 2] := 0.3755006094498054;
+            c2[11, 1] := 0.7515543969833788e-1;
+            c2[11, 2] := 0.3238400339292700;
+            c2[12, 1] := 0.7040879901685638e-1;
+            c2[12, 2] := 0.2686072427439079;
+            c2[13, 1] := 0.6515528854010540e-1;
+            c2[13, 2] := 0.2098650589782619;
+            c2[14, 1] := 0.5925168237177876e-1;
+            c2[14, 2] := 0.1471138832654873;
+            c2[15, 1] := 0.5225913954211672e-1;
+            c2[15, 2] := 0.7775248839507864e-1;
+          elseif order == 31 then
+            alpha := 0.1545067022920929;
+            c1[1] := 0.3100206996451866;
+            c2[1, 1] := 0.9591020358831668e-1;
+            c2[1, 2] := 0.6172474793293396;
+            c2[2, 1] := 0.9530301275601203e-1;
+            c2[2, 2] := 0.6088916323460413;
+            c2[3, 1] := 0.9429332655402368e-1;
+            c2[3, 2] := 0.5950511595503025;
+            c2[4, 1] := 0.9288445429894548e-1;
+            c2[4, 2] := 0.5758534119053522;
+            c2[5, 1] := 0.9108073420087422e-1;
+            c2[5, 2] := 0.5514734636081183;
+            c2[6, 1] := 0.8888719137536870e-1;
+            c2[6, 2] := 0.5221306199481831;
+            c2[7, 1] := 0.8630901440239650e-1;
+            c2[7, 2] := 0.4880834248148061;
+            c2[8, 1] := 0.8335074993373294e-1;
+            c2[8, 2] := 0.4496225358496770;
+            c2[9, 1] := 0.8001502494376102e-1;
+            c2[9, 2] := 0.4070602306679052;
+            c2[10, 1] := 0.7630041338037624e-1;
+            c2[10, 2] := 0.3607139804818122;
+            c2[11, 1] := 0.7219760885744920e-1;
+            c2[11, 2] := 0.3108783301229550;
+            c2[12, 1] := 0.6768185077153345e-1;
+            c2[12, 2] := 0.2577706252514497;
+            c2[13, 1] := 0.6269571766328638e-1;
+            c2[13, 2] := 0.2014081375889921;
+            c2[14, 1] := 0.5710081766945065e-1;
+            c2[14, 2] := 0.1412581515841926;
+            c2[15, 1] := 0.5047740914807019e-1;
+            c2[15, 2] := 0.7474725873250158e-1;
+          elseif order == 32 then
+            alpha := 0.1520196210848210;
+            c2[1, 1] := 0.9322163554339406e-1;
+            c2[1, 2] := 0.6101488690506050;
+            c2[2, 1] := 0.9285233997694042e-1;
+            c2[2, 2] := 0.6049832320721264;
+            c2[3, 1] := 0.9211494244473163e-1;
+            c2[3, 2] := 0.5946969295569034;
+            c2[4, 1] := 0.9101176786042449e-1;
+            c2[4, 2] := 0.5793791854364477;
+            c2[5, 1] := 0.8954614071360517e-1;
+            c2[5, 2] := 0.5591619969234026;
+            c2[6, 1] := 0.8772216763680164e-1;
+            c2[6, 2] := 0.5342177994699602;
+            c2[7, 1] := 0.8554440426912734e-1;
+            c2[7, 2] := 0.5047560942986598;
+            c2[8, 1] := 0.8301735302045588e-1;
+            c2[8, 2] := 0.4710187048140929;
+            c2[9, 1] := 0.8014469519188161e-1;
+            c2[9, 2] := 0.4332730387207936;
+            c2[10, 1] := 0.7692807528893225e-1;
+            c2[10, 2] := 0.3918021436411035;
+            c2[11, 1] := 0.7336507157284898e-1;
+            c2[11, 2] := 0.3468890521471250;
+            c2[12, 1] := 0.6944555312763458e-1;
+            c2[12, 2] := 0.2987898029050460;
+            c2[13, 1] := 0.6514446669420571e-1;
+            c2[13, 2] := 0.2476810747407199;
+            c2[14, 1] := 0.6040544477732702e-1;
+            c2[14, 2] := 0.1935412053397663;
+            c2[15, 1] := 0.5509478650672775e-1;
+            c2[15, 2] := 0.1358108994174911;
+            c2[16, 1] := 0.4881064725720192e-1;
+            c2[16, 2] := 0.7194819894416505e-1;
+          elseif order == 33 then
+            alpha := 0.1496489351138032;
+            c1[1] := 0.3009752799176432;
+            c2[1, 1] := 0.9041725460994505e-1;
+            c2[1, 2] := 0.5995521047364046;
+            c2[2, 1] := 0.8991117804113002e-1;
+            c2[2, 2] := 0.5923764112099496;
+            c2[3, 1] := 0.8906941547422532e-1;
+            c2[3, 2] := 0.5804822013853129;
+            c2[4, 1] := 0.8789442491445575e-1;
+            c2[4, 2] := 0.5639663528946501;
+            c2[5, 1] := 0.8638945831033775e-1;
+            c2[5, 2] := 0.5429623519607796;
+            c2[6, 1] := 0.8455834602616358e-1;
+            c2[6, 2] := 0.5176379938389326;
+            c2[7, 1] := 0.8240517431382334e-1;
+            c2[7, 2] := 0.4881921474066189;
+            c2[8, 1] := 0.7993380417355076e-1;
+            c2[8, 2] := 0.4548502528082586;
+            c2[9, 1] := 0.7714713890732801e-1;
+            c2[9, 2] := 0.4178579388038483;
+            c2[10, 1] := 0.7404596598181127e-1;
+            c2[10, 2] := 0.3774715722484659;
+            c2[11, 1] := 0.7062702339160462e-1;
+            c2[11, 2] := 0.3339432938810453;
+            c2[12, 1] := 0.6687952672391507e-1;
+            c2[12, 2] := 0.2874950693388235;
+            c2[13, 1] := 0.6277828912909767e-1;
+            c2[13, 2] := 0.2382680702894708;
+            c2[14, 1] := 0.5826808305383988e-1;
+            c2[14, 2] := 0.1862073169968455;
+            c2[15, 1] := 0.5321974125363517e-1;
+            c2[15, 2] := 0.1307323751236313;
+            c2[16, 1] := 0.4724820282032780e-1;
+            c2[16, 2] := 0.6933542082177094e-1;
+          elseif order == 34 then
+            alpha := 0.1473858373968463;
+            c2[1, 1] := 0.8801537152275983e-1;
+            c2[1, 2] := 0.5929204288972172;
+            c2[2, 1] := 0.8770594341007476e-1;
+            c2[2, 2] := 0.5884653382247518;
+            c2[3, 1] := 0.8708797598072095e-1;
+            c2[3, 2] := 0.5795895850253119;
+            c2[4, 1] := 0.8616320590689187e-1;
+            c2[4, 2] := 0.5663615383647170;
+            c2[5, 1] := 0.8493413175570858e-1;
+            c2[5, 2] := 0.5488825092350877;
+            c2[6, 1] := 0.8340387368687513e-1;
+            c2[6, 2] := 0.5272851839324592;
+            c2[7, 1] := 0.8157596213131521e-1;
+            c2[7, 2] := 0.5017313864372913;
+            c2[8, 1] := 0.7945402670834270e-1;
+            c2[8, 2] := 0.4724089864574216;
+            c2[9, 1] := 0.7704133559556429e-1;
+            c2[9, 2] := 0.4395276256463053;
+            c2[10, 1] := 0.7434009635219704e-1;
+            c2[10, 2] := 0.4033126590648964;
+            c2[11, 1] := 0.7135035113853376e-1;
+            c2[11, 2] := 0.3639961488919042;
+            c2[12, 1] := 0.6806813160738834e-1;
+            c2[12, 2] := 0.3218025212900124;
+            c2[13, 1] := 0.6448214312000864e-1;
+            c2[13, 2] := 0.2769235521088158;
+            c2[14, 1] := 0.6056719318430530e-1;
+            c2[14, 2] := 0.2294693573271038;
+            c2[15, 1] := 0.5626925196925040e-1;
+            c2[15, 2] := 0.1793564218840015;
+            c2[16, 1] := 0.5146352031547277e-1;
+            c2[16, 2] := 0.1259877129326412;
+            c2[17, 1] := 0.4578069074410591e-1;
+            c2[17, 2] := 0.6689147319568768e-1;
+          elseif order == 35 then
+            alpha := 0.1452224267615486;
+            c1[1] := 0.2926764667564367;
+            c2[1, 1] := 0.8551731299267280e-1;
+            c2[1, 2] := 0.5832758214629523;
+            c2[2, 1] := 0.8509109732853060e-1;
+            c2[2, 2] := 0.5770596582643844;
+            c2[3, 1] := 0.8438201446671953e-1;
+            c2[3, 2] := 0.5667497616665494;
+            c2[4, 1] := 0.8339191981579831e-1;
+            c2[4, 2] := 0.5524209816238369;
+            c2[5, 1] := 0.8212328610083385e-1;
+            c2[5, 2] := 0.5341766459916322;
+            c2[6, 1] := 0.8057906332198853e-1;
+            c2[6, 2] := 0.5121470053512750;
+            c2[7, 1] := 0.7876247299954955e-1;
+            c2[7, 2] := 0.4864870722254752;
+            c2[8, 1] := 0.7667670879950268e-1;
+            c2[8, 2] := 0.4573736721705665;
+            c2[9, 1] := 0.7432449556218945e-1;
+            c2[9, 2] := 0.4250013835198991;
+            c2[10, 1] := 0.7170742126011575e-1;
+            c2[10, 2] := 0.3895767735915445;
+            c2[11, 1] := 0.6882488171701314e-1;
+            c2[11, 2] := 0.3513097926737368;
+            c2[12, 1] := 0.6567231746957568e-1;
+            c2[12, 2] := 0.3103999917596611;
+            c2[13, 1] := 0.6223804362223595e-1;
+            c2[13, 2] := 0.2670123611280899;
+            c2[14, 1] := 0.5849696460782910e-1;
+            c2[14, 2] := 0.2212298104867592;
+            c2[15, 1] := 0.5439628409499822e-1;
+            c2[15, 2] := 0.1729443731341637;
+            c2[16, 1] := 0.4981540179136920e-1;
+            c2[16, 2] := 0.1215462157134930;
+            c2[17, 1] := 0.4439981033536435e-1;
+            c2[17, 2] := 0.6460098363520967e-1;
+          elseif order == 36 then
+            alpha := 0.1431515914458580;
+            c2[1, 1] := 0.8335881847130301e-1;
+            c2[1, 2] := 0.5770670512160201;
+            c2[2, 1] := 0.8309698922852212e-1;
+            c2[2, 2] := 0.5731929100172432;
+            c2[3, 1] := 0.8257400347039723e-1;
+            c2[3, 2] := 0.5654713811993058;
+            c2[4, 1] := 0.8179117911600136e-1;
+            c2[4, 2] := 0.5539556343603020;
+            c2[5, 1] := 0.8075042173126963e-1;
+            c2[5, 2] := 0.5387245649546684;
+            c2[6, 1] := 0.7945413151258206e-1;
+            c2[6, 2] := 0.5198817177723069;
+            c2[7, 1] := 0.7790506514288866e-1;
+            c2[7, 2] := 0.4975537629595409;
+            c2[8, 1] := 0.7610613635339480e-1;
+            c2[8, 2] := 0.4718884193866789;
+            c2[9, 1] := 0.7406012816626425e-1;
+            c2[9, 2] := 0.4430516443136726;
+            c2[10, 1] := 0.7176927060205631e-1;
+            c2[10, 2] := 0.4112237708115829;
+            c2[11, 1] := 0.6923460172504251e-1;
+            c2[11, 2] := 0.3765940116389730;
+            c2[12, 1] := 0.6645495833489556e-1;
+            c2[12, 2] := 0.3393522147815403;
+            c2[13, 1] := 0.6342528888937094e-1;
+            c2[13, 2] := 0.2996755899575573;
+            c2[14, 1] := 0.6013361864949449e-1;
+            c2[14, 2] := 0.2577053294053830;
+            c2[15, 1] := 0.5655503081322404e-1;
+            c2[15, 2] := 0.2135004731531631;
+            c2[16, 1] := 0.5263798119559069e-1;
+            c2[16, 2] := 0.1669320999865636;
+            c2[17, 1] := 0.4826589873626196e-1;
+            c2[17, 2] := 0.1173807590715484;
+            c2[18, 1] := 0.4309819397289806e-1;
+            c2[18, 2] := 0.6245036108880222e-1;
+          elseif order == 37 then
+            alpha := 0.1411669104782917;
+            c1[1] := 0.2850271036215707;
+            c2[1, 1] := 0.8111958235023328e-1;
+            c2[1, 2] := 0.5682412610563970;
+            c2[2, 1] := 0.8075727567979578e-1;
+            c2[2, 2] := 0.5628142923227016;
+            c2[3, 1] := 0.8015440554413301e-1;
+            c2[3, 2] := 0.5538087696879930;
+            c2[4, 1] := 0.7931239302677386e-1;
+            c2[4, 2] := 0.5412833323304460;
+            c2[5, 1] := 0.7823314328639347e-1;
+            c2[5, 2] := 0.5253190555393968;
+            c2[6, 1] := 0.7691895211595101e-1;
+            c2[6, 2] := 0.5060183741977191;
+            c2[7, 1] := 0.7537237072011853e-1;
+            c2[7, 2] := 0.4835036020049034;
+            c2[8, 1] := 0.7359601294804538e-1;
+            c2[8, 2] := 0.4579149413954837;
+            c2[9, 1] := 0.7159227884849299e-1;
+            c2[9, 2] := 0.4294078049978829;
+            c2[10, 1] := 0.6936295002846032e-1;
+            c2[10, 2] := 0.3981491350382047;
+            c2[11, 1] := 0.6690857785828917e-1;
+            c2[11, 2] := 0.3643121502867948;
+            c2[12, 1] := 0.6422751692085542e-1;
+            c2[12, 2] := 0.3280684291406284;
+            c2[13, 1] := 0.6131430866206096e-1;
+            c2[13, 2] := 0.2895750997170303;
+            c2[14, 1] := 0.5815677249570920e-1;
+            c2[14, 2] := 0.2489521814805720;
+            c2[15, 1] := 0.5473023527947980e-1;
+            c2[15, 2] := 0.2062377435955363;
+            c2[16, 1] := 0.5098441033167034e-1;
+            c2[16, 2] := 0.1612849131645336;
+            c2[17, 1] := 0.4680658811093562e-1;
+            c2[17, 2] := 0.1134672937045305;
+            c2[18, 1] := 0.4186928031694695e-1;
+            c2[18, 2] := 0.6042754777339966e-1;
+          elseif order == 38 then
+            alpha := 0.1392625697140030;
+            c2[1, 1] := 0.7916943373658329e-1;
+            c2[1, 2] := 0.5624158631591745;
+            c2[2, 1] := 0.7894592250257840e-1;
+            c2[2, 2] := 0.5590219398777304;
+            c2[3, 1] := 0.7849941672384930e-1;
+            c2[3, 2] := 0.5522551628416841;
+            c2[4, 1] := 0.7783093084875645e-1;
+            c2[4, 2] := 0.5421574325808380;
+            c2[5, 1] := 0.7694193770482690e-1;
+            c2[5, 2] := 0.5287909941093643;
+            c2[6, 1] := 0.7583430534712885e-1;
+            c2[6, 2] := 0.5122376814029880;
+            c2[7, 1] := 0.7451020436122948e-1;
+            c2[7, 2] := 0.4925978555548549;
+            c2[8, 1] := 0.7297197617673508e-1;
+            c2[8, 2] := 0.4699889739625235;
+            c2[9, 1] := 0.7122194706992953e-1;
+            c2[9, 2] := 0.4445436860615774;
+            c2[10, 1] := 0.6926216260386816e-1;
+            c2[10, 2] := 0.4164072786327193;
+            c2[11, 1] := 0.6709399961255503e-1;
+            c2[11, 2] := 0.3857341621868851;
+            c2[12, 1] := 0.6471757977022456e-1;
+            c2[12, 2] := 0.3526828388476838;
+            c2[13, 1] := 0.6213084287116965e-1;
+            c2[13, 2] := 0.3174082831364342;
+            c2[14, 1] := 0.5932799638550641e-1;
+            c2[14, 2] := 0.2800495563550299;
+            c2[15, 1] := 0.5629672408524944e-1;
+            c2[15, 2] := 0.2407078154782509;
+            c2[16, 1] := 0.5301264751544952e-1;
+            c2[16, 2] := 0.1994026830553859;
+            c2[17, 1] := 0.4942673259817896e-1;
+            c2[17, 2] := 0.1559719194038917;
+            c2[18, 1] := 0.4542996716979947e-1;
+            c2[18, 2] := 0.1097844277878470;
+            c2[19, 1] := 0.4070720755433961e-1;
+            c2[19, 2] := 0.5852181110523043e-1;
+          elseif order == 39 then
+            alpha := 0.1374332900196804;
+            c1[1] := 0.2779468246419593;
+            c2[1, 1] := 0.7715084161825772e-1;
+            c2[1, 2] := 0.5543001331300056;
+            c2[2, 1] := 0.7684028301163326e-1;
+            c2[2, 2] := 0.5495289890712267;
+            c2[3, 1] := 0.7632343924866024e-1;
+            c2[3, 2] := 0.5416083298429741;
+            c2[4, 1] := 0.7560141319808483e-1;
+            c2[4, 2] := 0.5305846713929198;
+            c2[5, 1] := 0.7467569064745969e-1;
+            c2[5, 2] := 0.5165224112570647;
+            c2[6, 1] := 0.7354807648551346e-1;
+            c2[6, 2] := 0.4995030679271456;
+            c2[7, 1] := 0.7222060351121389e-1;
+            c2[7, 2] := 0.4796242430956156;
+            c2[8, 1] := 0.7069540462458585e-1;
+            c2[8, 2] := 0.4569982440368368;
+            c2[9, 1] := 0.6897453353492381e-1;
+            c2[9, 2] := 0.4317502624832354;
+            c2[10, 1] := 0.6705970959388781e-1;
+            c2[10, 2] := 0.4040159353969854;
+            c2[11, 1] := 0.6495194541066725e-1;
+            c2[11, 2] := 0.3739379843169939;
+            c2[12, 1] := 0.6265098412417610e-1;
+            c2[12, 2] := 0.3416613843816217;
+            c2[13, 1] := 0.6015440984955930e-1;
+            c2[13, 2] := 0.3073260166338746;
+            c2[14, 1] := 0.5745615876877304e-1;
+            c2[14, 2] := 0.2710546723961181;
+            c2[15, 1] := 0.5454383762391338e-1;
+            c2[15, 2] := 0.2329316824061170;
+            c2[16, 1] := 0.5139340231935751e-1;
+            c2[16, 2] := 0.1929604256043231;
+            c2[17, 1] := 0.4795705862458131e-1;
+            c2[17, 2] := 0.1509655259246037;
+            c2[18, 1] := 0.4412933231935506e-1;
+            c2[18, 2] := 0.1063130748962878;
+            c2[19, 1] := 0.3960672309405603e-1;
+            c2[19, 2] := 0.5672356837211527e-1;
+          elseif order == 40 then
+            alpha := 0.1356742655825434;
+            c2[1, 1] := 0.7538038374294594e-1;
+            c2[1, 2] := 0.5488228264329617;
+            c2[2, 1] := 0.7518806529402738e-1;
+            c2[2, 2] := 0.5458297722483311;
+            c2[3, 1] := 0.7480383050347119e-1;
+            c2[3, 2] := 0.5398604576730540;
+            c2[4, 1] := 0.7422847031965465e-1;
+            c2[4, 2] := 0.5309482987446206;
+            c2[5, 1] := 0.7346313704205006e-1;
+            c2[5, 2] := 0.5191429845322307;
+            c2[6, 1] := 0.7250930053201402e-1;
+            c2[6, 2] := 0.5045099368431007;
+            c2[7, 1] := 0.7136868456879621e-1;
+            c2[7, 2] := 0.4871295553902607;
+            c2[8, 1] := 0.7004317764946634e-1;
+            c2[8, 2] := 0.4670962098860498;
+            c2[9, 1] := 0.6853470921527828e-1;
+            c2[9, 2] := 0.4445169164956202;
+            c2[10, 1] := 0.6684507689945471e-1;
+            c2[10, 2] := 0.4195095960479698;
+            c2[11, 1] := 0.6497570123412630e-1;
+            c2[11, 2] := 0.3922007419030645;
+            c2[12, 1] := 0.6292726794917847e-1;
+            c2[12, 2] := 0.3627221993494397;
+            c2[13, 1] := 0.6069918741663154e-1;
+            c2[13, 2] := 0.3312065181294388;
+            c2[14, 1] := 0.5828873983769410e-1;
+            c2[14, 2] := 0.2977798532686911;
+            c2[15, 1] := 0.5568964389813015e-1;
+            c2[15, 2] := 0.2625503293999835;
+            c2[16, 1] := 0.5288947816690705e-1;
+            c2[16, 2] := 0.2255872486520188;
+            c2[17, 1] := 0.4986456327645859e-1;
+            c2[17, 2] := 0.1868796731919594;
+            c2[18, 1] := 0.4656832613054458e-1;
+            c2[18, 2] := 0.1462410193532463;
+            c2[19, 1] := 0.4289867647614935e-1;
+            c2[19, 2] := 0.1030361558710747;
+            c2[20, 1] := 0.3856310684054106e-1;
+            c2[20, 2] := 0.5502423832293889e-1;
+          elseif order == 41 then
+            alpha := 0.1339811106984253;
+            c1[1] := 0.2713685065531391;
+            c2[1, 1] := 0.7355140275160984e-1;
+            c2[1, 2] := 0.5413274778282860;
+            c2[2, 1] := 0.7328319082267173e-1;
+            c2[2, 2] := 0.5371064088294270;
+            c2[3, 1] := 0.7283676160772547e-1;
+            c2[3, 2] := 0.5300963437270770;
+            c2[4, 1] := 0.7221298133014343e-1;
+            c2[4, 2] := 0.5203345998371490;
+            c2[5, 1] := 0.7141302173623395e-1;
+            c2[5, 2] := 0.5078728971879841;
+            c2[6, 1] := 0.7043831559982149e-1;
+            c2[6, 2] := 0.4927768111819803;
+            c2[7, 1] := 0.6929049381827268e-1;
+            c2[7, 2] := 0.4751250308594139;
+            c2[8, 1] := 0.6797129849758392e-1;
+            c2[8, 2] := 0.4550083840638406;
+            c2[9, 1] := 0.6648246325101609e-1;
+            c2[9, 2] := 0.4325285673076087;
+            c2[10, 1] := 0.6482554675958526e-1;
+            c2[10, 2] := 0.4077964789091151;
+            c2[11, 1] := 0.6300169683004558e-1;
+            c2[11, 2] := 0.3809299858742483;
+            c2[12, 1] := 0.6101130648543355e-1;
+            c2[12, 2] := 0.3520508315700898;
+            c2[13, 1] := 0.5885349417435808e-1;
+            c2[13, 2] := 0.3212801560701271;
+            c2[14, 1] := 0.5652528148656809e-1;
+            c2[14, 2] := 0.2887316252774887;
+            c2[15, 1] := 0.5402021575818373e-1;
+            c2[15, 2] := 0.2545001287790888;
+            c2[16, 1] := 0.5132588802608274e-1;
+            c2[16, 2] := 0.2186415296842951;
+            c2[17, 1] := 0.4841900639702602e-1;
+            c2[17, 2] := 0.1811322622296060;
+            c2[18, 1] := 0.4525419574485134e-1;
+            c2[18, 2] := 0.1417762065404688;
+            c2[19, 1] := 0.4173260173087802e-1;
+            c2[19, 2] := 0.9993834530966510e-1;
+            c2[20, 1] := 0.3757210572966463e-1;
+            c2[20, 2] := 0.5341611499960143e-1;
+          else
+            Streams.error("Input argument order (= " + String(order) +
+              ") of Bessel filter is not in the range 1..41");
+          end if;
+
+          annotation (Documentation(info="<html><p>The transfer function H(p) of a <i>n</i> 'th order Bessel filter is given by</p>
+<blockquote><pre>
+        Bn(0)
+H(p) = -------
+        Bn(p)
+ </pre>
+</blockquote>
+<p>with the denominator polynomial</p>
+<blockquote><pre>
+         n             n  (2n - k)!       p^k
+Bn(p) = sum c_k*p^k = sum ----------- * -------   (1)
+        k=0           k=0 (n - k)!k!    2^(n-k)
+</pre></blockquote>
+<p>and the numerator</p>
+<blockquote><pre>
+               (2n)!     1
+Bn(0) = c_0 = ------- * ---- .                    (2)
+                n!      2^n
+ </pre></blockquote>
+<p>Although the coefficients c_k are integer numbers, it is not advisable to use the
+polynomials in an unfactorized form because the coefficients are fast growing with order
+n (c_0 is approximately 0.3e24 and 0.8e59 for order n=20 and order n=40
+respectively).</p>
+
+<p>Therefore, the polynomial Bn(p) is factorized to first and second order polynomials with
+real coefficients corresponding to zeros and poles representation that is used in this library.</p>
+
+<p>The function returns the coefficients which resulted from factorization of the normalized transfer function</p>
+<blockquote><pre>
+H'(p') = H(p),  p' = p/w0
+</pre></blockquote>
+<p>as well as</p>
+<blockquote><pre>
+alpha = 1/w0
+</pre></blockquote>
+<p>the reciprocal of the cut of frequency w0 where the gain of the transfer function is
+decreased 3dB.</p>
+
+<p>Both, coefficients and cut off frequency were calculated symbolically and were eventually evaluated
+with high precision calculation. The results were stored in this function as real
+numbers.</p>
+
+<h4>Calculation of normalized Bessel filter coefficients</h4>
+<p>Equation</p>
+<blockquote><pre>
+abs(H(j*w0)) = abs(Bn(0)/Bn(j*w0)) = 10^(-3/20)
+</pre></blockquote>
+<p>which must be fulfilled for cut off frequency w = w0 leads to</p>
+<blockquote><pre>
+[Re(Bn(j*w0))]^2 + [Im(Bn(j*w0))]^2 - (Bn(0)^2)*10^(3/10) = 0
+</pre></blockquote>
+<p>which has exactly one real solution w0 for each order n. This solutions of w0 are
+calculated symbolically first and evaluated by using high precise values of the
+coefficients c_k calculated by following (1) and (2).</p>
+
+<p>With w0, the coefficients of the factorized polynomial can be computed by calculating the
+zeros of the denominator polynomial</p>
+<blockquote><pre>
+        n
+Bn(p) = sum w0^k*c_k*(p/w0)^k
+        k=0
+</pre></blockquote>
+<p>of the normalized transfer function H'(p'). There exist n/2 of conjugate complex
+pairs of zeros (beta +-j*gamma) if n is even and one additional real zero (alpha) if n is
+odd. Finally, the coefficients a, b1_k, b2_k of the polynomials</p>
+<blockquote><pre> a*p + 1,  n is odd </pre></blockquote>
+<p>and</p>
+<blockquote><pre>
+b2_k*p^2 + b1_k*p + 1,   k = 1,... div(n,2)
+</pre></blockquote>
+<p>results from</p>
+<blockquote><pre>
+a = -1/alpha
+</pre></blockquote>
+<p>and</p>
+<blockquote><pre>
+b2_k = 1/(beta_k^2 + gamma_k^2) b1_k = -2*beta_k/(beta_k^2 + gamma_k^2)
+</pre></blockquote>
+</html>"));
+        end BesselBaseCoefficients;
+
+        function toHighestPowerOne
+          "Transform filter to form with highest power of s equal 1"
+          extends Modelica.Icons.Function;
+
+          input Real den1[:] "[s] coefficients of polynomials (den1[i]*s + 1)";
+          input Real den2[:,2]
+            "[s^2, s] coefficients of polynomials (den2[i,1]*s^2 + den2[i,2]*s + 1)";
+          output Real cr[size(den1, 1)]
+            "[s^0] coefficients of polynomials cr[i]*(s+1/cr[i])";
+          output Real c0[size(den2, 1)]
+            "[s^0] coefficients of polynomials (s^2 + (den2[i,2]/den2[i,1])*s + (1/den2[i,1]))";
+          output Real c1[size(den2, 1)]
+            "[s^1] coefficients of polynomials (s^2 + (den2[i,2]/den2[i,1])*s + (1/den2[i,1]))";
+        algorithm
+          for i in 1:size(den1, 1) loop
+            cr[i] := 1/den1[i];
+          end for;
+
+          for i in 1:size(den2, 1) loop
+            c1[i] := den2[i, 2]/den2[i, 1];
+            c0[i] := 1/den2[i, 1];
+          end for;
+        end toHighestPowerOne;
+
+        function normalizationFactor
+          "Compute correction factor of low pass filter such that amplitude at cut-off frequency is -3db (=10^(-3/20) = 0.70794...)"
+          extends Modelica.Icons.Function;
+
+          import Modelica;
+          import Modelica.Utilities.Streams;
+
+          input Real c1[:]
+            "[p] coefficients of denominator polynomials (c1[i}*p + 1)";
+          input Real c2[:,2]
+            "[p^2, p] coefficients of denominator polynomials (c2[i,1]*p^2 + c2[i,2]*p + 1)";
+          output Real alpha "Correction factor (replace p by alpha*p)";
+        protected
+          Real alpha_min;
+          Real alpha_max;
+
+          function normalizationResidue
+            "Residue of correction factor computation"
+            extends Modelica.Icons.Function;
+            input Real c1[:]
+              "[p] coefficients of denominator polynomials (c1[i]*p + 1)";
+            input Real c2[:,2]
+              "[p^2, p] coefficients of denominator polynomials (c2[i,1]*p^2 + c2[i,2]*p + 1)";
+            input Real alpha;
+            output Real residue;
+          protected
+            constant Real beta= 10^(-3/20)
+              "Amplitude of -3db required, i.e., -3db = 20*log(beta)";
+            Real cc1;
+            Real cc2;
+            Real p;
+            Real alpha2=alpha*alpha;
+            Real alpha4=alpha2*alpha2;
+            Real A2=1.0;
+          algorithm
+            assert(size(c1,1) <= 1, "Internal error 2 (should not occur)");
+            if size(c1, 1) == 1 then
+              cc1 := c1[1]*c1[1];
+              p := 1 + cc1*alpha2;
+              A2 := A2*p;
+            end if;
+            for i in 1:size(c2, 1) loop
+              cc1 := c2[i, 2]*c2[i, 2] - 2*c2[i, 1];
+              cc2 := c2[i, 1]*c2[i, 1];
+              p := 1 + cc1*alpha2 + cc2*alpha4;
+              A2 := A2*p;
+            end for;
+            residue := 1/sqrt(A2) - beta;
+          end normalizationResidue;
+
+          function findInterval "Find interval for the root"
+            extends Modelica.Icons.Function;
+            input Real c1[:]
+              "[p] coefficients of denominator polynomials (a*p + 1)";
+            input Real c2[:,2]
+              "[p^2, p] coefficients of denominator polynomials (b*p^2 + a*p + 1)";
+            output Real alpha_min;
+            output Real alpha_max;
+          protected
+            Real alpha = 1.0;
+            Real residue;
+          algorithm
+            alpha_min :=0;
+            residue := normalizationResidue(c1, c2, alpha);
+            if residue < 0 then
+               alpha_max :=alpha;
+            else
+               while residue >= 0 loop
+                  alpha := 1.1*alpha;
+                  residue := normalizationResidue(c1, c2, alpha);
+               end while;
+               alpha_max :=alpha;
+            end if;
+          end findInterval;
+
+        function solveOneNonlinearEquation
+            "Solve f(u) = 0; f(u_min) and f(u_max) must have different signs"
+            extends Modelica.Icons.Function;
+            import Modelica.Utilities.Streams.error;
+
+          input Real c1[:]
+              "[p] coefficients of denominator polynomials (c1[i]*p + 1)";
+          input Real c2[:,2]
+              "[p^2, p] coefficients of denominator polynomials (c2[i,1]*p^2 + c2[i,2]*p + 1)";
+          input Real u_min "Lower bound of search interval";
+          input Real u_max "Upper bound of search interval";
+          input Real tolerance=100*Modelica.Constants.eps
+              "Relative tolerance of solution u";
+          output Real u "Value of independent variable so that f(u) = 0";
+
+          protected
+          constant Real eps=Modelica.Constants.eps "machine epsilon";
+          Real a=u_min "Current best minimum interval value";
+          Real b=u_max "Current best maximum interval value";
+          Real c "Intermediate point a <= c <= b";
+          Real d;
+          Real e "b - a";
+          Real m;
+          Real s;
+          Real p;
+          Real q;
+          Real r;
+          Real tol;
+          Real fa "= f(a)";
+          Real fb "= f(b)";
+          Real fc;
+          Boolean found=false;
+        algorithm
+          // Check that f(u_min) and f(u_max) have different sign
+          fa := normalizationResidue(c1,c2,u_min);
+          fb := normalizationResidue(c1,c2,u_max);
+          fc := fb;
+          if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+            error(
+              "The arguments u_min and u_max to solveOneNonlinearEquation(..)\n" +
+              "do not bracket the root of the single non-linear equation:\n" +
+              "  u_min  = " + String(u_min) + "\n" + "  u_max  = " + String(u_max)
+               + "\n" + "  fa = f(u_min) = " + String(fa) + "\n" +
+              "  fb = f(u_max) = " + String(fb) + "\n" +
+              "fa and fb must have opposite sign which is not the case");
+          end if;
+
+          // Initialize variables
+          c := a;
+          fc := fa;
+          e := b - a;
+          d := e;
+
+          // Search loop
+          while not found loop
+            if abs(fc) < abs(fb) then
+              a := b;
+              b := c;
+              c := a;
+              fa := fb;
+              fb := fc;
+              fc := fa;
+            end if;
+
+            tol := 2*eps*abs(b) + tolerance;
+            m := (c - b)/2;
+
+            if abs(m) <= tol or fb == 0.0 then
+              // root found (interval is small enough)
+              found := true;
+              u := b;
+            else
+              // Determine if a bisection is needed
+              if abs(e) < tol or abs(fa) <= abs(fb) then
+                e := m;
+                d := e;
+              else
+                s := fb/fa;
+                if a == c then
+                  // linear interpolation
+                  p := 2*m*s;
+                  q := 1 - s;
+                else
+                  // inverse quadratic interpolation
+                  q := fa/fc;
+                  r := fb/fc;
+                  p := s*(2*m*q*(q - r) - (b - a)*(r - 1));
+                  q := (q - 1)*(r - 1)*(s - 1);
+                end if;
+
+                if p > 0 then
+                  q := -q;
+                else
+                  p := -p;
+                end if;
+
+                s := e;
+                e := d;
+                if 2*p < 3*m*q - abs(tol*q) and p < abs(0.5*s*q) then
+                  // interpolation successful
+                  d := p/q;
+                else
+                  // use bi-section
+                  e := m;
+                  d := e;
+                end if;
+              end if;
+
+              // Best guess value is defined as "a"
+              a := b;
+              fa := fb;
+              b := b + (if abs(d) > tol then d else if m > 0 then tol else -tol);
+              fb := normalizationResidue(c1,c2,b);
+
+              if fb > 0 and fc > 0 or fb < 0 and fc < 0 then
+                // initialize variables
+                c := a;
+                fc := fa;
+                e := b - a;
+                d := e;
+              end if;
+            end if;
+          end while;
+
+          annotation (Documentation(info="<html>
+
+<p>
+This function determines the solution of <b>one non-linear algebraic equation</b> \"y=f(u)\"
+in <b>one unknown</b> \"u\" in a reliable way. It is one of the best numerical
+algorithms for this purpose. As input, the nonlinear function f(u)
+has to be given, as well as an interval u_min, u_max that
+contains the solution, i.e., \"f(u_min)\" and \"f(u_max)\" must
+have a different sign. If possible, a smaller interval is computed by
+inverse quadratic interpolation (interpolating with a quadratic polynomial
+through the last 3 points and computing the zero). If this fails,
+bisection is used, which always reduces the interval by a factor of 2.
+The inverse quadratic interpolation method has superlinear convergence.
+This is roughly the same convergence rate as a globally convergent Newton
+method, but without the need to compute derivatives of the non-linear
+function. The solver function is a direct mapping of the Algol 60 procedure
+\"zero\" to Modelica, from:
+</p>
+
+<dl>
+<dt> Brent R.P.:</dt>
+<dd> <b>Algorithms for Minimization without derivatives</b>.
+     Prentice Hall, 1973, pp. 58-59.</dd>
+</dl>
+
+</html>"));
+        end solveOneNonlinearEquation;
+
+        algorithm
+           // Find interval for alpha
+           (alpha_min, alpha_max) :=findInterval(c1, c2);
+
+           // Compute alpha, so that abs(G(p)) = -3db
+           alpha :=solveOneNonlinearEquation(
+            c1,
+            c2,
+            alpha_min,
+            alpha_max);
+        end normalizationFactor;
+
+        encapsulated function bandPassAlpha "Return alpha for band pass"
+          extends Modelica.Icons.Function;
+
+          import Modelica;
+           input Real a "Coefficient of s^1";
+           input Real b "Coefficient of s^0";
+           input Modelica.SIunits.AngularVelocity w
+            "Bandwidth angular frequency";
+           output Real alpha "Alpha factor to build up band pass";
+
+        protected
+          Real alpha_min;
+          Real alpha_max;
+          Real z_min;
+          Real z_max;
+          Real z;
+
+          function residue "Residue of non-linear equation"
+            extends Modelica.Icons.Function;
+            input Real a;
+            input Real b;
+            input Real w;
+            input Real z;
+            output Real res;
+          algorithm
+            res := z^2 + (a*w*z/(1+z))^2 - (2+b*w^2)*z + 1;
+          end residue;
+
+        function solveOneNonlinearEquation
+            "Solve f(u) = 0; f(u_min) and f(u_max) must have different signs"
+            extends Modelica.Icons.Function;
+            import Modelica.Utilities.Streams.error;
+
+          input Real aa;
+          input Real bb;
+          input Real ww;
+          input Real u_min "Lower bound of search interval";
+          input Real u_max "Upper bound of search interval";
+          input Real tolerance=100*Modelica.Constants.eps
+              "Relative tolerance of solution u";
+          output Real u "Value of independent variable so that f(u) = 0";
+
+          protected
+          constant Real eps=Modelica.Constants.eps "machine epsilon";
+          Real a=u_min "Current best minimum interval value";
+          Real b=u_max "Current best maximum interval value";
+          Real c "Intermediate point a <= c <= b";
+          Real d;
+          Real e "b - a";
+          Real m;
+          Real s;
+          Real p;
+          Real q;
+          Real r;
+          Real tol;
+          Real fa "= f(a)";
+          Real fb "= f(b)";
+          Real fc;
+          Boolean found=false;
+        algorithm
+          // Check that f(u_min) and f(u_max) have different sign
+          fa := residue(aa,bb,ww,u_min);
+          fb := residue(aa,bb,ww,u_max);
+          fc := fb;
+          if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+            error(
+              "The arguments u_min and u_max to solveOneNonlinearEquation(..)\n" +
+              "do not bracket the root of the single non-linear equation:\n" +
+              "  u_min  = " + String(u_min) + "\n" + "  u_max  = " + String(u_max)
+               + "\n" + "  fa = f(u_min) = " + String(fa) + "\n" +
+              "  fb = f(u_max) = " + String(fb) + "\n" +
+              "fa and fb must have opposite sign which is not the case");
+          end if;
+
+          // Initialize variables
+          c := a;
+          fc := fa;
+          e := b - a;
+          d := e;
+
+          // Search loop
+          while not found loop
+            if abs(fc) < abs(fb) then
+              a := b;
+              b := c;
+              c := a;
+              fa := fb;
+              fb := fc;
+              fc := fa;
+            end if;
+
+            tol := 2*eps*abs(b) + tolerance;
+            m := (c - b)/2;
+
+            if abs(m) <= tol or fb == 0.0 then
+              // root found (interval is small enough)
+              found := true;
+              u := b;
+            else
+              // Determine if a bisection is needed
+              if abs(e) < tol or abs(fa) <= abs(fb) then
+                e := m;
+                d := e;
+              else
+                s := fb/fa;
+                if a == c then
+                  // linear interpolation
+                  p := 2*m*s;
+                  q := 1 - s;
+                else
+                  // inverse quadratic interpolation
+                  q := fa/fc;
+                  r := fb/fc;
+                  p := s*(2*m*q*(q - r) - (b - a)*(r - 1));
+                  q := (q - 1)*(r - 1)*(s - 1);
+                end if;
+
+                if p > 0 then
+                  q := -q;
+                else
+                  p := -p;
+                end if;
+
+                s := e;
+                e := d;
+                if 2*p < 3*m*q - abs(tol*q) and p < abs(0.5*s*q) then
+                  // interpolation successful
+                  d := p/q;
+                else
+                  // use bi-section
+                  e := m;
+                  d := e;
+                end if;
+              end if;
+
+              // Best guess value is defined as "a"
+              a := b;
+              fa := fb;
+              b := b + (if abs(d) > tol then d else if m > 0 then tol else -tol);
+              fb := residue(aa,bb,ww,b);
+
+              if fb > 0 and fc > 0 or fb < 0 and fc < 0 then
+                // initialize variables
+                c := a;
+                fc := fa;
+                e := b - a;
+                d := e;
+              end if;
+            end if;
+          end while;
+
+          annotation (Documentation(info="<html>
+
+<p>
+This function determines the solution of <b>one non-linear algebraic equation</b> \"y=f(u)\"
+in <b>one unknown</b> \"u\" in a reliable way. It is one of the best numerical
+algorithms for this purpose. As input, the nonlinear function f(u)
+has to be given, as well as an interval u_min, u_max that
+contains the solution, i.e., \"f(u_min)\" and \"f(u_max)\" must
+have a different sign. If possible, a smaller interval is computed by
+inverse quadratic interpolation (interpolating with a quadratic polynomial
+through the last 3 points and computing the zero). If this fails,
+bisection is used, which always reduces the interval by a factor of 2.
+The inverse quadratic interpolation method has superlinear convergence.
+This is roughly the same convergence rate as a globally convergent Newton
+method, but without the need to compute derivatives of the non-linear
+function. The solver function is a direct mapping of the Algol 60 procedure
+\"zero\" to Modelica, from:
+</p>
+
+<dl>
+<dt> Brent R.P.:</dt>
+<dd> <b>Algorithms for Minimization without derivatives</b>.
+     Prentice Hall, 1973, pp. 58-59.</dd>
+</dl>
+
+</html>"));
+        end solveOneNonlinearEquation;
+
+        algorithm
+          assert( a^2/4 - b <= 0,  "Band pass transformation cannot be computed");
+          z :=solveOneNonlinearEquation(a, b, w, 0, 1);
+          alpha := sqrt(z);
+
+          annotation (Documentation(info="<html>
+<p>
+A band pass with bandwidth \"w\" is determined from a low pass
+</p>
+
+<pre>
+  1/(p^2 + a*p + b)
+</pre>
+
+<p>
+with the transformation
+</p>
+
+<pre>
+  new(p) = (p + 1/p)/w
+</pre>
+
+<p>
+This results in the following derivation:
+</p>
+
+<pre>
+  1/(p^2 + a*p + b) -> 1/( (p+1/p)^2/w^2 + a*(p + 1/p)/w + b )
+                     = 1 /( ( p^2 + 1/p^2 + 2)/w^2 + (p + 1/p)*a/w + b )
+                     = w^2*p^2 / (p^4 + 2*p^2 + 1 + (p^3 + p)a*w + b*w^2*p^2)
+                     = w^2*p^2 / (p^4 + a*w*p^3 + (2+b*w^2)*p^2 + a*w*p + 1)
+</pre>
+
+<p>
+This 4th order transfer function shall be split in to two transfer functions of order 2 each
+for numerical reasons. With the following formulation, the fourth order
+polynomial can be represented (with the unknowns \"c\" and \"alpha\"):
+</p>
+
+<pre>
+  g(p) = w^2*p^2 / ( (p*alpha)^2 + c*(p*alpha) + 1) * ( (p/alpha)^2 + c*(p/alpha) + 1)
+       = w^2*p^2 / ( p^4 + c*(alpha + 1/alpha)*p^3 + (alpha^2 + 1/alpha^2 + c^2)*p^2
+                                                   + c*(alpha + 1/alpha)*p + 1 )
+</pre>
+
+<p>
+Comparison of coefficients:
+</p>
+
+<pre>
+  c*(alpha + 1/alpha) = a*w           -> c = a*w / (alpha + 1/alpha)
+  alpha^2 + 1/alpha^2 + c^2 = 2+b*w^2 -> equation to determine alpha
+
+  alpha^4 + 1 + a^2*w^2*alpha^4/(1+alpha^2)^2 = (2+b*w^2)*alpha^2
+    or z = alpha^2
+  z^2 + a^2*w^2*z^2/(1+z)^2 - (2+b*w^2)*z + 1 = 0
+</pre>
+
+<p>
+Therefore the last equation has to be solved for \"z\" (basically, this means to compute
+a real zero of a fourth order polynomial):
+</p>
+
+<pre>
+   solve: 0 = f(z)  = z^2 + a^2*w^2*z^2/(1+z)^2 - (2+b*w^2)*z + 1  for \"z\"
+              f(0)  = 1  &gt; 0
+              f(1)  = 1 + a^2*w^2/4 - (2+b*w^2) + 1
+                    = (a^2/4 - b)*w^2  &lt; 0
+                    // since b - a^2/4 > 0 requirement for complex conjugate poles
+   -> 0 &lt; z &lt; 1
+</pre>
+
+<p>
+This function computes the solution of this equation and returns \"alpha = sqrt(z)\";
+</p>
+
+</html>"));
+        end bandPassAlpha;
+      end Utilities;
+    end Filter;
+  end Internal;
+  annotation (
+    Documentation(info="<html>
+<p>
+This package contains basic <b>continuous</b> input/output blocks
+described by differential equations.
+</p>
+
+<p>
+All blocks of this package can be initialized in different
+ways controlled by parameter <b>initType</b>. The possible
+values of initType are defined in
+<a href=\"modelica://Modelica.Blocks.Types.Init\">Modelica.Blocks.Types.Init</a>:
+</p>
+
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><td valign=\"top\"><b>Name</b></td>
+      <td valign=\"top\"><b>Description</b></td></tr>
+
+  <tr><td valign=\"top\"><b>Init.NoInit</b></td>
+      <td valign=\"top\">no initialization (start values are used as guess values with fixed=false)</td></tr>
+
+  <tr><td valign=\"top\"><b>Init.SteadyState</b></td>
+      <td valign=\"top\">steady state initialization (derivatives of states are zero)</td></tr>
+
+  <tr><td valign=\"top\"><b>Init.InitialState</b></td>
+      <td valign=\"top\">Initialization with initial states</td></tr>
+
+  <tr><td valign=\"top\"><b>Init.InitialOutput</b></td>
+      <td valign=\"top\">Initialization with initial outputs (and steady state of the states if possible)</td></tr>
+</table>
+
+<p>
+For backward compatibility reasons the default of all blocks is
+<b>Init.NoInit</b>, with the exception of Integrator and LimIntegrator
+where the default is <b>Init.InitialState</b> (this was the initialization
+defined in version 2.2 of the Modelica standard library).
+</p>
+
+<p>
+In many cases, the most useful initial condition is
+<b>Init.SteadyState</b> because initial transients are then no longer
+present. The drawback is that in combination with a non-linear
+plant, non-linear algebraic equations occur that might be
+difficult to solve if appropriate guess values for the
+iteration variables are not provided (i.e., start values with fixed=false).
+However, it is often already useful to just initialize
+the linear blocks from the Continuous blocks library in SteadyState.
+This is uncritical, because only linear algebraic equations occur.
+If Init.NoInit is set, then the start values for the states are
+interpreted as <b>guess</b> values and are propagated to the
+states with fixed=<b>false</b>.
+</p>
+
+<p>
+Note, initialization with Init.SteadyState is usually difficult
+for a block that contains an integrator
+(Integrator, LimIntegrator, PI, PID, LimPID).
+This is due to the basic equation of an integrator:
+</p>
+
+<pre>
+  <b>initial equation</b>
+     <b>der</b>(y) = 0;   // Init.SteadyState
+  <b>equation</b>
+     <b>der</b>(y) = k*u;
+</pre>
+
+<p>
+The steady state equation leads to the condition that the input to the
+integrator is zero. If the input u is already (directly or indirectly) defined
+by another initial condition, then the initialization problem is <b>singular</b>
+(has none or infinitely many solutions). This situation occurs often
+for mechanical systems, where, e.g., u = desiredSpeed - measuredSpeed and
+since speed is both a state and a derivative, it is always defined by
+Init.InitialState or Init.SteadyState initialization.
+</p>
+
+<p>
+In such a case, <b>Init.NoInit</b> has to be selected for the integrator
+and an additional initial equation has to be added to the system
+to which the integrator is connected. E.g., useful initial conditions
+for a 1-dim. rotational inertia controlled by a PI controller are that
+<b>angle</b>, <b>speed</b>, and <b>acceleration</b> of the inertia are zero.
+</p>
+
+</html>"), Icon(graphics={Line(
+          origin={0.061,4.184},
+          points={{81.939,36.056},{65.362,36.056},{14.39,-26.199},{-29.966,
+              113.485},{-65.374,-61.217},{-78.061,-78.184}},
+          color={95,95,95},
+          smooth=Smooth.Bezier)}));
+end Continuous;

--- a/modelica/examples/Joints.mo
+++ b/modelica/examples/Joints.mo
@@ -1,0 +1,8832 @@
+within Modelica.Mechanics.MultiBody;
+package Joints "Components that constrain the motion between two frames"
+  extends Modelica.Icons.Package;
+
+  model Prismatic
+    "Prismatic joint (1 translational degree-of-freedom, 2 potential states, optional axis flange)"
+
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialElementaryJoint;
+    Modelica.Mechanics.Translational.Interfaces.Flange_a axis if useAxisFlange
+      "1-dim. translational flange that drives the joint"
+      annotation (Placement(transformation(extent={{90,50},{70,70}})));
+    Modelica.Mechanics.Translational.Interfaces.Flange_b support if useAxisFlange
+      "1-dim. translational flange of the drive drive support (assumed to be fixed in the world frame, NOT in the joint)"
+      annotation (Placement(transformation(extent={{-30,50},{-50,70}})));
+
+    parameter Boolean useAxisFlange=false "= true, if axis flange is enabled"
+      annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
+    parameter Boolean animation=true "= true, if animation shall be enabled";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n={1,0,0}
+      "Axis of translation resolved in frame_a (= same as in frame_b)"
+      annotation (Evaluate=true);
+    constant SI.Position s_offset=0
+      "Relative distance offset (distance between frame_a and frame_b = s_offset + s)"
+      annotation (Evaluate=false);
+    parameter Types.Axis boxWidthDirection={0,1,0}
+      "Vector in width direction of box, resolved in frame_a"
+      annotation (Evaluate=true, Dialog(tab="Animation", group=
+            "if animation = true", enable=animation));
+    parameter SI.Distance boxWidth=world.defaultJointWidth
+      "Width of prismatic joint box"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance boxHeight=boxWidth "Height of prismatic joint box"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color boxColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of prismatic joint box"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter StateSelect stateSelect=StateSelect.prefer
+      "Priority to use distance s and v=der(s) as states" annotation(Dialog(tab="Advanced"));
+    final parameter Real e[3](each final unit="1")=
+       Modelica.Math.Vectors.normalizeWithAssert(n)
+      "Unit vector in direction of prismatic axis n";
+
+    SI.Position s(start=0, final stateSelect=stateSelect)
+      "Relative distance between frame_a and frame_b"
+      annotation (unassignedMessage="
+The relative distance s of a prismatic joint cannot be determined.
+Possible reasons:
+- A non-zero mass might be missing on either side of the parts
+  connected to the prismatic joint.
+- Too many StateSelect.always are defined and the model
+  has less degrees of freedom as specified with this setting
+  (remove all StateSelect.always settings).
+");
+
+    SI.Velocity v(start=0,final stateSelect=stateSelect)
+      "First derivative of s (relative velocity)";
+    SI.Acceleration a(start=0) "Second derivative of s (relative acceleration)";
+    SI.Force f "Actuation force in direction of joint axis";
+
+  protected
+    Visualizers.Advanced.Shape box(
+      shapeType="box",
+      color=boxColor,
+      specularCoefficient=specularCoefficient,
+      length=if noEvent(abs(s + s_offset) > 1.e-6) then s + s_offset else 1.e-6,
+      width=boxWidth,
+      height=boxHeight,
+      lengthDirection=e,
+      widthDirection=boxWidthDirection,
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+    Translational.Components.Fixed fixed
+      annotation (Placement(transformation(extent={{-50,30},{-30,50}})));
+    Translational.Interfaces.InternalSupport internalAxis(f = f)
+      annotation (Placement(transformation(extent={{70,50},{90,30}})));
+    Translational.Sources.ConstantForce constantForce(f_constant=0) if not useAxisFlange
+      annotation (Placement(transformation(extent={{40,30},{60,50}})));
+  equation
+    v = der(s);
+    a = der(v);
+
+    // relationships between kinematic quantities of frame_a and of frame_b
+    frame_b.r_0 = frame_a.r_0 + Frames.resolve1(frame_a.R, e*(s_offset + s));
+    frame_b.R = frame_a.R;
+
+    // Force and torque balance
+    zeros(3) = frame_a.f + frame_b.f;
+    zeros(3) = frame_a.t + frame_b.t + cross(e*(s_offset + s), frame_b.f);
+
+    // d'Alemberts principle
+    f = -e*frame_b.f;
+
+    // Connection to internal connectors
+    s = internalAxis.s;
+
+    connect(fixed.flange, support) annotation (Line(
+        points={{-40,40},{-40,60}},
+        color={0,127,0}));
+    connect(internalAxis.flange, axis)    annotation (Line(
+        points={{80,40},{80,60}},
+        color={0,127,0}));
+    connect(constantForce.flange, internalAxis.flange)    annotation (Line(
+        points={{60,40},{80,40}},
+        color={0,127,0}));
+    annotation (
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-100,-50},{-30,41}},
+            pattern=LinePattern.None,
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Rectangle(
+            extent={{-100,40},{-30,50}},
+            pattern=LinePattern.None,
+            fillColor={0,0,0},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Rectangle(
+            extent={{-30,-30},{100,20}},
+            pattern=LinePattern.None,
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Rectangle(
+            extent={{-30,20},{100,30}},
+            pattern=LinePattern.None,
+            fillColor={0,0,0},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(points={{-30,-50},{-30,50}}),
+          Line(points={{100,-30},{100,21}}),
+          Text(
+            extent={{60,12},{96,-13}},
+            lineColor={128,128,128},
+            textString="b"),
+          Text(
+            extent={{-95,13},{-60,-9}},
+            lineColor={128,128,128},
+            textString="a"),
+          Text(
+            visible=useAxisFlange,
+            extent={{-150,-135},{150,-95}},
+            textString="%name",
+            lineColor={0,0,255}),
+          Text(
+            extent={{-150,-90},{150,-60}},
+            lineColor={0,0,0},
+            textString="n=%n"),
+          Rectangle(
+            visible=useAxisFlange,
+            extent={{90,30},{100,70}},
+            pattern=LinePattern.None,
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Text(
+            visible=not useAxisFlange,
+            extent={{-150,60},{150,100}},
+            textString="%name",
+            lineColor={0,0,255})}),
+      Documentation(info="<html>
+<p>
+Joint where frame_b is translated along axis n which is fixed in frame_a.
+The two frames coincide when the relative distance \"s = 0\".
+</p>
+
+<p>
+Optionally, two additional 1-dimensional mechanical flanges
+(flange \"axis\" represents the driving flange and
+flange \"support\" represents the bearing) can be enabled via
+parameter <b>useAxisFlange</b>. The enabled axis flange can be
+driven with elements of the
+<a href=\"modelica://Modelica.Mechanics.Translational\">Modelica.Mechanics.Translational</a>
+library.
+
+</p>
+
+<p>
+In the \"Advanced\" menu it can be defined via parameter <b>stateSelect</b>
+that the relative distance \"s\" and its derivative shall be definitely
+used as states by setting stateSelect=StateSelect.always.
+Default is StateSelect.prefer to use the relative distance and its
+derivative as preferred states. The states are usually selected automatically.
+In certain situations, especially when closed kinematic loops are present,
+it might be slightly more efficient, when using the StateSelect.always setting.
+</p>
+
+<p>
+In the following figure the animation of a prismatic
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint. The black arrow is parameter
+vector \"n\" defining the translation axis
+(here: n = {1,1,0}).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Prismatic.png\">
+</p>
+
+</html>"));
+  end Prismatic;
+
+  model Revolute
+    "Revolute joint (1 rotational degree-of-freedom, 2 potential states, optional axis flange)"
+
+    Modelica.Mechanics.Rotational.Interfaces.Flange_a axis if useAxisFlange
+      "1-dim. rotational flange that drives the joint"
+      annotation (Placement(transformation(extent={{10,90},{-10,110}})));
+    Modelica.Mechanics.Rotational.Interfaces.Flange_b support if useAxisFlange
+      "1-dim. rotational flange of the drive support (assumed to be fixed in the world frame, NOT in the joint)"
+      annotation (Placement(transformation(extent={{-70,90},{-50,110}})));
+
+    Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_a
+      "Coordinate system fixed to the joint with one cut-force and cut-torque"
+      annotation (Placement(transformation(extent={{-116,-16},{-84,16}})));
+    Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_b
+      "Coordinate system fixed to the joint with one cut-force and cut-torque"
+      annotation (Placement(transformation(extent={{84,-16},{116,16}})));
+
+    parameter Boolean useAxisFlange=false "= true, if axis flange is enabled"
+      annotation(Evaluate=true, HideResult=true, choices(checkBox=true));
+    parameter Boolean animation=true
+      "= true, if animation shall be enabled (show axis as cylinder)";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n={0,0,1}
+      "Axis of rotation resolved in frame_a (= same as in frame_b)"
+      annotation (Evaluate=true);
+    constant SI.Angle phi_offset=0
+      "Relative angle offset (angle = phi_offset + phi)";
+    parameter SI.Distance cylinderLength=world.defaultJointLength
+      "Length of cylinder representing the joint axis"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+      "Diameter of cylinder representing the joint axis"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Modelica.Mechanics.MultiBody.Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of cylinder representing the joint axis"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    input Modelica.Mechanics.MultiBody.Types.SpecularCoefficient
+      specularCoefficient =                                                            world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter StateSelect stateSelect=StateSelect.prefer
+      "Priority to use joint angle phi and w=der(phi) as states" annotation(Dialog(tab="Advanced"));
+
+    SI.Angle phi(start=0, final stateSelect=stateSelect)
+      "Relative rotation angle from frame_a to frame_b"
+       annotation (unassignedMessage="
+The rotation angle phi of a revolute joint cannot be determined.
+Possible reasons:
+- A non-zero mass might be missing on either side of the parts
+  connected to the revolute joint.
+- Too many StateSelect.always are defined and the model
+  has less degrees of freedom as specified with this setting
+  (remove all StateSelect.always settings).
+");
+    SI.AngularVelocity w(start=0, stateSelect=stateSelect)
+      "First derivative of angle phi (relative angular velocity)";
+    SI.AngularAcceleration a(start=0)
+      "Second derivative of angle phi (relative angular acceleration)";
+    SI.Torque tau "Driving torque in direction of axis of rotation";
+    SI.Angle angle "= phi_offset + phi";
+
+  protected
+    outer Modelica.Mechanics.MultiBody.World world;
+    parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(n)
+      "Unit vector in direction of rotation axis, resolved in frame_a (= same as in frame_b)";
+    Frames.Orientation R_rel
+      "Relative orientation object from frame_a to frame_b or from frame_b to frame_a";
+    Visualizers.Advanced.Shape cylinder(
+      shapeType="cylinder",
+      color=cylinderColor,
+      specularCoefficient=specularCoefficient,
+      length=cylinderLength,
+      width=cylinderDiameter,
+      height=cylinderDiameter,
+      lengthDirection=e,
+      widthDirection={0,1,0},
+      r_shape=-e*(cylinderLength/2),
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+
+  protected
+    Modelica.Mechanics.Rotational.Components.Fixed fixed
+      "support flange is fixed to ground"
+      annotation (Placement(transformation(extent={{-70,70},{-50,90}})));
+    Rotational.Interfaces.InternalSupport internalAxis(tau=tau)
+      annotation (Placement(transformation(extent={{-10,90},{10,70}})));
+    Rotational.Sources.ConstantTorque constantTorque(tau_constant=0) if not useAxisFlange
+      annotation (Placement(transformation(extent={{40,70},{20,90}})));
+  equation
+    Connections.branch(frame_a.R, frame_b.R);
+
+    assert(cardinality(frame_a) > 0,
+      "Connector frame_a of revolute joint is not connected");
+    assert(cardinality(frame_b) > 0,
+      "Connector frame_b of revolute joint is not connected");
+
+    angle = phi_offset + phi;
+    w = der(phi);
+    a = der(w);
+
+    // relationships between quantities of frame_a and of frame_b
+    frame_b.r_0 = frame_a.r_0;
+
+    if Connections.rooted(frame_a.R) then
+      R_rel = Frames.planarRotation(e, phi_offset + phi, w);
+      frame_b.R = Frames.absoluteRotation(frame_a.R, R_rel);
+      frame_a.f = -Frames.resolve1(R_rel, frame_b.f);
+      frame_a.t = -Frames.resolve1(R_rel, frame_b.t);
+    else
+      R_rel = Frames.planarRotation(-e, phi_offset + phi, w);
+      frame_a.R = Frames.absoluteRotation(frame_b.R, R_rel);
+      frame_b.f = -Frames.resolve1(R_rel, frame_a.f);
+      frame_b.t = -Frames.resolve1(R_rel, frame_a.t);
+    end if;
+
+    // d'Alemberts principle
+    tau = -frame_b.t*e;
+
+    // Connection to internal connectors
+    phi = internalAxis.phi;
+
+    connect(fixed.flange, support) annotation (Line(
+        points={{-60,80},{-60,100}}));
+    connect(internalAxis.flange, axis) annotation (Line(
+        points={{0,80},{0,100}}));
+    connect(constantTorque.flange, internalAxis.flange) annotation (Line(
+        points={{20,80},{0,80}}));
+    annotation (
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-100,-60},{-30,60}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(
+            extent={{30,-60},{100,60}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(extent={{-100,60},{-30,-60}}, lineColor={64,64,64}, radius=10),
+          Rectangle(extent={{30,60},{100,-60}}, lineColor={64,64,64}, radius=10),
+          Text(
+            extent={{-90,14},{-54,-11}},
+            lineColor={128,128,128},
+            textString="a"),
+          Text(
+            extent={{51,11},{87,-14}},
+            lineColor={128,128,128},
+            textString="b"),
+          Line(
+            visible=useAxisFlange,
+            points={{-20,80},{-20,60}}),
+          Line(
+            visible=useAxisFlange,
+            points={{20,80},{20,60}}),
+          Rectangle(
+            visible=useAxisFlange,
+            extent={{-10,100},{10,50}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.VerticalCylinder,
+            fillColor={192,192,192}),
+          Polygon(
+            visible=useAxisFlange,
+            points={{-10,30},{10,30},{30,50},{-30,50},{-10,30}},
+            lineColor={64,64,64},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-30,11},{30,-10}},
+            lineColor={64,64,64},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            visible=useAxisFlange,
+            points={{10,30},{30,50},{30,-50},{10,-30},{10,30}},
+            lineColor={64,64,64},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-150,-110},{150,-80}},
+            lineColor={0,0,0},
+            textString="n=%n"),
+          Text(
+            visible=useAxisFlange,
+            extent={{-150,-155},{150,-115}},
+            textString="%name",
+            lineColor={0,0,255}),
+          Line(
+            visible=useAxisFlange,
+            points={{-20,70},{-60,70},{-60,60}}),
+          Line(
+            visible=useAxisFlange,
+            points={{20,70},{50,70},{50,60}}),
+          Line(
+            visible=useAxisFlange,
+            points={{-90,100},{-30,100}}),
+          Line(
+            visible=useAxisFlange,
+            points={{-30,100},{-50,80}}),
+          Line(
+            visible=useAxisFlange,
+            points={{-49,100},{-70,80}}),
+          Line(
+            visible=useAxisFlange,
+            points={{-70,100},{-90,80}}),
+          Text(
+            visible=not useAxisFlange,
+            extent={{-150,70},{150,110}},
+            textString="%name",
+            lineColor={0,0,255})}),
+      Documentation(info="<html>
+
+<p>
+Joint where frame_b rotates around axis n which is fixed in frame_a.
+The two frames coincide when the rotation angle \"phi = 0\".
+</p>
+
+<p>
+Optionally, two additional 1-dimensional mechanical flanges
+(flange \"axis\" represents the driving flange and
+flange \"support\" represents the bearing) can be enabled via
+parameter <b>useAxisFlange</b>. The enabled axis flange can be
+driven with elements of the
+<a href=\"modelica://Modelica.Mechanics.Rotational\">Modelica.Mechanics.Rotational</a>
+library.
+
+</p>
+
+<p>
+In the \"Advanced\" menu it can be defined via parameter <b>stateSelect</b>
+that the rotation angle \"phi\" and its derivative shall be definitely
+used as states by setting stateSelect=StateSelect.always.
+Default is StateSelect.prefer to use the joint angle and its
+derivative as preferred states. The states are usually selected automatically.
+In certain situations, especially when closed kinematic loops are present,
+it might be slightly more efficient, when using the StateSelect.always setting.
+</p>
+<p>
+If a <b>planar loop</b> is present, e.g., consisting of 4 revolute joints
+where the joint axes are all parallel to each other, then there is no
+longer a unique mathematical solution and the symbolic algorithms will
+fail. Usually, an error message will be printed pointing out this
+situation. In this case, one revolute joint of the loop has to be replaced
+by a Joints.RevolutePlanarLoopConstraint joint. The
+effect is that from the 5 constraints of a usual revolute joint,
+3 constraints are removed and replaced by appropriate known
+variables (e.g., the force in the direction of the axis of rotation is
+treated as known with value equal to zero; for standard revolute joints,
+this force is an unknown quantity).
+</p>
+
+<p>
+In the following figure the animation of a revolute
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint. The black arrow is parameter
+vector \"n\" defining the translation axis
+(here: n = {0,0,1}, phi.start = 45<sup>o</sup>).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Revolute.png\">
+</p>
+
+</html>"));
+  end Revolute;
+
+  model RevolutePlanarLoopConstraint
+    "Revolute joint that is described by 2 positional constraints for usage in a planar loop (the ambiguous cut-force perpendicular to the loop and the ambiguous cut-torques are set arbitrarily to zero)"
+
+    import T = Modelica.Mechanics.MultiBody.Frames.TransformationMatrices;
+    import Modelica.Mechanics.MultiBody.Types;
+
+    Interfaces.Frame_a frame_a
+      "Coordinate system fixed to the joint with one cut-force and cut-torque"
+      annotation (Placement(transformation(extent={{-116,-16},{-84,16}})));
+    Interfaces.Frame_b frame_b
+      "Coordinate system fixed to the joint with one cut-force and cut-torque"
+      annotation (Placement(transformation(extent={{84,-16},{116,16}})));
+
+    parameter Boolean animation=true
+      "= true, if animation shall be enabled (show axis as cylinder)";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n={0,0,1}
+      "Axis of rotation resolved in frame_a (= same as in frame_b)"
+      annotation (Evaluate=true);
+    parameter SI.Distance cylinderLength=world.defaultJointLength
+      "Length of cylinder representing the joint axis"
+      annotation (Dialog(group="if animation = true", enable=animation));
+    parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+      "Diameter of cylinder representing the joint axis"
+      annotation (Dialog(group="if animation = true", enable=animation));
+    input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of cylinder representing the joint axis"
+      annotation (Dialog(colorSelector=true, group="if animation = true", enable=animation));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(group="if animation = true", enable=animation));
+  protected
+    outer Modelica.Mechanics.MultiBody.World world;
+    parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(n)
+      "Unit vector in direction of rotation axis, resolved in frame_a (= same as in frame_b)";
+    parameter Real nnx_a[3](each final unit="1")=if abs(e[1]) > 0.1 then {0,1,0} else (if abs(e[2])
+         > 0.1 then {0,0,1} else {1,0,0})
+      "Arbitrary vector that is not aligned with rotation axis n"
+      annotation (Evaluate=true);
+    parameter Real ey_a[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(cross(e, nnx_a))
+      "Unit vector orthogonal to axis n of revolute joint, resolved in frame_a"
+      annotation (Evaluate=true);
+    parameter Real ex_a[3](each final unit="1")=cross(ey_a, e)
+      "Unit vector orthogonal to axis n of revolute joint and to ey_a, resolved in frame_a"
+      annotation (Evaluate=true);
+    Real ey_b[3](each final unit="1") "ey_a, resolved in frame_b";
+    Real ex_b[3](each final unit="1") "ex_a, resolved in frame_b";
+    Frames.Orientation R_rel
+      "Dummy or relative orientation object from frame_a to frame_b";
+    Modelica.SIunits.Position r_rel_a[3]
+      "Position vector from origin of frame_a to origin of frame_b, resolved in frame_a";
+    SI.Force f_c[2] "Dummy or constraint forces in direction of ex_a, ey_a";
+
+    Visualizers.Advanced.Shape cylinder(
+      shapeType="cylinder",
+      color=cylinderColor,
+      specularCoefficient=specularCoefficient,
+      length=cylinderLength,
+      width=cylinderDiameter,
+      height=cylinderDiameter,
+      lengthDirection=e,
+      widthDirection={0,1,0},
+      r_shape=-e*(cylinderLength/2),
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+  equation
+    assert(cardinality(frame_a) > 0,
+      "Connector frame_a of revolute joint is not connected");
+    assert(cardinality(frame_b) > 0,
+      "Connector frame_b of revolute joint is not connected");
+
+    // Determine relative position vector resolved in frame_a
+    R_rel = Frames.relativeRotation(frame_a.R, frame_b.R);
+    r_rel_a = Frames.resolve2(frame_a.R, frame_b.r_0 - frame_a.r_0);
+    // r_rel_a = T.resolve1(R_rel.T, T.resolve2(frame_b.R.T, frame_b.r_0 - frame_a.r_0));
+
+    // Constraint equations
+    0 = ex_a*r_rel_a;
+    0 = ey_a*r_rel_a;
+
+    /* Transform forces and torques
+     (the torques are assumed to be zero by the assumption
+      of a planar joint)
+  */
+    frame_a.t = zeros(3);
+    frame_b.t = zeros(3);
+
+    frame_a.f = [ex_a, ey_a]*f_c;
+    frame_b.f = -Frames.resolve2(R_rel, frame_a.f);
+
+    // check that revolute joint is used in planar loop
+    ex_b = Frames.resolve2(R_rel, ex_a);
+    ey_b = Frames.resolve2(R_rel, ey_a);
+    assert(noEvent(abs(e*r_rel_a) <= 1.e-10 and abs(e*ex_b) <= 1.e-10 and
+        abs(e*ey_b) <= 1.e-10), "
+The MultiBody.Joints.RevolutePlanarLoopConstraint joint is used as cut-joint of a
+planar loop. However, the revolute joint is not part of a planar loop where the
+axis of the revolute joint (parameter n) is orthogonal to the possible movements.
+Either use instead joint MultiBody.Joints.Revolute or correct the
+definition of the axes vectors n in the revolute joints of the planar loop.
+");
+    annotation (defaultComponentName="revolute",
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Text(
+            extent={{-150,70},{150,100}},
+            lineColor={0,0,0},
+            textString="n=%n"),
+          Text(
+            extent={{-150,-110},{150,-70}},
+            textString="%name",
+            lineColor={0,0,255}),
+          Rectangle(
+            extent={{-20,10},{20,-10}},
+            lineColor={64,64,64},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-100,-60},{-20,60}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(
+            extent={{20,-60},{100,60}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(extent={{-100,60},{-20,-60}}, lineColor={64,64,64}, radius=10),
+          Rectangle(extent={{20,60},{100,-60}}, lineColor={64,64,64}, radius=10),
+          Text(
+            extent={{-90,14},{-54,-11}},
+            lineColor={128,128,128},
+            textString="a"),
+          Text(
+            extent={{51,11},{87,-14}},
+            lineColor={128,128,128},
+            textString="b"),
+          Line(
+            points={{-91,-76},{-33,15},{30,-49},{87,61}},
+            color={255,0,0},
+            thickness=0.5)}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-100,-60},{-20,60}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(
+            extent={{-100,-60},{-20,60}},
+            lineColor={64,64,64},
+            radius=10),
+          Rectangle(
+            extent={{-20,10},{20,-10}},
+            lineColor={64,64,64},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{20,-60},{100,60}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(
+            extent={{20,-60},{100,60}},
+            lineColor={64,64,64},
+            radius=10)}),
+      Documentation(info="<html>
+<p>
+Joint where frame_b rotates around axis n which is fixed in frame_a and
+where this joint is used in a planar loop providing 2 constraint equations
+on position level.
+</p>
+
+<p>
+If a <b>planar loop</b> is present, e.g., consisting of 4 revolute joints
+where the joint axes are all parallel to each other, then there is no
+unique mathematical solution if all revolute joints are modelled with
+Joints.Revolute and the symbolic algorithms will
+fail. The reason is that, e.g., the cut-forces in the revolute joints perpendicular
+to the planar loop are not uniquely defined when 3-dim. descriptions of revolute
+joints are used. Usually, an error message will be printed pointing out this
+situation. In this case, <b>one</b> revolute joint in the loop has to be replaced by
+model Joints.RevolutePlanarLoopCutJoint. The
+effect is that from the 5 constraints of a 3-dim. revolute joint,
+3 constraints are removed and replaced by appropriate known
+variables (e.g., the force in the direction of the axis of rotation is
+treated as known with value equal to zero; for standard revolute joints,
+this force is an unknown quantity).
+</p>
+
+</html>"));
+  end RevolutePlanarLoopConstraint;
+
+  model Cylindrical
+    "Cylindrical joint (2 degrees-of-freedom, 4 potential states)"
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+    parameter Boolean animation=true
+      "= true, if animation shall be enabled (show cylinder)";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n={1,0,0}
+      "Cylinder axis resolved in frame_a (= same as in frame_b)"
+      annotation (Evaluate=true);
+    parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+      "Diameter of cylinder"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of cylinder"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter StateSelect stateSelect=StateSelect.prefer
+      "Priority to use joint coordinates (phi, s, w, v) as states" annotation(Dialog(tab="Advanced"));
+
+    Prismatic prismatic(
+      n=n,
+      animation=false,
+      stateSelect=StateSelect.never) annotation (Placement(transformation(extent={{-70,-25},{
+              -15,25}})));
+    Revolute revolute(
+      n=n,
+      animation=false,
+      stateSelect=StateSelect.never) annotation (Placement(transformation(extent={{10,-25},{
+              65,25}})));
+
+    SI.Position s(start=0, stateSelect=stateSelect)
+      "Relative distance between frame_a and frame_b";
+    SI.Angle phi(start=0, stateSelect=stateSelect)
+      "Relative rotation angle from frame_a to frame_b";
+    SI.Velocity v(start=0, stateSelect=stateSelect)
+      "First derivative of s (relative velocity)";
+    SI.AngularVelocity w(start=0, stateSelect=stateSelect)
+      "First derivative of angle phi (relative angular velocity)";
+    SI.Acceleration a(start=0) "Second derivative of s (relative acceleration)";
+    SI.AngularAcceleration wd(start=0)
+      "Second derivative of angle phi (relative angular acceleration)";
+
+  protected
+    Visualizers.Advanced.Shape cylinder(
+      shapeType="cylinder",
+      color=cylinderColor,
+      specularCoefficient=specularCoefficient,
+      length=prismatic.s,
+      width=cylinderDiameter,
+      height=cylinderDiameter,
+      lengthDirection=prismatic.n,
+      widthDirection={0,1,0},
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation
+      annotation (Placement(transformation(extent={{-20,40},{0,60}})));
+  equation
+    phi = revolute.phi;
+    w = der(phi);
+    wd = der(w);
+    s = prismatic.s;
+    v = der(s);
+    a = der(v);
+    connect(frame_a, prismatic.frame_a)
+      annotation (Line(
+        points={{-100,0},{-70,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(prismatic.frame_b, revolute.frame_a)
+      annotation (Line(
+        points={{-15,0},{10,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(revolute.frame_b, frame_b)
+      annotation (Line(
+        points={{65,0},{100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    annotation (
+      Documentation(info="<html>
+<p>
+Joint where frame_b rotates around and translates along axis n
+which is fixed in frame_a. The two frames coincide when
+\"phi=revolute.phi=0\" and \"s=prismatic.s=0\". This joint
+has the following potential states;
+</p>
+<ul>
+<li> The relative angle phi [rad] around axis n, </li>
+<li> the relative distance s [m] along axis n, </li>
+<li> the relative angular velocity w [rad/s] (= der(phi))
+     and </li>
+<li> the relative velocity v [m/s] (= der(s)).</li>
+</ul>
+<p>
+They are used as candidates for automatic selection of states
+from the tool. This may be enforced by setting \"stateSelect=StateSelect.<b>always</b>\"
+in the <b>Advanced</b> menu. The states are usually selected automatically.
+In certain situations, especially when closed kinematic loops are present,
+it might be slightly more efficient, when using the \"StateSelect.always\" setting.
+</p>
+<p>
+In the following figure the animation of a cylindrical
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint. The black arrow is parameter
+vector \"n\" defining the cylinder axis
+(here: n = {0,0,1}).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Cylindrical.png\">
+</p>
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-30,-30},{100,30}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(
+            extent={{-30,-30},{100,30}},
+            lineColor={64,64,64},
+            radius=10),
+          Rectangle(
+            extent={{-100,-50},{0,50}},
+            lineColor={64,64,64},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={255,255,255},
+            radius=10),
+          Rectangle(
+            extent={{-100,-50},{0,50}},
+            lineColor={64,64,64},
+            radius=10),
+          Text(
+            extent={{-150,100},{150,60}},
+            textString="%name",
+            lineColor={0,0,255}),
+          Text(
+            extent={{-150,-65},{150,-95}},
+            lineColor={0,0,0},
+            textString="n=%n")}));
+  end Cylindrical;
+
+  model Universal "Universal joint (2 degrees-of-freedom, 4 potential states)"
+
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+    parameter Boolean animation=true "= true, if animation shall be enabled";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n_a={1,0,0}
+      "Axis of revolute joint 1 resolved in frame_a" annotation (Evaluate=true);
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n_b={0,1,0}
+      "Axis of revolute joint 2 resolved in frame_b" annotation (Evaluate=true);
+
+    parameter SI.Distance cylinderLength=world.defaultJointLength
+      "Length of cylinders representing the joint axes"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+      "Diameter of cylinders representing the joint axes"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of cylinders representing the joint axes"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter StateSelect stateSelect=StateSelect.prefer
+      "Priority to use joint coordinates (phi_a, phi_b, w_a, w_b) as states" annotation(Dialog(tab="Advanced"));
+
+    Modelica.Mechanics.MultiBody.Joints.Revolute revolute_a(
+      n=n_a,
+      stateSelect=StateSelect.never,
+      cylinderDiameter=cylinderDiameter,
+      cylinderLength=cylinderLength,
+      cylinderColor=cylinderColor,
+      specularCoefficient=specularCoefficient,
+      animation=animation) annotation (Placement(transformation(extent={{-60,
+              -25},{-10,25}})));
+    Modelica.Mechanics.MultiBody.Joints.Revolute revolute_b(
+      n=n_b,
+      stateSelect=StateSelect.never,
+      animation=animation,
+      cylinderDiameter=cylinderDiameter,
+      cylinderLength=cylinderLength,
+      cylinderColor=cylinderColor,
+      specularCoefficient=specularCoefficient)
+      annotation (Placement(transformation(
+          origin={35,45},
+          extent={{-25,-25},{25,25}},
+          rotation=90)));
+
+    SI.Angle phi_a(start=0, stateSelect=stateSelect)
+      "Relative rotation angle from frame_a to intermediate frame";
+    SI.Angle phi_b(start=0, stateSelect=stateSelect)
+      "Relative rotation angle from intermediate frame to frame_b";
+    SI.AngularVelocity w_a(start=0, stateSelect=stateSelect)
+      "First derivative of angle phi_a (relative angular velocity a)";
+    SI.AngularVelocity w_b(start=0, stateSelect=stateSelect)
+      "First derivative of angle phi_b (relative angular velocity b)";
+    SI.AngularAcceleration a_a(start=0)
+      "Second derivative of angle phi_a (relative angular acceleration a)";
+    SI.AngularAcceleration a_b(start=0)
+      "Second derivative of angle phi_b (relative angular acceleration b)";
+
+  equation
+    phi_a = revolute_a.phi;
+    phi_b = revolute_b.phi;
+    w_a = der(phi_a);
+    w_b = der(phi_b);
+    a_a = der(w_a);
+    a_b = der(w_b);
+    connect(frame_a, revolute_a.frame_a)
+      annotation (Line(
+        points={{-100,0},{-60,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(revolute_b.frame_b, frame_b) annotation (Line(
+        points={{35,70},{35,90},{70,90},{70,0},{100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(revolute_a.frame_b, revolute_b.frame_a) annotation (Line(
+        points={{-10,0},{35,0},{35,20}},
+        color={95,95,95},
+        thickness=0.5));
+    annotation (
+      Documentation(info="<html>
+<p>
+Joint where frame_a rotates around axis n_a which is fixed in frame_a
+and frame_b rotates around axis n_b which is fixed in frame_b.
+The two frames coincide when
+\"revolute_a.phi=0\" and \"revolute_b.phi=0\". This joint
+has the following potential states;
+</p>
+<ul>
+<li> The relative angle phi_a = revolute_a.phi [rad] around axis n_a, </li>
+<li> the relative angle phi_b = revolute_b.phi [rad] around axis n_b, </li>
+<li> the relative angular velocity w_a (= der(phi_a))  and </li>
+<li> the relative angular velocity w_b (= der(phi_b)).</li>
+</ul>
+<p>
+They are used as candidates for automatic selection of states
+from the tool. This may be enforced by setting \"stateSelect=StateSelect.<b>always</b>\"
+in the <b>Advanced</b> menu. The states are usually selected automatically.
+In certain situations, especially when closed kinematic loops are present,
+it might be slightly more efficient, when using the \"StateSelect.always\" setting.
+</p>
+
+<p>
+In the following figure the animation of a universal
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint
+(here: n_a = {0,0,1}, n_b = {0,1,0}, phi_a.start = 90<sup>o</sup>,
+phi_b.start = 45<sup>o</sup>).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Universal.png\">
+</p>
+</html>"),
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-100,15},{-65,-15}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={235,235,235}),
+          Ellipse(
+            extent={{-80,-80},{80,80}},
+            lineColor={160,160,164},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{-60,-60},{60,60}},
+            lineColor={160,160,164},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-150,-80},{150,-120}},
+            textString="%name",
+            lineColor={0,0,255}),
+          Rectangle(
+            extent={{12,82},{80,-82}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{56,15},{100,-15}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={235,235,235}),
+          Line(
+            points={{12,78},{12,-78}},
+            thickness=0.5),
+          Ellipse(
+            extent={{-52,-40},{80,40}},
+            lineColor={160,160,164},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{-32,-20},{60,26}},
+            lineColor={160,160,164},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            points={{-22,-54},{-60,0},{-22,50},{40,52},{-22,-54}},
+            pattern=LinePattern.None,
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(
+            points={{12,78},{12,-20}},
+            thickness=0.5),
+          Line(
+            points={{32,38},{-12,-36}},
+            thickness=0.5)}));
+  end Universal;
+
+  model Planar "Planar joint (3 degrees-of-freedom, 6 potential states)"
+
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+    parameter Boolean animation=true "= true, if animation shall be enabled";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n={0,0,1}
+      "Axis orthogonal to unconstrained plane, resolved in frame_a (= same as in frame_b)"
+      annotation (Evaluate=true);
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n_x={1,0,0}
+      "Vector in direction of x-axis of plane, resolved in frame_a (n_x shall be orthogonal to n)"
+      annotation (Evaluate=true);
+    parameter SI.Distance cylinderLength=world.defaultJointLength
+      "Length of revolute cylinder"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+      "Diameter of revolute cylinder"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of revolute cylinder"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance boxWidth=0.3*cylinderDiameter
+      "Width of prismatic joint boxes"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance boxHeight=boxWidth "Height of prismatic joint boxes"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color boxColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of prismatic joint boxes"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    parameter StateSelect stateSelect=StateSelect.prefer
+      "Priority to use joint coordinates (s_x, s_y, phi, v_x, v_y, w) as states"
+                                                                                 annotation(Dialog(tab="Advanced"));
+
+    Prismatic prismatic_x(
+      stateSelect=StateSelect.never,
+      n=(cross(cross(n, n_x), n)),
+      animation=false) annotation (Placement(transformation(extent={{-69,-20},{
+              -29,20}})));
+    Prismatic prismatic_y(
+      stateSelect=StateSelect.never,
+      n=(cross(n, n_x)),
+      animation=false) annotation (Placement(transformation(
+          origin={0,50},
+          extent={{-20,-20},{20,20}},
+          rotation=90)));
+    Revolute revolute(
+      stateSelect=StateSelect.never,
+      n=n,
+      animation=false) annotation (Placement(transformation(extent={{41,-20},{
+              81,20}})));
+
+    SI.Position s_x(start=0, stateSelect=stateSelect)
+      "Relative distance along first prismatic joint starting at frame_a";
+    SI.Position s_y(start=0, stateSelect=stateSelect)
+      "Relative distance along second prismatic joint starting at first prismatic joint";
+    SI.Angle phi(start=0, stateSelect=stateSelect)
+      "Relative rotation angle from frame_a to frame_b";
+    SI.Velocity v_x(start=0, stateSelect=stateSelect)
+      "First derivative of s_x (relative velocity in s_x direction)";
+    SI.Velocity v_y(start=0, stateSelect=stateSelect)
+      "First derivative of s_y (relative velocity in s_y direction)";
+    SI.AngularVelocity w(start=0, stateSelect=stateSelect)
+      "First derivative of angle phi (relative angular velocity)";
+    SI.Acceleration a_x(start=0)
+      "Second derivative of s_x (relative acceleration in s_x direction)";
+    SI.Acceleration a_y(start=0)
+      "Second derivative of s_y (relative acceleration in s_y direction)";
+    SI.AngularAcceleration wd(start=0)
+      "Second derivative of angle phi (relative angular acceleration)";
+
+  protected
+    parameter Integer ndim=if world.enableAnimation and animation then 1 else 0;
+    parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalize(
+                                         n);
+  protected
+    Visualizers.Advanced.Shape box_x[ndim](
+      each shapeType="box",
+      each color=boxColor,
+      each length=prismatic_x.s,
+      each width=boxWidth,
+      each height=boxWidth,
+      each lengthDirection=prismatic_x.e,
+      each widthDirection={0,1,0},
+      each r=frame_a.r_0,
+      each R=frame_a.R) annotation (Placement(transformation(extent={{-80,30},{
+              -60,50}})));
+    Visualizers.Advanced.Shape box_y[ndim](
+      each shapeType="box",
+      each color=boxColor,
+      each length=prismatic_y.s,
+      each width=boxWidth,
+      each height=boxWidth,
+      each lengthDirection=prismatic_y.e,
+      each widthDirection={1,0,0},
+      each r=prismatic_y.frame_a.r_0,
+      each R=prismatic_y.frame_a.R) annotation (Placement(transformation(extent={{-46,69},
+              {-26,89}})));
+    Visualizers.Advanced.Shape cylinder[ndim](
+      each shapeType="cylinder",
+      each color=cylinderColor,
+      each length=cylinderLength,
+      each width=cylinderDiameter,
+      each height=cylinderDiameter,
+      each lengthDirection=n,
+      each widthDirection={0,1,0},
+      each r_shape=-e*(cylinderLength/2),
+      each r=revolute.frame_b.r_0,
+      each R=revolute.frame_b.R) annotation (Placement(transformation(extent={{50,30},
+              {70,50}})));
+  equation
+    s_x = prismatic_x.s;
+    s_y = prismatic_y.s;
+    phi = revolute.phi;
+    v_x = der(s_x);
+    v_y = der(s_y);
+    w   = der(phi);
+    a_x = der(v_x);
+    a_y = der(v_y);
+    wd  = der(w);
+
+    connect(frame_a, prismatic_x.frame_a)
+      annotation (Line(
+        points={{-100,0},{-84,0},{-84,0},{-69,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(prismatic_x.frame_b, prismatic_y.frame_a) annotation (Line(
+        points={{-29,0},{0,0},{0,30}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(prismatic_y.frame_b, revolute.frame_a) annotation (Line(
+        points={{0,70},{0,80},{30,80},{30,0},{41,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(revolute.frame_b, frame_b)
+      annotation (Line(
+        points={{81,0},{92,0},{92,0},{100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    annotation (
+      Documentation(info="<html>
+<p>
+Joint where frame_b can move in a plane and can rotate around an
+axis orthogonal to the plane. The plane is defined by
+vector n which is perpendicular to the plane and by vector n_x,
+which points in the direction of the x-axis of the plane.
+frame_a and frame_b coincide when s_x=prismatic_x.s=0,
+s_y=prismatic_y.s=0 and phi=revolute.phi=0. This joint has the following
+potential states:
+</p>
+<ul>
+<li> the relative distance s_x = prismatic_x.s [m] along axis n_x, </li>
+<li> the relative distance s_y = prismatic_y.s [m] along axis n_y = cross(n,n_x), </li>
+<li> the relative angle phi = revolute.phi [rad] around axis n, </li>
+<li> the relative velocity v_x (= der(s_x)).</li>
+<li> the relative velocity v_y (= der(s_y)).</li>
+<li> the relative angular velocity w (= der(phi))</li>
+</ul>
+<p>
+They are used as candidates for automatic selection of states
+from the tool. This may be enforced by setting \"stateSelect=StateSelect.<b>always</b>\"
+in the <b>Advanced</b> menu. The states are usually selected automatically.
+In certain situations, especially when closed kinematic loops are present,
+it might be slightly more efficient, when using the \"StateSelect.always\" setting.
+</p>
+<p>
+In the following figure the animation of a planar
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint. The black arrows are parameter
+vectors \"n\" and \"n_x\"
+(here: n = {0,1,0}, n_x = {0,0,1}, s_x.start = 0.5,
+s_y.start = 0.5, phi.start = 45<sup>o</sup>).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Planar.png\">
+</p>
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Rectangle(
+            extent={{-30,-60},{-10,60}},
+            lineColor={0,0,0},
+            pattern=LinePattern.None,
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{10,-60},{30,60}},
+            lineColor={0,0,0},
+            pattern=LinePattern.None,
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-100,-10},{-30,10}},
+            lineColor={0,0,0},
+            pattern=LinePattern.None,
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{100,-10},{30,10}},
+            lineColor={0,0,0},
+            pattern=LinePattern.None,
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-150,-75},{150,-105}},
+            lineColor={0,0,0},
+            textString="n=%n"),
+          Text(
+            extent={{-150,110},{150,70}},
+            textString="%name",
+            lineColor={0,0,255})}));
+  end Planar;
+
+  model Spherical
+    "Spherical joint (3 constraints and no potential states, or 3 degrees-of-freedom and 3 states)"
+
+    import Modelica.Mechanics.MultiBody.Frames;
+
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+    parameter Boolean animation=true
+      "= true, if animation shall be enabled (show sphere)";
+    parameter SI.Distance sphereDiameter=world.defaultJointLength
+      "Diameter of sphere representing the spherical joint"
+      annotation (Dialog(group="if animation = true", enable=animation));
+    input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of sphere representing the spherical joint"
+      annotation (Dialog(colorSelector=true, group="if animation = true", enable=animation));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(group="if animation = true", enable=animation));
+
+    parameter Boolean angles_fixed = false
+      "= true, if angles_start are used as initial values, else as guess values"
+      annotation(Evaluate=true, choices(checkBox=true), Dialog(tab="Initialization"));
+    parameter SI.Angle angles_start[3]={0,0,0}
+      "Initial values of angles to rotate frame_a around 'sequence_start' axes into frame_b"
+      annotation (Dialog(tab="Initialization"));
+    parameter Types.RotationSequence sequence_start={1,2,3}
+      "Sequence of rotations to rotate frame_a into frame_b at initial time"
+      annotation (Evaluate=true, Dialog(tab="Initialization"));
+
+    parameter Boolean w_rel_a_fixed = false
+      "= true, if w_rel_a_start are used as initial values, else as guess values"
+      annotation(Evaluate=true, choices(checkBox=true), Dialog(tab="Initialization"));
+    parameter SI.AngularVelocity w_rel_a_start[3]={0,0,0}
+      "Initial values of angular velocity of frame_b with respect to frame_a, resolved in frame_a"
+      annotation (Dialog(tab="Initialization"));
+
+    parameter Boolean z_rel_a_fixed = false
+      "= true, if z_rel_a_start are used as initial values, else as guess values"
+      annotation(Evaluate=true, choices(checkBox=true), Dialog(tab="Initialization"));
+    parameter SI.AngularAcceleration z_rel_a_start[3]={0,0,0}
+      "Initial values of angular acceleration z_rel_a = der(w_rel_a)"
+      annotation (Dialog(tab="Initialization"));
+
+    parameter Boolean enforceStates=false
+      "= true, if relative variables of spherical joint shall be used as states (StateSelect.always)"
+      annotation (Dialog(tab="Advanced"));
+    parameter Boolean useQuaternions=true
+      "= true, if quaternions shall be used as states otherwise use 3 angles as states (provided enforceStates=true)"
+      annotation (Dialog(tab="Advanced", enable=enforceStates));
+    parameter Types.RotationSequence sequence_angleStates={1,2,3}
+      "Sequence of rotations to rotate frame_a into frame_b around the 3 angles used as states"
+       annotation (Evaluate=true, Dialog(tab="Advanced", enable=enforceStates
+             and not useQuaternions));
+
+    final parameter Frames.Orientation R_rel_start=
+        Frames.axesRotations(sequence_start, angles_start, zeros(3))
+      "Orientation object from frame_a to frame_b at initial time";
+
+  protected
+    Visualizers.Advanced.Shape sphere(
+      shapeType="sphere",
+      color=sphereColor,
+      specularCoefficient=specularCoefficient,
+      length=sphereDiameter,
+      width=sphereDiameter,
+      height=sphereDiameter,
+      lengthDirection={1,0,0},
+      widthDirection={0,1,0},
+      r_shape={-0.5,0,0}*sphereDiameter,
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+
+    // Declarations for quaternions (dummies, if quaternions are not used)
+    parameter Frames.Quaternions.Orientation Q_start=
+              Modelica.Mechanics.MultiBody.Frames.to_Q(R_rel_start)
+      "Quaternion orientation object from frame_a to frame_b at initial time";
+    Frames.Quaternions.Orientation Q(start=Q_start, each stateSelect=if
+          enforceStates and useQuaternions then StateSelect.prefer else
+          StateSelect.never)
+      "Quaternion orientation object from frame_a to frame_b (dummy value, if quaternions are not used as states)";
+
+    // Declaration for 3 angles
+    parameter SI.Angle phi_start[3]=if sequence_start[1] ==
+        sequence_angleStates[1] and sequence_start[2] == sequence_angleStates[2]
+         and sequence_start[3] == sequence_angleStates[3] then angles_start else
+         Frames.axesRotationsAngles(R_rel_start, sequence_angleStates)
+      "Potential angle states at initial time";
+    SI.Angle phi[3](start=phi_start, each stateSelect=if enforceStates and not
+          useQuaternions then StateSelect.always else StateSelect.never)
+      "Dummy or 3 angles to rotate frame_a into frame_b";
+    SI.AngularVelocity phi_d[3](each stateSelect=if enforceStates and not
+          useQuaternions then StateSelect.always else StateSelect.never)
+      "= der(phi)";
+    SI.AngularAcceleration phi_dd[3] "= der(phi_d)";
+
+    // Other declarations
+    SI.AngularVelocity w_rel[3](start=Frames.resolve2(R_rel_start, w_rel_a_start),
+          fixed = fill(w_rel_a_fixed,3), each stateSelect=if
+          enforceStates and useQuaternions then StateSelect.always else
+          StateSelect.never)
+      "Dummy or relative angular velocity of frame_b with respect to frame_a, resolved in frame_b";
+    Frames.Orientation R_rel
+      "Dummy or relative orientation object to rotate from frame_a to frame_b";
+    Frames.Orientation R_rel_inv
+      "Dummy or relative orientation object to rotate from frame_b to frame_a";
+  initial equation
+    if angles_fixed then
+      if not enforceStates then
+        // no states defined in spherical object
+        zeros(3) = Frames.Orientation.equalityConstraint(Frames.absoluteRotation(frame_a.R,R_rel_start),frame_b.R);
+      elseif useQuaternions then
+        // Quaternions Q are used as states
+        zeros(3) = Frames.Quaternions.Orientation.equalityConstraint(Q, Q_start);
+      else
+        // The 3 angles 'phi' are used as states
+        phi = phi_start;
+      end if;
+    end if;
+
+    if z_rel_a_fixed then
+      // Initialize acceleration variables
+      der(w_rel) = Frames.resolve2(R_rel_start, z_rel_a_start);
+    end if;
+  equation
+    // torque balance
+    zeros(3) = frame_a.t;
+    zeros(3) = frame_b.t;
+
+    if enforceStates then
+      Connections.branch(frame_a.R, frame_b.R);
+
+      frame_b.r_0 = frame_a.r_0;
+      if Connections.rooted(frame_a.R) then
+        R_rel_inv = Frames.nullRotation();
+        frame_b.R = Frames.absoluteRotation(frame_a.R, R_rel);
+        zeros(3) = frame_a.f + Frames.resolve1(R_rel, frame_b.f);
+      else
+        R_rel_inv = Frames.inverseRotation(R_rel);
+        frame_a.R = Frames.absoluteRotation(frame_b.R, R_rel_inv);
+        zeros(3) = frame_b.f + Frames.resolve2(R_rel, frame_a.f);
+      end if;
+
+      // Compute relative orientation object
+      if useQuaternions then
+        // Use Quaternions as states (with dynamic state selection)
+        {0} = Frames.Quaternions.orientationConstraint(Q);
+        w_rel = Frames.Quaternions.angularVelocity2(Q, der(Q));
+        R_rel = Frames.from_Q(Q, w_rel);
+
+        // Dummies
+        phi = zeros(3);
+        phi_d = zeros(3);
+        phi_dd = zeros(3);
+
+      else
+        // Use angles as states
+        phi_d = der(phi);
+        phi_dd = der(phi_d);
+        R_rel = Frames.axesRotations(sequence_angleStates, phi, phi_d);
+        w_rel = Frames.angularVelocity2(R_rel);
+
+        // Dummies
+        Q = zeros(4);
+      end if;
+
+    else
+      // Spherical joint does not have states
+      frame_b.r_0 = frame_a.r_0;
+      //frame_b.r_0 = transpose(frame_b.R.T)*(frame_b.R.T*(transpose(frame_a.R.T)*(frame_a.R.T*frame_a.r_0)));
+
+      zeros(3) = frame_a.f + Frames.resolveRelative(frame_b.f, frame_b.R, frame_a.R);
+
+      if w_rel_a_fixed or z_rel_a_fixed then
+        w_rel = Frames.angularVelocity2(frame_b.R) - Frames.resolve2(frame_b.R,
+           Frames.angularVelocity1(frame_a.R));
+      else
+        w_rel = zeros(3);
+      end if;
+
+      // Dummies
+      R_rel = Frames.nullRotation();
+      R_rel_inv = Frames.nullRotation();
+      Q = zeros(4);
+      phi = zeros(3);
+      phi_d = zeros(3);
+      phi_dd = zeros(3);
+    end if;
+    annotation (
+      Documentation(info="<html>
+<p>
+Joint with <b>3 constraints</b> that define that the origin of
+frame_a and the origin of frame_b coincide. By default this joint
+defines only the 3 constraints without any potential states.
+If parameter <b>enforceStates</b> is set to <b>true</b>
+in the \"Advanced\" menu, three states are introduced.
+Depending on parameter <b>useQuaternions</b> these are either
+quaternions and the relative angular velocity or 3 angles
+and the angle derivatives. In the latter case the orientation
+of frame_b is computed by rotating frame_a along the axes defined
+in parameter vector \"sequence_angleStates\" (default = {1,2,3}, i.e.,
+the Cardan angle sequence) around the angles used as states.
+For example, the default is to rotate the x-axis of frame_a
+around angles[1], the new y-axis around angles[2] and the new z-axis
+around angles[3], arriving at frame_b. If angles are used
+as states there is the slight disadvantage that
+a singular configuration is present leading to a division by zero.
+</p>
+<p>
+If this joint is used in a <b>chain</b> structure, a Modelica translator
+has to select orientation coordinates of a body as states, if the
+default setting is used. It is usually better to use relative coordinates
+in the spherical joint as states, and therefore in this situation
+parameter enforceStates might be set to <b>true</b>.
+</p>
+<p>
+If this joint is used in a <b>loop</b> structure, the default
+setting results in a <b>cut-joint</b> that
+breaks the loop in independent kinematic pieces, hold together
+by the constraints of this joint. As a result, a Modelica translator
+will first try to select 3 generalized coordinates in the joints of
+the remaining parts of the loop and their first derivative as states
+and if this is not possible, e.g., because there are only spherical
+joints in the loop, will select coordinates from a body of the loop
+as states.
+</p>
+<p>
+In the following figure the animation of a spherical
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint.
+(here: angles_start = {45, 45, 45}<sup>o</sup>).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Spherical.png\">
+</p>
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Ellipse(
+            extent={{-70,-70},{70,70}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-49,-50},{51,50}},
+            lineColor={128,128,128},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{30,70},{71,-68}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-100,10},{-68,-10}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Rectangle(
+            extent={{23,10},{100,-10}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-24,25},{26,-25}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={160,160,164}),
+          Text(
+            extent={{-150,-115},{150,-75}},
+            textString="%name",
+            lineColor={0,0,255})}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Ellipse(
+            extent={{-70,-70},{70,70}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-49,-50},{51,50}},
+            lineColor={128,128,128},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{30,70},{71,-68}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-100,10},{-68,-10}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Rectangle(
+            extent={{23,10},{100,-10}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-24,25},{26,-25}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={160,160,164})}));
+  end Spherical;
+
+  model FreeMotion
+    "Free motion joint (6 degrees-of-freedom, 12 potential states)"
+
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+
+    parameter Boolean animation=true
+      "= true, if animation shall be enabled (show arrow from frame_a to frame_b)";
+
+    SI.Position r_rel_a[3](start={0,0,0}, each stateSelect=if enforceStates then
+                StateSelect.always else StateSelect.prefer)
+      "Position vector from origin of frame_a to origin of frame_b, resolved in frame_a"
+      annotation(Dialog(group="Initialization", showStartAttribute=true));
+    SI.Velocity v_rel_a[3](start={0,0,0}, each stateSelect=if enforceStates then StateSelect.always else
+                StateSelect.prefer)
+      "= der(r_rel_a), i.e., velocity of origin of frame_b with respect to origin of frame_a, resolved in frame_a"
+      annotation(Dialog(group="Initialization", showStartAttribute=true));
+    SI.Acceleration a_rel_a[3](start={0,0,0}) "= der(v_rel_a)"
+      annotation(Dialog(group="Initialization", showStartAttribute=true));
+
+    parameter Boolean angles_fixed = false
+      "= true, if angles_start are used as initial values, else as guess values"
+      annotation(Evaluate=true, choices(checkBox=true), Dialog(group="Initialization"));
+    parameter SI.Angle angles_start[3]={0,0,0}
+      "Initial values of angles to rotate frame_a around 'sequence_start' axes into frame_b"
+      annotation (Dialog(group="Initialization"));
+    parameter Types.RotationSequence sequence_start={1,2,3}
+      "Sequence of rotations to rotate frame_a into frame_b at initial time"
+      annotation (Evaluate=true, Dialog(group="Initialization"));
+
+    parameter Boolean w_rel_a_fixed = false
+      "= true, if w_rel_a_start are used as initial values, else as guess values"
+      annotation(Evaluate=true, choices(checkBox=true), Dialog(group="Initialization"));
+    parameter SI.AngularVelocity w_rel_a_start[3]={0,0,0}
+      "Initial values of angular velocity of frame_b with respect to frame_a, resolved in frame_a"
+      annotation (Dialog(group="Initialization"));
+
+    parameter Boolean z_rel_a_fixed = false
+      "= true, if z_rel_a_start are used as initial values, else as guess values"
+      annotation(Evaluate=true, choices(checkBox=true), Dialog(group="Initialization"));
+    parameter SI.AngularAcceleration z_rel_a_start[3]={0,0,0}
+      "Initial values of angular acceleration z_rel_a = der(w_rel_a)"
+      annotation (Dialog(group="Initialization"));
+
+    parameter SI.Length arrowDiameter=world.defaultArrowDiameter
+      "Diameter of arrow from frame_a to frame_b"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color arrowColor=Modelica.Mechanics.MultiBody.Types.Defaults.SensorColor
+      "Color of arrow"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter Boolean enforceStates=true
+      "= true, if relative variables between frame_a and frame_b shall be used as states"
+      annotation (Dialog(tab="Advanced"));
+    parameter Boolean useQuaternions=true
+      "= true, if quaternions shall be used as states otherwise use 3 angles as states"
+      annotation (Dialog(tab="Advanced"));
+    parameter Types.RotationSequence sequence_angleStates={1,2,3}
+      "Sequence of rotations to rotate frame_a into frame_b around the 3 angles used as states"
+       annotation (Evaluate=true, Dialog(tab="Advanced", enable=not
+            useQuaternions));
+
+    final parameter Frames.Orientation R_rel_start=
+        Modelica.Mechanics.MultiBody.Frames.axesRotations(sequence_start, angles_start,zeros(3))
+      "Orientation object from frame_a to frame_b at initial time";
+
+  protected
+    Visualizers.Advanced.Arrow arrow(
+      r_head=r_rel_a,
+      diameter=arrowDiameter,
+      color=arrowColor,
+      specularCoefficient=specularCoefficient,
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+
+    // Declarations for quaternions (dummies, if quaternions are not used)
+    parameter Frames.Quaternions.Orientation Q_start=Frames.to_Q(R_rel_start)
+      "Quaternion orientation object from frame_a to frame_b at initial time";
+    Frames.Quaternions.Orientation Q(start=Q_start, each stateSelect=if
+          enforceStates then (if useQuaternions then StateSelect.prefer else
+          StateSelect.never) else StateSelect.default)
+      "Quaternion orientation object from frame_a to frame_b (dummy value, if quaternions are not used as states)";
+
+    // Declaration for 3 angles
+    parameter SI.Angle phi_start[3]=if sequence_start[1] ==
+        sequence_angleStates[1] and sequence_start[2] == sequence_angleStates[2]
+         and sequence_start[3] == sequence_angleStates[3] then angles_start else
+              Frames.axesRotationsAngles(R_rel_start,
+        sequence_angleStates) "Potential angle states at initial time";
+    SI.Angle phi[3](start=phi_start, each stateSelect=if enforceStates then (if
+          useQuaternions then StateSelect.never else StateSelect.always) else
+          StateSelect.prefer)
+      "Dummy or 3 angles to rotate frame_a into frame_b";
+    SI.AngularVelocity phi_d[3](each stateSelect=if enforceStates then (if
+          useQuaternions then StateSelect.never else StateSelect.always) else
+          StateSelect.prefer) "= der(phi)";
+    SI.AngularAcceleration phi_dd[3] "= der(phi_d)";
+
+    // Other declarations
+    SI.AngularVelocity w_rel_b[3](start=Frames.resolve2(R_rel_start, w_rel_a_start),
+                                  fixed=fill(w_rel_a_fixed,3),
+                                  each stateSelect=if enforceStates then
+                                  (if useQuaternions then StateSelect.always else
+                                  StateSelect.avoid) else StateSelect.prefer)
+      "Dummy or relative angular velocity of frame_b with respect to frame_a, resolved in frame_b";
+    Frames.Orientation R_rel
+      "Dummy or relative orientation object to rotate from frame_a to frame_b";
+    Frames.Orientation R_rel_inv
+      "Dummy or relative orientation object to rotate from frame_b to frame_a";
+
+  initial equation
+    if angles_fixed then
+      // Initialize positional variables
+      if not enforceStates then
+        // no states defined
+        zeros(3) = Frames.Orientation.equalityConstraint(Frames.absoluteRotation(frame_a.R,R_rel_start),frame_b.R);
+      elseif useQuaternions then
+        // Quaternions Q are used as states
+        zeros(3) = Frames.Quaternions.Orientation.equalityConstraint(Q, Q_start);
+      else
+        // The 3 angles 'phi' are used as states
+        phi = phi_start;
+      end if;
+    end if;
+
+    if z_rel_a_fixed then
+      // Initialize acceleration variables
+      der(w_rel_b) = Frames.resolve2(R_rel_start, z_rel_a_start);
+    end if;
+
+  equation
+    // Kinematic differential equations for translational motion
+    der(r_rel_a) = v_rel_a;
+    der(v_rel_a) = a_rel_a;
+
+    // Kinematic relationships
+    frame_b.r_0 = frame_a.r_0 + Frames.resolve1(frame_a.R, r_rel_a);
+
+    // Cut-forces and cut-torques are zero
+    frame_a.f = zeros(3);
+    frame_a.t = zeros(3);
+    frame_b.f = zeros(3);
+    frame_b.t = zeros(3);
+
+    if enforceStates then
+      Connections.branch(frame_a.R, frame_b.R);
+
+      if Connections.rooted(frame_a.R) then
+        R_rel_inv = Frames.nullRotation();
+        frame_b.R = Frames.absoluteRotation(frame_a.R, R_rel);
+      else
+        R_rel_inv = Frames.inverseRotation(R_rel);
+        frame_a.R = Frames.absoluteRotation(frame_b.R, R_rel_inv);
+      end if;
+
+      // Compute relative orientation object
+      if useQuaternions then
+        // Use Quaternions as states (with dynamic state selection)
+        {0} = Frames.Quaternions.orientationConstraint(Q);
+        w_rel_b = Frames.Quaternions.angularVelocity2(Q, der(Q));
+        R_rel = Frames.from_Q(Q, w_rel_b);
+
+        // Dummies
+        phi = zeros(3);
+        phi_d = zeros(3);
+        phi_dd = zeros(3);
+
+      else
+        // Use angles as states
+        phi_d = der(phi);
+        phi_dd = der(phi_d);
+        R_rel = Frames.axesRotations(sequence_angleStates, phi, phi_d);
+        w_rel_b = Frames.angularVelocity2(R_rel);
+
+        // Dummies
+        Q = zeros(4);
+      end if;
+
+    else
+      // Free motion joint does not have states
+      if w_rel_a_fixed or z_rel_a_fixed then
+        w_rel_b = Frames.angularVelocity2(frame_b.R) - Frames.resolve2(frame_b.
+          R, Frames.angularVelocity1(frame_a.R));
+      else
+        // dummy
+        w_rel_b = zeros(3);
+      end if;
+
+      // Dummies
+      R_rel = Frames.nullRotation();
+      R_rel_inv = Frames.nullRotation();
+      Q = zeros(4);
+      phi = zeros(3);
+      phi_d = zeros(3);
+      phi_dd = zeros(3);
+    end if;
+    annotation (
+      Documentation(info="<html>
+<p>
+Joint which does not constrain the motion between frame_a and frame_b.
+Such a joint is only meaningful if the <b>relative</b> distance and orientation
+between frame_a and frame_b, and their derivatives, shall be used
+as <b>states</b>.
+</p>
+<p>
+Note, that <b>bodies</b> such as Parts.Body, Parts.BodyShape,
+have potential states describing the distance
+and orientation, and their derivatives, between the <b>world frame</b> and
+a <b>body fixed frame</b>.
+Therefore, if these potential state variables are suited,
+a FreeMotion joint is not needed.
+</p>
+<p>
+The states of the FreeMotion object are:
+</p>
+<ul>
+<li> The <b>relative position vector</b> r_rel_a from the origin of
+     frame_a to the origin of frame_b, resolved in
+     frame_a and the <b>relative velocity</b> v_rel_a of the origin of
+     frame_b with respect to the origin of frame_a, resolved in frame_a
+     (= der(r_rel_a)).
+</li>
+<li> If parameter <b>useQuaternions</b> in the \"Advanced\" menu
+     is <b>true</b> (this is the default), then <b>4 quaternions</b>
+     are states. Additionally, the coordinates of the
+     relative angular velocity vector are 3 potential states.<br>
+     If <b>useQuaternions</b> in the \"Advanced\" menu
+     is <b>false</b>, then <b>3 angles</b> and the derivatives of
+     these angles are potential states. The orientation of frame_b
+     is computed by rotating frame_a along the axes defined
+     in parameter vector \"sequence_angleStates\" (default = {1,2,3}, i.e.,
+     the Cardan angle sequence) around the angles used as states.
+     For example, the default is to rotate the x-axis of frame_a
+     around angles[1], the new y-axis around angles[2] and the new z-axis
+     around angles[3], arriving at frame_b.
+ </li>
+</ul>
+<p>
+The quaternions have the slight disadvantage that there is a
+non-linear constraint equation between the 4 quaternions.
+Therefore, at least one non-linear equation has to be solved
+during simulation. A tool might, however, analytically solve this
+simple constraint equation. Using the 3 angles as states has the
+disadvantage that there is a singular configuration in which a
+division by zero will occur. If it is possible to determine in advance
+for an application class that this singular configuration is outside
+of the operating region, the 3 angles might be used as
+states by setting <b>useQuaternions</b> = <b>false</b>.
+</p>
+<p>
+In text books about 3-dimensional mechanics often 3 angles and the
+angular velocity are used as states. This is not the case here, since
+3 angles and their derivatives are used as states
+(if useQuaternions = false). The reason
+is that for real-time simulation the discretization formula of the
+integrator might be \"inlined\" and solved together with the model equations.
+By appropriate symbolic transformation the performance is
+drastically increased if angles and their
+derivatives are used as states, instead of angles and the angular
+velocity.
+</p>
+<p>
+If parameter
+<b>enforceStates</b> is set to <b>true</b> (= the default)
+in the \"Advanced\" menu,
+then FreeMotion variables are forced to be used as states according
+to the setting of parameters \"useQuaternions\" and
+\"sequence_angleStates\".
+</p>
+<p>
+In the following figure the animation of a FreeMotion
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint.
+(here: r_rel_a_start = {0.5, 0, 0.5}, angles_start = {45, 45, 45}<sup>o</sup>).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/FreeMotion.png\">
+</p>
+
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(
+            points={{-86,31},{-74,61},{-49,83},{-17,92},{19,88},{40,69},{59,48}},
+            color={160,160,164},
+            thickness=0.5,
+            smooth=Smooth.Bezier),
+          Polygon(
+            points={{90,0},{50,20},{50,-20},{90,0}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            points={{69,58},{49,40},{77,28},{69,58}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{150,-35},{-150,-75}},
+            lineColor={0,0,255},
+            textString="%name"),
+          Rectangle(
+            extent={{-70,-5},{-90,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{50,-5},{30,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{11,-5},{-9,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-30,-5},{-50,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid)}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(
+            points={{-86,31},{-74,61},{-49,83},{-17,92},{19,88},{40,69},{59,48}},
+            color={160,160,164},
+            thickness=0.5,
+            smooth=Smooth.Bezier),
+          Polygon(
+            points={{90,0},{50,20},{50,-20},{90,0}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            points={{69,58},{49,40},{77,28},{69,58}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{50,-5},{30,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{11,-5},{-9,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-30,-5},{-50,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-70,-5},{-90,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid)}));
+  end FreeMotion;
+
+  model FreeMotionScalarInit
+    "Free motion joint with scalar initialization and state selection (6 degrees-of-freedom, 12 potential states)"
+
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+
+    parameter Boolean animation=true
+      "= true, if animation shall be enabled (show arrow from frame_a to frame_b)"
+      annotation(Dialog(enable=use_r));
+
+    parameter Boolean use_r = false "= true, if r_rel_a shall be used"
+        annotation(Evaluate=true, HideResult=true,Dialog(tab="Translational Initialization", group="Position vector r_rel_a from origin of frame_a to origin of frame_b, resolved in frame_a"));
+    Modelica.Blocks.Interfaces.RealOutput r_rel_a_1(final quantity="Length", final unit="m", start=0, final stateSelect=r_rel_a_1_stateSelect) if use_r
+      "Relative distance r_rel_a[1]"
+      annotation(Dialog(enable=use_r, tab="Translational Initialization", group="Position vector r_rel_a from origin of frame_a to origin of frame_b, resolved in frame_a",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput r_rel_a_2(final quantity="Length", final unit="m", start=0, final stateSelect=r_rel_a_2_stateSelect) if use_r
+      "Relative distance r_rel_a[2]"
+      annotation(Dialog(enable=use_r, tab="Translational Initialization", group="Position vector r_rel_a from origin of frame_a to origin of frame_b, resolved in frame_a",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput r_rel_a_3(final quantity="Length", final unit="m", start=0, final stateSelect=r_rel_a_3_stateSelect) if use_r
+      "Relative distance r_rel_a[3]"
+      annotation(Dialog(enable=use_r, tab="Translational Initialization", group="Position vector r_rel_a from origin of frame_a to origin of frame_b, resolved in frame_a",showStartAttribute=true));
+
+    parameter StateSelect r_rel_a_1_stateSelect=StateSelect.never
+      "StateSelect of r_rel_a[1]" annotation(HideResult=true,
+       Dialog(enable=use_r, tab="Translational Initialization", group="Position vector r_rel_a from origin of frame_a to origin of frame_b, resolved in frame_a"));
+    parameter StateSelect r_rel_a_2_stateSelect=StateSelect.never
+      "StateSelect of r_rel_a[2]" annotation(HideResult=true,
+       Dialog(enable=use_r, tab="Translational Initialization", group="Position vector r_rel_a from origin of frame_a to origin of frame_b, resolved in frame_a"));
+    parameter StateSelect r_rel_a_3_stateSelect=StateSelect.never
+      "StateSelect of r_rel_a[3]" annotation(HideResult=true,
+       Dialog(enable=use_r, tab="Translational Initialization", group="Position vector r_rel_a from origin of frame_a to origin of frame_b, resolved in frame_a"));
+
+    parameter Boolean use_v = false "= true, if v_rel_a shall be used"
+        annotation(Evaluate=true, HideResult=true,Dialog(enable=use_r, tab="Translational Initialization", group="Velocity vector v_rel_a = der(r_rel_a)"));
+    Modelica.Blocks.Interfaces.RealOutput v_rel_a_1(final quantity="Velocity", final unit="m/s", start=0, final stateSelect=v_rel_a_1_stateSelect) if use_r and use_v
+      "Relative velocity v_rel_a[1]"
+      annotation(Dialog(enable=use_r and use_v, tab="Translational Initialization", group="Velocity vector v_rel_a = der(r_rel_a)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput v_rel_a_2(final quantity="Velocity", final unit="m/s", start=0, final stateSelect=v_rel_a_2_stateSelect) if use_r and use_v
+      "Relative velocity v_rel_a[2]"
+      annotation(Dialog(enable=use_r and use_v, tab="Translational Initialization", group="Velocity vector v_rel_a = der(r_rel_a)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput v_rel_a_3(final quantity="Velocity", final unit="m/s", start=0, final stateSelect=v_rel_a_3_stateSelect) if use_r and use_v
+      "Relative velocity v_rel_a[3]"
+      annotation(Dialog(enable=use_r and use_v, tab="Translational Initialization", group="Velocity vector v_rel_a = der(r_rel_a)",showStartAttribute=true));
+
+    parameter StateSelect v_rel_a_1_stateSelect=StateSelect.never
+      "StateSelect of v_rel_a[1]" annotation(HideResult=true,
+       Dialog(enable=use_r and use_v, tab="Translational Initialization", group="Velocity vector v_rel_a = der(r_rel_a)"));
+    parameter StateSelect v_rel_a_2_stateSelect=StateSelect.never
+      "StateSelect of v_rel_a[2]" annotation(HideResult=true,
+       Dialog(enable=use_r and use_v, tab="Translational Initialization", group="Velocity vector v_rel_a = der(r_rel_a)"));
+    parameter StateSelect v_rel_a_3_stateSelect=StateSelect.never
+      "StateSelect of v_rel_a[3]" annotation(HideResult=true,
+       Dialog(enable=use_r and use_v, tab="Translational Initialization", group="Velocity vector v_rel_a = der(r_rel_a)"));
+
+    parameter Boolean use_a = false "= true, if a_rel_a shall be used"
+        annotation(Evaluate=true, HideResult=true,Dialog(enable=use_r and use_v, tab="Translational Initialization", group="Acceleration vector a_rel_a = der(v_rel_a)"));
+    Modelica.Blocks.Interfaces.RealOutput a_rel_a_1(final quantity="Acceleration", final unit="m/s2", start=0) if use_r and use_v and use_a
+      "Relative acceleration a_rel_a[1]"
+      annotation(Dialog(enable=use_r and use_v and use_a, tab="Translational Initialization", group="Acceleration vector a_rel_a = der(v_rel_a)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput a_rel_a_2(final quantity="Acceleration", final unit="m/s2", start=0) if use_r and use_v and use_a
+      "Relative acceleration a_rel_a[2]"
+      annotation(Dialog(enable=use_r and use_v and use_a, tab="Translational Initialization", group="Acceleration vector a_rel_a = der(v_rel_a)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput a_rel_a_3(final quantity="Acceleration", final unit="m/s2", start=0) if use_r and use_v and use_a
+      "Relative acceleration a_rel_a[3]"
+      annotation(Dialog(enable=use_r and use_v and use_a, tab="Translational Initialization", group="Acceleration vector a_rel_a = der(v_rel_a)",showStartAttribute=true));
+
+    parameter Boolean use_angle = false "= true, if angle shall be used"
+      annotation(Evaluate=true, HideResult=true,Dialog(tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start"));
+
+    parameter Types.RotationSequence sequence_start={1,2,3}
+      "Sequence of angle rotations"
+      annotation(Evaluate=true,Dialog(enable=use_angle, tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start"));
+
+    Modelica.Blocks.Interfaces.RealOutput angle_1(final quantity="Angle", final unit="rad", start=0, stateSelect=angle_1_stateSelect) if use_angle
+      "First rotation angle or dummy"
+      annotation(Dialog(enable=use_angle, tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput angle_2(final quantity="Angle", final unit="rad", start=0, stateSelect=angle_2_stateSelect) if use_angle
+      "Second rotation angle or dummy"
+      annotation(Dialog(enable=use_angle, tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput angle_3(final quantity="Angle", final unit="rad", start=0, stateSelect=angle_3_stateSelect) if use_angle
+      "Third rotation angle or dummy"
+      annotation(Dialog(enable=use_angle, tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start",showStartAttribute=true));
+
+    parameter StateSelect angle_1_stateSelect=StateSelect.never
+      "StateSelect of angle_1"
+       annotation(HideResult=true, Dialog(enable=use_angle, tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start"));
+    parameter StateSelect angle_2_stateSelect=StateSelect.never
+      "StateSelect of angle_2"
+       annotation(HideResult=true, Dialog(enable=use_angle, tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start"));
+    parameter StateSelect angle_3_stateSelect=StateSelect.never
+      "StateSelect of angle_3"
+       annotation(HideResult=true, Dialog(enable=use_angle, tab="Angle Initialization", group="Angles to rotate frame_a to frame_b along sequence_start"));
+
+    parameter Boolean use_angle_d= false "= true, if angle_d shall be used"
+      annotation(Evaluate=true, HideResult=true,Dialog(enable=use_angle, tab="Angle Initialization", group="angle_d = der(angle)"));
+
+    Modelica.Blocks.Interfaces.RealOutput angle_d_1(final quantity="AngularVelocity", final unit="rad/s", start=0, final stateSelect=angle_d_1_stateSelect) if use_angle and use_angle_d
+      "= der(angle_1)"
+      annotation(Dialog(enable=use_angle and use_angle_d, tab="Angle Initialization", group="angle_d = der(angle)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput angle_d_2(final quantity="AngularVelocity", final unit="rad/s", start=0, final stateSelect=angle_d_2_stateSelect) if use_angle and use_angle_d
+      "= der(angle_2)"
+      annotation(Dialog(enable=use_angle and use_angle_d, tab="Angle Initialization", group="angle_d = der(angle)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput angle_d_3(final quantity="AngularVelocity", final unit="rad/s", start=0, final stateSelect=angle_d_3_stateSelect) if use_angle and use_angle_d
+      "= der(angle_3)"
+      annotation(Dialog(enable=use_angle and use_angle_d, tab="Angle Initialization", group="angle_d = der(angle)",showStartAttribute=true));
+
+    parameter StateSelect angle_d_1_stateSelect=StateSelect.never
+      "StateSelect of angle_d_1" annotation(HideResult=true,
+       Dialog(enable=use_angle and use_angle_d, tab="Angle Initialization", group="angle_d = der(angle)"));
+    parameter StateSelect angle_d_2_stateSelect=StateSelect.never
+      "StateSelect of angle_d_2" annotation(HideResult=true,
+       Dialog(enable=use_angle and use_angle_d, tab="Angle Initialization", group="angle_d = der(angle)"));
+    parameter StateSelect angle_d_3_stateSelect=StateSelect.never
+      "StateSelect of angle_d_3" annotation(HideResult=true,
+       Dialog(enable=use_angle and use_angle_d, tab="Angle Initialization", group="angle_d = der(angle)"));
+
+    parameter Boolean use_angle_dd = false "= true, if angle_dd shall be used"
+        annotation(Evaluate=true, HideResult=true,Dialog(enable=use_angle and use_angle_d, tab="Angle Initialization", group="angle_dd = der(angle_d)"));
+    Modelica.Blocks.Interfaces.RealOutput angle_dd_1(final quantity="AngularAcceleration", final unit="rad/s2", start=0) if use_angle and use_angle_d and use_angle_dd
+      "= der(angle_d_1)"
+      annotation(Dialog(enable=use_angle and use_angle_d and use_angle_dd, tab="Angle Initialization", group="angle_dd = der(angle_d)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput angle_dd_2(final quantity="AngularAcceleration", final unit="rad/s2", start=0) if use_angle and use_angle_d and use_angle_dd
+      "= der(angle_d_2)"
+      annotation(Dialog(enable=use_angle and use_angle_d and use_angle_dd, tab="Angle Initialization", group="angle_dd = der(angle_d)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput angle_dd_3(final quantity="AngularAcceleration", final unit="rad/s2", start=0) if use_angle and use_angle_d and use_angle_dd
+      "= der(angle_d_3)"
+      annotation(Dialog(enable=use_angle and use_angle_d and use_angle_dd, tab="Angle Initialization", group="angle_dd = der(angle_d)",showStartAttribute=true));
+
+    parameter Boolean use_w = false "= true, if w_rel_b shall be used"
+      annotation(Evaluate=true, HideResult=true,Dialog(tab="Angular Velocity Initialization", group="Angular velocity w_rel_b of frame_b with respect to frame_a, resolved in frame_b"));
+
+    Modelica.Blocks.Interfaces.RealOutput w_rel_b_1(final quantity="AngularVelocity", final unit="rad/s", start=0, stateSelect=w_rel_b_1_stateSelect) if use_w
+      "Relative angular velocity w_rel_b[1]"
+      annotation(Dialog(enable=use_w, tab="Angular Velocity Initialization", group="Angular velocity w_rel_b of frame_b with respect to frame_a, resolved in frame_b",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput w_rel_b_2(final quantity="AngularVelocity", final unit="rad/s", start=0, stateSelect=w_rel_b_2_stateSelect) if use_w
+      "Relative angular velocity w_rel_b[2]"
+      annotation(Dialog(enable=use_w, tab="Angular Velocity Initialization", group="Angular velocity w_rel_b of frame_b with respect to frame_a, resolved in frame_b",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput w_rel_b_3(final quantity="AngularVelocity", final unit="rad/s", start=0, stateSelect=w_rel_b_3_stateSelect) if use_w
+      "Relative angular velocity w_rel_b[3]"
+      annotation(Dialog(enable=use_w, tab="Angular Velocity Initialization", group="Angular velocity w_rel_b of frame_b with respect to frame_a, resolved in frame_b",showStartAttribute=true));
+
+    parameter StateSelect w_rel_b_1_stateSelect=StateSelect.never
+      "StateSelect of w_rel_b[1]" annotation(HideResult=true,
+       Dialog(enable=use_w, tab="Angular Velocity Initialization", group="Angular velocity w_rel_b of frame_b with respect to frame_a, resolved in frame_b"));
+    parameter StateSelect w_rel_b_2_stateSelect=StateSelect.never
+      "StateSelect of w_rel_b[2]" annotation(HideResult=true,
+       Dialog(enable=use_w, tab="Angular Velocity Initialization", group="Angular velocity w_rel_b of frame_b with respect to frame_a, resolved in frame_b"));
+    parameter StateSelect w_rel_b_3_stateSelect=StateSelect.never
+      "StateSelect of w_rel_b[3]" annotation(HideResult=true,
+       Dialog(enable=use_w, tab="Angular Velocity Initialization", group="Angular velocity w_rel_b of frame_b with respect to frame_a, resolved in frame_b"));
+
+    parameter Boolean use_z = false "= true, if z_rel_b shall be used"
+      annotation(Evaluate=true, HideResult=true,Dialog(enable=use_w, tab="Angular Velocity Initialization", group="Angular acceleration z_rel_b = der(w_rel_b)"));
+    Modelica.Blocks.Interfaces.RealOutput z_rel_b_1(final quantity="AngularAcceleration", final unit="rad/s2", start=0) if use_w and use_z
+      "Relative angular acceleration z_rel_b[1]"
+      annotation(Dialog(enable=use_w and use_z, tab="Angular Velocity Initialization", group="Angular acceleration z_rel_b = der(w_rel_b)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput z_rel_b_2(final quantity="AngularAcceleration", final unit="rad/s2", start=0) if use_w and use_z
+      "Relative angular acceleration z_rel_b[2]"
+      annotation(Dialog(enable=use_w and use_z, tab="Angular Velocity Initialization", group="Angular acceleration z_rel_b = der(w_rel_b)",showStartAttribute=true));
+    Modelica.Blocks.Interfaces.RealOutput z_rel_b_3(final quantity="AngularAcceleration", final unit="rad/s2", start=0) if use_w and use_z
+      "Relative angular acceleration z_rel_b[3]"
+      annotation(Dialog(enable=use_w and use_z, tab="Angular Velocity Initialization", group="Angular acceleration z_rel_b = der(w_rel_b)",showStartAttribute=true));
+
+    parameter SI.Length arrowDiameter=world.defaultArrowDiameter
+      "Diameter of arrow from frame_a to frame_b"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation and use_r));
+    input Types.Color arrowColor=Modelica.Mechanics.MultiBody.Types.Defaults.SensorColor
+      "Color of arrow"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation and use_r));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation and use_r));
+
+  protected
+    Modelica.Mechanics.MultiBody.Joints.Internal.InitPosition initPosition(r_a_0=frame_a.r_0, r_b_0=frame_b.r_0, R_a = frame_a.R) if use_r
+      annotation (Placement(transformation(extent={{-20,60},{0,80}})));
+    Modelica.Mechanics.MultiBody.Joints.Internal.InitAngle initAngle(sequence_start = sequence_start) if use_angle
+      annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+    Modelica.Mechanics.MultiBody.Joints.Internal.InitAngularVelocity initAngularVelocity(R_a = frame_a.R, R_b = frame_b.R) if use_w
+      annotation (Placement(transformation(extent={{-20,20},{0,40}})));
+    Modelica.Blocks.Continuous.Der derv[3] if use_r and use_v
+      annotation (Placement(transformation(extent={{20,60},{40,80}})));
+    Modelica.Blocks.Continuous.Der dera[3] if use_r and use_v and use_a
+      annotation (Placement(transformation(extent={{60,60},{80,80}})));
+    Modelica.Blocks.Continuous.Der derd[3] if use_angle and use_angle_d
+      annotation (Placement(transformation(extent={{-20,-30},{0,-10}})));
+    Modelica.Blocks.Continuous.Der derdd[3] if use_angle and use_angle_d and use_angle_dd
+      annotation (Placement(transformation(extent={{20,-30},{40,-10}})));
+    Modelica.Blocks.Continuous.Der derz[3] if use_w and use_z
+      annotation (Placement(transformation(extent={{20,20},{40,40}})));
+    Modelica.Mechanics.MultiBody.Sensors.Internal.ZeroForceAndTorque zeroForceAndTorque1
+      annotation (Placement(transformation(extent={{-80,-50},{-60,-30}})));
+    Modelica.Mechanics.MultiBody.Sensors.Internal.ZeroForceAndTorque zeroForceAndTorque2
+      annotation (Placement(transformation(extent={{80,-50},{60,-30}})));
+    Modelica.Mechanics.MultiBody.Visualizers.SignalArrow arrow(
+      diameter=arrowDiameter,
+      color=arrowColor,
+      specularCoefficient=specularCoefficient) if world.enableAnimation and animation and use_r
+      annotation (Placement(transformation(extent={{-80,60},{-60,80}})));
+  equation
+    // r_rel_a
+    connect(initPosition.r_rel_a[1], r_rel_a_1);
+    connect(initPosition.r_rel_a[2], r_rel_a_2);
+    connect(initPosition.r_rel_a[3], r_rel_a_3);
+
+    // v_rel_a
+    connect(derv[1].y, v_rel_a_1);
+    connect(derv[2].y, v_rel_a_2);
+    connect(derv[3].y, v_rel_a_3);
+
+    // a_rel_a
+    connect(dera[1].y, a_rel_a_1);
+    connect(dera[2].y, a_rel_a_2);
+    connect(dera[3].y, a_rel_a_3);
+
+    // angle
+    connect(initAngle.angle[1], angle_1);
+    connect(initAngle.angle[2], angle_2);
+    connect(initAngle.angle[3], angle_3);
+
+    // angle_d
+    connect(derd[1].y, angle_d_1);
+    connect(derd[2].y, angle_d_2);
+    connect(derd[3].y, angle_d_3);
+
+    // angle_dd
+    connect(derdd[1].y, angle_dd_1);
+    connect(derdd[2].y, angle_dd_2);
+    connect(derdd[3].y, angle_dd_3);
+
+    // w_rel_b
+    connect(initAngularVelocity.w_rel_b[1], w_rel_b_1);
+    connect(initAngularVelocity.w_rel_b[2], w_rel_b_2);
+    connect(initAngularVelocity.w_rel_b[3], w_rel_b_3);
+
+    // z_rel_b
+    connect(derz[1].y, z_rel_b_1);
+    connect(derz[2].y, z_rel_b_2);
+    connect(derz[3].y, z_rel_b_3);
+
+    connect(initPosition.r_rel_a, derv.u) annotation (Line(
+        points={{1,70},{18,70}},
+        color={0,0,127}));
+    connect(derv.y, dera.u) annotation (Line(
+        points={{41,70},{58,70}},
+        color={0,0,127}));
+    connect(initAngle.frame_a, frame_a) annotation (Line(
+        points={{-60,0},{-100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(initAngle.frame_b, frame_b) annotation (Line(
+        points={{-40,0},{100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(initAngle.angle, derd.u) annotation (Line(
+        points={{-50,-11},{-50,-20},{-22,-20}},
+        color={0,0,127}));
+    connect(derd.y, derdd.u) annotation (Line(
+        points={{1,-20},{18,-20}},
+        color={0,0,127}));
+    connect(zeroForceAndTorque1.frame_a, frame_a) annotation (Line(
+        points={{-80,-40},{-88,-40},{-88,0},{-100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(zeroForceAndTorque2.frame_a, frame_b) annotation (Line(
+        points={{80,-40},{90,-40},{90,0},{100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(initAngularVelocity.w_rel_b, derz.u) annotation (Line(
+        points={{1,30},{18,30}},
+        color={0,0,127}));
+    connect(frame_a, arrow.frame_a)       annotation (Line(
+        points={{-100,0},{-88,0},{-88,70},{-80,70}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(initPosition.r_rel_a, arrow.r_head)       annotation (Line(
+        points={{1,70},{10,70},{10,52},{-70,52},{-70,58}},
+        color={0,0,127}));
+    annotation (
+      Documentation(info="<html>
+<p>
+Joint which does not constrain the motion between frame_a and frame_b.
+Such a joint is meaningful if the <b>relative</b> distance and orientation
+between frame_a and frame_b, and their derivatives, shall be used
+as <b>states</b> or shall be used for non-standard
+<b>initialization</b>. This joint allows to <b>initialize</b>
+every <b>scalar</b> element of the relative quantities, as well
+as to define <b>StateSelect</b> attributes for every
+<b>scalar</b> element separately.
+</p>
+
+<p>
+In the following figure the animation of a FreeMotionScalarInit
+joint is shown. The light blue coordinate system is
+frame_a and the dark blue coordinate system is
+frame_b of the joint.
+(here: r_rel_a_1(start = 0.5), r_rel_a_2(start = 0), r_rel_a_3(start = 0.5),
+       angle_1(start = 45<sup>o</sup>), angle_2(start = 45<sup>o</sup>), angle_3(start = 45<sup>o</sup>)).
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/FreeMotion.png\">
+</p>
+
+<p>
+A example to use this joint for the initialization of a planar double pendulum by providing
+its tip position, is shown in
+<a href=\"modelica://Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip\">Examples.Elementary.DoublePendulumInitTip</a>.
+</p>
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(
+            points={{-86,31},{-74,61},{-49,83},{-17,92},{19,88},{40,69},{59,48}},
+            color={160,160,164},
+            thickness=0.5,
+            smooth=Smooth.Bezier),
+          Polygon(
+            points={{90,0},{50,20},{50,-20},{90,0}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            points={{69,58},{49,40},{77,28},{69,58}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{150,-44},{-150,-84}},
+            lineColor={0,0,255},
+            textString="%name"),
+          Rectangle(
+            extent={{-70,-5},{-90,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{50,-5},{30,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{11,-5},{-9,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-30,-5},{-50,5}},
+            lineColor={0,0,0},
+            fillColor={192,192,192},
+            fillPattern=FillPattern.Solid)}));
+  end FreeMotionScalarInit;
+
+  model SphericalSpherical
+    "Spherical - spherical joint aggregation (1 constraint, no potential states) with an optional point mass in the middle"
+
+    import Modelica.Mechanics.MultiBody.Types;
+    extends Interfaces.PartialTwoFrames;
+
+    parameter Boolean animation=true "= true, if animation shall be enabled";
+    parameter Boolean showMass=true
+      "= true, if mass shall be shown (provided animation = true and m > 0)";
+    parameter Boolean computeRodLength=false
+      "= true, if rodLength shall be computed during initialization (see info)";
+    parameter SI.Length rodLength(
+      min=Modelica.Constants.eps,
+      fixed=not computeRodLength, start = 1)
+      "Distance between the origins of frame_a and frame_b (if computeRodLength=true, guess value)";
+    parameter SI.Mass m(min=0)=0
+      "Mass of rod (= point mass located in middle of rod)";
+    parameter SI.Diameter sphereDiameter=world.defaultJointLength
+      "Diameter of spheres representing the spherical joints"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of spheres representing the spherical joints"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Diameter rodDiameter=sphereDiameter/Types.Defaults.JointRodDiameterFraction
+      "Diameter of rod connecting the two spherical joint"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color rodColor=Modelica.Mechanics.MultiBody.Types.Defaults.RodColor
+      "Color of rod connecting the two spherical joints"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Diameter massDiameter=sphereDiameter
+      "Diameter of sphere representing the mass point"
+      annotation (Dialog(tab=
+            "Animation", group="if animation = true and showMass = true and m > 0",
+            enable=animation and showMass and m > 0));
+    input Types.Color massColor=Modelica.Mechanics.MultiBody.Types.Defaults.BodyColor
+      "Color of sphere representing the mass point"  annotation (
+        Dialog(colorSelector=true, tab="Animation", group=
+            "if animation = true and showMass = true and m > 0",
+            enable=animation and showMass and m > 0));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+    parameter Boolean kinematicConstraint=true
+      "= false, if no constraint shall be defined, due to analytically solving a kinematic loop (\"false\" should not be used by user, but only by MultiBody.Joints.Assemblies joints)"
+      annotation (Dialog(tab="Advanced"));
+    Real constraintResidue = rRod_0*rRod_0 - rodLength*rodLength
+      "Constraint equation of joint in residue form: Either length constraint (= default) or equation to compute rod force (for analytic solution of loops in combination with Internal.RevoluteWithLengthConstraint/PrismaticWithLengthConstraint)"
+      annotation (Dialog(tab="Advanced", enable=not kinematicConstraint));
+    parameter Boolean checkTotalPower=false
+      "= true, if total power flowing into this component shall be determined (must be zero)"
+      annotation (Dialog(tab="Advanced"));
+
+    SI.Force f_rod
+      "Constraint force in direction of the rod (positive on frame_a, when directed from frame_a to frame_b)";
+    SI.Position rRod_0[3]
+      "Position vector from frame_a to frame_b resolved in world frame";
+    SI.Position rRod_a[3]
+      "Position vector from frame_a to frame_b resolved in frame_a";
+    Real eRod_a[3](each final unit="1")
+      "Unit vector in direction from frame_a to frame_b, resolved in frame_a";
+    SI.Position r_CM_0[3]
+      "Dummy if m==0, or position vector from world frame to mid-point of rod, resolved in world frame";
+    SI.Velocity v_CM_0[3] "First derivative of r_CM_0";
+    SI.Force f_CM_a[3]
+      "Dummy if m==0, or inertial force acting at mid-point of rod due to mass oint acceleration, resolved in frame_a";
+    SI.Force f_CM_e[3]
+      "Dummy if m==0, or projection of f_CM_a onto eRod_a, resolved in frame_a";
+    SI.Force f_b_a1[3]
+      "Force acting at frame_b, but without force in rod, resolved in frame_a";
+    SI.Power totalPower
+      "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+  protected
+    Visualizers.Advanced.Shape shape_rod(
+      shapeType="cylinder",
+      color=rodColor,
+      specularCoefficient=specularCoefficient,
+      length=rodLength,
+      width=rodDiameter,
+      height=rodDiameter,
+      lengthDirection=eRod_a,
+      widthDirection={0,1,0},
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+    Visualizers.Advanced.Shape shape_a(
+      shapeType="sphere",
+      color=sphereColor,
+      specularCoefficient=specularCoefficient,
+      length=sphereDiameter,
+      width=sphereDiameter,
+      height=sphereDiameter,
+      lengthDirection=eRod_a,
+      widthDirection={0,1,0},
+      r_shape=-eRod_a*(sphereDiameter/2),
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+    Visualizers.Advanced.Shape shape_b(
+      shapeType="sphere",
+      color=sphereColor,
+      specularCoefficient=specularCoefficient,
+      length=sphereDiameter,
+      width=sphereDiameter,
+      height=sphereDiameter,
+      lengthDirection=eRod_a,
+      widthDirection={0,1,0},
+      r_shape=eRod_a*(rodLength - sphereDiameter/2),
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation;
+    Visualizers.Advanced.Shape shape_mass(
+      shapeType="sphere",
+      color=massColor,
+      specularCoefficient=specularCoefficient,
+      length=massDiameter,
+      width=massDiameter,
+      height=massDiameter,
+      lengthDirection=eRod_a,
+      widthDirection={0,1,0},
+      r_shape=eRod_a*(rodLength/2 - sphereDiameter/2),
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation and showMass and m > 0;
+  equation
+    // Determine relative position vector between the two frames
+    if kinematicConstraint then
+      rRod_0 = transpose(frame_b.R.T)*(frame_b.R.T*frame_b.r_0) - transpose(
+        frame_a.R.T)*(frame_a.R.T*frame_a.r_0);
+    else
+      rRod_0 = frame_b.r_0 - frame_a.r_0;
+    end if;
+
+    //rRod_0 = frame_b.r_0 - frame_a.r_0;
+    rRod_a = Frames.resolve2(frame_a.R, rRod_0);
+    eRod_a = rRod_a/rodLength;
+
+    // Constraint equation
+    constraintResidue = 0;
+
+    // Cut-torques at frame_a and frame_b
+    frame_a.t = zeros(3);
+    frame_b.t = zeros(3);
+
+    /* Force and torque balance of rod
+     - Kinematics for center of mass CM of mass point
+       r_CM_0 = frame_a.r_0 + rRod_0/2;
+       v_CM_0 = der(r_CM_0);
+       a_CM_a = resolve2(frame_a.R, der(v_CM_0) - world.gravityAcceleration(r_CM_0));
+     - Inertial and gravity force in direction (f_CM_e) and orthogonal (f_CM_n) to rod
+       f_CM_a = m*a_CM_a
+       f_CM_e = f_CM_a*eRod_a;           // in direction of rod
+       f_CM_n = rodLength(f_CM_a - f_CM_e);  // orthogonal to rod
+     - Force balance in direction of rod
+       f_CM_e = fa_rod_e + fb_rod_e;
+     - Force balance orthogonal to rod
+       f_CM_n = fa_rod_n + fb_rod_n;
+     - Torque balance with respect to frame_a
+       0 = (-f_CM_n)*rodLength/2 + fb_rod_n*rodLength
+     The result is:
+     fb_rod_n = f_CM_n/2;
+     fa_rod_n = fb_rod_n;
+     fb_rod_e = f_CM_e - fa_rod_e;
+     fa_rod_e is the unknown computed from loop
+  */
+
+      // f_b_a1 is needed in aggregation joints to solve kinematic loops analytically
+    if m > 0 then
+      r_CM_0 = frame_a.r_0 + rRod_0/2;
+      v_CM_0 = der(r_CM_0);
+      f_CM_a = m*Frames.resolve2(frame_a.R, der(v_CM_0) -
+        world.gravityAcceleration(r_CM_0));
+      f_CM_e = (f_CM_a*eRod_a)*eRod_a;
+      frame_a.f = (f_CM_a - f_CM_e)/2 + f_rod*eRod_a;
+      f_b_a1 = (f_CM_a + f_CM_e)/2;
+      frame_b.f = Frames.resolveRelative(f_b_a1 - f_rod*eRod_a, frame_a.R,
+        frame_b.R);
+    else
+      r_CM_0 = zeros(3);
+      v_CM_0 = zeros(3);
+      f_CM_a = zeros(3);
+      f_CM_e = zeros(3);
+      f_b_a1 = zeros(3);
+      frame_a.f = f_rod*eRod_a;
+      frame_b.f = -Frames.resolveRelative(frame_a.f, frame_a.R, frame_b.R);
+    end if;
+
+    if checkTotalPower then
+      totalPower = frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+        frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) + (-m)*(der(
+        v_CM_0) - world.gravityAcceleration(r_CM_0))*v_CM_0 + frame_a.t*
+        Frames.angularVelocity2(frame_a.R) + frame_b.t*Frames.angularVelocity2(
+        frame_b.R);
+    else
+      totalPower = 0;
+    end if;
+    annotation (
+      Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Ellipse(
+            extent={{-95,-40},{-15,40}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-84,-30},{-24,30}},
+            lineColor={0,0,0},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{15,-40},{95,40}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{25,-29},{85,30}},
+            lineColor={128,128,128},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-150,90},{150,50}},
+            textString="%name",
+            lineColor={0,0,255}),
+          Rectangle(
+            extent={{-40,40},{41,-41}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-51,6},{48,-4}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-68,15},{-39,-13}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{39,14},{68,-14}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Text(
+            extent={{-150,-60},{150,-90}},
+            lineColor={0,0,0},
+            textString="%rodLength")}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Ellipse(
+            extent={{-98,-40},{-18,40}},
+            lineColor={0,0,0},
+            fillColor={160,160,164},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{-88,-30},{-28,30}},
+            lineColor={160,160,164},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{18,-40},{98,40}},
+            lineColor={160,160,164},
+            fillColor={160,160,164},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{29,-30},{89,29}},
+            lineColor={192,192,192},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-56,-60},{46,-60}}, color={0,0,255}),
+          Polygon(
+            points={{56,-60},{41,-54},{41,-66},{56,-60}},
+            lineColor={0,0,255},
+            fillColor={0,0,255},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-37,-63},{33,-79}},
+            textString="rodLength",
+            lineColor={0,0,255}),
+          Rectangle(
+            extent={{-40,41},{40,-40}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-51,6},{48,-4}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-71,15},{-42,-13}},
+            lineColor={0,0,0},
+            fillColor={0,0,0},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{42,14},{71,-14}},
+            lineColor={0,0,0},
+            fillColor={0,0,0},
+            fillPattern=FillPattern.Solid),
+          Line(points={{-56,-71},{-56,1}}, color={0,0,255}),
+          Line(points={{56,-72},{56,0}}, color={0,0,255}),
+          Polygon(points={{11,1},{-1,4},{-1,-2},{11,1}}, lineColor={0,0,255}),
+          Line(points={{-56,1},{-1,1}}, color={0,0,255}),
+          Text(
+            extent={{-32,-4},{4,-29}},
+            lineColor={0,0,0},
+            textString="eRod_a")}),
+      Documentation(info="<html>
+<p>
+Joint that has a spherical joint on each of its two ends.
+The rod connecting the two spherical joints is approximated by a
+point mass that is located in the middle of the rod. When the mass
+is set to zero (default), special code for a massless body is generated.
+In the following default animation figure, the two spherical joints are
+represented by two red spheres, the connecting rod by a grey cylinder
+and the point mass in the middle of the rod by a light blue sphere:
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/SphericalSpherical.png\" ALT=\"model Joints.SphericalSpherical\">
+</p>
+
+<p>
+This joint introduces <b>one constraint</b> defining that the distance between
+the origin of frame_a and the origin of frame_b is constant (= rodLength).
+It is highly recommended to use this joint in loops
+whenever possible, because this enhances the efficiency
+considerably due to smaller systems of non-linear algebraic
+equations.
+</p>
+<p>
+It is sometimes desirable to <b>compute</b> the <b>rodLength</b>
+of the connecting rod during initialization. For this, parameter
+<b>computeLength</b> has to be set to <b>true</b> and instead <b>one</b> other,
+easier to determine, position variable in the same loop
+needs to have a fixed attribute of <b>true</b>. For example,
+if a loop consists of one Revolute joint, one Prismatic joint and
+a SphericalSpherical joint, one may fix the start values of the revolute
+joint angle and of the relative distance of the prismatic joint
+in order to compute the rodLength of the rod.
+</p>
+<p>
+It is not possible to connect other components, such as a body with mass
+properties or a special visual shape object to the rod connecting
+the two spherical joints. If this is needed, use instead joint Joints.<b>UniversalSpherical</b>
+that has this property.
+</p>
+</html>"));
+  end SphericalSpherical;
+
+  model UniversalSpherical
+    "Universal - spherical joint aggregation (1 constraint, no potential states)"
+
+    import Modelica.Mechanics.MultiBody.Types;
+
+    extends Interfaces.PartialTwoFrames;
+    Interfaces.Frame_a frame_ia
+      "Coordinate system at the origin of frame_a, fixed at the rod connecting the universal with the spherical joint"
+      annotation (Placement(transformation(
+          origin={-40,100},
+          extent={{-16,-16},{16,16}},
+          rotation=270)));
+    parameter Boolean animation=true "= true, if animation shall be enabled";
+    parameter Boolean showUniversalAxes=true
+      "= true, if universal joint shall be visualized with two cylinders, otherwise with a sphere (provided animation=true)";
+    parameter Boolean computeRodLength=false
+      "= true, if distance between frame_a and frame_b shall be computed during initialization (see info)";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n1_a={0,0,1}
+      "Axis 1 of universal joint resolved in frame_a (axis 2 is orthogonal to axis 1 and to rod)"
+      annotation (Evaluate=true);
+    parameter SI.Position rRod_ia[3]={1,0,0}
+      "Vector from origin of frame_a to origin of frame_b, resolved in frame_ia (if computeRodLength=true, rRod_ia is only an axis vector along the connecting rod)"
+      annotation (Evaluate=true);
+    parameter SI.Diameter sphereDiameter=world.defaultJointLength
+      "Diameter of spheres representing the universal and the spherical joint"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of spheres representing the universal and the spherical joint"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    parameter Types.ShapeType rodShapeType="cylinder"
+      "Shape type of rod connecting the universal and the spherical joint"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance rodWidth=sphereDiameter/Types.Defaults.JointRodDiameterFraction
+      "Width of rod shape in direction of axis 2 of universal joint."
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance rodHeight=rodWidth
+      "Height of rod shape in direction that is orthogonal to rod and to axis 2"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    parameter Types.ShapeExtra rodExtra=0.0
+      "Additional parameter depending on rodShapeType"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+    input Types.Color rodColor=Modelica.Mechanics.MultiBody.Types.Defaults.RodColor
+      "Color of rod shape connecting the universal and the spherical joints"
+      annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+    parameter SI.Distance cylinderLength=world.defaultJointLength
+      "Length of cylinders representing the two universal joint axes" annotation (
+       Dialog(tab="Animation", group="if animation = true and showUniversalAxes",
+                               enable=animation and showUniversalAxes));
+    parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+      "Diameter of cylinders representing the two universal joint axes"
+      annotation (Dialog(tab="Animation", group=
+            "if animation = true and showUniversalAxes",
+            enable=animation and showUniversalAxes));
+    input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+      "Color of cylinders representing the two universal joint axes" annotation (
+        Dialog(colorSelector=true, tab="Animation", group="if animation = true and showUniversalAxes",
+                                enable=animation and showUniversalAxes));
+    input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+      "Reflection of ambient light (= 0: light is completely absorbed)"
+      annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+    parameter Boolean kinematicConstraint=true
+      "= false, if no constraint shall be defined, due to analytically solving a kinematic loop"
+      annotation (Dialog(tab="Advanced"));
+    Real constraintResidue = rRod_0*rRod_0 - rodLength*rodLength
+      "Constraint equation of joint in residue form: Either length constraint (= default) or equation to compute rod force (for analytic solution of loops in combination with Internal.RevoluteWithLengthConstraint/PrismaticWithLengthConstraint)"
+      annotation (Dialog(tab="Advanced", enable=not kinematicConstraint));
+    parameter Boolean checkTotalPower=false
+      "= true, if total power flowing into this component shall be determined (must be zero)"
+      annotation (Dialog(tab="Advanced"));
+    SI.Force f_rod
+      "Constraint force in direction of the rod (positive, if rod is pressed)";
+    final parameter SI.Distance rodLength(fixed=false, start=Modelica.Math.Vectors.length(rRod_ia))
+      "Length of rod (distance between origin of frame_a and origin of frame_b)";
+    final parameter Real eRod_ia[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(rRod_ia)
+      "Unit vector from origin of frame_a to origin of frame_b, resolved in frame_ia";
+    final parameter Real e2_ia[3](each final unit="1")=Modelica.Math.Vectors.normalize(
+                                                   cross(n1_a, eRod_ia))
+      "Unit vector in direction of axis 2 of universal joint, resolved in frame_ia (orthogonal to n1_a and eRod_ia; note: frame_ia is parallel to frame_a when the universal joint angles are zero)";
+    final parameter Real e3_ia[3](each final unit="1")=cross(eRod_ia, e2_ia)
+      "Unit vector perpendicular to eRod_ia and e2_ia, resolved in frame_ia";
+    SI.Power totalPower
+      "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+    SI.Force f_b_a1[3]
+      "frame_b.f without f_rod part, resolved in frame_a (needed for analytic loop handling)";
+    Real eRod_a[3](each final unit="1")
+      "Unit vector in direction of rRod_a, resolved in frame_a (needed for analytic loop handling)";
+    SI.Position rRod_0[3](start=rRod_ia)
+      "Position vector from origin of frame_a to origin of frame_b resolved in world frame";
+    SI.Position rRod_a[3](start=rRod_ia)
+      "Position vector from origin of frame_a to origin of frame_b resolved in frame_a";
+
+  protected
+    SI.Force f_b_a[3] "frame_b.f resolved in frame_a";
+    SI.Force f_ia_a[3] "frame_ia.f resolved in frame_a";
+    SI.Torque t_ia_a[3] "frame_ia.t resolved in frame_a";
+    Real n2_a[3](each final unit="1")
+      "Vector in direction of axis 2 of the universal joint (e2_ia), resolved in frame_a";
+    Real length2_n2_a(start=1, unit="1") "Square of length of vector n2_a";
+    Real length_n2_a(unit="1") "Length of vector n2_a";
+    Real e2_a[3](each final unit="1")
+      "Unit vector in direction of axis 2 of the universal joint (e2_ia), resolved in frame_a";
+    Real e3_a[3](each final unit="1")
+      "Unit vector perpendicular to eRod_ia and e2_a, resolved in frame_a";
+    Real der_rRod_a_L[3](each unit="1/s") "= der(rRod_a)/rodLength";
+    SI.AngularVelocity w_rel_ia1[3];
+    Frames.Orientation R_rel_ia1;
+    Frames.Orientation R_rel_ia2;
+    // Real T_rel_ia[3, 3];
+    Frames.Orientation R_rel_ia "Rotation from frame_a to frame_ia";
+
+    Visualizers.Advanced.Shape rodShape(
+      shapeType=rodShapeType,
+      color=rodColor,
+      specularCoefficient=specularCoefficient,
+      length=rodLength,
+      width=rodWidth,
+      height=rodHeight,
+      lengthDirection=eRod_ia,
+      widthDirection=e2_ia,
+      r=frame_ia.r_0,
+      R=frame_ia.R) if world.enableAnimation and animation;
+    Visualizers.Advanced.Shape sphericalShape_b(
+      shapeType="sphere",
+      color=sphereColor,
+      specularCoefficient=specularCoefficient,
+      length=sphereDiameter,
+      width=sphereDiameter,
+      height=sphereDiameter,
+      lengthDirection={1,0,0},
+      widthDirection={0,1,0},
+      r_shape={-0.5,0,0}*sphereDiameter,
+      r=frame_b.r_0,
+      R=frame_b.R) if world.enableAnimation and animation;
+    Visualizers.Advanced.Shape sphericalShape_a(
+      shapeType="sphere",
+      color=sphereColor,
+      specularCoefficient=specularCoefficient,
+      length=sphereDiameter,
+      width=sphereDiameter,
+      height=sphereDiameter,
+      lengthDirection={1,0,0},
+      widthDirection={0,1,0},
+      r_shape={-0.5,0,0}*sphereDiameter,
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation and not showUniversalAxes;
+    Visualizers.Advanced.Shape universalShape1(
+      shapeType="cylinder",
+      color=cylinderColor,
+      specularCoefficient=specularCoefficient,
+      length=cylinderLength,
+      width=cylinderDiameter,
+      height=cylinderDiameter,
+      lengthDirection=n1_a,
+      widthDirection={0,1,0},
+      r_shape=-n1_a*(cylinderLength/2),
+      r=frame_a.r_0,
+      R=frame_a.R) if world.enableAnimation and animation and showUniversalAxes;
+    Visualizers.Advanced.Shape universalShape2(
+      shapeType="cylinder",
+      color=cylinderColor,
+      specularCoefficient=specularCoefficient,
+      length=cylinderLength,
+      width=cylinderDiameter,
+      height=cylinderDiameter,
+      lengthDirection=e2_ia,
+      widthDirection={0,1,0},
+      r_shape=-e2_ia*(cylinderLength/2),
+      r=frame_ia.r_0,
+      R=frame_ia.R) if world.enableAnimation and animation and showUniversalAxes;
+
+  initial equation
+  if not computeRodLength then
+    rodLength = Modelica.Math.Vectors.length(rRod_ia);
+  end if;
+
+  equation
+    Connections.branch(frame_a.R, frame_ia.R);
+    if kinematicConstraint then
+      rRod_0 = transpose(frame_b.R.T)*(frame_b.R.T*frame_b.r_0) - transpose(
+        frame_a.R.T)*(frame_a.R.T*frame_a.r_0);
+    else
+      rRod_0 = frame_b.r_0 - frame_a.r_0;
+    end if;
+    //rRod_0 = frame_b.r_0 - frame_a.r_0;
+    rRod_a = Frames.resolve2(frame_a.R, rRod_0);
+
+    // Constraint equation
+    constraintResidue = 0;
+
+    /* Determine relative Rotation R_rel_ia from frame_a to frame_ia
+     and absolute rotation of frame_a.R.
+  */
+    eRod_a = rRod_a/rodLength;
+    n2_a = cross(n1_a, eRod_a);
+    length2_n2_a = n2_a*n2_a;
+
+    assert(length2_n2_a > 1.e-10, "
+A Modelica.Mechanics.MultiBody.Joints.UniversalSpherical joint (consisting of
+a universal joint and a spherical joint connected together
+by a rigid rod) is in the singular configuration of the
+universal joint. This means that axis 1 of the universal
+joint defined via parameter \"n1_a\" is parallel to vector
+\"rRod_ia\" that is directed from the origin of frame_a to the
+origin of frame_b.
+   You may try to use another \"n1_a\" vector. If this fails,
+use instead Modelica.Mechanics.MultiBody.Joints.SphericalSpherical, if this is
+possible, because this joint aggregation does not have a
+singular configuration.
+");
+
+    length_n2_a = sqrt(length2_n2_a);
+    e2_a = n2_a/length_n2_a;
+    e3_a = cross(eRod_a, e2_a);
+
+    /* The statements below are an efficient implementation of the
+   original equations:
+     T_rel_ia = [eRod_ia, e2_ia, e3_ia]*transpose([eRod_a, e2_a, e3_a]);
+     R_rel_ia = Frames.from_T(T_rel_ia,
+                   Frames.TransformationMatrices.angularVelocity2(T_rel_ia, der(T_rel_ia)));
+   To perform this, the rotation is split into two parts:
+     R_rel_ia : Rotation object from frame_a to frame_ia
+     R_rel_ia1: Rotation object from frame_a to frame_ia1
+                (frame that is fixed in frame_ia such that x-axis
+                is along the rod axis)
+                T = transpose([eRod_a, e2_a, e3_a]; w = w_rel_ia1
+     R_rel_ia2: Fixed rotation object from frame_ia1 to frame_ia
+                T = [eRod_ia, e2_ia, e3_ia]; w = zeros(3)
+
+   The difficult part is to compute w_rel_ia1:
+      w_rel_ia1 = [  e3_a*der(e2_a);
+                    -e3_a*der(eRod_a);
+                     e2_a*der(eRod_a)]
+   der(eRod_a) is directly given, since eRod_a is a function
+   of translational quantities only.
+      der(eRod_a) = (der(rRod_a) - eRod_a*(eRod_a*der(rRod_a)))/rodLength
+      der(n2_a)   = cross(n1_a, der(eRod_a))
+      der(e2_a)   = (der(n2_a) - e2_a*(e2_a*der(n2_a)))/length_n2_a
+   Inserting these equations in w_rel_ia1 results in:
+      e3_a*der(eRod_a) = e3_a*der(rRod_a)/rodLength       // e3_a*eRod_a = 0
+      e2_a*der(eRod_a) = e2_a*der(rRod_a)/rodLength       // e2_a*eRod_a = 0
+      e3_a*der(e2_a)   = e3_a*der(n2_a)/length_n2_a       // e3_a*e2_a = 0
+                       = e3_a*cross(n1_a, der(eRod_a))/length_n2_a
+                       = e3_a*cross(n1_a, der(rRod_a) - eRod_a*(eRod_a*der(rRod_a)))/(length_n2_a*rodLength)
+                       = e3_a*cross(n1_a, der(rRod_a))/(length_n2_a*rodLength)
+   Furthermore, we have:
+     rRod_a            = resolve2(frame_a.R, rRod_0);
+     der(rRod_a)       = resolve2(frame_a.R, der(rRod_0)) - cross(frame_a.R.w, rRod_a));
+*/
+    der_rRod_a_L = (Frames.resolve2(frame_a.R, der(rRod_0)) - cross(frame_a.R.w,
+       rRod_a))/rodLength;
+    w_rel_ia1 = {e3_a*cross(n1_a, der_rRod_a_L)/length_n2_a,-e3_a*der_rRod_a_L,
+      e2_a*der_rRod_a_L};
+    R_rel_ia1 = Frames.from_T(transpose([eRod_a, e2_a, e3_a]), w_rel_ia1);
+    R_rel_ia2 = Frames.from_T([eRod_ia, e2_ia, e3_ia], zeros(3));
+    R_rel_ia = Frames.absoluteRotation(R_rel_ia1, R_rel_ia2);
+    /*
+  T_rel_ia = [eRod_ia, e2_ia, e3_ia]*transpose([eRod_a, e2_a, e3_a]);
+  R_rel_ia = Frames.from_T(T_rel_ia,
+    Frames.TransformationMatrices.angularVelocity2(T_rel_ia, der(T_rel_ia)));
+*/
+
+    // Compute kinematic quantities of frame_ia
+    frame_ia.r_0 = frame_a.r_0;
+    frame_ia.R = Frames.absoluteRotation(frame_a.R, R_rel_ia);
+
+    /* In the following formulas f_a, f_b, f_ia, t_a, t_b, t_ia are
+     the forces and torques at frame_a, frame_b, frame_ia, respectively,
+     resolved in frame_a. e_x, e_y, e_z are the unit vectors resolved in frame_a.
+     Torque balance at the rod around the origin of frame_a:
+       0 = t_a + t_ia + cross(rRod_a, f_b)
+     with
+         rRod_a = rodLength*e_x
+         f_b     = -f_rod*e_x + f_b[2]*e_y + f_b[3]*e_z
+     follows:
+       0 = t_a + t_ia + rodLength*(f_b[2]*e_z - f_b[3]*e_y)
+     The projection of t_a with respect to universal joint axes vanishes:
+       n1_a*t_a = 0
+       e_y*t_a = 0
+     Therefore:
+        0 = n1_a*t_ia + rodLength*f_b[2]*(n1_a*e_z)
+        0 = e_y*t_ia - rodLength*f_b[3]
+     or
+        f_b = -f_rod*e_x - e_y*(n1_a*t_ia)/(rodLength*(n1_a*e_z)) + e_z*(e_y*t_ia)/rodLength
+     Force balance:
+        0 = f_a + f_b + f_ia
+  */
+    f_ia_a = Frames.resolve1(R_rel_ia, frame_ia.f);
+    t_ia_a = Frames.resolve1(R_rel_ia, frame_ia.t);
+
+      // f_b_a1 is needed in aggregation joints to solve kinematic loops analytically
+    f_b_a1 = -e2_a*((n1_a*t_ia_a)/(rodLength*(n1_a*e3_a))) + e3_a*((e2_a*t_ia_a)
+      /rodLength);
+    f_b_a = -f_rod*eRod_a + f_b_a1;
+    frame_b.f = Frames.resolveRelative(f_b_a, frame_a.R, frame_b.R);
+    frame_b.t = zeros(3);
+    zeros(3) = frame_a.f + f_b_a + f_ia_a;
+    zeros(3) = frame_a.t + t_ia_a + cross(rRod_a, f_b_a);
+
+    // Measure power for test purposes
+    if checkTotalPower then
+      totalPower = frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+        frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) + frame_ia.f*
+        Frames.resolve2(frame_ia.R, der(frame_ia.r_0)) + frame_a.t*
+        Frames.angularVelocity2(frame_a.R) + frame_b.t*Frames.angularVelocity2(
+        frame_b.R) + frame_ia.t*Frames.angularVelocity2(frame_ia.R);
+    else
+      totalPower = 0;
+    end if;
+    annotation (
+      Documentation(info="<html>
+<p>
+This component consists of a <b>universal joint</b> at frame_a and
+a <b>spherical joint</b> at frame_b that are connected together with
+a <b>rigid rod</b>, see default animation figure (the arrows are not
+part of the default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/UniversalSpherical.png\" ALT=\"model Joints.UniversalSpherical\">
+</p>
+
+<p>
+This joint aggregation has no mass and no inertia and introduces the constraint
+that the distance between the origin of frame_a and the origin of frame_b is constant
+(= Frames.length(rRod_ia)). The universal joint is defined in the following way:
+</p>
+
+<ul>
+<li> The rotation <b>axis</b> of revolute joint <b>1</b> is along parameter
+     vector n1_a which is fixed in frame_a.</li>
+<li> The rotation <b>axis</b> of revolute joint <b>2</b> is perpendicular to
+     axis 1 and to the line connecting the universal and the spherical joint.</li>
+</ul>
+<p>
+The definition of axis 2 of the universal joint is performed according
+to the most often occurring case. In a future release, axis 2 might
+be explicitly definable via a parameter. However, the treatment is much more
+complicated and the number of operations is considerably higher,
+if axis 2 is not orthogonal to axis 1 and to the connecting rod.
+</p>
+<p>
+Note, there is a <b>singularity</b> when axis 1 and the connecting rod are parallel
+to other. Therefore, if possible n1_a should be selected in such a way that it
+is perpendicular to rRod_ia in the initial configuration (i.e., the
+distance to the singularity is as large as possible).
+</p>
+<p>
+An additional <b>frame_ia</b> is present. It is <b>fixed</b> in the connecting
+<b>rod</b> at the origin of <b>frame_a</b>. The placement of frame_ia on the rod
+is implicitly defined by the universal joint (frame_a and frame_ia coincide
+when the angles of the two revolute joints of the universal joint are zero)
+and by parameter vector <b>rRod_ia</b>, the position vector
+from the origin of frame_a to the origin of frame_b, resolved in frame_<b>ia</b>.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to other (alternatively,
+at least frame_a and frame_ia of the UniversalSpherical joint
+should be parallel to other when defining an instance of this
+component). Since frame_a and frame_ia are parallel to other,
+vector <b>rRod_ia</b> from frame_a to frame_b resolved in frame_<b>ia</b> can be resolved
+in frame_<b>a</b> (or the <b>world frame</b>, if all frames are parallel to other).
+</p>
+<p>
+This joint aggregation can be used in cases where
+in reality a rod with spherical joints at end are present.
+Such a system has an additional degree of freedom to rotate
+the rod along its axis. In practice this rotation is usually
+of no interest and is mathematically removed by replacing one
+of the spherical joints by a universal joint. Still, in most
+cases the Joints.SphericalSpherical joint aggregation can be used instead
+of the UniversalSpherical joint
+since the rod is animated and its mass properties are approximated by
+a point mass in the middle of the rod. The SphericalSpherical joint
+has the advantage that it does not have a singular configuration.
+</p>
+<p>
+In the public interface of the UniversalSpherical joint, the following
+(final) <b>parameters</b> are provided:
+</p>
+<pre>
+  <b>parameter</b> Real rodLength(unit=\"m\")  \"Length of rod\";
+  <b>parameter</b> Real eRod_ia[3] \"Unit vector along rod, resolved in frame_ia\";
+  <b>parameter</b> Real e2_ia  [3] \"Unit vector along axis 2, resolved in frame_ia\";
+</pre>
+<p>
+This allows a more convenient definition of data which is related to the rod.
+For example, if a box shall be connected at frame_ia directing from
+the origin of frame_a to the middle of the rod, this might be defined as:
+</p>
+<pre>
+    Modelica.Mechanics.MultiBody.Joints.UniversalSpherical jointUS(rRod_ia={1.2, 1, 0.2});
+    Modelica.Mechanics.MultiBody.Visualizers.FixedShape    shape(shapeType       = \"box\",
+                                              lengthDirection = jointUS.eRod_ia,
+                                              widthDirection  = jointUS.e2_ia,
+                                              length          = jointUS.rodLength/2,
+                                              width           = jointUS.rodLength/10);
+  <b>equation</b>
+    <b>connect</b>(jointUS.frame_ia, shape.frame_a);
+</pre>
+</html>"),   Icon(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Text(
+            extent={{-150,-50},{150,-90}},
+            lineColor={0,0,255},
+            textString="%name"),
+          Ellipse(
+            extent={{-100,-40},{-19,40}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-90,-30},{-29,29}},
+            lineColor={160,160,164},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-60,41},{-9,-44}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Line(
+            points={{-60,40},{-60,-40}},
+            thickness=0.5),
+          Ellipse(
+            extent={{-83,-17},{-34,21}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-74,-12},{-40,15}},
+            lineColor={160,160,164},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            points={{-72,-20},{-89,3},{-69,25},{-45,27},{-72,-20}},
+            pattern=LinePattern.None,
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(
+            points={{-60,40},{-60,-10}},
+            thickness=0.5),
+          Line(
+            points={{-49,20},{-69,-15}},
+            thickness=0.5),
+          Ellipse(
+            extent={{44,14},{73,-14}},
+            lineColor={0,0,0},
+            fillColor={0,0,0},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{20,-40},{100,40}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{30,-30},{90,30}},
+            lineColor={192,192,192},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-22,45},{40,-43}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{46,14},{75,-14}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Rectangle(
+            extent={{-36,-8},{48,8}},
+            lineColor={0,0,0},
+            pattern=LinePattern.None,
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Text(
+            extent={{-105,118},{-67,86}},
+            lineColor={128,128,128},
+            textString="ia"),
+          Text(
+            extent={{-24,95},{167,65}},
+            lineColor={0,0,0},
+            textString="%rRod_ia"),
+          Line(
+            points={{-40,101},{-40,60},{-60,1}},
+            color={128,128,128},
+            thickness=0.5)}),
+      Diagram(coordinateSystem(
+          preserveAspectRatio=true,
+          extent={{-100,-100},{100,100}}), graphics={
+          Line(points={{-60,-70},{46,-70}}, color={0,0,255}),
+          Polygon(
+            points={{60,-70},{45,-64},{45,-76},{60,-70}},
+            lineColor={0,0,255},
+            fillColor={0,0,255},
+            fillPattern=FillPattern.Solid),
+          Text(
+            extent={{-56,-71},{56,-90}},
+            textString="rRod",
+            lineColor={0,0,255}),
+          Ellipse(
+            extent={{-100,-40},{-19,40}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-90,-30},{-29,29}},
+            lineColor={160,160,164},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-60,41},{-19,-41}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Line(
+            points={{-60,40},{-60,-40}},
+            thickness=0.5),
+          Ellipse(
+            extent={{-83,-17},{-34,21}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{-74,-12},{-40,15}},
+            lineColor={160,160,164},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Polygon(
+            points={{-72,-20},{-89,3},{-69,25},{-45,27},{-72,-20}},
+            pattern=LinePattern.None,
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid,
+            lineColor={0,0,255}),
+          Line(
+            points={{-60,40},{-60,-10}},
+            thickness=0.5),
+          Line(
+            points={{-49,20},{-69,-15}},
+            thickness=0.5),
+          Polygon(points={{7,-1},{-5,2},{-5,-4},{7,-1}}, lineColor={0,0,255}),
+          Line(points={{-50,19},{-30,57}}, color={0,0,255}),
+          Text(
+            extent={{-34,78},{8,62}},
+            lineColor={0,0,0},
+            textString="e2"),
+          Polygon(points={{-25,64},{-33,56},{-27,53},{-25,64}}, lineColor={0,0,
+                255}),
+          Line(points={{-60,41},{-60,65}}, color={0,0,255}),
+          Polygon(points={{-60,75},{-64,63},{-56,63},{-60,75}}, lineColor={0,0,
+                255}),
+          Text(
+            extent={{-93,82},{-64,62}},
+            lineColor={0,0,0},
+            textString="n1"),
+          Line(points={{-60,-40},{-60,-72}}, color={0,0,255}),
+          Ellipse(
+            extent={{20,-40},{100,40}},
+            lineColor={0,0,0},
+            fillPattern=FillPattern.Sphere,
+            fillColor={192,192,192}),
+          Ellipse(
+            extent={{30,-30},{90,30}},
+            lineColor={192,192,192},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-22,45},{40,-43}},
+            lineColor={255,255,255},
+            fillColor={255,255,255},
+            fillPattern=FillPattern.Solid),
+          Ellipse(
+            extent={{45,14},{74,-14}},
+            lineColor={0,0,0},
+            fillColor={0,0,0},
+            fillPattern=FillPattern.Solid),
+          Rectangle(
+            extent={{-36,-8},{48,8}},
+            lineColor={0,0,0},
+            pattern=LinePattern.None,
+            fillPattern=FillPattern.HorizontalCylinder,
+            fillColor={192,192,192}),
+          Text(
+            extent={{-31,-7},{0,-28}},
+            lineColor={0,0,0},
+            textString="eRod"),
+          Line(points={{-60,0},{-5,0}}, color={0,0,255}),
+          Polygon(points={{7,0},{-5,3},{-5,-3},{7,0}}, lineColor={0,0,255}),
+          Line(points={{60,-1},{60,-72}}, color={0,0,255}),
+          Line(
+            points={{-40,100},{-40,70},{-60,0}},
+            color={128,128,128},
+            thickness=0.5),
+          Text(
+            extent={{-23,30},{26,10}},
+            textString=" eRod*e2 = 0;  n1*e2 = 0",
+            lineColor={0,0,255})}));
+  end UniversalSpherical;
+
+  model GearConstraint "Ideal 3-dim. gearbox (arbitrary shaft directions)"
+    import Modelica.Mechanics.MultiBody.Frames;
+    extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+    Interfaces.Frame_a bearing "Coordinate system fixed in the bearing"
+     annotation (Placement(transformation(
+          origin={0,-100},
+          extent={{-16,-16},{16,16}},
+          rotation=90)));
+
+    parameter Real ratio(start=2) "Gear speed ratio";
+
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n_a={1,0,0}
+      "Axis of rotation of shaft a (same coordinates in frame_a, frame_b, bearing)";
+    parameter Modelica.Mechanics.MultiBody.Types.Axis n_b={1,0,0}
+      "Axis of rotation of shaft b (same coordinates in frame_a, frame_b, bearing)";
+
+    parameter Modelica.SIunits.Position r_a[3]={0,0,0}
+      "Vector from frame bearing to frame_a resolved in bearing";
+    parameter Modelica.SIunits.Position r_b[3]={0,0,0}
+      "Vector from frame bearing to frame_b resolved in bearing";
+    parameter StateSelect stateSelect=StateSelect.default
+      "Priority to use joint coordinates (phi_a, phi_b, w_a, w_b) as states" annotation(Dialog(tab="Advanced"));
+    parameter Boolean checkTotalPower=false
+      "= true, if total power flowing into this component shall be determined (must be zero)"
+      annotation (Dialog(tab="Advanced"));
+
+    SI.Angle phi_b(start=0, stateSelect=stateSelect)
+      "Relative rotation angle of revolute joint at frame_b";
+    SI.AngularVelocity w_b(start=0, stateSelect=stateSelect)
+      "First derivative of angle phi_b (relative angular velocity b)";
+    SI.AngularAcceleration a_b(start=0)
+      "Second derivative of angle phi_b (relative angular acceleration b)";
+    SI.Power totalPower
+      "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+    Modelica.Mechanics.MultiBody.Joints.Revolute actuatedRevolute_a(useAxisFlange=true, n=n_a, animation=false)
+      annotation (Placement(transformation(extent={{-40,-10},{-60,10}})));
+    Modelica.Mechanics.MultiBody.Joints.Revolute actuatedRevolute_b(useAxisFlange=true,n=n_b, animation=false)
+      annotation (Placement(transformation(extent={{40,-10},{60,10}})));
+    Modelica.Mechanics.Rotational.Components.IdealGear idealGear(
+                                                      ratio=ratio)
+      annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+    Modelica.Mechanics.MultiBody.Parts.FixedTranslation fixedTranslation1(animation=false, r=r_b)
+      annotation (Placement(transformation(extent={{10,-10},{30,10}})));
+    Modelica.Mechanics.MultiBody.Parts.FixedTranslation fixedTranslation2(animation=false, r=r_a)
+      annotation (Placement(transformation(
+          origin={-20,0},
+          extent={{-10,-10},{10,10}},
+          rotation=180)));
+  equation
+    /* Implementation notes:
+
+     The GearConstraint model consists primarily of two revolute joints that are
+     connected together and to a support/mounting. In this first phase the two
+     revolute joints can be rotated independently from each other and therefore
+     there are two degrees of freedom. If the rotational angles of these joints
+     would be used as generalized coordinates phi_a, phi_b with associated generalized
+     torques tau_a, tau_b (torques along the axes of rotations), then the equations
+     of motion (Kanes' equations or Lagranges' equations of the second kind) are
+     in the rows for phi_a, phi_b:
+        .... = ... + {...., tau_a, tau_b, ....}
+
+     Now the kinematic constraint for the gear is added:
+
+         0 = phi_a - ratio*phi_b;
+
+     or on velocity level:
+
+         0 = G * {der(phi_a), der(phi_b)};   G = [1, -ratio]
+
+     According to Lagranges' equations of the first kind, the generalized forces
+     must be replaced by G'*lambda, where lambda is the new constraint force
+     due this constraint. Therefore, the equations of motions are changed to
+
+       .... = .... + {...., G'*lambda, .....}
+
+     This is equivalent to add the equations
+
+       tau_a = lambda
+       tau_b = -ratio*lambda
+
+     or
+
+       0 = tau_b + ratio*tau_a;
+
+     The two equations
+
+       0 = phi_a - ratio*phi_b
+       0 = tau_b + ratio*tau_a
+
+     are completely identical to the equations of an ideal gear (without mounting)
+     that connects the axis flanges of the two revolute joints. This in turn
+     means that the two rotational flanges of the revolute joints just have to be
+     connected by an IdealGear component (without mounting).
+  */
+    assert(cardinality(bearing) > 0,
+      "Connector bearing of component is not connected");
+
+    phi_b = actuatedRevolute_b.phi;
+    w_b = der(phi_b);
+    a_b = der(w_b);
+
+    // Measure power for test purposes
+    if checkTotalPower then
+      totalPower =
+        frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+        frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) +
+        bearing.f*Frames.resolve2(bearing.R, der(bearing.r_0)) +
+        frame_a.t*Frames.angularVelocity2(frame_a.R) +
+        frame_b.t*Frames.angularVelocity2(frame_b.R) +
+        bearing.t*Frames.angularVelocity2(bearing.R);
+    else
+      totalPower = 0;
+    end if;
+
+    connect(actuatedRevolute_a.axis, idealGear.flange_a)
+      annotation (Line(points={{-50,10},{-50,40},{-10,40}}));
+    connect(idealGear.flange_b, actuatedRevolute_b.axis)
+      annotation (Line(points={{10,40},{50,40},{50,10}}));
+    connect(actuatedRevolute_a.frame_a,fixedTranslation2. frame_b) annotation (Line(
+        points={{-40,0},{-35,0},{-30,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(fixedTranslation2.frame_a, bearing) annotation (Line(
+        points={{-10,0},{-4,0},{0,0},{0,-100}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(fixedTranslation1.frame_a, bearing)
+      annotation (Line(
+        points={{10,0},{0,0},{0,-100}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(fixedTranslation1.frame_b, actuatedRevolute_b.frame_a)
+      annotation (Line(
+        points={{30,0},{40,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(frame_a, actuatedRevolute_a.frame_b)
+      annotation (Line(
+        points={{-100,0},{-80,0},{-80,0},{-60,0}},
+        color={95,95,95},
+        thickness=0.5));
+    connect(actuatedRevolute_b.frame_b, frame_b)
+      annotation (Line(
+        points={{60,0},{80,0},{80,0},{100,0}},
+        color={95,95,95},
+        thickness=0.5));
+    annotation (
+      Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100,-100},{100,100}}), graphics={
+        Text(origin = {0,-20},
+          lineColor = {0,0,255},
+          extent = {{-150,135},{150,175}},
+          textString = "%name"),
+        Text(origin = {0,12},
+          extent = {{-150,-94},{150,-64}},
+          textString = "%ratio"),
+        Rectangle(origin = {-35,60},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.HorizontalCylinder,
+          extent = {{-15,-40},{15,40}}),
+        Rectangle(origin = {-35,0},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.HorizontalCylinder,
+          extent = {{-15,-21},{15,21}}),
+        Line(points = {{-80,20},{-60,20}}),
+        Line(points = {{-80,-20},{-60,-20}}),
+        Line(points = {{-70,-20},{-70,-86}}),
+        Line(points = {{0,40},{0,-100}}),
+        Line(points = {{-10,40},{10,40}}),
+        Line(points = {{-10,80},{10,80}}),
+        Line(points = {{60,-20},{80,-20}}),
+        Line(points = {{60,20},{80,20}}),
+        Line(points = {{70,-20},{70,-86}}),
+        Rectangle(origin = {-75,0},
+          lineColor = {64,64,64},
+          fillColor = {191,191,191},
+          fillPattern = FillPattern.HorizontalCylinder,
+          extent = {{-25,-10},{25,10}}),
+        Rectangle(origin = {75,0},
+          lineColor = {64,64,64},
+          fillColor = {191,191,191},
+          fillPattern = FillPattern.HorizontalCylinder,
+          extent = {{-25,-10},{25,10}}),
+        Rectangle(origin = {-35,-19},
+          fillColor = {153,153,153},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-2},{15,2}}),
+        Rectangle(origin = {-35,-8},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {-35,19},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-2},{15,2}}),
+        Rectangle(origin = {-35,8},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {0,60},
+          lineColor = {64,64,64},
+          fillColor = {191,191,191},
+          fillPattern = FillPattern.HorizontalCylinder,
+          extent = {{-20,-10},{20,10}}),
+        Rectangle(origin = {-35,98},
+          fillColor = {153,153,153},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-2},{15,2}}),
+        Rectangle(origin = {-35,87},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {-35,50},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-4},{15,4}}),
+        Rectangle(origin = {-35,22},
+          fillColor = {102,102,102},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-2},{15,2}}),
+        Rectangle(origin = {-35,33},
+          fillColor = {153,153,153},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {-35,70},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-4},{15,4}}),
+        Rectangle(origin = {35,60},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.HorizontalCylinder,
+          extent = {{-15,-21},{15,21}}),
+        Rectangle(origin = {35,41},
+          fillColor = {153,153,153},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-2},{15,2}}),
+        Rectangle(origin = {35,52},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {35,79},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-2},{15,2}}),
+        Rectangle(origin = {35,68},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {35,0},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.HorizontalCylinder,
+          extent = {{-15,-40},{15,40}}),
+        Rectangle(origin = {35,38},
+          fillColor = {153,153,153},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-2},{15,2}}),
+        Rectangle(origin = {35,27},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {35,-10},
+          fillColor = {204,204,204},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-4},{15,4}}),
+        Rectangle(origin = {35,-27},
+          fillColor = {153,153,153},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-3},{15,3}}),
+        Rectangle(origin = {35,10},
+          fillColor = {255,255,255},
+          fillPattern = FillPattern.Solid,
+          extent = {{-15,-4},{15,4}}),
+        Rectangle(origin = {-35,40},
+          fillColor = {255,255,255},
+          extent = {{-15,-61},{15,60}}),
+        Rectangle(origin = {35,21},
+          fillColor = {255,255,255},
+          extent = {{-15,-61},{15,60}}),
+        Line(points = {{70,-86},{-70,-86}})}),
+      Documentation(info="<html>
+<p>This ideal massless joint provides a gear constraint between
+frames <code>frame_a</code> and <code>frame_b</code>. The axes of rotation
+of <code>frame_a</code> and <code>frame_b</code> may be arbitrary.</p>
+<p><b>Reference</b><br>
+<span style=\"font-variant:small-caps\">Schweiger</span>, Christian ;
+<span style=\"font-variant:small-caps\">Otter</span>, Martin:
+<a href=\"https://www.modelica.org/events/Conference2003/papers/h06_Schweiger_powertrains_v5.pdf\">Modelling
+3D Mechanical Effects of 1-dim. Powertrains</a>. In: <i>Proceedings of the 3rd International
+Modelica Conference</i>. Link&ouml;ping : The Modelica Association and Link&ouml;ping University,
+November 3-4, 2003, pp. 149-158</p>
+</html>"));
+  end GearConstraint;
+
+    model RollingWheel
+    "Joint (no mass, no inertia) that describes an ideal rolling wheel (rolling on the plane z=0)"
+
+    import Modelica.Mechanics.MultiBody.Frames;
+
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_a
+      "Frame fixed in wheel center point. x-Axis: upwards, y-axis: along wheel axis"
+        annotation (Placement(transformation(extent={{-16,-16},{16,16}})));
+
+      parameter SI.Radius wheelRadius "Wheel radius";
+      parameter StateSelect stateSelect=StateSelect.always
+      "Priority to use generalized coordinates as states"   annotation(HideResult=true,Evaluate=true);
+
+      SI.Position x(start=0, stateSelect=stateSelect)
+      "x-coordinate of wheel axis";
+
+      SI.Position y(start=0, stateSelect=stateSelect)
+      "y-coordinate of wheel axis";
+      SI.Position z;
+
+      SI.Angle angles[3](start={0,0,0}, each stateSelect=stateSelect)
+      "Angles to rotate world-frame in to frame_a around z-, y-, x-axis"
+        annotation(Dialog(group="Initialization", showStartAttribute=true));
+
+      SI.AngularVelocity der_angles[3](start={0,0,0}, each stateSelect=stateSelect)
+      "Derivative of angles"
+        annotation(Dialog(group="Initialization", showStartAttribute=true));
+
+       SI.Position r_road_0[3]
+      "Position vector from world frame to contact point on road, resolved in world frame";
+
+      // Contact force
+      SI.Force f_wheel_0[3]
+      "Contact force acting on wheel, resolved in world frame";
+      SI.Force f_n "Contact force acting on wheel in normal direction";
+      SI.Force f_lat "Contact force acting on wheel in lateral direction";
+      SI.Force f_long "Contact force acting on wheel in longitudinal direction";
+      SI.Position err
+      "|r_road_0 - frame_a.r_0| - wheelRadius (must be zero; used for checking)";
+  protected
+       Real e_axis_0[3] "Unit vector along wheel axis, resolved in world frame";
+       SI.Position delta_0[3](start={0,0,-wheelRadius})
+      "Distance vector from wheel center to contact point";
+
+       // Coordinate system at contact point
+       Real e_n_0[3]
+      "Unit vector in normal direction of road at contact point, resolved in world frame";
+       Real e_lat_0[3]
+      "Unit vector in lateral direction of wheel at contact point, resolved in world frame";
+       Real e_long_0[3]
+      "Unit vector in longitudinal direction of wheel at contact point, resolved in world frame";
+
+       // Road description
+       SI.Position s "Road surface parameter 1";
+       SI.Position w "Road surface parameter 2";
+       Real e_s_0[3]
+      "Road heading at (s,w), resolved in world frame (unit vector)";
+
+       // Slip velocities
+       SI.Velocity v_0[3] "Velocity of wheel center, resolved in world frame";
+       SI.AngularVelocity w_0[3]
+      "Angular velocity of wheel, resolved in world frame";
+
+       SI.Velocity vContact_0[3]
+      "Velocity of wheel contact point, resolved in world frame";
+
+       // Utility vectors
+       Real aux[3];
+
+    equation
+       // frame_a.R is computed from generalized coordinates
+       Connections.root(frame_a.R);
+       frame_a.r_0 = {x,y,z};
+       der_angles  = der(angles);
+       frame_a.R = Frames.axesRotations({3,2,1}, angles, der_angles);
+
+       // Road description
+       r_road_0 = {s,w,0};
+       e_n_0    = {0,0,1};
+       e_s_0    = {1,0,0};
+
+       // Coordinate system at contact point (e_long_0, e_lat_0, e_n_0)
+       e_axis_0  = Frames.resolve1(frame_a.R, {0,1,0});
+       aux       = cross(e_n_0, e_axis_0);
+       e_long_0 = aux / Modelica.Math.Vectors.length(aux);
+       e_lat_0  = cross(e_long_0, e_n_0);
+
+       // Determine point on road where the wheel is in contact with the road
+       delta_0 = r_road_0 - frame_a.r_0;
+       0 = delta_0*e_axis_0;
+       0 = delta_0*e_long_0;
+
+       // One holonomic positional constraint equation (no penetration in to the ground)
+       0 = wheelRadius - delta_0*cross(e_long_0, e_axis_0);
+
+       // only for testing
+       err = Modelica.Math.Vectors.length(delta_0) - wheelRadius;
+
+       // Slip velocities
+       v_0 = der(frame_a.r_0);
+       w_0 = Frames.angularVelocity1(frame_a.R);
+       vContact_0 = v_0 + cross(w_0, delta_0);
+
+       // Two non-holonomic constraint equations on velocity level (ideal rolling, no slippage)
+       0 = vContact_0*e_long_0;
+       0 = vContact_0*e_lat_0;
+
+       // Contact force
+       f_wheel_0 = f_n*e_n_0 + f_lat*e_lat_0 + f_long*e_long_0;
+
+       // Force and torque balance at the wheel center
+       zeros(3) = frame_a.f + Frames.resolve2(frame_a.R, f_wheel_0);
+       zeros(3) = frame_a.t + Frames.resolve2(frame_a.R, cross(delta_0, f_wheel_0));
+
+       // Guard against singularity
+       assert(abs(e_n_0*e_axis_0) < 0.99, "Wheel lays nearly on the ground (which is a singularity)");
+      annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
+                -100},{100,100}}), graphics={
+            Rectangle(
+              extent={{-100,-80},{100,-100}},
+              lineColor={0,0,0},
+              fillColor={175,175,175},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-154,124},{146,84}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Ellipse(
+              extent={{-80,80},{80,-80}},
+              lineColor={0,0,0},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid)}));
+    end RollingWheel;
+
+    model RollingWheelSet
+    "Joint (no mass, no inertia) that describes an ideal rolling wheel set (two ideal rolling wheels connected together by an axis)"
+     Modelica.Mechanics.MultiBody.Interfaces.Frame_a frameMiddle
+      "Frame fixed in middle of axis connecting both wheels (y-axis: along wheel axis, z-Axis: upwards)"
+        annotation (Placement(transformation(extent={{-16,16},{16,-16}}),
+            iconTransformation(extent={{-16,-16},{16,16}})));
+
+      parameter Boolean animation=true
+      "= true, if animation of wheel set shall be enabled";
+
+      parameter SI.Radius wheelRadius "Radius of one wheel";
+      parameter SI.Distance wheelDistance "Distance between the two wheels";
+
+      parameter StateSelect stateSelect = StateSelect.default
+      "Priority to use the generalized coordinates as states";
+
+      Modelica.SIunits.Position x(start=0, stateSelect=stateSelect)
+      "x coordinate for center between wheels";
+      Modelica.SIunits.Position y(start=0, stateSelect=stateSelect)
+      "y coordinate for center between wheels";
+      Modelica.SIunits.Angle phi(start=0, stateSelect=stateSelect)
+      "Orientation angle of wheel axis along z-axis";
+      Modelica.SIunits.Angle theta1(start=0, stateSelect=stateSelect)
+      "Angle of wheel 1";
+      Modelica.SIunits.Angle theta2(start=0, stateSelect=stateSelect)
+      "Angle of wheel 2";
+      Modelica.SIunits.AngularVelocity der_theta1(start=0, stateSelect=stateSelect)
+      "Derivative of theta 1";
+      Modelica.SIunits.AngularVelocity der_theta2(start=0, stateSelect=stateSelect)
+      "Derivative of theta 2";
+
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame1
+      "Frame fixed in center point of left wheel (y-axis: along wheel axis, z-Axis: upwards)"
+        annotation (Placement(transformation(extent={{-96,16},{-64,-16}}),
+            iconTransformation(extent={{-96,16},{-64,-16}})));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame2
+      "Frame fixed in center point of right wheel (y-axis: along wheel axis, z-Axis: upwards)"
+        annotation (Placement(transformation(extent={{64,16},{96,-16}})));
+      Modelica.Mechanics.MultiBody.Parts.Fixed fixed(                 r={0,0,
+            wheelRadius}, animation=animation)
+                          annotation (Placement(transformation(
+            extent={{-10,-10},{10,10}},
+            rotation=90,
+            origin={0,-90})));
+      Modelica.Mechanics.MultiBody.Parts.FixedTranslation rod1(                 r={
+            0,wheelDistance/2,0}, animation=animation)
+        annotation (Placement(transformation(extent={{-8,-10},{-28,10}})));
+      Modelica.Mechanics.MultiBody.Joints.Prismatic prismatic1(animation=
+            animation)                   annotation (Placement(transformation(
+            extent={{-10,-10},{10,10}},
+            rotation=90,
+            origin={0,-66})));
+      Modelica.Mechanics.MultiBody.Joints.Prismatic prismatic2(
+        n={0,1,0}, animation=animation)  annotation (Placement(transformation(
+            extent={{-10,-10},{10,10}},
+            rotation=180,
+            origin={-24,-50})));
+      Modelica.Mechanics.MultiBody.Joints.Revolute revolute(animation=animation)
+                                         annotation (Placement(transformation(
+            extent={{-10,-10},{10,10}},
+            rotation=90,
+            origin={0,-22})));
+      Modelica.Mechanics.MultiBody.Parts.FixedTranslation rod2(                 r={
+            0,-wheelDistance/2,0}, animation=animation)
+        annotation (Placement(transformation(extent={{12,-10},{32,10}})));
+      Modelica.Mechanics.MultiBody.Joints.Revolute revolute1(
+        n={0,1,0},
+        useAxisFlange=true,
+        animation=animation)
+        annotation (Placement(transformation(extent={{-34,-10},{-54,10}})));
+      Modelica.Mechanics.MultiBody.Joints.Revolute revolute2(
+        n={0,1,0},
+        useAxisFlange=true,
+        animation=animation)
+        annotation (Placement(transformation(extent={{40,-10},{60,10}})));
+      Modelica.Mechanics.MultiBody.Joints.Internal.RollingConstraintVerticalWheel
+      rolling1(                             radius=wheelRadius)
+        annotation (Placement(transformation(extent={{-70,-60},{-50,-40}})));
+      Modelica.Mechanics.MultiBody.Joints.Internal.RollingConstraintVerticalWheel
+      rolling2(                             radius=wheelRadius,
+          lateralSlidingConstraint=false)
+        annotation (Placement(transformation(extent={{54,-60},{74,-40}})));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_a axis1
+      "1-dim. rotational flange that drives the joint"
+        annotation (Placement(transformation(extent={{-110,90},{-90,110}})));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_a axis2
+      "1-dim. rotational flange that drives the joint"
+        annotation (Placement(transformation(extent={{90,90},{110,110}})));
+      Modelica.Mechanics.MultiBody.Parts.Mounting1D mounting1D
+        annotation (Placement(transformation(extent={{-10,38},{10,58}})));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_b support
+      "Support of 1D axes"   annotation (Placement(transformation(extent={{-10,70},
+              {10,90}}),       iconTransformation(extent={{-10,70},{10,90}})));
+    equation
+      prismatic1.s  = x;
+      prismatic2.s  = y;
+      revolute.phi  = phi;
+      revolute1.phi = theta1;
+      revolute2.phi = theta2;
+      der_theta1 = der(theta1);
+      der_theta2 = der(theta2);
+
+      connect(revolute.frame_b, frameMiddle) annotation (Line(
+          points={{0,-12},{0,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_a, frameMiddle) annotation (Line(
+          points={{-8,0},{0,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_a, frameMiddle) annotation (Line(
+          points={{12,0},{0,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_b, revolute1.frame_a) annotation (Line(
+          points={{-28,0},{-34,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(revolute1.frame_b, frame1) annotation (Line(
+          points={{-54,0},{-80,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(revolute2.frame_a, rod2.frame_b) annotation (Line(
+          points={{40,0},{32,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(revolute2.frame_b, frame2) annotation (Line(
+          points={{60,0},{80,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(prismatic1.frame_a, fixed.frame_b) annotation (Line(
+          points={{0,-76},{0,-80}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(prismatic1.frame_b, prismatic2.frame_a) annotation (Line(
+          points={{0,-56},{0,-50},{-14,-50}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(prismatic2.frame_b, revolute.frame_a) annotation (Line(
+          points={{-34,-50},{-40,-50},{-40,-36},{0,-36},{0,-32}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rolling1.frame_a, revolute1.frame_b) annotation (Line(
+          points={{-60,-48},{-60,0},{-54,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rolling2.frame_a, revolute2.frame_b) annotation (Line(
+          points={{64,-48},{64,0},{60,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(revolute1.axis, axis1) annotation (Line(
+          points={{-44,10},{-44,100},{-100,100}}));
+      connect(revolute2.axis, axis2) annotation (Line(
+          points={{50,10},{50,100},{100,100}}));
+      connect(frameMiddle, mounting1D.frame_a) annotation (Line(
+          points={{0,0},{0,38}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(mounting1D.flange_b, support) annotation (Line(
+          points={{10,48},{16,48},{16,80},{0,80}}));
+      annotation (defaultComponentName="wheelSet",Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
+                -100},{100,100}}), graphics={
+            Rectangle(
+              extent={{-100,-80},{100,-100}},
+              lineColor={0,0,0},
+              fillColor={175,175,175},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-146,-98},{154,-138}},
+              textString="%name",
+              lineColor={0,0,255}),
+            Ellipse(
+              extent={{42,80},{118,-80}},
+              lineColor={0,0,0},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-62,2},{64,-6}},
+              lineColor={0,0,0},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-118,80},{-42,-80}},
+              lineColor={0,0,0},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{86,24},{64,24},{64,10},{56,10}}),
+            Line(
+              points={{86,-24},{64,-24},{64,-12},{56,-12}}),
+            Line(
+              points={{-96,100},{-80,100},{-80,4}}),
+            Line(
+              points={{100,100},{80,100},{80,-2}}),
+            Line(
+              points={{0,72},{0,40},{-20,40},{-20,2}}),
+            Line(
+              points={{0,40},{20,40},{20,2}})}),
+        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
+                {100,100}}), graphics={
+            Line(
+              points={{-68,24},{-68,52}},
+              color={0,0,255}),
+            Polygon(
+              points={{-68,70},{-74,52},{-62,52},{-68,70}},
+              lineColor={0,0,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-56,62},{-38,50}},
+              lineColor={0,0,255},
+              textString="x"),
+            Line(
+              points={{-62,30},{-94,30}},
+              color={0,0,255}),
+            Polygon(
+              points={{-90,36},{-90,24},{-108,30},{-90,36}},
+              lineColor={0,0,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-114,50},{-96,38}},
+              lineColor={0,0,255},
+              textString="y")}));
+    end RollingWheelSet;
+
+  package Assemblies
+    "Components that aggregate several joints for analytic loop handling"
+    extends Modelica.Icons.Package;
+
+    model JointUPS
+      "Universal - prismatic - spherical joint aggregation (no constraints, no potential states)"
+
+      import Modelica.Mechanics.MultiBody.Types;
+      extends Interfaces.PartialTwoFramesDoubleSize;
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_ia
+        "Coordinate system at origin of frame_a fixed at prismatic joint"
+        annotation (Placement(transformation(
+            origin={-80,100},
+            extent={{-8,-8},{8,8}},
+            rotation=270)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_ib
+        "Coordinate system at origin of frame_b fixed at prismatic joint"
+        annotation (Placement(transformation(
+            origin={80,100},
+            extent={{-8,8},{8,-8}},
+            rotation=270)));
+      Modelica.Mechanics.Translational.Interfaces.Flange_a axis
+        "1-dim. translational flange that drives the prismatic joint"
+        annotation (Placement(transformation(extent={{45,95},{35,105}})));
+      Modelica.Mechanics.Translational.Interfaces.Flange_b bearing
+        "1-dim. translational flange of the drive bearing of the prismatic joint"
+        annotation (Placement(transformation(extent={{-35,95},{-45,105}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter Boolean showUniversalAxes=true
+        "= true, if universal joint shall be visualized with two cylinders, otherwise with a sphere (provided animation=true)";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n1_a={0,0,1}
+        "Axis 1 of universal joint resolved in frame_a (axis 2 is orthogonal to axis 1 and to line from universal to spherical joint)"
+        annotation (Evaluate=true);
+      parameter SI.Position nAxis_ia[3]={1,0,0}
+        "Axis vector along line from origin of frame_a to origin of frame_b, resolved in frame_ia"
+        annotation (Evaluate=true);
+      parameter SI.Position s_offset=0
+        "Relative distance offset (distance between frame_a and frame_b = s(t) + s_offset)";
+      parameter SI.Diameter sphereDiameter=world.defaultJointLength
+        "Diameter of spheres representing the spherical joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of spheres representing the spherical joints"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter axisDiameter=sphereDiameter/Types.Defaults.
+          JointRodDiameterFraction
+        "Diameter of cylinder on the connecting line from frame_a to frame_b"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color axisColor=Modelica.Mechanics.MultiBody.Types.Defaults.SensorColor
+        "Color of cylinder on the connecting line from frame_a to frame_b"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance cylinderLength=world.defaultJointLength
+        "Length of cylinders representing the two universal joint axes" annotation (
+         Dialog(tab="Animation", group="if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+      parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+        "Diameter of cylinders representing the two universal joint axes"
+        annotation (Dialog(tab="Animation", group=
+              "if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+     input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of cylinders representing the two universal joint axes" annotation (
+          Dialog(colorSelector=true, tab="Animation", group="if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+
+      parameter Boolean checkTotalPower=false
+        "= true, if total power flowing into this component shall be determined (must be zero)"
+        annotation (Dialog(tab="Advanced"));
+      final parameter Real eAxis_ia[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(nAxis_ia)
+        "Unit vector from origin of frame_a to origin of frame_b, resolved in frame_ia";
+      final parameter Real e2_ia[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(
+                                                     cross(n1_a, eAxis_ia))
+        "Unit vector in direction of second rotation axis of universal joint, resolved in frame_ia";
+      final parameter Real e3_ia[3](each final unit="1")=cross(eAxis_ia, e2_ia)
+        "Unit vector perpendicular to eAxis_ia and e2_ia, resolved in frame_ia";
+      SI.Position s
+        "Relative distance between frame_a and frame_b along axis nAxis = s + s_offset";
+      SI.Force f "= axis.f (driving force in the axis; = -bearing.f)";
+      SI.Length axisLength "Distance between frame_a and frame_b";
+      SI.Power totalPower
+        "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+    protected
+      SI.Force f_c_a[3] "frame_ia.f resolved in frame_a";
+      SI.Torque t_cd_a[3] "frame_ia.t + frame_ib.t resolved in frame_a";
+      SI.Force f_bd_a[3] "frame_b.f + frame_ib.f resolved in frame_a";
+      SI.Position rAxis_0[3]
+        "Position vector from origin of frame_a to origin of frame_b resolved in world frame";
+      SI.Position rAxis_a[3]
+        "Position vector from origin of frame_a to origin of frame_b resolved in frame_a";
+      Real eAxis_a[3](each final unit="1")
+        "Unit vector in direction of rAxis_a, resolved in frame_a";
+      Real e2_a[3](each final unit="1")
+        "Unit vector in direction of second rotation axis of universal joint, resolved in frame_a";
+      Real e3_a[3](each final unit="1")
+        "Unit vector perpendicular to eAxis_a and e2_a, resolved in frame_a";
+      Real n2_a[3](each final unit="1")
+        "Vector in direction of second rotation axis of universal joint, resolved in frame_a";
+      Real length2_n2_a(unit="1") "Square of length of vector n2_a";
+      Real length_n2_a(unit="1") "Length of vector n2_a";
+      Real der_rAxis_a_L[3](each unit="1/s") "= der(rAxis_a)/axisLength";
+      SI.AngularVelocity w_rel_ia1[3];
+      Frames.Orientation R_ia1_a;
+      Frames.Orientation R_ia2_a;
+      Frames.Orientation R_ia_a "Rotation from frame_a to frame_ia";
+      // Real T_ia_a[3, 3] "Transformation matrix from frame_a to frame_ia";
+
+      Visualizers.Advanced.Shape axisCylinder(
+        shapeType="cylinder",
+        color=axisColor,
+        specularCoefficient=specularCoefficient,
+        length=axisLength,
+        width=axisDiameter,
+        height=axisDiameter,
+        lengthDirection=eAxis_ia,
+        widthDirection=e2_ia,
+        r=frame_ia.r_0,
+        R=frame_ia.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape sphericalShape_b(
+        shapeType="sphere",
+        color=sphereColor,
+        specularCoefficient=specularCoefficient,
+        length=sphereDiameter,
+        width=sphereDiameter,
+        height=sphereDiameter,
+        lengthDirection={1,0,0},
+        widthDirection={0,1,0},
+        r_shape={-0.5,0,0}*sphereDiameter,
+        r=frame_b.r_0,
+        R=frame_b.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape sphericalShape_a(
+        shapeType="sphere",
+        color=sphereColor,
+        specularCoefficient=specularCoefficient,
+        length=sphereDiameter,
+        width=sphereDiameter,
+        height=sphereDiameter,
+        lengthDirection={1,0,0},
+        widthDirection={0,1,0},
+        r_shape={-0.5,0,0}*sphereDiameter,
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape universalShape1(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=n1_a,
+        widthDirection={0,1,0},
+        r_shape=-n1_a*(cylinderLength/2),
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation and showUniversalAxes;
+      Visualizers.Advanced.Shape universalShape2(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=e2_ia,
+        widthDirection={0,1,0},
+        r_shape=-e2_ia*(cylinderLength/2),
+        r=frame_ia.r_0,
+        R=frame_ia.R) if world.enableAnimation and animation and showUniversalAxes;
+    equation
+      Connections.branch(frame_a.R, frame_ia.R);
+      Connections.branch(frame_ia.R, frame_ib.R);
+
+      // Translational flanges
+      axisLength = s + s_offset;
+      bearing.s = 0;
+      axis.s = s;
+      axis.f = f;
+
+      // Position vector rAxis from frame_a to frame_b
+      rAxis_0 = frame_b.r_0 - frame_a.r_0;
+      rAxis_a = Frames.resolve2(frame_a.R, rAxis_0);
+
+      /* Determine relative Rotation R_rel_c from frame_a to frame_ia
+     and absolute rotation of frame_a.R.
+  */
+      axisLength = sqrt(rAxis_0*rAxis_0);
+      assert(axisLength > 1.0e-15, "
+Distance between frame_a and frame_b of a JointUPS joint
+became zero. This is not allowed. If this occurs during
+initialization, the initial conditions are probably wrong.");
+
+      eAxis_a = rAxis_a/axisLength;
+      n2_a = cross(n1_a, eAxis_a);
+      length2_n2_a = n2_a*n2_a;
+      assert(noEvent(length2_n2_a > 1.e-10), "
+A Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUPS joint (consisting of
+a universal, prismatic and spherical joint) is in the singular
+configuration of the universal joint. This means that axis 1 of
+the universal joint defined via parameter \"n1_a\" is parallel to vector
+\"eAxis_ia\" that is directed from the origin of frame_a to the
+origin of frame_b. You may try to use another \"n1_a\" vector.
+");
+      length_n2_a = sqrt(length2_n2_a);
+      e2_a = n2_a/length_n2_a;
+      e3_a = cross(eAxis_a, e2_a);
+
+      /* The statements below are an efficient implementation of the
+     original equations:
+       T_ia_a = [eAxis_ia, e2_ia, e3_ia]*transpose([eAxis_a, e2_a, e3_a]);
+       R_ia_a = Frames.from_T(T_ia_a,
+                     Frames.TransformationMatrices.angularVelocity2(T_ia_a, der(T_ia_a)));
+   To perform this, the rotation is split into two parts:
+     R_ia_a : Rotation object from frame_a to frame_ia
+     R_ia1_a: Rotation object from frame_a to frame_ia1
+                (frame that is fixed in frame_ia such that x-axis
+                is along the rod axis)
+                T = transpose([eAxis_a, e2_a, e3_a]; w = w_rel_ia1
+     R_ia2_a: Fixed rotation object from frame_ia1 to frame_ia
+                T = [eAxis_a, e2_ia, e3_ia]; w = zeros(3)
+
+   The difficult part is to compute w_rel_ia1:
+      w_rel_ia1 = [  e3_a*der(e2_a);
+                    -e3_a*der(eAxis_a);
+                     e2_a*der(eAxis_a)]
+   der(eAxis_a) is directly given, since eAxis_a is a function
+   of translational quantities only.
+      der(eAxis_a) = (der(rAxis_a) - eAxis_a*(eAxis_a*der(rAxis_a)))/axisLength
+      der(n2_a)    = cross(n1_a, der(eAxis_a))
+      der(e2_a)    = (der(n2_a) - e2_a*(e2_a*der(n2_a)))/length_n2_a
+   Inserting these equations in w_rel_ia1 results in:
+      e3_a*der(eAxis_a) = e3_a*der(rAxis_a)/axisLength       // e3_a*eAxis_a = 0
+      e2_a*der(eAxis_a) = e2_a*der(rAxis_a)/axisLength       // e2_a*eAxis_a = 0
+      e3_a*der(e2_a)    = e3_a*der(n2_a)/length_n2_a       // e3_a*e2_a = 0
+                        = e3_a*cross(n1_a, der(eAxis_a))/length_n2_a
+                        = e3_a*cross(n1_a, der(rAxis_a) - eAxis_a*(eAxis_a*der(rAxis_a)))/(length_n2_a*axisLength)
+                        = e3_a*cross(n1_a, der(rAxis_a))/(length_n2_a*axisLength)
+   Furthermore, we have:
+     rAxis_a      = resolve2(frame_a.R, rAxis_0);
+     der(rAxis_a) = resolve2(frame_a.R, der(rAxis_0)) - cross(frame_a.R.w, rAxis_a));
+*/
+      der_rAxis_a_L = (Frames.resolve2(frame_a.R, der(rAxis_0)) - cross(frame_a.
+         R.w, rAxis_a))/axisLength;
+      w_rel_ia1 = {e3_a*cross(n1_a, der_rAxis_a_L)/length_n2_a,-e3_a*
+        der_rAxis_a_L,e2_a*der_rAxis_a_L};
+      R_ia1_a = Frames.from_T(transpose([eAxis_a, e2_a, e3_a]), w_rel_ia1);
+      R_ia2_a = Frames.from_T([eAxis_ia, e2_ia, e3_ia], zeros(3));
+      R_ia_a = Frames.absoluteRotation(R_ia1_a, R_ia2_a);
+      /*
+  T_ia_a = [eAxis_ia, e2_ia, e3_ia]*transpose([eAxis_a, e2_a, e3_a]);
+  R_ia_a = Frames.from_T(T_ia_a, Frames.TransformationMatrices.angularVelocity2
+    (T_ia_a, der(T_ia_a)));
+*/
+
+      // Compute kinematic quantities of frame_ia and frame_ib
+      frame_ia.r_0 = frame_a.r_0;
+      frame_ib.r_0 = frame_b.r_0;
+      frame_ia.R = Frames.absoluteRotation(frame_a.R, R_ia_a);
+      frame_ib.R = frame_ia.R;
+
+      /* In the following formulas f_a, f_b, f_ia, f_ib, t_a, t_b, t_ia, t_ib are
+     the forces and torques at frame_a, frame_b, frame_ia, frame_ib respectively,
+     resolved in frame_a. eAxis, e2, e3 are the unit vectors resolved in frame_a.
+     Torque balance at the rod around the origin of frame_a:
+       0 = t_a + t_ia + t_ib + cross(rAxis, (f_b+f_ib))
+     with
+         rAxis = axisLength*eAxis
+         f_bd  = f_b + f_ib
+         f_bd  = f*eAxis + f_bd[2]*e2 + f_bd[3]*e3
+     follows:
+         0 = t_a + t_ia + axisLength*(f_bd[2]*e_z - f_bd[3]*e_y)
+     The projection of t_a with respect to universal joint axes vanishes:
+       e1*t_a = 0
+       e2*t_a = 0
+     Therefore:
+        0 = e1*(t_ia + t_ib) + axisLength*f_bd[2]*(e1*e3)
+        0 = e2*(t_ia + t_ib) - axisLength*f_bd[3]
+     or
+        f_bd = f*eAxis - e2*(e1*(t_ia+t_ib))/(axisLength*(e1*e3)) +
+                e3*(e2*(t_ia+t_ib))/axisLength
+     Force balance:
+        0 = f_a + f_bd + f_ia
+  */
+      f_c_a = Frames.resolve1(R_ia_a, frame_ia.f);
+      t_cd_a = Frames.resolve1(R_ia_a, frame_ia.t + frame_ib.t);
+      f_bd_a = -eAxis_a*f - e2_a*((n1_a*t_cd_a)/(axisLength*(n1_a*e3_a))) +
+        e3_a*((e2_a*t_cd_a)/axisLength);
+      zeros(3) = frame_b.f + Frames.resolveRelative(frame_ib.f, frame_ib.R,
+        frame_b.R) - Frames.resolveRelative(f_bd_a, frame_a.R, frame_b.R);
+      zeros(3) = frame_b.t;
+      zeros(3) = frame_a.f + f_c_a + f_bd_a;
+      zeros(3) = frame_a.t + t_cd_a + cross(rAxis_a, f_bd_a);
+
+      // Measure power for test purposes
+      if checkTotalPower then
+        totalPower = frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+          frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) + frame_ia.f*
+          Frames.resolve2(frame_ia.R, der(frame_ia.r_0)) + frame_ib.f*
+          Frames.resolve2(frame_ib.R, der(frame_ib.r_0)) + frame_a.t*
+          Frames.angularVelocity2(frame_a.R) + frame_b.t*
+          Frames.angularVelocity2(frame_b.R) + frame_ia.t*
+          Frames.angularVelocity2(frame_ia.R) + frame_ib.t*
+          Frames.angularVelocity2(frame_ib.R) + axis.f*der(axis.s) + bearing.f*
+          der(bearing.s);
+      else
+        totalPower = 0;
+      end if;
+      annotation (
+        Documentation(info="<html>
+<p>
+This component consists of a <b>universal</b> joint at frame_a,
+a <b>spherical</b> joint at frame_b and a <b>prismatic</b> joint along the
+line connecting the origin of frame_a and the origin of frame_b,
+see the default animation in the following figure (the axes vectors
+are not part of the default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUPS.png\" ALT=\"model Joints.Assemblies.JointUPS\">
+</p>
+
+<p>
+This joint aggregation has no mass and no inertia and
+introduces neither constraints nor potential state variables.
+It is especially useful to build up more complicated force elements
+where the mass and/or inertia of the force element shall be taken
+into account.
+</p>
+<p>
+The universal joint is defined in the following way:
+</p>
+<ul>
+<li> The rotation <b>axis</b> of revolute joint <b>1</b> is along parameter
+     vector n1_a which is fixed in frame_a.</li>
+<li> The rotation <b>axis</b> of revolute joint <b>2</b> is perpendicular to
+     axis 1 and to the line connecting the universal and the spherical joint.</li>
+</ul>
+<p>
+The definition of axis 2 of the universal joint is performed according
+to the most often occurring case. In a future release, axis 2 might
+be explicitly definable via a parameter. However, the treatment is much more
+complicated and the number of operations is considerably higher,
+if axis 2 is not orthogonal to axis 1 and to the connecting rod.
+</p>
+<p>
+Note, there is a <b>singularity</b> when axis 1 and the connecting line are parallel
+to each other. Therefore, if possible n1_a should be selected in such a way that it
+is perpendicular to nAxis_ia in the initial configuration (i.e., the
+distance to the singularity is as large as possible).
+</p>
+<p>
+An additional <b>frame_ia</b> is present. It is <b>fixed</b> on the line
+connecting the universal and the spherical joint at the
+origin of <b>frame_a</b>. The placement of frame_ia on this line
+is implicitly defined by the universal joint (frame_a and frame_ia coincide
+when the angles of the two revolute joints of the universal joint are zero)
+and by parameter vector <b>nAxis_ia</b>, an axis vector directed
+along the line from the origin of frame_a to the spherical joint,
+resolved in frame_<b>ia</b>.
+</p>
+<p>
+An additional <b>frame_ib</b> is present. It is <b>fixed</b> in the line
+connecting the prismatic and the spherical joint at the
+origin of <b>frame_b</b>.
+It is always parallel to <b>frame_ia</b>.
+</p>
+<p>
+Note, this joint aggregation can be used in cases where
+in reality a rod with spherical joints at each end are present.
+Such a system has an additional degree of freedom to rotate
+the rod along its axis. In practice this rotation is usually
+of no interest and is mathematically removed by replacing one
+of the spherical joints by a universal joint.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to each other (alternatively,
+at least frame_a, frame_ia and frame_ib of the JointUSP joint
+should be parallel to each other when defining an instance of this
+component).
+</p>
+</html>"),
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Text(
+              extent={{-140,-50},{140,-75}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Ellipse(
+              extent={{-100,-40},{-19,40}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-90,-30},{-29,29}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-60,41},{-9,-44}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{-60,40},{-60,-40}},
+              thickness=0.5),
+            Ellipse(
+              extent={{-83,-17},{-34,21}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-74,-12},{-40,15}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-72,-20},{-89,3},{-69,25},{-45,27},{-72,-20}},
+              pattern=LinePattern.None,
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(
+              points={{-60,40},{-60,-10}},
+              thickness=0.5),
+            Line(
+              points={{-49,20},{-69,-15}},
+              thickness=0.5),
+            Ellipse(
+              extent={{44,14},{73,-14}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{20,-40},{100,40}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{30,-30},{90,30}},
+              lineColor={192,192,192},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-22,45},{40,-43}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{45,14},{74,-14}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Text(
+              extent={{-98,84},{-60,65}},
+              lineColor={128,128,128},
+              textString="ia"),
+            Line(
+              points={{-40,0},{-40,90},{-80,90},{-80,97}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{61,86},{109,64}},
+              lineColor={128,128,128},
+              textString="ib"),
+            Rectangle(
+              extent={{-35,-13},{-6,14}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-35,14},{-6,18}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-6,-7},{46,6}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-6,6},{46,10}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(points={{-6,-13},{-6,18}}),
+            Line(
+              points={{60,-1},{60,90},{80,90},{80,97}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{60,90},{40,90},{40,95}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(points={{-30,70},{10,70}}),
+            Polygon(
+              points={{30,70},{10,76},{10,63},{30,70}},
+              lineColor={128,128,128},
+              fillColor={128,128,128},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{-40,90},{-40,90},{-40,95}},
+              color={95,95,95},
+              thickness=0.5)}),
+        Diagram(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Line(points={{-60,-70},{46,-70}}, color={0,0,255}),
+            Polygon(
+              points={{60,-70},{45,-64},{45,-76},{60,-70}},
+              lineColor={0,0,255},
+              fillColor={0,0,255},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-62,-73},{65,-90}},
+              textString="rAxis",
+              lineColor={0,0,255}),
+            Ellipse(
+              extent={{-100,-40},{-19,40}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-90,-30},{-29,29}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-60,41},{-19,-41}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{-60,40},{-60,-40}},
+              thickness=0.5),
+            Ellipse(
+              extent={{-83,-17},{-34,21}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-74,-12},{-40,15}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-72,-20},{-89,3},{-69,25},{-45,27},{-72,-20}},
+              pattern=LinePattern.None,
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(
+              points={{-60,40},{-60,-10}},
+              thickness=0.5),
+            Line(
+              points={{-49,20},{-69,-15}},
+              thickness=0.5),
+            Line(
+              points={{-40,0},{-40,90},{-80,90},{-80,99}},
+              color={95,95,95},
+              thickness=0.5),
+            Polygon(points={{7,-1},{-5,2},{-5,-4},{7,-1}}, lineColor={0,0,255}),
+            Line(points={{-50,19},{-30,57}}, color={0,0,255}),
+            Text(
+              extent={{-24,74},{7,53}},
+              lineColor={0,0,0},
+              textString="e2"),
+            Polygon(points={{-25,64},{-33,56},{-27,53},{-25,64}}, lineColor={0,
+                  0,255}),
+            Line(points={{-60,41},{-60,65}}, color={0,0,255}),
+            Polygon(points={{-60,75},{-64,63},{-56,63},{-60,75}}, lineColor={0,
+                  0,255}),
+            Text(
+              extent={{-96,82},{-65,61}},
+              lineColor={0,0,0},
+              textString="n1"),
+            Line(points={{-60,-40},{-60,-72}}, color={0,0,255}),
+            Ellipse(
+              extent={{20,-40},{100,40}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{30,-30},{90,30}},
+              lineColor={192,192,192},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-22,45},{40,-43}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{45,14},{74,-14}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={128,128,128}),
+            Line(points={{60,0},{60,-74}}, color={0,0,255}),
+            Rectangle(
+              extent={{-35,14},{-6,18}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-35,-13},{-6,14}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-6,6},{46,10}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-6,-7},{46,6}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(points={{-6,-13},{-6,18}}),
+            Text(
+              extent={{-40,-2},{-1,-16}},
+              lineColor={0,0,0},
+              textString="nAxis"),
+            Line(points={{-61,1},{-2,1}}, color={0,0,255}),
+            Polygon(points={{10,1},{-2,4},{-2,-2},{10,1}}, lineColor={0,0,255}),
+            Line(
+              points={{60,-1},{60,90},{80,90},{80,99}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-24,117},{-9,102}},
+              textString="f",
+              lineColor={0,0,255}),
+            Polygon(
+              points={{-26,103},{-36,100},{-26,97},{-26,103}},
+              lineColor={0,0,255},
+              fillColor={0,0,255},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{26,103},{36,100},{26,97},{26,103}},
+              lineColor={0,0,255},
+              fillColor={0,0,255},
+              fillPattern=FillPattern.Solid),
+            Line(points={{14,100},{36,100}}, color={0,0,255}),
+            Text(
+              extent={{12,116},{27,101}},
+              textString="f",
+              lineColor={0,0,255}),
+            Polygon(
+              points={{30,93},{40,90},{30,87},{30,93}},
+              lineColor={128,128,128},
+              fillColor={128,128,128},
+              fillPattern=FillPattern.Solid),
+            Line(points={{-40,90},{40,90}}, color={128,128,128}),
+            Line(points={{-25,100},{-10,100}}, color={0,0,255}),
+            Text(
+              extent={{-18,90},{19,77}},
+              lineColor={128,128,128},
+              textString="s"),
+            Line(
+              points={{60,90},{40,90},{40,98}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{-40,90},{-40,96},{-40,98}},
+              color={135,135,135},
+              thickness=0.5)}));
+    end JointUPS;
+
+    model JointUSR
+      "Universal - spherical - revolute joint aggregation (no constraints, no potential states)"
+
+      import Modelica.Mechanics.MultiBody.Types;
+
+      extends Interfaces.PartialTwoFramesDoubleSize;
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_ia
+        "Coordinate system at origin of frame_a fixed at connecting rod of universal and spherical joint"
+        annotation (Placement(transformation(
+            origin={-80,100},
+            extent={{-8,-8},{8,8}},
+            rotation=90)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_ib
+        "Coordinate system at origin of frame_b fixed at connecting rod of spherical and revolute joint"
+        annotation (Placement(transformation(
+            origin={80,100},
+            extent={{-8,8},{8,-8}},
+            rotation=270)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_im
+        "Coordinate system at origin of spherical joint fixed at connecting rod of spherical and revolute joint"
+        annotation (Placement(transformation(
+            origin={0,100},
+            extent={{8,-8},{-8,8}},
+            rotation=270)));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_a axis
+        "1-dim. rotational flange that drives the revolute joint"
+        annotation (Placement(transformation(extent={{105,85},{95,75}})));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_b bearing
+        "1-dim. rotational flange of the drive bearing of the revolute joint"
+        annotation (Placement(transformation(extent={{95,45},{105,35}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter Boolean showUniversalAxes=true
+        "= true, if universal joint shall be visualized with two cylinders, otherwise with a sphere (provided animation=true)";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n1_a={0,0,1}
+        "Axis 1 of universal joint fixed and resolved in frame_a (axis 2 is orthogonal to axis 1 and to rod 1)"
+        annotation (Evaluate=true);
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n_b={0,0,1}
+        "Axis of revolute joint fixed and resolved in frame_b"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod1_ia[3]={1,0,0}
+        "Vector from origin of frame_a to spherical joint, resolved in frame_ia"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod2_ib[3]={-1,0,0}
+        "Vector from origin of frame_ib to spherical joint, resolved in frame_ib";
+      parameter Cv.NonSIunits.Angle_deg phi_offset=0
+        "Relative angle offset of revolute joint (angle = phi(t) + from_deg(phi_offset))";
+      parameter Cv.NonSIunits.Angle_deg phi_guess=0
+        "Select the configuration such that at initial time |phi(t0) - from_deg(phi_guess)| is minimal";
+      parameter SI.Diameter sphereDiameter=world.defaultJointLength
+        "Diameter of the spheres representing the universal and the spherical joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.
+           JointColor
+        "Color of the spheres representing the universal and the spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rod1Diameter=sphereDiameter/Types.Defaults.
+          JointRodDiameterFraction
+        "Diameter of rod 1 connecting the universal and the spherical joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod1Color=Modelica.Mechanics.MultiBody.Types.Defaults.
+          RodColor
+        "Color of rod 1 connecting the universal and the spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+
+      parameter SI.Diameter rod2Diameter=rod1Diameter
+        "Diameter of rod 2 connecting the revolute and the spherical joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod2Color=rod1Color
+        "Color of rod 2 connecting the revolute and the spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter revoluteDiameter=world.defaultJointWidth
+        "Diameter of cylinder representing the revolute joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance revoluteLength=world.defaultJointLength
+        "Length of cylinder representing the revolute joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color revoluteColor=Modelica.Mechanics.MultiBody.Types.
+          Defaults.JointColor
+        "Color of cylinder representing the revolute joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance cylinderLength=world.defaultJointLength
+        "Length of cylinders representing the two universal joint axes" annotation (
+         Dialog(tab="Animation", group="if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+      parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+        "Diameter of cylinders representing the two universal joint axes"
+        annotation (Dialog(tab="Animation", group=
+              "if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+      input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of cylinders representing the two universal joint axes" annotation (
+          Dialog(colorSelector=true, tab="Animation", group="if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+      parameter Boolean checkTotalPower=false
+        "= true, if total power flowing into this component shall be determined (must be zero)"
+        annotation (Dialog(tab="Advanced"));
+      final parameter Real eRod1_ia[3](each final unit="1")=rod1.eRod_ia
+        "Unit vector from origin of frame_a to origin of spherical joint, resolved in frame_ia";
+      final parameter Real e2_ia[3](each final unit="1")=rod1.e2_ia
+        "Unit vector in direction of axis 2 of universal joint, resolved in frame_ia";
+      final parameter SI.Distance rod1Length=rod1.rodLength
+        "Length of rod 1 (= distance between universal and spherical joint)";
+      SI.Power totalPower
+        "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+      SI.Position aux
+        "Denominator used to compute force in rod connecting universal and spherical joint";
+      SI.Force f_rod
+        "Constraint force in direction of the rod (positive, if rod is pressed)";
+
+      Modelica.Mechanics.MultiBody.Joints.Internal.RevoluteWithLengthConstraint
+        revolute(
+        animation=animation,
+        lengthConstraint=rod1Length,
+        n=n_b,
+        phi_offset=phi_offset,
+        phi_guess=phi_guess,
+        cylinderDiameter=revoluteDiameter,
+        cylinderLength=revoluteLength,
+        cylinderColor=revoluteColor,
+        specularCoefficient=specularCoefficient) annotation (Placement(
+            transformation(extent={{75,-20},{35,20}})));
+      Modelica.Mechanics.MultiBody.Joints.UniversalSpherical rod1(
+        animation=animation,
+        showUniversalAxes=showUniversalAxes,
+        rRod_ia=rRod1_ia,
+        n1_a=n1_a,
+        sphereDiameter=sphereDiameter,
+        sphereColor=sphereColor,
+        rodWidth=rod1Diameter,
+        rodHeight=rod1Diameter,
+        rodColor=rod1Color,
+        cylinderLength=cylinderLength,
+        cylinderDiameter=cylinderDiameter,
+        cylinderColor=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        kinematicConstraint=false,
+        constraintResidue=rod1.f_rod - f_rod)
+                                   annotation (Placement(transformation(extent=
+                {{-92,-20},{-52,20}})));
+      Modelica.Mechanics.MultiBody.Parts.FixedTranslation rod2(
+        animation=animation,
+        width=rod2Diameter,
+        height=rod2Diameter,
+        color=rod2Color,
+        specularCoefficient=specularCoefficient,
+        r=rRod2_ib) annotation (Placement(transformation(extent={{15,-20},{-25,
+                20}})));
+      Sensors.RelativePosition relativePosition(resolveInFrame=Modelica.Mechanics.MultiBody.Types.ResolveInFrameAB.frame_a)
+        annotation (Placement(transformation(extent={{60,-70},{40,-90}})));
+      Modelica.Blocks.Sources.Constant position_b[3](k=rRod2_ib)
+        annotation (Placement(transformation(extent={{-20,-50},{0,-30}})));
+    equation
+     // Connections.root(frame_ib.R);
+
+      /* Compute the unknown force in the rod of the rod1 joint
+     by a torque balance at the revolute joint:
+       0 = revolute.frame_b.t + frame_ib.t + frame_im.t + cross(rRod2_ib, frame_im.f)
+           + cross(r_ib, -rod1.f_b_a1)
+           + cross(r_ib, Frames.resolve2(rod1.R_rel, rod1.f_rod*rod1.eRod1_ia))
+     The condition is that the projection of the torque in the revolute
+     joint along the axis of the revolute joint is equal to the driving
+     axis torque in the flange:
+       -revolute.tau = revolute.e*frame_b.t
+     Therefore, we have
+        tau = e*(frame_ib.t  + frame_im.t + cross(rRod2_ib, frame_im.f)
+              + cross(rRod2_ib, -rod1.f_b_a1))
+              + e*cross(rRod2_ib, Frames.resolve2(rod1.R_rel, rod1.f_rod*rod1.eRod_a))
+            = e*(frame_ib.t + frame_im.t + cross(rRod2_ib, frame_im.f)
+              + cross(rRod2_ib, -rod.f_b_a1))
+              + rod1.f_rod*e*cross(rRod2_ib, Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Solving this equation for f_rod results in
+       f_rod = (-tau - e*(frame_ib.t + frame_im.t + cross(rRod2_ib, frame_im.f)
+               + cross(rRod2_ib, -rod1.f_b_a1)))
+               / (cross(e,rRod2_ib)*Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Additionally, a guard against division by zero is introduced
+
+     f_rod is passed to component JointsUSR.rod1 via variable "constraintResidue" in the Advanced menu
+  */
+      aux = cross(revolute.e, rRod2_ib)*Frames.resolveRelative(rod1.eRod_a,
+        rod1.frame_a.R, rod1.frame_b.R);
+      f_rod = (-revolute.tau - revolute.e*(frame_ib.t + frame_im.t + cross(
+        rRod2_ib, frame_im.f) - cross(rRod2_ib, Frames.resolveRelative(rod1.
+        f_b_a1, rod1.frame_a.R, rod1.frame_b.R))))/noEvent(if abs(aux) < 1.e-10 then
+              1.e-10 else aux);
+
+      // Measure power for test purposes
+      if checkTotalPower then
+        totalPower = frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+          frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) + frame_ia.f*
+          Frames.resolve2(frame_ia.R, der(frame_ia.r_0)) + frame_ib.f*
+          Frames.resolve2(frame_ib.R, der(frame_ib.r_0)) + frame_im.f*
+          Frames.resolve2(frame_im.R, der(frame_im.r_0)) + frame_a.t*
+          Frames.angularVelocity2(frame_a.R) + frame_b.t*
+          Frames.angularVelocity2(frame_b.R) + frame_ia.t*
+          Frames.angularVelocity2(frame_ia.R) + frame_ib.t*
+          Frames.angularVelocity2(frame_ib.R) + frame_im.t*
+          Frames.angularVelocity2(frame_im.R) + axis.tau*der(axis.phi) +
+          bearing.tau*der(bearing.phi);
+      else
+        totalPower = 0;
+      end if;
+
+      connect(revolute.frame_b, rod2.frame_a) annotation (Line(
+          points={{35,0},{15,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_b, rod1.frame_b) annotation (Line(
+          points={{-25,0},{-52,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(revolute.frame_a, frame_b) annotation (Line(
+          points={{75,0},{100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_a, frame_ib) annotation (Line(
+          points={{15,0},{26,0},{26,70},{80,70},{80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_a, frame_a) annotation (Line(
+          points={{-92,0},{-100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(relativePosition.frame_b, frame_a)
+                                               annotation (Line(
+          points={{40,-80},{-96,-80},{-96,0},{-100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(relativePosition.frame_a, frame_b)
+                                               annotation (Line(
+          points={{60,-80},{96,-80},{96,0},{100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(position_b.y, revolute.position_b)       annotation (Line(
+          points={{1,-40},{20,-40},{20,-12},{31,-12}},
+          color={0,0,127}));
+      connect(rod2.frame_b, frame_im) annotation (Line(
+          points={{-25,0},{-40,0},{-40,80},{0,80},{0,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_ia, frame_ia) annotation (Line(
+          points={{-80,20},{-80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(revolute.axis, axis) annotation (Line(points={{55,20},{55,60},{90,
+              60},{90,80},{100,80}}));
+      connect(relativePosition.r_rel, revolute.position_a) annotation (Line(
+          points={{50,-69},{50,-40},{90,-40},{90,-12},{79,-12}},
+          color={0,0,127}));
+      connect(revolute.bearing, bearing) annotation (Line(
+          points={{67,20},{67,40},{100,40}}));
+      annotation (
+        Documentation(info="<html>
+<p>
+This component consists of a <b>universal</b> joint at frame_a, a <b>revolute</b>
+joint at frame_b and a <b>spherical</b> joint which is connected via <b>rod1</b>
+to the universal and via <b>rod2</b> to the revolute joint, see the default
+animation in the following figure (the axes vectors are not part of the
+default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUSR.png\" ALT=\"model Joints.Assemblies.JointUSR\">
+</p>
+
+<p>
+This joint aggregation has no mass and no inertia and
+introduces neither constraints nor potential state variables.
+It should be used in kinematic loops whenever possible since
+the non-linear system of equations introduced by this joint aggregation
+is solved <b>analytically</b> (i.e., a solution is always computed, if a
+unique solution exists).
+</p>
+<p>
+The universal joint is defined in the following way:
+</p>
+<ul>
+<li> The rotation <b>axis</b> of revolute joint <b>1</b> is along parameter
+     vector n1_a which is fixed in frame_a.</li>
+<li> The rotation <b>axis</b> of revolute joint <b>2</b> is perpendicular to
+     axis 1 and to the line connecting the universal and the spherical joint
+     (= rod 1).</li>
+</ul>
+<p>
+The definition of axis 2 of the universal joint is performed according
+to the most often occurring case. In a future release, axis 2 might
+be explicitly definable via a parameter. However, the treatment is much more
+complicated and the number of operations is considerably higher,
+if axis 2 is not orthogonal to axis 1 and to the connecting rod.
+</p>
+<p>
+Note, there is a <b>singularity</b> when axis 1 and the connecting rod are parallel
+to each other. Therefore, if possible n1_a should be selected in such a way that it
+is perpendicular to rRod1_ia in the initial configuration (i.e., the
+distance to the singularity is as large as possible).
+</p>
+<p>
+The rest of this joint aggregation is defined by the following parameters:
+</p>
+<ul>
+<li> The position of the spherical joint with respect to the universal
+     joint is defined by vector <b>rRod1_ia</b>. This vector is directed from
+     frame_a to the spherical joint and is resolved in frame_ia
+     (it is most simple to select frame_ia such that it is parallel to
+     frame_a in the reference or initial configuration).</li>
+<li> The position of the spherical joint with respect to the revolute
+     joint is defined by vector <b>rRod2_ib</b>. This vector is directed from
+     the inner frame of the revolute joint (frame_ib or revolute.frame_a)
+     to the spherical joint and is resolved in frame_ib (note, that frame_ib
+     and frame_b are parallel to each other).</li>
+<li> The axis of rotation of the revolute joint is defined by axis
+     vector <b>n_b</b>. It is fixed and resolved in frame_b.</li>
+<li> When specifying this joint aggregation with the definitions above, <b>two</b>
+     different <b>configurations</b> are possible. Via parameter <b>phi_guess</b>
+     a guess value for revolute.phi(t0) at the initial time t0 is given. The configuration is selected that is closest to phi_guess (|revolute.phi - phi_guess| is minimal).</li>
+</ul>
+<p>
+An additional <b>frame_ia</b> is present. It is <b>fixed</b> in the rod
+connecting the universal and the spherical joint at the
+origin of <b>frame_a</b>. The placement of frame_ia on the rod
+is implicitly defined by the universal joint (frame_a and frame_ia coincide
+when the angles of the two revolute joints of the universal joint are zero)
+and by parameter vector <b>rRod1_ia</b>, the position vector
+from the origin of frame_a to the spherical joint, resolved in frame_<b>ia</b>.
+</p>
+<p>
+An additional <b>frame_ib</b> is present. It is <b>fixed</b> in the rod
+connecting the revolute and the spherical joint at the side of the revolute
+joint that is connected to this rod (= rod2.frame_a = revolute.frame_a).
+</p>
+<p>
+An additional <b>frame_im</b> is present. It is <b>fixed</b> in the rod
+connecting the revolute and the spherical joint at the side of the spherical
+joint that is connected to this rod (= rod2.frame_b).
+It is always parallel to <b>frame_ib</b>.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to each other (alternatively,
+at least frame_a and frame_ia of the JointUSR joint
+should be parallel to each other when defining an instance of this
+component).
+</p>
+<p>
+In the public interface of the JointUSR joint, the following
+(final) <b>parameters</b> are provided:
+</p>
+<pre>
+  <b>parameter</b> Real rod1Length(unit=\"m\")  \"Length of rod 1\";
+  <b>parameter</b> Real eRod1_ia[3] \"Unit vector along rod 1, resolved in frame_ia\";
+  <b>parameter</b> Real e2_ia  [3]  \"Unit vector along axis 2, resolved in frame_ia\";
+</pre>
+<p>
+This allows a more convenient definition of data which is related to rod 1.
+For example, if a box shall be connected at frame_ia directing from
+the origin of frame_a to the middle of rod 1, this might be defined as:
+</p>
+<pre>
+    Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSP jointUSR(rRod1_ia={1.2, 1, 0.2});
+    Modelica.Mechanics.MultiBody.Visualizers.FixedShape     shape(shapeType       = \"box\",
+                                               lengthDirection = jointUSR.eRod1_ia,
+                                               widthDirection  = jointUSR.e2_ia,
+                                               length          = jointUSR.rod1Length/2,
+                                               width           = jointUSR.rod1Length/10);
+  <b>equation</b>
+    <b>connect</b>(jointUSP.frame_ia, shape.frame_a);
+</pre>
+</html>"),
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Text(
+              extent={{-140,-41},{140,-66}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Ellipse(
+              extent={{-100,-30},{-40,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-93,-22},{-48,23}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-70,40},{-39,-33}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{-70,28},{-70,-30}},
+              thickness=0.5),
+            Ellipse(
+              extent={{-89,-18},{-48,18}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-84,-12},{-53,13}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-81,-17},{-92,-1},{-83,16},{-57,24},{-81,-17}},
+              pattern=LinePattern.None,
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(
+              points={{-70,30},{-70,-10}},
+              thickness=0.5),
+            Line(
+              points={{-61,16},{-79,-15}},
+              thickness=0.5),
+            Line(
+              points={{-50,0},{-50,80},{-80,80},{-80,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Ellipse(
+              extent={{-40,-30},{20,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-33,-22},{12,23}},
+              lineColor={192,192,192},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-44,31},{-14,-30}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-23,10},{-3,-10}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{19,6},{61,-6}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{-50,5},{-21,-5}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{60,-30},{76,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{85,-30},{100,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{76,10},{85,-10}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(extent={{60,30},{76,-30}}, lineColor={0,0,0}),
+            Rectangle(extent={{85,30},{100,-30}}, lineColor={0,0,0}),
+            Text(
+              extent={{40,109},{77,91}},
+              lineColor={128,128,128},
+              textString="ib"),
+            Text(
+              extent={{-124,109},{-95,92}},
+              lineColor={128,128,128},
+              textString="ia"),
+            Line(
+              points={{60,30},{60,80},{80,80},{80,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-43,108},{-10,92}},
+              lineColor={128,128,128},
+              textString="im"),
+            Line(
+              points={{19,6},{19,80},{0,80},{0,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{80,80},{101,80}},
+              color={128,128,128},
+              thickness=0.5),
+            Line(
+              points={{90,30},{90,40},{95,40}},
+              color={95,95,95},
+              thickness=0.5)}));
+    end JointUSR;
+
+    model JointUSP
+      "Universal - spherical - prismatic joint aggregation (no constraints, no potential states)"
+
+      import Modelica.Mechanics.MultiBody.Types;
+
+      extends Interfaces.PartialTwoFramesDoubleSize;
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_ia
+        "Coordinate system at origin of frame_a fixed at connecting rod of universal and spherical joint"
+        annotation (Placement(transformation(
+            origin={-80,100},
+            extent={{-8,-8},{8,8}},
+            rotation=90)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_ib
+        "Coordinate system at origin of frame_b fixed at connecting rod of spherical and prismatic joint"
+        annotation (Placement(transformation(
+            origin={80,100},
+            extent={{-8,8},{8,-8}},
+            rotation=270)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_im
+        "Coordinate system at origin of spherical joint fixed at connecting rod of spherical and prismatic joint"
+        annotation (Placement(transformation(
+            origin={0,100},
+            extent={{8,-8},{-8,8}},
+            rotation=270)));
+      Modelica.Mechanics.Translational.Interfaces.Flange_a axis
+        "1-dim. translational flange that drives the prismatic joint"
+        annotation (Placement(transformation(extent={{95,75},{105,85}})));
+      Modelica.Mechanics.Translational.Interfaces.Flange_b bearing
+        "1-dim. translational flange of the drive bearing of the prismatic joint"
+        annotation (Placement(transformation(extent={{105,35},{95,45}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter Boolean showUniversalAxes=true
+        "= true, if universal joint shall be visualized with two cylinders, otherwise with a sphere (provided animation=true)";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n1_a={0,0,1}
+        "Axis 1 of universal joint fixed and resolved in frame_a (axis 2 is orthogonal to axis 1 and to rod 1)"
+        annotation (Evaluate=true);
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n_b={-1,0,0}
+        "Axis of prismatic joint fixed and resolved in frame_b"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod1_ia[3]={1,0,0}
+        "Vector from origin of frame_a to spherical joint, resolved in frame_ia"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod2_ib[3]={-1,0,0}
+        "Vector from origin of frame_ib to spherical joint, resolved in frame_ib (frame_ib is parallel to frame_b)"
+        annotation (Evaluate=true);
+      parameter SI.Position s_offset=0
+        "Relative distance offset of prismatic joint (distance between the prismatic joint frames = s(t) + s_offset)";
+      parameter SI.Position s_guess=0
+        "Select the configuration such that at initial time |s(t0)-s_guess| is minimal";
+      parameter SI.Diameter sphereDiameter=world.defaultJointLength
+        "Diameter of the spheres representing the universal and the spherical joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of the spheres representing the universal and the spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rod1Diameter=sphereDiameter/Types.Defaults.
+          JointRodDiameterFraction
+        "Diameter of rod 1 connecting the universal and the spherical joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod1Color=Modelica.Mechanics.MultiBody.Types.Defaults.RodColor
+        "Color of rod 1 connecting the universal and the spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rod2Diameter=rod1Diameter
+        "Diameter of rod 2 connecting the prismatic and the spherical joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod2Color=rod1Color
+        "Color of rod 2 connecting the prismatic and the spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter Types.Axis boxWidthDirection={0,1,0}
+        "Vector in width direction of prismatic joint, resolved in frame_b"
+        annotation (Evaluate=true, Dialog(tab="Animation", group=
+              "if animation = true", enable=animation));
+      parameter SI.Distance boxWidth=world.defaultJointWidth
+        "Width of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance boxHeight=boxWidth "Height of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color boxColor=sphereColor "Color of prismatic joint box"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance cylinderLength=world.defaultJointLength
+        "Length of cylinders representing the two universal joint axes" annotation (
+         Dialog(tab="Animation", group="if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+      parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+        "Diameter of cylinders representing the two universal joint axes"
+        annotation (Dialog(tab="Animation", group=
+              "if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+      input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of cylinders representing the two universal joint axes" annotation (
+          Dialog(colorSelector=true, tab="Animation", group="if animation = true and showUniversalAxes",
+                enable=animation and showUniversalAxes));
+      parameter Boolean checkTotalPower=false
+        "= true, if total power flowing into this component shall be determined (must be zero)"
+        annotation (Dialog(tab="Advanced"));
+      final parameter Real eRod1_ia[3](each final unit="1")=rod1.eRod_ia
+        "Unit vector from origin of frame_a to origin of spherical joint, resolved in frame_ia";
+      final parameter Real e2_ia[3](each final unit="1")=rod1.e2_ia
+        "Unit vector in direction of axis 2 of universal joint, resolved in frame_ia";
+      final parameter SI.Distance rod1Length=rod1.rodLength
+        "Length of rod 1 (= distance between universal and spherical joint)";
+      SI.Force f_rod
+        "Constraint force in direction of the rod (positive, if rod is pressed)";
+      SI.Power totalPower
+        "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+      Modelica.Mechanics.MultiBody.Joints.Internal.PrismaticWithLengthConstraint
+        prismatic(
+        animation=animation,
+        length=rod1.rodLength,
+        n=n_b,
+        s_offset=s_offset,
+        s_guess=s_guess,
+        boxWidthDirection=boxWidthDirection,
+        boxWidth=boxWidth,
+        boxHeight=boxHeight,
+        boxColor=boxColor,
+        specularCoefficient=specularCoefficient)
+                                annotation (Placement(transformation(extent={{
+                76,-20},{36,20}})));
+      Modelica.Mechanics.MultiBody.Joints.UniversalSpherical rod1(
+        animation=animation,
+        showUniversalAxes=showUniversalAxes,
+        rRod_ia=rRod1_ia,
+        n1_a=n1_a,
+        sphereDiameter=sphereDiameter,
+        sphereColor=sphereColor,
+        rodWidth=rod1Diameter,
+        rodHeight=rod1Diameter,
+        rodColor=rod1Color,
+        specularCoefficient=specularCoefficient,
+        cylinderLength=cylinderLength,
+        cylinderDiameter=cylinderDiameter,
+        cylinderColor=cylinderColor,
+        kinematicConstraint=false,
+        constraintResidue=rod1.f_rod - f_rod)
+                                   annotation (Placement(transformation(extent=
+                {{-92,-20},{-52,20}})));
+      Modelica.Mechanics.MultiBody.Parts.FixedTranslation rod2(
+        animation=animation,
+        r=rRod2_ib,
+        width=rod2Diameter,
+        height=rod2Diameter,
+        specularCoefficient=specularCoefficient,
+        color=rod2Color) annotation (Placement(transformation(extent={{0,20},{
+                -40,-20}})));
+      Sensors.RelativePosition relativePosition(resolveInFrame=Modelica.Mechanics.MultiBody.Types.ResolveInFrameAB.frame_a)
+        annotation (Placement(transformation(extent={{50,-70},{30,-90}})));
+      Modelica.Blocks.Sources.Constant position_b[3](k=rRod2_ib)
+        annotation (Placement(transformation(extent={{-20,-60},{0,-40}})));
+    protected
+      Real aux
+        "Denominator used to compute force in rod connecting universal and spherical joint";
+    equation
+      /* Compute the unknown force in rod1 connecting the universal and
+     the spherical joint by a force balance at the prismatic joint
+        0 = -prismatic.frame_b.f + frame_ib.f + frame_im.f - rod1.frame_b.f
+     The force at rod1.frame_b is split into two parts:
+        rod1.frame_b.f = Frames.resolve2(rod1.R_rel, rod1.f_b_a1 - rod1.f_rod*rod1.eRod_a)
+     where rod1.f_rod is the unknown force in rod1.
+     The condition is that the projection of the force in the prismatic
+     joint along the axis of its translation axis is equal to the driving
+     axis force in the flange:
+       -prismatic.f = prismatic.e*prismatic.frame_b.f
+     Therefore, we have with e=prismatic.e and f=prismatic.f
+       -f = e*(frame_ib.f + frame_im.f
+               - Frames.resolve2(rod1.R_rel, rod1.f_b_a1 - rod1.f_rod*rod1.eRod_a))
+          = e*(frame_ib.f + frame_im.f - Frames.resolve2(rod1.R_rel, rod1.f_b_a1)
+              + rod1.f_rod*Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Solving this equation for f_rod results in
+       rod1.f_rod = -(f+e*(frame_ib.f + frame_im.f - Frames.resolve2(rod1.R_rel, rod1.f_b_a1)))
+                   /(e*Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Additionally, a guard against division by zero is introduced
+  */
+      aux = prismatic.e*Frames.resolveRelative(rod1.eRod_a, rod1.frame_a.R,
+        rod1.frame_b.R);
+      f_rod = (-prismatic.f - prismatic.e*(frame_ib.f + frame_im.f -
+        Frames.resolveRelative(rod1.f_b_a1, rod1.frame_a.R, rod1.frame_b.R)))/
+        noEvent(if abs(aux) < 1.e-10 then 1.e-10 else aux);
+      // Measure power for test purposes
+      if checkTotalPower then
+        totalPower = frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+          frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) + frame_ia.f*
+          Frames.resolve2(frame_ia.R, der(frame_ia.r_0)) + frame_ib.f*
+          Frames.resolve2(frame_ib.R, der(frame_ib.r_0)) + frame_im.f*
+          Frames.resolve2(frame_im.R, der(frame_im.r_0)) + frame_a.t*
+          Frames.angularVelocity2(frame_a.R) + frame_b.t*
+          Frames.angularVelocity2(frame_b.R) + frame_ia.t*
+          Frames.angularVelocity2(frame_ia.R) + frame_ib.t*
+          Frames.angularVelocity2(frame_ib.R) + frame_im.t*
+          Frames.angularVelocity2(frame_im.R) + axis.f*der(axis.s) + bearing.f*
+          der(bearing.s);
+      else
+        totalPower = 0;
+      end if;
+
+      connect(prismatic.frame_b, rod2.frame_a) annotation (Line(
+          points={{36,0},{0,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_b, rod1.frame_b) annotation (Line(
+          points={{-40,0},{-52,0}},
+          thickness=0.5));
+      connect(prismatic.frame_a, frame_b) annotation (Line(
+          points={{76,0},{100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_a, frame_ib) annotation (Line(
+          points={{0,0},{7,0},{7,70},{80,70},{80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_a, frame_a) annotation (Line(
+          points={{-92,0},{-100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(relativePosition.frame_b, frame_a)
+                                               annotation (Line(
+          points={{30,-80},{-97,-80},{-97,0},{-100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(relativePosition.frame_a, frame_b)
+                                               annotation (Line(
+          points={{50,-80},{95,-80},{95,0},{100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(rod2.frame_b, frame_im) annotation (Line(
+          points={{-40,0},{-46,0},{-46,80},{0,80},{0,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_ia, frame_ia) annotation (Line(
+          points={{-80,20},{-80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(position_b.y, prismatic.position_b)       annotation (Line(
+          points={{1,-50},{10,-50},{10,-12},{32,-12}},
+          color={0,0,127}));
+      connect(prismatic.axis, axis) annotation (Line(points={{40,14},{40,56},{
+              90,56},{90,80},{100,80}}, color={0,191,0}));
+      connect(prismatic.bearing, bearing)
+        annotation (Line(points={{64,14},{64,40},{100,40}}, color={0,191,0}));
+      connect(relativePosition.r_rel, prismatic.position_a)
+                                                          annotation (Line(
+          points={{40,-69},{40,-50},{90,-50},{90,-12},{80,-12}},
+          color={0,0,127}));
+      annotation (
+        Documentation(info="<html>
+<p>
+This component consists of a <b>universal</b> joint at frame_a, a <b>prismatic</b>
+joint at frame_b and a <b>spherical</b> joint which is connected via <b>rod1</b>
+to the universal and via <b>rod2</b> to the prismatic joint, see the default
+animation in the following figure (the axes vectors are not part of the
+default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUSP.png\" ALT=\"model Joints.Assemblies.JointUSP\">
+</p>
+
+<p>
+This joint aggregation has no mass and no inertia and
+introduces neither constraints nor potential state variables.
+It should be used in kinematic loops whenever possible since
+the non-linear system of equations introduced by this joint aggregation
+is solved <b>analytically</b> (i.e., a solution is always computed, if a
+unique solution exists).
+</p>
+<p>
+The universal joint is defined in the following way:
+</p>
+<ul>
+<li> The rotation <b>axis</b> of revolute joint <b>1</b> is along parameter
+     vector n1_a which is fixed in frame_a.</li>
+<li> The rotation <b>axis</b> of revolute joint <b>2</b> is perpendicular to
+     axis 1 and to the line connecting the universal and the spherical joint
+     (= rod 1).</li>
+</ul>
+<p>
+The definition of axis 2 of the universal joint is performed according
+to the most often occurring case. In a future release, axis 2 might
+be explicitly definable via a parameter. However, the treatment is much more
+complicated and the number of operations is considerably higher,
+if axis 2 is not orthogonal to axis 1 and to the connecting rod.
+</p>
+<p>
+Note, there is a <b>singularity</b> when axis 1 and the connecting rod are parallel
+to each other. Therefore, if possible n1_a should be selected in such a way that it
+is perpendicular to rRod1_ia in the initial configuration (i.e., the
+distance to the singularity is as large as possible).
+</p>
+<p>
+The rest of this joint aggregation is defined by the following parameters:
+</p>
+<ul>
+<li> The position of the spherical joint with respect to the universal
+     joint is defined by vector <b>rRod1_ia</b>. This vector is directed from
+     frame_a to the spherical joint and is resolved in frame_ia
+     (it is most simple to select frame_ia such that it is parallel to
+     frame_a in the reference or initial configuration).</li>
+<li> The position of the spherical joint with respect to the prismatic
+     joint is defined by vector <b>rRod2_ib</b>. This vector is directed from
+     the inner frame of the prismatic joint (frame_ib or prismatic.frame_a)
+     to the spherical joint and is resolved in frame_ib (note, that frame_ib
+     and frame_b are parallel to each other).</li>
+<li> The axis of translation of the prismatic joint is defined by axis
+     vector <b>n_b</b>. It is fixed and resolved in frame_b.</li>
+<li> The two frames of the prismatic joint, i.e., frame_b and frame_ib,
+     are parallel to each other.
+     The distance between the origins of these two frames along axis n_b
+     is equal to \"prismatic.s(t) + s_offset\", where \"prismatic.s(t)\" is
+     a time varying variable and \"s_offset\" is a fixed, constant offset
+     parameter.</li>
+<li> When specifying this joint aggregation with the definitions above, <b>two</b>
+     different <b>configurations</b> are possible. Via parameter <b>s_guess</b>
+     a guess value for prismatic.s(t0) at the initial time t0 is given. The configuration
+     is selected that is closest to s_guess (|prismatic.s - s_guess| is minimal).</li>
+</ul>
+<p>
+An additional <b>frame_ia</b> is present. It is <b>fixed</b> in the rod
+connecting the universal and the spherical joint at the
+origin of <b>frame_a</b>. The placement of frame_ia on the rod
+is implicitly defined by the universal joint (frame_a and frame_ia coincide
+when the angles of the two revolute joints of the universal joint are zero)
+and by parameter vector <b>rRod1_ia</b>, the position vector
+from the origin of frame_a to the spherical joint, resolved in frame_<b>ia</b>.
+</p>
+<p>
+An additional <b>frame_ib</b> is present. It is <b>fixed</b> in the rod
+connecting the prismatic and the spherical joint at the side of the prismatic
+joint that is connected to this rod (= rod2.frame_a = prismatic.frame_a).
+It is always parallel to <b>frame_b</b>.
+</p>
+<p>
+An additional <b>frame_im</b> is present. It is <b>fixed</b> in the rod
+connecting the prismatic and the spherical joint at the side of the spherical
+joint that is connected to this rod (= rod2.frame_b).
+It is always parallel to <b>frame_b</b>.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to each other (alternatively,
+at least frame_a and frame_ia of the JointUSP joint
+should be parallel to each other when defining an instance of this
+component).
+</p>
+<p>
+In the public interface of the JointUSP joint, the following
+(final) <b>parameters</b> are provided:
+</p>
+<pre>
+  <b>parameter</b> Real rod1Length(unit=\"m\")  \"Length of rod 1\";
+  <b>parameter</b> Real eRod1_ia[3] \"Unit vector along rod 1, resolved in frame_ia\";
+  <b>parameter</b> Real e2_ia  [3]  \"Unit vector along axis 2, resolved in frame_ia\";
+</pre>
+<p>
+This allows a more convenient definition of data which is related to rod 1.
+For example, if a box shall be connected at frame_ia directing from
+the origin of frame_a to the middle of rod 1, this might be defined as:
+</p>
+<pre>
+    Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSP jointUSP(rRod1_ia={1.2, 1, 0.2});
+    Modelica.Mechanics.MultiBody.Visualizers.FixedShape     shape(shapeType       = \"box\",
+                                               lengthDirection = jointUSP.eRod1_ia,
+                                               widthDirection  = jointUSP.e2_ia,
+                                               length          = jointUSP.rod1Length/2,
+                                               width           = jointUSP.rod1Length/10);
+  <b>equation</b>
+    <b>connect</b>(jointUSP.frame_ia, shape.frame_a);
+</pre>
+</html>"),
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Rectangle(
+              extent={{50,20},{80,-20}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{80,30},{100,-30}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-140,-45},{140,-70}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Ellipse(
+              extent={{-100,-30},{-40,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-93,-22},{-48,23}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-70,40},{-39,-33}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{-70,28},{-70,-30}},
+              thickness=0.5),
+            Ellipse(
+              extent={{-89,-18},{-48,18}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-84,-12},{-53,13}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-81,-17},{-92,-1},{-83,16},{-57,24},{-81,-17}},
+              pattern=LinePattern.None,
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(
+              points={{-70,30},{-70,-10}},
+              thickness=0.5),
+            Line(
+              points={{-61,16},{-79,-15}},
+              thickness=0.5),
+            Line(
+              points={{-50,0},{-50,80},{-80,80},{-80,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Ellipse(
+              extent={{-40,-30},{20,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-33,-22},{12,23}},
+              lineColor={192,192,192},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-44,31},{-14,-30}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-23,10},{-3,-10}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{19,6},{50,-6}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{-50,5},{-21,-5}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Text(
+              extent={{37,109},{68,90}},
+              lineColor={128,128,128},
+              textString="ib"),
+            Text(
+              extent={{-124,110},{-93,90}},
+              lineColor={128,128,128},
+              textString="ia"),
+            Line(
+              points={{50,6},{50,80},{80,80},{80,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-44,111},{-8,91}},
+              lineColor={128,128,128},
+              textString="im"),
+            Line(
+              points={{19,6},{19,80},{0,80},{0,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Rectangle(
+              extent={{80,24},{100,30}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{50,14},{80,20}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(
+              points={{95,80},{79,80}},
+              color={135,135,135},
+              thickness=0.5),
+            Line(
+              points={{95,40},{90,40},{90,30}},
+              color={135,135,135},
+              thickness=0.5)}),
+        Diagram(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Line(
+              points={{-78,30},{-50,30}},
+              color={128,128,128},
+              arrow={Arrow.None,Arrow.Filled}),
+            Text(
+              extent={{-76,39},{-49,32}},
+              lineColor={128,128,128},
+              textString="rRod1_ia"),
+            Text(
+              extent={{-27,40},{0,33}},
+              lineColor={128,128,128},
+              textString="rRod2_ib"),
+            Line(
+              points={{3,30},{-43,30}},
+              color={128,128,128},
+              arrow={Arrow.None,Arrow.Filled})}));
+    end JointUSP;
+
+    model JointSSR
+      "Spherical - spherical - revolute joint aggregation with mass (no constraints, no potential states)"
+
+      import Modelica.Mechanics.MultiBody.Types;
+
+      extends Interfaces.PartialTwoFramesDoubleSize;
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_ib
+        "Coordinate system at origin of frame_b fixed at connecting rod of spherical and revolute joint"
+        annotation (Placement(transformation(
+            origin={80,100},
+            extent={{-8,8},{8,-8}},
+            rotation=270)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_im
+        "Coordinate system at origin of spherical joint in the middle fixed at connecting rod of spherical and revolute joint"
+        annotation (Placement(transformation(
+            origin={0,100},
+            extent={{8,-8},{-8,8}},
+            rotation=270)));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_a axis
+        "1-dim. rotational flange that drives the revolute joint"
+        annotation (Placement(transformation(extent={{105,85},{95,75}})));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_b bearing
+        "1-dim. rotational flange of the drive bearing of the revolute joint"
+        annotation (Placement(transformation(extent={{95,45},{105,35}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter Boolean showMass=true
+        "= true, if point mass on rod 1 shall be shown (provided animation = true and rod1Mass > 0)";
+      parameter SI.Length rod1Length(min=Modelica.Constants.eps, start = 1)
+        "Distance between the origins of the two spherical joints";
+      parameter SI.Mass rod1Mass(min=0)=0
+        "Mass of rod 1 (= point mass located in middle of rod connecting the two spherical joints)";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n_b={0,0,1}
+        "Axis of revolute joint fixed and resolved in frame_b";
+      parameter SI.Position rRod2_ib[3]={1,0,0}
+        "Vector from origin of frame_ib to spherical joint in the middle, resolved in frame_ib";
+      parameter Cv.NonSIunits.Angle_deg phi_offset=0
+        "Relative angle offset of revolute joint (angle = phi(t) + from_deg(phi_offset))";
+      parameter Cv.NonSIunits.Angle_deg phi_guess=0
+        "Select the configuration such that at initial time |phi(t0) - from_deg(phi_guess)| is minimal";
+      parameter SI.Diameter sphereDiameter=world.defaultJointLength
+        "Diameter of the spheres representing the two spherical joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.
+           JointColor
+        "Color of the spheres representing the two spherical joints"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rod1Diameter=sphereDiameter/Types.Defaults.
+          JointRodDiameterFraction
+        "Diameter of rod 1 connecting the two spherical joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod1Color=Modelica.Mechanics.MultiBody.Types.Defaults.
+          RodColor "Color of rod 1 connecting the two spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rod2Diameter=rod1Diameter
+        "Diameter of rod 2 connecting the revolute joint and spherical joint 2"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod2Color=rod1Color
+        "Color of rod 2 connecting the revolute joint and spherical joint 2"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter revoluteDiameter=world.defaultJointWidth
+        "Diameter of cylinder representing the revolute joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance revoluteLength=world.defaultJointLength
+        "Length of cylinder representing the revolute joint"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color revoluteColor=Modelica.Mechanics.MultiBody.Types.
+          Defaults.JointColor
+        "Color of cylinder representing the revolute joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter Boolean checkTotalPower=false
+        "= true, if total power flowing into this component shall be determined (must be zero)"
+        annotation (Dialog(tab="Advanced"));
+      SI.Position aux
+        "Denominator used to compute force in rod connecting universal and spherical joint";
+      SI.Force f_rod
+        "Constraint force in direction of the rod (positive, if rod is pressed)";
+      SI.Power totalPower
+        "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+      Modelica.Mechanics.MultiBody.Joints.Internal.RevoluteWithLengthConstraint
+        revolute(
+        animation=animation,
+        lengthConstraint=rod1Length,
+        n=n_b,
+        phi_offset=phi_offset,
+        phi_guess=phi_guess,
+        cylinderDiameter=revoluteDiameter,
+        cylinderLength=revoluteLength,
+        cylinderColor=revoluteColor,
+        specularCoefficient=specularCoefficient)
+                                 annotation (Placement(transformation(extent={{
+                75,-20},{35,20}})));
+      Modelica.Mechanics.MultiBody.Joints.SphericalSpherical rod1(
+        animation=animation,
+        showMass=showMass,
+        m=rod1Mass,
+        rodLength=rod1Length,
+        rodDiameter=rod1Diameter,
+        sphereDiameter=sphereDiameter,
+        rodColor=rod1Color,
+        specularCoefficient=specularCoefficient,
+        kinematicConstraint=false,
+        sphereColor=sphereColor,
+        constraintResidue=rod1.f_rod - f_rod)
+                                 annotation (Placement(transformation(extent={{
+                -89,-20},{-49,20}})));
+      Modelica.Mechanics.MultiBody.Parts.FixedTranslation rod2(
+        animation=animation,
+        width=rod2Diameter,
+        height=rod2Diameter,
+        color=rod2Color,
+        specularCoefficient=specularCoefficient,
+        r=rRod2_ib) annotation (Placement(transformation(extent={{15,-20},{-25,
+                20}})));
+      Sensors.RelativePosition relativePosition(resolveInFrame=Modelica.Mechanics.MultiBody.Types.ResolveInFrameAB.frame_a)
+        annotation (Placement(transformation(extent={{60,-70},{40,-90}})));
+      Modelica.Blocks.Sources.Constant position_b[3](k=rRod2_ib)
+        annotation (Placement(transformation(extent={{-20,-50},{0,-30}})));
+    equation
+      /* Compute the unknown force in the rod of the rod1 joint
+     by a torque balance at the revolute joint:
+       0 = frame_b.t + frame_ib.t + frame_im.t + cross(rRod2_ib, frame_im.f)
+           + cross(rRod2_ib, -rod1.f_b_a1)
+           + cross(rRod2_ib, Frames.resolve2(rod1.R_rel, rod1.f_rod*rod1.eRod_a))
+     The condition is that the projection of the torque in the revolute
+     joint along the axis of the revolute joint is equal to the driving
+     axis torque in the flange:
+       -revolute.tau = revolute.e*frame_b.t
+     Therefore, we have with e=revolute.e and tau=revolute.tau
+        tau = e*(frame_ib.t  + frame_im.t + cross(rRod2_ib, frame_im.f)
+              + cross(rRod2_ib, -rod1.f_b_a1))
+              + e*cross(rRod2_ib, Frames.resolve2(rod1.R_rel, rod1.f_rod*rod1.eRod_a))
+            = e*(frame_ib.t + frame_im.t + cross(rRod2_ib, frame_im.f)
+              + cross(rRod2_ib, -rod.f_b_a1))
+              + rod1.f_rod*e*cross(rRod2_ib, Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Solving this equation for f_rod results in
+       rod1.f_rod = (tau - e*(frame_ib.t + frame_im.t + cross(rRod2_ib, frame_im.f)
+                   + cross(rRod2_ib, -rod1.f_b_a1)))
+                   / (cross(e,rRod2_ib)*Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Additionally, a guard against division by zero is introduced
+  */
+
+      aux = cross(revolute.e, rRod2_ib)*Frames.resolveRelative(rod1.eRod_a,
+        rod1.frame_a.R, rod1.frame_b.R);
+      f_rod = (-revolute.tau - revolute.e*(frame_ib.t + frame_im.t + cross(
+        rRod2_ib, frame_im.f) - cross(rRod2_ib, Frames.resolveRelative(rod1.
+        f_b_a1, rod1.frame_a.R, rod1.frame_b.R))))/noEvent(if abs(aux) < 1.e-10 then
+              1.e-10 else aux);
+
+      // Measure power for test purposes
+      if checkTotalPower then
+        totalPower = frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+          frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) + frame_ib.f*
+          Frames.resolve2(frame_ib.R, der(frame_ib.r_0)) + frame_im.f*
+          Frames.resolve2(frame_im.R, der(frame_im.r_0)) + frame_a.t*
+          Frames.angularVelocity2(frame_a.R) + frame_b.t*
+          Frames.angularVelocity2(frame_b.R) + frame_ib.t*
+          Frames.angularVelocity2(frame_ib.R) + frame_im.t*
+          Frames.angularVelocity2(frame_im.R) + axis.tau*der(axis.phi) +
+          bearing.tau*der(bearing.phi) + (-rod1Mass)*(der(rod1.v_CM_0) -
+          world.gravityAcceleration(rod1.r_CM_0))*rod1.v_CM_0;
+      else
+        totalPower = 0;
+      end if;
+
+      connect(revolute.frame_b, rod2.frame_a) annotation (Line(
+          points={{35,0},{15,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_b, rod1.frame_b) annotation (Line(
+          points={{-25,0},{-49,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(revolute.frame_a, frame_b) annotation (Line(
+          points={{75,0},{100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_a, frame_ib) annotation (Line(
+          points={{15,0},{26,0},{26,70},{80,70},{80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_a, frame_a) annotation (Line(
+          points={{-89,0},{-100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(relativePosition.frame_b, frame_a)
+                                               annotation (Line(
+          points={{40,-80},{-95,-80},{-95,0},{-100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(relativePosition.frame_a, frame_b)
+                                               annotation (Line(
+          points={{60,-80},{96,-80},{96,0},{100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(position_b.y, revolute.position_b)       annotation (Line(
+          points={{1,-40},{20,-40},{20,-12},{31,-12}},
+          color={0,0,127}));
+      connect(revolute.axis, axis) annotation (Line(points={{55,20},{55,60},{90,
+              60},{90,80},{100,80}}));
+      connect(rod2.frame_b, frame_im) annotation (Line(
+          points={{-25,0},{-35,0},{-35,60},{0,60},{0,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(relativePosition.r_rel, revolute.position_a)
+                                                         annotation (Line(
+          points={{50,-69},{50,-50},{90,-50},{90,-12},{79,-12}},
+          color={0,0,127}));
+      connect(revolute.bearing, bearing) annotation (Line(
+          points={{67,20},{67,40},{100,40}}));
+      annotation (
+        Documentation(info="<html>
+<p>
+This component consists of a <b>spherical</b> joint 1 at frame_a, a <b>revolute</b>
+joint at frame_b and a <b>spherical</b> joint 2 which is connected via rod 1
+to the spherical joint 1 and via rod 2 to the revolute joint, see the default
+animation in the following figure (the axes vectors are not part of the
+default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointSSR.png\" ALT=\"model Joints.Assemblies.JointSSR\">
+</p>
+
+<p>
+Besides an optional point mass in the middle of rod 1,
+this joint aggregation has no mass and no inertia,
+and introduces neither constraints nor potential state variables.
+It should be used in kinematic loops whenever possible since
+the non-linear system of equations introduced by this joint aggregation
+is solved <b>analytically</b> (i.e., a solution is always computed, if a
+unique solution exists).
+</p>
+<p>
+An additional <b>frame_ib</b> is present. It is <b>fixed</b> in rod 2
+connecting the revolute and the spherical joint at the side of the revolute
+joint that is connected to this rod (= rod2.frame_a = revolute.frame_a).
+</p>
+<p>
+An additional <b>frame_im</b> is present. It is <b>fixed</b> in rod 2
+connecting the revolute and the spherical joint at the side of spherical
+joint 2 that is connected to this rod (= rod2.frame_b).
+It is always parallel to <b>frame_ib</b>.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to each other (alternatively,
+at least frame_b and frame_ib of the JointSSR joint
+should be parallel to each other when defining an instance of this
+component).
+</p>
+</html>"),
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Text(
+              extent={{-141,-41},{139,-66}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Ellipse(
+              extent={{-100,-30},{-40,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-93,-22},{-48,23}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-63,33},{-39,-33}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-40,-30},{20,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-33,-22},{12,23}},
+              lineColor={192,192,192},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-44,31},{-19,-30}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-23,10},{-3,-10}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{19,6},{61,-6}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{60,-30},{76,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{85,-30},{100,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{76,10},{85,-10}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(extent={{60,30},{76,-30}}, lineColor={0,0,0}),
+            Rectangle(extent={{85,30},{100,-30}}, lineColor={0,0,0}),
+            Text(
+              extent={{88,112},{127,92}},
+              lineColor={128,128,128},
+              textString="ib"),
+            Ellipse(
+              extent={{-80,11},{-60,-9}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-62,6},{-21,-5}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Line(
+              points={{80,80},{100,80}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{19,6},{19,80},{0,80},{0,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-47,111},{-8,92}},
+              lineColor={128,128,128},
+              textString="im"),
+            Line(
+              points={{68,30},{68,80},{80,80},{80,98}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{90,30},{90,40},{95,40}},
+              color={95,95,95},
+              thickness=0.5)}));
+    end JointSSR;
+
+    model JointSSP
+      "Spherical - spherical - prismatic joint aggregation with mass (no constraints, no potential states)"
+
+      import Modelica.Mechanics.MultiBody.Types;
+
+      extends Interfaces.PartialTwoFramesDoubleSize;
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_ib
+        "Coordinate system at origin of frame_b fixed at connecting rod of spherical and prismatic joint"
+        annotation (Placement(transformation(
+            origin={80,100},
+            extent={{-8,8},{8,-8}},
+            rotation=270)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_im
+        "Coordinate system at origin of spherical joint in the middle fixed at connecting rod of spherical and prismatic joint"
+        annotation (Placement(transformation(
+            origin={0,100},
+            extent={{8,-8},{-8,8}},
+            rotation=270)));
+      Modelica.Mechanics.Translational.Interfaces.Flange_a axis
+        "1-dim. translational flange that drives the prismatic joint"
+        annotation (Placement(transformation(extent={{95,75},{105,85}})));
+      Modelica.Mechanics.Translational.Interfaces.Flange_b bearing
+        "1-dim. translational flange of the drive bearing of the prismatic joint"
+        annotation (Placement(transformation(extent={{105,35},{95,45}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter Boolean showMass=true
+        "= true, if point mass on rod 1 shall be shown (provided animation = true and rod1Mass > 0)";
+      parameter SI.Length rod1Length(min=Modelica.Constants.eps, start = 1)
+        "Distance between the origins of the two spherical joints";
+      parameter SI.Mass rod1Mass(min=0)=0
+        "Mass of rod 1 (= point mass located in middle of rod connecting the two spherical joints)";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n_b={0,0,1}
+        "Axis of prismatic joint fixed and resolved in frame_b";
+      parameter SI.Position rRod2_ib[3]={1,0,0}
+        "Vector from origin of frame_ib to spherical joint in the middle, resolved in frame_ib";
+      parameter SI.Position s_offset=0
+        "Relative distance offset of prismatic joint (distance between frame_b and frame_ib = s(t) + s_offset)";
+      parameter SI.Position s_guess=0
+        "Select the configuration such that at initial time |s(t0)-s_guess| is minimal";
+
+      parameter SI.Diameter sphereDiameter=world.defaultJointLength
+        "Diameter of the spheres representing the two spherical joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color sphereColor=Modelica.Mechanics.MultiBody.Types.Defaults.
+           JointColor
+        "Color of the spheres representing the two spherical joints"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rod1Diameter=sphereDiameter/Types.Defaults.
+          JointRodDiameterFraction
+        "Diameter of rod 1 connecting the two spherical joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod1Color=Modelica.Mechanics.MultiBody.Types.Defaults.
+          RodColor "Color of rod 1 connecting the two spherical joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+
+      parameter SI.Diameter rod2Diameter=rod1Diameter
+        "Diameter of rod 2 connecting the revolute joint and spherical joint 2"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rod2Color=rod1Color
+        "Color of rod 2 connecting the revolute joint and spherical joint 2"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+
+      parameter Types.Axis boxWidthDirection={0,1,0}
+        "Vector in width direction of prismatic joint box, resolved in frame_b"
+        annotation (Evaluate=true, Dialog(tab="Animation", group=
+              "if animation = true", enable=animation));
+      parameter SI.Distance boxWidth=world.defaultJointWidth
+        "Width of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance boxHeight=boxWidth "Height of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color boxColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of prismatic joint box"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter Boolean checkTotalPower=false
+        "= true, if total power flowing into this component shall be determined (must be zero)"
+        annotation (Dialog(tab="Advanced"));
+      Real aux
+        "Denominator used to compute force in rod connecting universal and spherical joint";
+      SI.Force f_rod
+        "Constraint force in direction of the rod (positive, if rod is pressed)";
+      SI.Power totalPower
+        "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+      Modelica.Mechanics.MultiBody.Joints.Internal.PrismaticWithLengthConstraint
+        prismatic(
+        animation=animation,
+        length=rod1Length,
+        n=n_b,
+        s_offset=s_offset,
+        s_guess=s_guess,
+        boxWidthDirection=boxWidthDirection,
+        boxWidth=boxWidth,
+        boxHeight=boxHeight,
+        specularCoefficient=specularCoefficient,
+        boxColor=boxColor) annotation (Placement(transformation(extent={{75,-20},
+                {35,20}})));
+      Modelica.Mechanics.MultiBody.Joints.SphericalSpherical rod1(
+        animation=animation,
+        showMass=showMass,
+        m=rod1Mass,
+        rodLength=rod1Length,
+        rodDiameter=rod1Diameter,
+        sphereDiameter=sphereDiameter,
+        rodColor=rod1Color,
+        kinematicConstraint=false,
+        specularCoefficient=specularCoefficient,
+        sphereColor=sphereColor,
+        constraintResidue=rod1.f_rod - f_rod)
+                                 annotation (Placement(transformation(extent={{
+                -89,-20},{-49,20}})));
+      Modelica.Mechanics.MultiBody.Parts.FixedTranslation rod2(
+        animation=animation,
+        width=rod2Diameter,
+        height=rod2Diameter,
+        specularCoefficient=specularCoefficient,
+        color=rod2Color,
+        r=rRod2_ib) annotation (Placement(transformation(extent={{15,-20},{-25,
+                20}})));
+      Sensors.RelativePosition relativePosition(resolveInFrame=Modelica.Mechanics.MultiBody.Types.ResolveInFrameAB.frame_a)
+        annotation (Placement(transformation(extent={{60,-70},{40,-90}})));
+      Modelica.Blocks.Sources.Constant position_b[3](k=rRod2_ib)
+        annotation (Placement(transformation(extent={{-20,-50},{0,-30}})));
+    equation
+      /* Compute the unknown force in the rod of the rod1 joint
+     by a force balance:
+       0 = frame_b.f + frame_ib.f + frame_im.f +
+           Frames.resolve2(rod1.R_rel, rod1.f_rod*rod1.eRod_a)
+     The condition is that the projection of the force in the prismatic
+     joint along the axis of the prismatic joint is equal to the driving
+     axis force in the flange:
+       -prismatic.f = prismatic.e*frame_b.f
+     Therefore, we have with e=prismatic.e and f=prismatic.f
+        f = e*(frame_ib.f + frame_im.f +
+               Frames.resolve2(rod1.R_rel, rod1.f_rod*rod1.eRod_a))
+          = e*(frame_ib.f + frame_im.f +
+               rod1.f_rod*Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Solving this equation for f_rod results in
+       rod1.f_rod = (f - e*(frame_ib.f + frame_im.f))
+                    / (e*Frames.resolve2(rod1.R_rel, rod1.eRod_a))
+     Additionally, a guard against division by zero is introduced
+  */
+      aux = prismatic.e*Frames.resolveRelative(rod1.eRod_a, rod1.frame_a.R,
+        rod1.frame_b.R);
+      f_rod = (-prismatic.f - prismatic.e*(frame_ib.f + frame_im.f))/
+        noEvent(if abs(aux) < 1.e-10 then 1.e-10 else aux);
+
+      // Measure power for test purposes
+      if checkTotalPower then
+        totalPower = frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0)) +
+          frame_b.f*Frames.resolve2(frame_b.R, der(frame_b.r_0)) + frame_ib.f*
+          Frames.resolve2(frame_ib.R, der(frame_ib.r_0)) + frame_im.f*
+          Frames.resolve2(frame_im.R, der(frame_im.r_0)) + frame_a.t*
+          Frames.angularVelocity2(frame_a.R) + frame_b.t*
+          Frames.angularVelocity2(frame_b.R) + frame_ib.t*
+          Frames.angularVelocity2(frame_ib.R) + frame_im.t*
+          Frames.angularVelocity2(frame_im.R) + axis.f*der(axis.s) + bearing.f*
+          der(bearing.s) + (-rod1Mass)*(der(rod1.v_CM_0) -
+          world.gravityAcceleration(rod1.r_CM_0))*rod1.v_CM_0;
+      else
+        totalPower = 0;
+      end if;
+
+      connect(prismatic.frame_b, rod2.frame_a) annotation (Line(
+          points={{35,0},{15,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_b, rod1.frame_b) annotation (Line(
+          points={{-25,0},{-49,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(prismatic.frame_a, frame_b) annotation (Line(
+          points={{75,0},{100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod2.frame_a, frame_ib) annotation (Line(
+          points={{15,0},{26,0},{26,70},{80,70},{80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(rod1.frame_a, frame_a) annotation (Line(
+          points={{-89,0},{-100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(relativePosition.frame_b, frame_a)
+                                               annotation (Line(
+          points={{40,-80},{-95,-80},{-95,0},{-100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(relativePosition.frame_a, frame_b)
+                                               annotation (Line(
+          points={{60,-80},{96,-80},{96,0},{100,0}},
+          color={95,95,95},
+          pattern=LinePattern.Dot));
+      connect(position_b.y, prismatic.position_b)       annotation (Line(
+          points={{1,-40},{20,-40},{20,-12},{31,-12}},
+          color={0,0,127}));
+      connect(prismatic.axis, axis) annotation (Line(points={{39,14},{40,14},{
+              40,60},{90,60},{90,80},{100,80}}));
+      connect(prismatic.bearing, bearing)
+        annotation (Line(points={{63,14},{63,40},{100,40}}));
+      connect(rod2.frame_b, frame_im) annotation (Line(
+          points={{-25,0},{-35,0},{-35,60},{0,60},{0,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(relativePosition.r_rel, prismatic.position_a)
+                                                          annotation (Line(
+          points={{50,-69},{50,-50},{90,-50},{90,-12},{79,-12}},
+          color={0,0,127}));
+      annotation (
+        Documentation(info="<html>
+<p>
+This component consists of a <b>spherical</b> joint 1 at frame_a, a <b>prismatic</b>
+joint at frame_b and a <b>spherical</b> joint 2 which is connected via rod 1
+to the spherical joint 1 and via rod 2 to the prismatic joint, see the default
+animation in the following figure (the axes vectors are not part of the
+default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointSSP.png\" ALT=\"model Joints.Assemblies.JointSSP\">
+</p>
+
+<p>
+Besides an optional point mass in the middle of rod 1,
+this joint aggregation has no mass and no inertia,
+and introduces neither constraints nor potential state variables.
+It should be used in kinematic loops whenever possible since
+the non-linear system of equations introduced by this joint aggregation
+is solved <b>analytically</b> (i.e., a solution is always computed, if a
+unique solution exists).
+</p>
+<p>
+An additional <b>frame_ib</b> is present. It is <b>fixed</b> in rod 2
+connecting the prismatic and the spherical joint at the side of the prismatic
+joint that is connected to this rod (= rod2.frame_a = prismatic.frame_a).
+</p>
+<p>
+An additional <b>frame_im</b> is present. It is <b>fixed</b> in rod 2
+connecting the prismatic and the spherical joint at the side of spherical
+joint 2 that is connected to this rod (= rod2.frame_b).
+It is always parallel to <b>frame_ib</b>.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to each other (alternatively,
+at least frame_b and frame_ib of the JointSSP joint
+should be parallel to each other when defining an instance of this
+component).
+</p>
+</html>"),
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Text(
+              extent={{-140,-40},{140,-65}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Ellipse(
+              extent={{-100,-30},{-40,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-93,-22},{-48,23}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-63,33},{-39,-33}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-40,-30},{20,30}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-33,-22},{12,23}},
+              lineColor={192,192,192},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-44,31},{-19,-30}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-23,10},{-3,-10}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{19,6},{61,-6}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Text(
+              extent={{89,115},{132,92}},
+              lineColor={128,128,128},
+              textString="ib"),
+            Ellipse(
+              extent={{-80,11},{-60,-9}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-62,6},{-21,-5}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Line(
+              points={{19,6},{19,80},{0,80},{0,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-49,114},{-11,92}},
+              lineColor={128,128,128},
+              textString="im"),
+            Rectangle(
+              extent={{50,20},{80,-20}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{80,30},{100,-30}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{50,14},{80,20}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{80,24},{100,30}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(
+              points={{50,6},{50,80},{80,80},{80,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{101,80},{80,80}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{99,40},{90,40},{90,30}},
+              color={95,95,95},
+              thickness=0.5)}));
+    end JointSSP;
+
+    model JointRRR
+      "Planar revolute - revolute - revolute joint aggregation (no constraints, no potential states)"
+
+      import Modelica.Mechanics.MultiBody.Types;
+      import Modelica.SIunits.Conversions.to_unit1;
+
+      extends Interfaces.PartialTwoFramesDoubleSize;
+
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_ia
+        "Coordinate system at origin of frame_a fixed at connecting rod of left and middle revolute joint"
+        annotation (Placement(transformation(
+            origin={-80,100},
+            extent={{-8,-8},{8,8}},
+            rotation=90)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_ib
+        "Coordinate system at origin of frame_b fixed at connecting rod of middle and right revolute joint"
+        annotation (Placement(transformation(
+            origin={80,100},
+            extent={{-8,8},{8,-8}},
+            rotation=270)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_im
+        "Coordinate system at origin of revolute joint in the middle fixed at connecting rod of middle and right revolute joint"
+        annotation (Placement(transformation(
+            origin={0,100},
+            extent={{8,-8},{-8,8}},
+            rotation=270)));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_a axis
+        "1-dim. rotational flange that drives the right revolute joint at frame_b"
+        annotation (Placement(transformation(extent={{105,85},{95,75}})));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_b bearing
+        "1-dim. rotational flange of the drive bearing of the right revolute joint at frame_b"
+        annotation (Placement(transformation(extent={{95,45},{105,35}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n_a={0,0,1}
+        "Axes of revolute joints resolved in frame_a (all axes are parallel to each other)"
+        annotation (Evaluate=true);
+      final parameter Real n_b[3](each final unit="1",each fixed=false, start = {0,0,1})
+        "Axis of revolute joint fixed and resolved in frame_b"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod1_ia[3]={1,0,0}
+        "Vector from origin of frame_a to revolute joint in the middle, resolved in frame_ia"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod2_ib[3]={-1,0,0}
+        "Vector from origin of frame_ib to revolute joint in the middle, resolved in frame_ib";
+      parameter Cv.NonSIunits.Angle_deg phi_offset=0
+        "Relative angle offset of revolute joint at frame_b (angle = phi(t) + from_deg(phi_offset))";
+      parameter Cv.NonSIunits.Angle_deg phi_guess=0
+        "Select the configuration such that at initial time |phi(t0) - from_deg(phi_guess)| is minimal";
+      parameter SI.Distance cylinderLength=world.defaultJointLength
+        "Length of cylinders representing the revolute joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+        "Diameter of cylinders representing the revolute joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of cylinders representing the revolute joints"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rodDiameter=1.1*cylinderDiameter
+        "Diameter of the two rods connecting the revolute joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rodColor=Modelica.Mechanics.MultiBody.Types.Defaults.RodColor
+        "Color of the two rods connecting the revolute joint"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+      parameter Boolean checkTotalPower=false
+        "= true, if total power flowing into this component shall be determined (must be zero)"
+        annotation (Dialog(tab="Advanced"));
+      final parameter Real e_a[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(
+                                                   n_a)
+        "Unit vector along axes of rotations, resolved in frame_a";
+      final parameter Real e_ia[3](each final unit="1")=jointUSR.e2_ia
+        "Unit vector along axes of rotations, resolved in frame_ia";
+      final parameter Real e_b[3](each final unit="1")=jointUSR.revolute.e
+        "Unit vector along axes of rotations, resolved in frame_b, frame_ib and frame_im";
+      SI.Power totalPower=jointUSR.totalPower
+        "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+      JointUSR jointUSR(
+        animation=false,
+        n1_a=n_a,
+        n_b=n_b,
+        phi_offset=phi_offset,
+        rRod2_ib=rRod2_ib,
+        showUniversalAxes=false,
+        rRod1_ia=rRod1_ia,
+        checkTotalPower=checkTotalPower,
+        phi_guess=phi_guess) annotation (Placement(transformation(extent={{-30,
+                -20},{10,20}})));
+
+    protected
+     Visualizers.Advanced.Shape shape_rev1(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=e_a,
+        widthDirection={0,1,0},
+        r_shape=-e_a*(cylinderLength/2),
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_rev2(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=e_b,
+        widthDirection={0,1,0},
+        r_shape=-e_b*(cylinderLength/2),
+        r=frame_im.r_0,
+        R=frame_im.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_rev3(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=e_b,
+        widthDirection={0,1,0},
+        r_shape=-e_b*(cylinderLength/2),
+        r=frame_b.r_0,
+        R=frame_b.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_rod1(
+        shapeType="cylinder",
+        color=rodColor,
+        specularCoefficient=specularCoefficient,
+        length=Modelica.Math.Vectors.length(
+                             rRod1_ia),
+        width=rodDiameter,
+        height=rodDiameter,
+        lengthDirection = to_unit1(rRod1_ia),
+        widthDirection=e_ia,
+        r=frame_ia.r_0,
+        R=frame_ia.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_rod2(
+        shapeType="cylinder",
+        color=rodColor,
+        specularCoefficient=specularCoefficient,
+        length=Modelica.Math.Vectors.length(
+                             rRod2_ib),
+        width=rodDiameter,
+        height=rodDiameter,
+        lengthDirection = to_unit1(rRod2_ib),
+        widthDirection=e_b,
+        r=frame_ib.r_0,
+        R=frame_ib.R) if world.enableAnimation and animation;
+    initial equation
+      n_b = Frames.resolve2(frame_b.R, Frames.resolve1(frame_a.R, n_a));
+
+    equation
+      connect(jointUSR.frame_a, frame_a)
+        annotation (Line(
+          points={{-30,0},{-100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSR.frame_b, frame_b)
+        annotation (Line(
+          points={{10,0},{100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSR.frame_ia, frame_ia) annotation (Line(
+          points={{-26,20},{-26,70},{-80,70},{-80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSR.frame_im, frame_im) annotation (Line(
+          points={{-10,20},{-10,70},{0,70},{0,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSR.frame_ib, frame_ib) annotation (Line(
+          points={{6,20},{6,50},{80,50},{80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSR.axis, axis)
+        annotation (Line(points={{10,16},{86,16},{86,80},{100,80}}, color={0,0,
+              0}));
+      connect(jointUSR.bearing, bearing)
+        annotation (Line(points={{10,8},{94,8},{94,40},{100,40}}));
+      annotation (
+        Documentation(info="<html>
+<p>
+This component consists of <b>3 revolute</b> joints with parallel
+axes of rotation that are connected together by two rods, see the default
+animation in the following figure (the axes vectors are not part of the
+default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointRRR.png\" ALT=\"model Joints.Assemblies.JointRRR\">
+</p>
+
+<p>
+This joint aggregation introduces neither constraints nor state variables and
+should therefore be used in kinematic loops whenever possible to
+avoid non-linear systems of equations. It is only meaningful to
+use this component in <b>planar loops</b>. Basically, the position
+and orientation of the 3 revolute joints as well as of frame_ia, frame_ib, and
+frame_im are calculated by solving analytically a non-linear equation,
+given the position and orientation at frame_a and at frame_b.
+</p>
+<p>
+Connector <b>frame_a</b> is the \"left\" side of the first revolute joint
+whereas <b>frame_ia</b> is the \"right side of this revolute joint, fixed in rod 1.
+Connector <b>frame_b</b> is the \"right\" side of the third revolute joint
+whereas <b>frame_ib</b> is the \"left\" side of this revolute joint, fixed in rod 2.
+Finally, connector <b>frame_im</b> is the connector at the \"right\" side
+of the revolute joint in the middle, fixed in rod 2.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to each other (alternatively,
+at least frame_a, frame_ia, frame_im, frame_ib, frame_b of the JointRRR joint
+should be parallel to each other when defining an instance of this
+component).
+</p>
+<p>
+Basically, the JointRRR model consists internally of a universal -
+spherical - revolute joint aggregation (= JointUSR). In a planar
+loop this will behave as if 3 revolute joints with parallel axes
+are connected by rigid rods.
+</p>
+</html>"),
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Rectangle(
+              extent={{-90,90},{90,-90}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-140,-55},{140,-80}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Text(
+              extent={{36,114},{71,92}},
+              lineColor={128,128,128},
+              textString="ib"),
+            Text(
+              extent={{-126,115},{-87,90}},
+              lineColor={128,128,128},
+              textString="ia"),
+            Ellipse(
+              extent={{-100,25},{-50,-25}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-85,10},{-65,-10}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{50,25},{100,-25}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{65,10},{85,-10}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-26,80},{24,30}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-10,66},{10,46}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-71,9},{-24,45},{-19,39},{-66,3},{-71,9}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{54,12},{5,47},{10,52},{59,18},{54,12}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{100,-4},{83,-4},{84,3},{100,3},{100,-4}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{80,24},{80,80},{80,80},{80,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-128,-29},{136,-47}},
+              lineColor={0,0,0},
+              textString="n_a=%n_a"),
+            Line(
+              points={{0,57},{0,86},{0,86},{0,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-46,114},{-7,91}},
+              lineColor={128,128,128},
+              textString="im"),
+            Line(
+              points={{-80,100},{-80,8}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{80,80},{101,80}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{100,40},{93,40},{93,3}},
+              color={95,95,95},
+              thickness=0.5)}));
+    end JointRRR;
+
+    model JointRRP
+      "Planar revolute - revolute - prismatic joint aggregation (no constraints, no potential states)"
+
+      import Modelica.Mechanics.MultiBody.Types;
+      import Modelica.SIunits.Conversions.to_unit1;
+
+      extends Interfaces.PartialTwoFramesDoubleSize;
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_ia
+        "Coordinate system at origin of frame_a fixed at connecting rod of revolute joints"
+        annotation (Placement(transformation(
+            origin={-80,100},
+            extent={{-8,-8},{8,8}},
+            rotation=90)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_ib
+        "Coordinate system at origin of frame_b fixed at connecting rod of revolute and prismatic joint"
+        annotation (Placement(transformation(
+            origin={80,100},
+            extent={{-8,8},{8,-8}},
+            rotation=270)));
+      Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_im
+        "Coordinate system at origin of revolute joint in the middle fixed at connecting rod of revolute and prismatic joint"
+        annotation (Placement(transformation(
+            origin={0,100},
+            extent={{8,-8},{-8,8}},
+            rotation=270)));
+      Modelica.Mechanics.Translational.Interfaces.Flange_a axis
+        "1-dim. translational flange that drives the prismatic joint"
+        annotation (Placement(transformation(extent={{95,75},{105,85}})));
+      Modelica.Mechanics.Translational.Interfaces.Flange_b bearing
+        "1-dim. translational flange of the drive bearing of the prismatic joint"
+        annotation (Placement(transformation(extent={{105,35},{95,45}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n_a={0,0,1}
+        "Axes of the two revolute joints resolved in frame_a (both axes are parallel to each other)"
+        annotation (Evaluate=true);
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n_b={-1,0,0}
+        "Axis of prismatic joint fixed and resolved in frame_b (must be orthogonal to revolute joint axes)"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod1_ia[3]={1,0,0}
+        "Vector from origin of frame_a to revolute joint in the middle, resolved in frame_ia"
+        annotation (Evaluate=true);
+      parameter SI.Position rRod2_ib[3]={-1,0,0}
+        "Vector from origin of frame_ib to revolute joint in the middle, resolved in frame_ib (frame_ib is parallel to frame_b)";
+      parameter SI.Position s_offset=0
+        "Relative distance offset of prismatic joint (distance between the prismatic joint frames = s(t) + s_offset)";
+      parameter SI.Position s_guess=0
+        "Select the configuration such that at initial time |s(t0)-s_guess| is minimal";
+      parameter SI.Distance cylinderLength=world.defaultJointLength
+        "Length of cylinders representing the revolute joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+        "Diameter of cylinders representing the revolute joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of cylinders representing the revolute joints"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter Types.Axis boxWidthDirection={0,1,0}
+        "Vector in width direction of prismatic joint, resolved in frame_b"
+        annotation (Evaluate=true, Dialog(tab="Animation", group=
+              "if animation = true", enable=animation));
+      parameter SI.Distance boxWidth=world.defaultJointWidth
+        "Width of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance boxHeight=boxWidth "Height of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color boxColor=cylinderColor "Color of prismatic joint box"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Diameter rodDiameter=1.1*cylinderDiameter
+        "Diameter of the two rods connecting the joints"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color rodColor=Modelica.Mechanics.MultiBody.Types.Defaults.RodColor
+        "Color of the two rods connecting the joints"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter Boolean checkTotalPower=false
+        "= true, if total power flowing into this component shall be determined (must be zero)"
+        annotation (Dialog(tab="Advanced"));
+      final parameter Real e_a[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(
+                                                   n_a)
+        "Unit vector along axes of rotations, resolved in frame_a";
+      final parameter Real e_ia[3](each final unit="1")=jointUSP.e2_ia
+        "Unit vector along axes of rotations, resolved in frame_ia";
+      final parameter Real e_im[3](each final unit="1", each fixed=false)
+        "Unit vector along axes of rotations, resolved in frame_im";
+      final parameter Real e_b[3](each final unit="1")=jointUSP.prismatic.e
+        "Unit vector along axes of translation of the prismatic joint, resolved in frame_b and frame_ib";
+      SI.Power totalPower=jointUSP.totalPower
+        "Total power flowing into this element, if checkTotalPower=true (otherwise dummy)";
+
+      JointUSP jointUSP(
+        animation=false,
+        showUniversalAxes=false,
+        n1_a=n_a,
+        n_b=n_b,
+        s_offset=s_offset,
+        s_guess=s_guess,
+        rRod1_ia=rRod1_ia,
+        rRod2_ib=rRod2_ib,
+        checkTotalPower=checkTotalPower) annotation (Placement(transformation(
+              extent={{-30,-20},{10,20}})));
+
+    protected
+      Visualizers.Advanced.Shape shape_rev1(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=e_a,
+        widthDirection={0,1,0},
+        r_shape=-e_a*(cylinderLength/2),
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_rev2(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=e_im,
+        widthDirection={0,1,0},
+        r_shape=-e_im*(cylinderLength/2),
+        r=frame_im.r_0,
+        R=frame_im.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_prism(
+        shapeType="box",
+        color=boxColor,
+        specularCoefficient=specularCoefficient,
+        length=jointUSP.prismatic.distance,
+        width=boxWidth,
+        height=boxHeight,
+        lengthDirection=e_b,
+        widthDirection=e_im,
+        r=frame_b.r_0,
+        R=frame_b.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_rod1(
+        shapeType="cylinder",
+        color=rodColor,
+        specularCoefficient=specularCoefficient,
+        length=Modelica.Math.Vectors.length(
+                             rRod1_ia),
+        width=rodDiameter,
+        height=rodDiameter,
+        lengthDirection = to_unit1(rRod1_ia),
+        widthDirection=e_ia,
+        r=frame_ia.r_0,
+        R=frame_ia.R) if world.enableAnimation and animation;
+      Visualizers.Advanced.Shape shape_rod2(
+        shapeType="cylinder",
+        color=rodColor,
+        specularCoefficient=specularCoefficient,
+        length=Modelica.Math.Vectors.length(
+                             rRod2_ib),
+        width=rodDiameter,
+        height=rodDiameter,
+        lengthDirection = to_unit1(rRod2_ib),
+        widthDirection=e_b,
+        r=frame_ib.r_0,
+        R=frame_ib.R) if world.enableAnimation and animation;
+    initial equation
+      e_im = Frames.resolve2(frame_im.R, Frames.resolve1(frame_a.R, e_a));
+
+    equation
+      connect(jointUSP.frame_a, frame_a)
+        annotation (Line(
+          points={{-30,0},{-100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSP.frame_b, frame_b)
+        annotation (Line(
+          points={{10,0},{100,0}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSP.frame_ia, frame_ia) annotation (Line(
+          points={{-26,20},{-26,70},{-80,70},{-80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSP.frame_im, frame_im) annotation (Line(
+          points={{-10,20},{-10,70},{0,70},{0,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSP.frame_ib, frame_ib) annotation (Line(
+          points={{6,20},{6,50},{80,50},{80,100}},
+          color={95,95,95},
+          thickness=0.5));
+      connect(jointUSP.axis, axis)
+        annotation (Line(points={{10,16},{86,16},{86,80},{100,80}}, color={0,0,
+              0}));
+      connect(jointUSP.bearing, bearing)
+        annotation (Line(points={{10,8},{94,8},{94,40},{100,40}}));
+      annotation (
+        Documentation(info="<html>
+<p>
+This component consists of <b>2 revolute</b> joints with parallel
+axes of rotation that and a <b>prismatic</b> joint with a translational
+axis that is orthogonal to the revolute joint axes, see the default
+animation in the following figure (the axes vectors are not part of the
+default animation):
+</p>
+
+<p>
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointRRP.png\" ALT=\"model Joints.Assemblies.JointRRP\">
+</p>
+
+<p>
+This joint aggregation introduces neither constraints nor state variables and
+should therefore be used in kinematic loops whenever possible to
+avoid non-linear systems of equations. It is only meaningful to
+use this component in <b>planar loops</b>. Basically, the position
+and orientation of the 3 joints as well as of frame_ia, frame_ib, and
+frame_im are calculated by solving analytically a non-linear equation,
+given the position and orientation at frame_a and at frame_b.
+</p>
+<p>
+Connector <b>frame_a</b> is the \"left\" side of the first revolute joint
+whereas <b>frame_ia</b> is the \"right side of this revolute joint, fixed in rod 1.
+Connector <b>frame_b</b> is the \"right\" side of the prismatic joint
+whereas <b>frame_ib</b> is the \"left\" side of this prismatic joint, fixed in rod 2.
+Finally, connector <b>frame_im</b> is the connector at the \"right\" side
+of the revolute joint in the middle, fixed in rod 2. The frames
+frame_b, frame_ib, frame_im are always parallel to each other.
+</p>
+<p>
+The easiest way to define the parameters of this joint is by moving the
+MultiBody system in a <b>reference configuration</b> where <b>all frames</b>
+of all components are <b>parallel</b> to each other (alternatively,
+at least frame_a, frame_ia, frame_im, frame_ib, frame_b of the JointRRP joint
+should be parallel to each other when defining an instance of this
+component).
+</p>
+<p>
+Basically, the JointRRP model consists internally of a universal -
+spherical - prismatic joint aggregation (= JointUSP). In a planar
+loop this will behave as if 2 revolute joints with parallel axes
+and 1 prismatic joint are connected by rigid rods.
+</p>
+</html>"),
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}},
+            initialScale=0.2), graphics={
+            Rectangle(
+              extent={{-90,90},{90,-90}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-139,-53},{141,-78}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Text(
+              extent={{26,124},{68,93}},
+              lineColor={128,128,128},
+              textString="ib"),
+            Text(
+              extent={{-134,128},{-94,94}},
+              lineColor={128,128,128},
+              textString="ia"),
+            Ellipse(
+              extent={{-100,25},{-50,-25}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-85,10},{-65,-10}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-26,80},{24,30}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-10,66},{10,46}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-71,9},{-24,45},{-19,39},{-66,3},{-71,9}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{54,5},{5,47},{8,53},{58,11},{54,5}},
+              lineColor={0,0,0},
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-128,-29},{139,-47}},
+              lineColor={0,0,0},
+              textString="n_a=%n_a"),
+            Line(
+              points={{0,57},{0,86},{0,86},{0,100}},
+              color={95,95,95},
+              thickness=0.5),
+            Text(
+              extent={{-55,126},{-15,92}},
+              lineColor={128,128,128},
+              textString="im"),
+            Line(
+              points={{-80,100},{-80,8}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{80,80},{101,80}},
+              color={95,95,95},
+              thickness=0.5),
+            Line(
+              points={{100,40},{93,40},{93,3}},
+              color={95,95,95},
+              thickness=0.5),
+            Rectangle(
+              extent={{80,15},{100,21}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{53,5},{80,11}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{53,5},{80,-15}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{80,15},{100,-21}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{80,100},{80,80},{57,11}},
+              color={95,95,95},
+              thickness=0.5)}));
+    end JointRRP;
+    annotation ( Documentation(info="<html>
+<p>
+The joints in this package are mainly designed to be used
+in <b>kinematic loop</b> structures. Every component consists of
+<b>3 elementary joints</b>. These joints are combined in such a
+way that the kinematics of the 3 joints between frame_a and
+frame_b are computed from the movement of frame_a and frame_b,
+i.e., there are <b>no constraints</b> between frame_a and frame_b.
+This requires to solve a <b>non-linear system of equations</b> which
+is performed <b>analytically</b> (i.e., when a mathematical
+solution exists, it is computed efficiently and reliably).
+A detailed description how to use these joints is provided in
+<a href=\"modelica://Modelica.Mechanics.MultiBody.UsersGuide.Tutorial.LoopStructures.AnalyticLoopHandling\">MultiBody.UsersGuide.Tutorial.LoopStructures.AnalyticLoopHandling</a>.
+</p>
+<p>
+The assembly joints in this package are named <b>JointXYZ</b> where
+<b>XYZ</b> are the first letters of the elementary joints used in the
+component, in particular:
+</p>
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><td valign=\"top\"><b>P</b></td><td valign=\"top\">Prismatic joint</td></tr>
+  <tr><td valign=\"top\"><b>R</b></td><td valign=\"top\">Revolute joint</td></tr>
+  <tr><td valign=\"top\"><b>S</b></td><td valign=\"top\">Spherical joint</td></tr>
+  <tr><td valign=\"top\"><b>U</b></td><td valign=\"top\">Universal joint</td></tr>
+</table>
+<p>
+For example, JointUSR is an assembly joint consisting
+of a universal, a spherical and a revolute joint.
+</p>
+<p> This package contains the following models:
+</p>
+<h4>Content</h4>
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><th><b><i>Model</i></b></th><th><b><i>Description</i></b></th></tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUPS\">JointUPS</a></td>
+      <td valign=\"top\"> Universal - prismatic - spherical joint aggregation<br>
+     <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUPS.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSR\">JointUSR</a></td>
+      <td valign=\"top\"> Universal - spherical - revolute joint aggregation<br>
+     <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUSR.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointUSP\">JointUSP</a></td>
+      <td valign=\"top\"> Universal - spherical - prismatic joint aggregation<br>
+     <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointUSP.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointSSR\">JointSSR</a></td>
+      <td valign=\"top\"> Spherical - spherical - revolute joint aggregation
+           with an optional mass point at the rod connecting
+           the two spherical joints<br>
+     <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointSSR.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointSSP\">JointSSP</a></td>
+      <td valign=\"top\"> Spherical - spherical - prismatic joint aggregation
+           with an optional mass point at the rod connecting
+           the two spherical joints<br>
+     <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointSSP.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointRRR\">JointRRR</a></td>
+      <td valign=\"top\"> Revolute - revolute - revolute joint aggregation for planar loops<br>
+     <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointRRR.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies.JointRRP\">JointRRP</a></td>
+      <td valign=\"top\"> Revolute - revolute - prismatic joint aggregation for planar loops<br>
+     <img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/JointRRP.png\">
+      </td>
+  </tr>
+</table>
+<p>
+Note, no component of this package has potential states, since the
+components are designed in such a way that the generalized coordinates
+of the used elementary joints are computed from the frame_a and frame_b
+coordinates. Still, it is possible to use the components in a
+tree structure. In this case states are selected from bodies that are
+connected to the frame_a or frame_b side of the component.
+In most cases this gives a less efficient solution, as if elementary
+joints of package Modelica.Mechanics.MultiBody.Joints would be used directly.
+</p>
+<p>
+The analytic handling of kinematic loops by using joint aggregations
+with 6 degrees of freedom as provided in this package, is a <b>new</b>
+methodology. It is based on a more general method for solving
+non-linear equations of kinematic loops developed by Woernle and
+Hiller. An automatic application of this more general method
+is difficult, and a manual application is only suited for
+specialists in this field. The method introduced here is a
+compromise: It can be quite easily applied by an end user, but
+for a smaller class of kinematic loops. The method of the \"characteristic
+pair of joints\" from Woernle and Hiller is described in:
+</p>
+<dl>
+<dt>Woernle C.:</dt>
+<dd><b>Ein systematisches Verfahren zur Aufstellung der geometrischen
+    Schliessbedingungen in kinematischen Schleifen mit Anwendung
+    bei der R&uuml;ckw&auml;rtstransformation f&uuml;r
+    Industrieroboter.</b><br>
+    Fortschritt-Berichte VDI, Reihe 18, Nr. 59, Duesseldorf: VDI-Verlag 1988,
+    ISBN 3-18-145918-6.<br>&nbsp;</dd>
+<dt>Hiller M., and Woernle C.:</dt>
+<dd><b>A Systematic Approach for Solving the Inverse Kinematic
+    Problem of Robot Manipulators</b>.<br>
+    Proceedings 7th World Congress Th. Mach. Mech., Sevilla 1987. </dd>
+</dl>
+</html>"));
+  end Assemblies;
+
+  package Constraints "Components that define joints by constraints"
+    extends Modelica.Icons.Package;
+
+    model Prismatic
+      "Prismatic cut-joint and translational directions may be constrained or released"
+      extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+      import Cv = Modelica.SIunits.Conversions;
+
+      parameter Boolean x_locked=true
+        "= true: constraint force in x-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints"),choices(checkBox=true));
+      parameter Boolean y_locked=true
+        "= true: constraint force in y-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints"),choices(checkBox=true));
+      parameter Boolean z_locked=true
+        "= true: constraint force in z-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints"),choices(checkBox=true));
+
+      parameter Boolean animation=true
+        "= true, if animation shall be enabled (show sphere)";
+      parameter SI.Distance sphereDiameter=world.defaultJointLength /3
+        "Diameter of sphere representing the spherical joint"
+          annotation (Dialog(group="if animation = true", enable=animation));
+      input Types.Color sphereColor=Types.Defaults.JointColor
+        "Color of sphere representing the spherical joint"
+          annotation (Dialog(colorSelector=true, group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient=world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+          annotation (Dialog(group="if animation = true", enable=animation));
+
+    protected
+      Frames.Orientation R_rel
+        "Dummy or relative orientation object from frame_a to frame_b";
+      Modelica.SIunits.Position r_rel_a[3]
+        "Position vector from origin of frame_a to origin of frame_b, resolved in frame_a";
+      Modelica.SIunits.InstantaneousPower P;
+
+    public
+      Visualizers.Advanced.Shape sphere(
+        shapeType="sphere",
+        color=sphereColor,
+        specularCoefficient=specularCoefficient,
+        length=sphereDiameter,
+        width=sphereDiameter,
+        height=sphereDiameter,
+        lengthDirection={1,0,0},
+        widthDirection={0,1,0},
+        r_shape={-0.5,0,0}*sphereDiameter,
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+    equation
+      // Determine relative position vector resolved in frame_a
+      R_rel = Frames.relativeRotation(frame_a.R, frame_b.R);
+      r_rel_a = Frames.resolve2(frame_a.R, frame_b.r_0 - frame_a.r_0);
+
+      // Constraint equations concerning rotations
+      ones(3)={R_rel.T[1,1], R_rel.T[2,2], R_rel.T[3,3]};
+
+      // Constraint equations concerning translations
+      if x_locked and y_locked and z_locked then
+        r_rel_a=zeros(3);
+      elseif x_locked and y_locked and not z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[2]=0;
+        frame_a.f[3]=0;
+      elseif x_locked and not y_locked and z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[3]=0;
+        frame_a.f[2]=0;
+      elseif x_locked and not y_locked and not z_locked then
+        r_rel_a[1]=0;
+        frame_a.f[2]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and y_locked and z_locked then
+        r_rel_a[2]=0;
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+      elseif not x_locked and y_locked and not z_locked then
+        r_rel_a[2]=0;
+        frame_a.f[1]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and not y_locked and z_locked then
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+        frame_a.f[2]=0;
+      else
+        frame_a.f=zeros(3);
+      end if;
+
+      zeros(3) = frame_a.t + Frames.resolve1(R_rel, frame_b.t) + cross(r_rel_a,
+        Frames.resolve1(R_rel, frame_b.f));
+      zeros(3) = Frames.resolve1(R_rel, frame_b.f) + frame_a.f;
+      P = frame_a.t*Frames.angularVelocity2(frame_a.R) + frame_b.t*
+        Frames.angularVelocity2(frame_b.R) + frame_b.f*Frames.resolve2(frame_b.R,
+        der(frame_b.r_0)) + frame_a.f*Frames.resolve2(frame_a.R, der(frame_a.r_0));
+
+      annotation (
+        defaultComponentName="constraint",
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}}), graphics={
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x",
+              visible=x_locked and not y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: y",
+              visible=not x_locked and y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: z",
+              visible=not x_locked and not y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, y",
+              visible=x_locked and y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, z",
+              visible=x_locked and not y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: y, z",
+              visible=not x_locked and y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, y, z",
+              visible=x_locked and y_locked and z_locked),
+            Rectangle(
+              extent={{-100,46},{-30,56}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-100,-44},{-30,47}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-30,24},{100,34}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-30,-26},{100,24}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(points={{100,-26},{100,25}}),
+            Line(points={{-30,-44},{-30,56}}),
+            Text(
+              extent={{-150,120},{150,80}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Line(
+              points={{-81,-66},{-23,25},{40,-39},{97,71}},
+              color={255,0,0},
+              thickness=0.5)}),
+        Documentation(info="<html>
+<p>This model does not use explicit variables e.g. state variables in order to describe the relative motion of frame_b with respect to frame_a, but defines kinematic constraints between the frame_a and frame_b. The forces and torques at both frames are then evaluated in such a way that the constraints are satisfied.  Sometimes this type of formulation is also called an implicit joint in literature.</p>
+<p>As a consequence of the formulation the relative kinematics between frame_a and frame_b cannot be initialized.</p>
+<p>In particular in complex multibody systems with closed loops this may help to simplify the system of non-linear equations. Please compare the translation log using the classical joint formulation and the alternative formulation used here in order to check whether this fact applies to the particular system under consideration.</p>
+<p>In systems without closed loops the use of this implicit joint does not make sense or may even be disadvantageous.</p>
+<p>See the subpackage <a href=\"Modelica://Modelica.Mechanics.MultiBody.Examples.Constraints\">Examples.Constraints</a> for testing the joint. </p>
+</html>"));
+    end Prismatic;
+
+    model Revolute
+      "Revolute cut-joint and translational directions may be constrained or released"
+      extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+
+      parameter Boolean x_locked=true
+        "= true: constraint force in x-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints in translational motion"),choices(checkBox=true));
+      parameter Boolean y_locked=true
+        "= true: constraint force in y-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints in translational motion"),choices(checkBox=true));
+      parameter Boolean z_locked=true
+        "= true: constraint force in z-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints in translational motion"),choices(checkBox=true));
+
+      parameter Boolean animation=true
+        "= true, if animation shall be enabled (show sphere)";
+      parameter Types.Axis n={0,1,0}
+        "Axis of rotation resolved in frame_a (= same as in frame_b)"
+        annotation (Evaluate=true);
+
+      parameter SI.Distance sphereDiameter=world.defaultJointLength /3
+        "Diameter of sphere representing the spherical joint"
+        annotation (Dialog(group="if animation = true", enable=animation));
+      input Types.Color sphereColor=Types.Defaults.JointColor
+        "Color of sphere representing the spherical joint"
+        annotation (Dialog(colorSelector=true, group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient=world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(group="if animation = true", enable=animation));
+
+    protected
+      Frames.Orientation R_rel
+        "Dummy or relative orientation object from frame_a to frame_b";
+      Modelica.SIunits.Position r_rel_a[3]
+        "Position vector from origin of frame_a to origin of frame_b, resolved in frame_a";
+      Modelica.SIunits.InstantaneousPower P;
+      parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(
+                                           n)
+        "Unit vector in direction of rotation axis, resolved in frame_a (= same as in frame_b)";
+
+      parameter Real nnx_a[3](each final unit="1")=if abs(e[1]) > 0.1 then {0,1,0} else (if abs(e[2])
+           > 0.1 then {0,0,1} else {1,0,0})
+        "Arbitrary vector that is not aligned with rotation axis n"
+        annotation (Evaluate=true);
+          parameter Real ey_a[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(
+                                              cross(e, nnx_a))
+        "Unit vector orthogonal to axis n of revolute joint, resolved in frame_a"
+        annotation (Evaluate=true);
+      parameter Real ex_a[3](each final unit="1")=cross(ey_a, e)
+        "Unit vector orthogonal to axis n of revolute joint and to ey_a, resolved in frame_a";
+
+    public
+      Visualizers.Advanced.Shape sphere(
+        shapeType="sphere",
+        color=sphereColor,
+        specularCoefficient=specularCoefficient,
+        length=sphereDiameter,
+        width=sphereDiameter,
+        height=sphereDiameter,
+        lengthDirection={1,0,0},
+        widthDirection={0,1,0},
+        r_shape={-0.5,0,0}*sphereDiameter,
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+
+    equation
+      // Determine relative position vector resolved in frame_a
+      R_rel = Frames.relativeRotation(frame_a.R, frame_b.R);
+      r_rel_a = Frames.resolve2(frame_a.R, frame_b.r_0 - frame_a.r_0);
+
+      // Constraint equations concerning translations
+      if x_locked and y_locked and z_locked then
+        r_rel_a=zeros(3);
+      elseif x_locked and y_locked and not z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[2]=0;
+        frame_a.f[3]=0;
+      elseif x_locked and not y_locked and z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[3]=0;
+        frame_a.f[2]=0;
+      elseif x_locked and not y_locked and not z_locked then
+        r_rel_a[1]=0;
+        frame_a.f[2]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and y_locked and z_locked then
+        r_rel_a[2]=0;
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+      elseif not x_locked and y_locked and not z_locked then
+        r_rel_a[2]=0;
+        frame_a.f[1]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and not y_locked and z_locked then
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+        frame_a.f[2]=0;
+      else
+        frame_a.f=zeros(3);
+      end if;
+
+      // Constraint equations concerning rotations
+      0 = ex_a*R_rel.T*e;
+      0 = ey_a*R_rel.T*e;
+      frame_a.t*n=0;
+
+      zeros(3) = frame_a.f + Frames.resolve1(R_rel, frame_b.f);
+      zeros(3) = frame_a.t + Frames.resolve1(R_rel, frame_b.t) - cross(r_rel_a,
+        frame_a.f);
+      P = frame_a.t*Frames.angularVelocity2(frame_a.R) + frame_b.t*
+        Frames.angularVelocity2(frame_b.R) + Frames.resolve1(frame_b.R, frame_b.f)
+        *der(frame_b.r_0) + Frames.resolve1(frame_a.R, frame_a.f)*der(frame_a.r_0);
+
+        annotation ( defaultComponentName="constraint",
+          Icon(coordinateSystem(
+              preserveAspectRatio=true,
+              extent={{-100,-100},{100,100}}), graphics={
+            Text(
+              extent={{-63,-63},{53,-93}},
+              lineColor={0,0,0},
+              textString="n=%n",
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-100,-60},{-30,60}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={255,255,255},
+              radius=10),
+            Rectangle(
+              extent={{30,-60},{100,60}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={255,255,255},
+              radius=10),
+            Rectangle(extent={{-100,60},{-30,-60}}, lineColor={64,64,64}, radius=10),
+            Rectangle(extent={{30,60},{100,-60}}, lineColor={64,64,64}, radius=10),
+            Text(
+              extent={{-90,14},{-54,-11}},
+              lineColor={128,128,128},
+              textString="a"),
+            Text(
+              extent={{51,11},{87,-14}},
+              lineColor={128,128,128},
+              textString="b"),
+            Rectangle(
+              extent={{-30,11},{30,-10}},
+              lineColor={64,64,64},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Line(
+              points={{-81,-66},{-23,25},{40,-39},{97,71}},
+              color={255,0,0},
+              thickness=0.5),
+            Text(
+              extent={{-49,82},{45,59}},
+              textString="constraint"),
+            Text(
+              extent={{-150,120},{150,80}},
+              lineColor={0,0,255},
+              textString="%name")}),
+          Documentation(info="<html>
+<p>This model does not use explicit variables e.g. state variables in order to describe the relative motion of frame_b with respect to frame_a, but defines kinematic constraints between the frame_a and frame_b. The forces and torques at both frames are then evaluated in such a way that the constraints are satisfied. Sometimes this type of formulation is also called an implicit joint in literature.</p>
+<p>As a consequence of the formulation the relative kinematics between frame_a and frame_b cannot be initialized.</p>
+<p>In particular in complex multibody systems with closed loops this may help to simplify the system of non-linear equations. Please compare the translation log using the classical joint formulation and the alternative formulation used here in order to check whether this fact applies to the particular system under consideration.</p>
+<p>In systems without closed loops the use of this implicit joint does not make sense or may even be disadvantageous.</p>
+<p>See the subpackage <a href=\"Modelica://Modelica.Mechanics.MultiBody.Examples.Constraints\">Examples.Constraints</a> for testing the joint. </p>
+</html>"));
+    end Revolute;
+
+    model Spherical
+      "Spherical cut joint and translational directions may be constrained or released"
+      extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+      import MBS = Modelica.Mechanics.MultiBody;
+
+      parameter Boolean x_locked=true
+        "= true: constraint force in x-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints"), choices(checkBox=true));
+      parameter Boolean y_locked=true
+        "= true: constraint force in y-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints"), choices(checkBox=true));
+      parameter Boolean z_locked=true
+        "= true: constraint force in z-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints"), choices(checkBox=true));
+
+      parameter Boolean animation=true
+        "= true, if animation shall be enabled (show sphere)"
+        annotation (Dialog(group="Animation"));
+      parameter Modelica.SIunits.Distance sphereDiameter=world.defaultJointLength /3
+        "Diameter of sphere representing the spherical joint"
+        annotation (Dialog(group="Animation", enable=animation));
+      input MBS.Types.Color sphereColor=MBS.Types.Defaults.JointColor
+        "Color of sphere representing the spherical joint"
+        annotation (Dialog(colorSelector=true, group="Animation", enable=animation));
+      input MBS.Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(group="Animation", enable=animation));
+
+      Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape sphere(
+        shapeType="sphere",
+        color=sphereColor,
+        specularCoefficient=specularCoefficient,
+        length=sphereDiameter,
+        width=sphereDiameter,
+        height=sphereDiameter,
+        lengthDirection={1,0,0},
+        widthDirection={0,1,0},
+        r_shape={-0.5,0,0}*sphereDiameter,
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+    protected
+      MBS.Frames.Orientation R_rel
+        "Dummy or relative orientation object from frame_a to frame_b";
+      Modelica.SIunits.Position r_rel_a[3]
+        "Position vector from origin of frame_a to origin of frame_b, resolved in frame_a";
+      Modelica.SIunits.InstantaneousPower P;
+
+    equation
+      // Determine relative position vector resolved in frame_a
+      R_rel = MBS.Frames.relativeRotation(frame_a.R, frame_b.R);
+      r_rel_a = MBS.Frames.resolve2(frame_a.R, frame_b.r_0 - frame_a.r_0);
+
+      // Constraint equations concerning translation
+      if x_locked and y_locked and z_locked then
+        r_rel_a=zeros(3);
+      elseif x_locked and y_locked and not z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[2]=0;
+        frame_a.f[3]=0;
+      elseif x_locked and not y_locked and z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[3]=0;
+        frame_a.f[2]=0;
+      elseif x_locked and not y_locked and not z_locked then
+        r_rel_a[1]=0;
+        frame_a.f[2]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and y_locked and z_locked then
+        r_rel_a[2]=0;
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+      elseif not x_locked and y_locked and not z_locked then
+        r_rel_a[2]=0;
+        frame_a.f[1]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and not y_locked and z_locked then
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+        frame_a.f[2]=0;
+      else
+        frame_a.f=zeros(3);
+      end if;
+
+      //frame_a.t = zeros(3);
+      frame_b.t = zeros(3);
+      frame_b.f = -MBS.Frames.resolve2(R_rel, frame_a.f);
+      zeros(3) = frame_a.t + MBS.Frames.resolve1(R_rel, frame_b.t) - cross(r_rel_a, frame_a.f);
+      P= frame_a.t*MBS.Frames.angularVelocity2(frame_a.R)+frame_b.t*MBS.Frames.angularVelocity2(frame_b.R) + MBS.Frames.resolve1(frame_b.R,frame_b.f)*der(frame_b.r_0)+MBS.Frames.resolve1(frame_a.R,frame_a.f)*der(frame_a.r_0);
+      annotation (
+        defaultComponentName="constraint",
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}}), graphics={
+            Text(
+              extent={{-150,120},{150,80}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x",
+              visible=x_locked and not y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: y",
+              visible=not x_locked and y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: z",
+              visible=not x_locked and not y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, y",
+              visible=x_locked and y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, z",
+              visible=x_locked and not y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: y, z",
+              visible=not x_locked and y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, y, z",
+              visible=x_locked and y_locked and z_locked),
+            Ellipse(
+              extent={{-66,-70},{74,70}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-45,-50},{55,50}},
+              lineColor={128,128,128},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{34,70},{75,-68}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-96,10},{-64,-10}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Rectangle(
+              extent={{27,10},{104,-10}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={192,192,192}),
+            Ellipse(
+              extent={{-20,25},{30,-25}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.Sphere,
+              fillColor={160,160,164}),
+            Line(
+              points={{-81,-66},{-23,25},{40,-39},{97,71}},
+              color={255,0,0},
+              thickness=0.5)}),
+        Documentation(info="<html>
+<p>This model does not use explicit variables e.g. state variables in order to describe the relative motion of frame_b with to respect to frame_a, but defines kinematic constraints between the frame_a and frame_b. The forces and torques at both frames are then evaluated in such a way that the constraints are satisfied. Sometimes this type of formulation is also called an implicit joint in literature.</p>
+<p>As a consequence of the formulation the relative kinematics between frame_a and frame_b cannot be initialized.</p>
+<p>In particular in complex multibody systems with closed loops this may help to simplify the system of non-linear equations. Please compare the translation log using the classical joint formulation and the alternative formulation used here in order to check whether this fact applies to the particular system under consideration.</p>
+<p>In systems without closed loops the use of this implicit joint does not make sense or may even be disadvantageous.</p>
+<p>See the subpackage <a href=\"Modelica://Modelica.Mechanics.MultiBody.Examples.Constraints\">Examples.Constraints</a> for testing the joint. </p>
+</html>"));
+    end Spherical;
+
+    model Universal
+      "Universal cut-joint and translational directions may be constrained or released"
+      extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+      import MBS = Modelica.Mechanics.MultiBody;
+
+      parameter MBS.Types.Axis n_a={1,0,0}
+        "Axis of revolute joint 1 resolved in frame_a" annotation (Evaluate=true);
+      parameter MBS.Types.Axis n_b={0,1,0}
+        "Axis of revolute joint 2 resolved in frame_b" annotation (Evaluate=true);
+
+      parameter Boolean x_locked=true
+        "= true: constraint force in x-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints in translational motion"), choices(checkBox=true));
+      parameter Boolean y_locked=true
+        "= true: constraint force in y-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints in translational motion"), choices(checkBox=true));
+      parameter Boolean z_locked=true
+        "= true: constraint force in z-direction, resolved in frame_a"
+        annotation (Dialog(group="Constraints in translational motion"), choices(checkBox=true));
+
+      parameter Boolean animation=true
+        "= true, if animation shall be enabled (show sphere)"
+        annotation (Dialog(group="Animation"));
+      parameter SI.Distance sphereDiameter=world.defaultJointLength /3
+        "Diameter of sphere representing the spherical joint"
+        annotation (Dialog(group="Animation", enable=animation));
+      input MBS.Types.Color sphereColor=MBS.Types.Defaults.JointColor
+        "Color of sphere representing the spherical joint"
+        annotation (Dialog(colorSelector=true, group="Animation", enable=animation));
+      input MBS.Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(group="Animation", enable=animation));
+    protected
+      MBS.Frames.Orientation R_rel
+        "Dummy or relative orientation object from frame_a to frame_b";
+      Real w_rel[3];
+      Modelica.SIunits.Position r_rel_a[3]
+        "Position vector from origin of frame_a to origin of frame_b, resolved in frame_a";
+
+      Modelica.SIunits.InstantaneousPower P;
+    equation
+      // Determine relative position vector resolved in frame_a
+      R_rel = MBS.Frames.relativeRotation(frame_a.R, frame_b.R);
+      w_rel = MBS.Frames.angularVelocity1(R_rel);
+      r_rel_a = MBS.Frames.resolve2(frame_a.R, frame_b.r_0 - frame_a.r_0);
+
+      // Constraint equations concerning translations
+      if x_locked and y_locked and z_locked then
+        r_rel_a=zeros(3);
+      elseif x_locked and y_locked and not z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[2]=0;
+        frame_a.f[3]=0;
+      elseif x_locked and not y_locked and z_locked then
+        r_rel_a[1]=0;
+        r_rel_a[3]=0;
+        frame_a.f[2]=0;
+      elseif x_locked and not y_locked and not z_locked then
+        r_rel_a[1]=0;
+        frame_a.f[2]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and y_locked and z_locked then
+        r_rel_a[2]=0;
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+      elseif not x_locked and y_locked and not z_locked then
+        r_rel_a[2]=0;
+        frame_a.f[1]=0;
+        frame_a.f[3]=0;
+      elseif not x_locked and not y_locked and z_locked then
+        r_rel_a[3]=0;
+        frame_a.f[1]=0;
+        frame_a.f[2]=0;
+      else
+        frame_a.f=zeros(3);
+      end if;
+      // Constraint equations concerning rotations
+      frame_a.t*n_a=0;
+      frame_b.t*n_b=0;
+      n_b*R_rel.T*n_a=0;
+      assert(abs(n_a*n_b) < Modelica.Constants.eps, "The two axes that constitute the Constraints.Universal joint must be different");
+
+      zeros(3)=frame_a.f + MBS.Frames.resolve1(R_rel, frame_b.f);
+      zeros(3) = frame_a.t+MBS.Frames.resolve1(R_rel, frame_b.t)- cross(r_rel_a, frame_a.f);
+      P = frame_a.t*MBS.Frames.angularVelocity2(frame_a.R)+frame_b.t*MBS.Frames.angularVelocity2(frame_b.R) + MBS.Frames.resolve1(frame_b.R,frame_b.f)*der(frame_b.r_0)+MBS.Frames.resolve1(frame_a.R,frame_a.f)*der(frame_a.r_0);
+
+      annotation (
+        defaultComponentName="constraint",
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}}), graphics={
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x",
+              visible=x_locked and not y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: y",
+              visible=not x_locked and y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: z",
+              visible=not x_locked and not y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, y",
+              visible=x_locked and y_locked and not z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: x, z",
+              visible=x_locked and not y_locked and z_locked),
+            Text(
+              extent={{-100,-70},{100,-100}},
+              lineColor={95,95,95},
+              textString="lock: y, z",
+              visible=not x_locked and y_locked and z_locked),
+            Text(
+              extent={{-100,-76},{100,-106}},
+              lineColor={95,95,95},
+              textString="lock: x, y, z",
+              visible=x_locked and y_locked and z_locked),
+            Rectangle(
+              extent={{-96,15},{-61,-15}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={235,235,235}),
+            Ellipse(
+              extent={{-76,-80},{84,80}},
+              lineColor={160,160,164},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-56,-60},{64,60}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{16,82},{84,-82}},
+              lineColor={255,255,255},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{60,15},{104,-15}},
+              lineColor={0,0,0},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={235,235,235}),
+            Line(
+              points={{16,78},{16,-78}},
+              thickness=0.5),
+            Ellipse(
+              extent={{-48,-40},{84,40}},
+              lineColor={160,160,164},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Ellipse(
+              extent={{-28,-20},{64,26}},
+              lineColor={160,160,164},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{-18,-54},{-56,0},{-18,50},{44,52},{-18,-54}},
+              pattern=LinePattern.None,
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Line(
+              points={{16,78},{16,-20}},
+              thickness=0.5),
+            Line(
+              points={{36,38},{-8,-36}},
+              thickness=0.5),
+            Text(
+              extent={{-150,120},{150,80}},
+              lineColor={0,0,255},
+              textString="%name"),
+            Line(
+              points={{-81,-66},{-23,25},{40,-39},{97,71}},
+              color={255,0,0},
+              thickness=0.5)}),
+        Documentation(info="<html>
+<p>This model does not use explicit variables e.g. state variables in order to describe the relative motion of frame_b with respect to frame_a, but defines kinematic constraints between the frame_a and frame_b. The forces and torques at both frames are then evaluated in such a way that the constraints are satisfied. Sometimes this type of formulation is also called an implicit joint in literature.</p>
+<p>As a consequence of the formulation the relative kinematics between frame_a and frame_b cannot be initialized.</p>
+<p>In particular in complex multibody systems with closed loops this may help to simplify the system of non-linear equations. Please compare the translation log using the classical joint formulation and the alternative formulation used here in order to check whether this fact applies to the particular system under consideration.</p>
+<p>In systems without closed loops the use of this implicit joint does not make sense or may even be disadvantageous.</p>
+<p>See the subpackage <a href=\"Modelica://Modelica.Mechanics.MultiBody.Examples.Constraints\">Examples.Constraints</a> for testing the joint. </p>
+</html>"));
+    end Universal;
+
+    annotation (Documentation(info="<html>
+<p>
+This package contains <b>constraint components</b>, that is, idealized, massless elements that
+constrain the motion between frames by means of kinematic constraints. The constraint
+elements are especially aimed to be used for multibody models which contain <b>kinematic loops</b>.
+Usually, kinematic loops are automatically handled. However, the performance might be improved
+by either solving certain kinds of loops analytically with the help of the components of
+subpackage  <a href=\"Modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies\">Assemblies</a>, or
+by providing numerically better loop constraint formulations with the help of the components
+of this subpackage.
+</p>
+</html>"));
+  end Constraints;
+
+  package Internal
+    "Components used for analytic solution of kinematic loops (use only if you know what you are doing)"
+
+    extends Modelica.Icons.InternalPackage;
+
+    model RevoluteWithLengthConstraint
+      "Revolute joint where the rotation angle is computed from a length constraint (1 degree-of-freedom, no potential state)"
+
+      extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+      Modelica.Mechanics.Rotational.Interfaces.Flange_a axis
+        "1-dim. rotational flange that drives the joint"
+        annotation (Placement(transformation(extent={{10,90},{-10,110}})));
+      Modelica.Mechanics.Rotational.Interfaces.Flange_b bearing
+        "1-dim. rotational flange of the drive bearing"
+        annotation (Placement(transformation(extent={{-50,90},{-70,110}})));
+
+      Modelica.Blocks.Interfaces.RealInput position_a[3](each final quantity="Length", each final unit="m")
+        "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint"
+        annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
+      Modelica.Blocks.Interfaces.RealInput position_b[3](each final quantity="Length", each final unit="m")
+        "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint"
+        annotation (Placement(transformation(extent={{140,-80},{100,-40}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter SI.Position lengthConstraint(start=1)
+        "Fixed length of length constraint";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n={0,0,1}
+        "Axis of rotation resolved in frame_a (= same as in frame_b)"
+        annotation (Evaluate=true);
+      parameter Cv.NonSIunits.Angle_deg phi_offset=0
+        "Relative angle offset (angle = phi + from_deg(phi_offset))";
+      parameter Cv.NonSIunits.Angle_deg phi_guess=0
+        "Select the configuration such that at initial time |phi - from_deg(phi_guess)| is minimal";
+      parameter SI.Distance cylinderLength=world.defaultJointLength
+        "Length of cylinder representing the joint axis"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+        "Diameter of cylinder representing the joint axis"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of cylinder representing the joint axis"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+      final parameter Boolean positiveBranch(fixed=false)
+        "Based on phi_guess, selection of one of the two solutions of the non-linear constraint equation";
+      final parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(n)
+        "Unit vector in direction of rotation axis, resolved in frame_a";
+
+      SI.Angle phi "Rotation angle of revolute joint";
+      Frames.Orientation R_rel
+        "Relative orientation object from frame_a to frame_b";
+      SI.Angle angle
+        "= phi + from_deg(phi_offset) (relative rotation angle between frame_a and frame_b)";
+      SI.Torque tau "= axis.tau (driving torque in the axis)";
+
+    protected
+      SI.Position r_a[3]=position_a
+        "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint";
+      SI.Position r_b[3]=position_b
+        "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint";
+      Real e_r_a "Projection of r_a on e";
+      Real e_r_b "Projection of r_b on e";
+      Real A "Coefficient A of equation: A*cos(phi) + B*sin(phi) + C = 0";
+      Real B "Coefficient B of equation: A*cos(phi) + B*sin(phi) + C = 0";
+      Real C "Coefficient C of equation: A*cos(phi) + B*sin(phi) + C = 0";
+      Real k1 "Constant of quadratic equation";
+      Real k2 "Constant of quadratic equation";
+      Real k1a(start=1);
+      Real k1b;
+      Real kcos_angle "= k1*cos(angle)";
+      Real ksin_angle "= k1*sin(angle)";
+
+      Visualizers.Advanced.Shape cylinder(
+        shapeType="cylinder",
+        color=cylinderColor,
+        specularCoefficient=specularCoefficient,
+        length=cylinderLength,
+        width=cylinderDiameter,
+        height=cylinderDiameter,
+        lengthDirection=e,
+        widthDirection={0,1,0},
+        r_shape=-e*(cylinderLength/2),
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+
+      function selectBranch
+        "Determine branch which is closest to initial angle=0"
+        extends Modelica.Icons.Function;
+        input SI.Length L "Length of length constraint";
+        input Real e[3](each final unit="1")
+          "Unit vector along axis of rotation, resolved in frame_a (= same in frame_b)";
+        input SI.Angle angle_guess
+          "Select the configuration such that at initial time |angle-angle_guess| is minimal (angle=0: frame_a and frame_b coincide)";
+        input SI.Position r_a[3]
+          "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint";
+        input SI.Position r_b[3]
+          "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint";
+        output Boolean positiveBranch "Branch of the initial solution";
+      protected
+        Real e_r_a "Projection of r_a on e";
+        Real e_r_b "Projection of r_b on e";
+        Real A "Coefficient A of equation: A*cos(phi) + B*sin(phi) + C = 0";
+        Real B "Coefficient B of equation: A*cos(phi) + B*sin(phi) + C = 0";
+        Real C "Coefficient C of equation: A*cos(phi) + B*sin(phi) + C = 0";
+        Real k1 "Constant of quadratic equation";
+        Real k2 "Constant of quadratic equation";
+        Real k1a;
+        Real k1b;
+        Real kcos1 "k1*cos(angle1)";
+        Real ksin1 "k1*sin(angle1)";
+        Real kcos2 "k2*cos(angle2)";
+        Real ksin2 "k2*sin(angle2)";
+        SI.Angle angle1 "solution 1 of nonlinear equation";
+        SI.Angle angle2 "solution 2 of nonlinear equation";
+      algorithm
+        /* The position vector r_rel from frame_a to frame_b of the length constraint
+       element, resolved in frame_b of the revolute joint is given by
+       (T_rel is the planar transformation matrix from frame_a to frame_b of
+        the revolute joint):
+          r_rel = r_b - T_rel*r_a
+       The length constraint can therefore be formulated as:
+          r_rel*r_rel = L*L
+       with
+          (r_b - T_rel*r_a)*(r_b - T_rel*r_a)
+             = r_b*r_b - 2*r_b*T_rel*r_a + r_a*transpose(T_rel)*T_rel*r_a
+             = r_b*r_b + r_a*r_a - 2*r_b*T_rel*r_a
+       follows
+          (1) 0 = r_a*r_a + r_b*r_b - 2*r_b*T_rel*r_a - L*L
+       The vectors r_a, r_b and parameter L are NOT a function of
+       the angle of the revolute joint. Since T_rel = T_rel(angle) is a function
+       of the unknown angle of the revolute joint, this is a non-linear
+       equation in this angle.
+          T_rel = [e]*transpose([e]) + (identity(3) - [e]*transpose([e]))*cos(angle)
+                  - skew(e)*sin(angle);
+       with
+          r_b*T_rel*r_a
+             = r_b*(e*(e*r_a) + (r_a - e*(e*r_a))*cos(angle) - cross(e,r_a)*sin(angle)
+             = (e*r_b)*(e*r_a) + (r_b*r_a - (e*r_b)*(e*r_a))*cos(angle) - r_b*cross(e,r_a)*sin(angle)
+       follows for the constraint equation (1)
+          (2) 0 = r_a*r_a + r_b*r_b - L*L
+                  - 2*(e*r_b)*(e*r_a)
+                  - 2*(r_b*r_a - (e*r_b)*(e*r_a))*cos(angle)
+                  + 2*r_b*cross(e,r_a)*sin(angle)
+       or
+          (3) A*cos(angle) + B*sin(angle) + C = 0
+       with
+              A = -2*(r_b*r_a - (e*r_b)*(e*r_a))
+              B = 2*r_b*cross(e,r_a)
+              C = r_a*r_a + r_b*r_b - L*L - 2*(e*r_b)*(e*r_a)
+       Equation (3) is solved by computing sin(angle) and cos(angle)
+       independently from each other. This allows to compute
+       angle in the range: -180 deg <= angle <= 180 deg
+    */
+        e_r_a := e*r_a;
+        e_r_b := e*r_b;
+        A := -2*(r_b*r_a - e_r_b*e_r_a);
+        B := 2*r_b*cross(e, r_a);
+        C := r_a*r_a + r_b*r_b - L*L - 2*e_r_b*e_r_a;
+        k1 := A*A + B*B;
+        k1a :=k1 - C*C;
+        assert(k1a > 1.e-10, "
+Singular position of loop (either no or two analytic solutions;
+the mechanism has lost one-degree-of freedom in this position).
+Try first to use another Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXXX component.
+In most cases it is best that the joints outside of the JointXXX
+component are revolute and NOT prismatic joints. If this also
+lead to singular positions, it could be that this kinematic loop
+cannot be solved analytically. In this case you have to build
+up the loop with basic joints (NO aggregation JointXXX components)
+and rely on dynamic state selection, i.e., during simulation
+the states will be dynamically selected in such a way that in no
+position a degree of freedom is lost.
+");
+        k1b := max(k1a, 1.0e-12);
+        k2 := sqrt(k1b);
+
+        kcos1 := -A*C + B*k2;
+        ksin1 := -B*C - A*k2;
+        angle1 := atan2(ksin1, kcos1);
+
+        kcos2 := -A*C - B*k2;
+        ksin2 := -B*C + A*k2;
+        angle2 := atan2(ksin2, kcos2);
+
+        if abs(angle1 - angle_guess) <= abs(angle2 - angle_guess) then
+          positiveBranch := true;
+        else
+          positiveBranch := false;
+        end if;
+      end selectBranch;
+    initial equation
+      positiveBranch = selectBranch(lengthConstraint, e, Cv.from_deg(phi_offset
+         + phi_guess), r_a, r_b);
+    equation
+      Connections.branch(frame_a.R, frame_b.R);
+      axis.tau = tau;
+      axis.phi = phi;
+      bearing.phi = 0;
+
+      angle = Cv.from_deg(phi_offset) + phi;
+
+      // transform kinematic quantities from frame_a to frame_b
+      frame_b.r_0 = frame_a.r_0;
+
+      R_rel = Frames.planarRotation(e, angle, der(angle));
+      frame_b.R = Frames.absoluteRotation(frame_a.R, R_rel);
+
+      // Force and torque balance
+      zeros(3) = frame_a.f + Frames.resolve1(R_rel, frame_b.f);
+      zeros(3) = frame_a.t + Frames.resolve1(R_rel, frame_b.t);
+
+      // Compute rotation angle (details, see function "selectBranch")
+      e_r_a = e*r_a;
+      e_r_b = e*r_b;
+      A = -2*(r_b*r_a - e_r_b*e_r_a);
+      B = 2*r_b*cross(e, r_a);
+      C = r_a*r_a + r_b*r_b - lengthConstraint*lengthConstraint - 2*e_r_b*e_r_a;
+      k1 = A*A + B*B;
+      k1a = k1 - C*C;
+
+      assert(k1a > 1.e-10, "
+Singular position of loop (either no or two analytic solutions;
+the mechanism has lost one-degree-of freedom in this position).
+Try first to use another Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXXX component.
+In most cases it is best that the joints outside of the JointXXX
+component are revolute and NOT prismatic joints. If this also
+lead to singular positions, it could be that this kinematic loop
+cannot be solved analytically. In this case you have to build
+up the loop with basic joints (NO aggregation JointXXX components)
+and rely on dynamic state selection, i.e., during simulation
+the states will be dynamically selected in such a way that in no
+position a degree of freedom is lost.
+");
+
+      k1b = Frames.Internal.maxWithoutEvent(k1a, 1.0e-12);
+      k2 = sqrt(k1b);
+      kcos_angle = -A*C + (if positiveBranch then B else -B)*k2;
+      ksin_angle = -B*C + (if positiveBranch then -A else A)*k2;
+
+      angle = Modelica.Math.atan2(ksin_angle, kcos_angle);
+      annotation (
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}}), graphics={
+            Rectangle(
+              extent={{-30,10},{10,-10}},
+              lineColor={64,64,64},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-100,-60},{-30,60}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={255,255,255},
+              radius=10),
+            Rectangle(
+              extent={{30,-60},{100,60}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={255,255,255},
+              radius=10),
+            Text(
+              extent={{-139,-168},{137,-111}},
+              textString="%name",
+              lineColor={0,0,255}),
+            Rectangle(extent={{-100,60},{-30,-60}}, lineColor={64,64,64}, radius=10),
+            Rectangle(extent={{30,60},{100,-60}}, lineColor={64,64,64}, radius=10),
+            Text(
+              extent={{-142,-108},{147,-69}},
+              lineColor={0,0,0},
+              textString="n=%n"),
+            Line(points={{-60,60},{-60,90}}),
+            Line(points={{-20,70},{-60,70}}),
+            Line(points={{-20,80},{-20,60}}),
+            Line(points={{20,80},{20,60}}),
+            Line(points={{20,70},{41,70}}),
+            Polygon(
+              points={{-9,30},{10,30},{30,50},{-29,50},{-9,30}},
+              lineColor={64,64,64},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{10,30},{30,50},{30,-51},{10,-31},{10,30}},
+              lineColor={64,64,64},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-10,90},{10,50}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.VerticalCylinder,
+              fillColor={192,192,192})}),
+        Diagram(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}}), graphics={
+            Rectangle(
+              extent={{-100,-60},{-30,60}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={255,255,255},
+              radius=10),
+            Rectangle(
+              extent={{-100,-60},{-30,60}},
+              lineColor={64,64,64},
+              radius=10),
+            Rectangle(
+              extent={{-30,10},{10,-10}},
+              lineColor={64,64,64},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{30,-60},{100,60}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.HorizontalCylinder,
+              fillColor={255,255,255},
+              radius=10),
+            Rectangle(
+              extent={{30,-60},{100,60}},
+              lineColor={64,64,64},
+              radius=10),
+            Line(points={{-60,60},{-60,96}}),
+            Line(points={{-20,70},{-60,70}}),
+            Line(points={{-20,80},{-20,60}}),
+            Line(points={{20,80},{20,60}}),
+            Line(points={{20,70},{41,70}}),
+            Polygon(
+              points={{-9,30},{10,30},{30,50},{-29,50},{-9,30}},
+              lineColor={64,64,64},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Polygon(
+              points={{10,30},{30,50},{30,-51},{10,-31},{10,30}},
+              lineColor={64,64,64},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-10,50},{10,100}},
+              lineColor={64,64,64},
+              fillPattern=FillPattern.VerticalCylinder,
+              fillColor={192,192,192})}),
+        Documentation(info="<html>
+<p>
+Joint where frame_b rotates around axis n which is fixed in frame_a.
+The two frames coincide when \"phi + phi_offset = 0\", where
+\"phi_offset\" is a parameter with a zero default
+and \"phi\" is the rotation angle.
+</p>
+<p>
+This variant of the revolute joint is designed to work together
+with a length constraint in a kinematic loop. This means that the
+angle of the revolute joint, phi, is computed such that the
+length constraint is fulfilled.
+</p>
+<p>
+<b>Usually, this joint should not be used by a user of the MultiBody
+library. It is only provided to built-up the Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXYZ
+joints.</b>
+</p>
+
+<p>
+In releases before version 3.0 of the Modelica Standard Library, it was possible
+to activate the torque projection equation (= cut-torque projected to the rotation
+axis must be identical to the drive torque of flange axis) via parameter
+<b>axisTorqueBalance</b>. This is no longer possible, since otherwise this
+model would not be \"balanced\" (= same number of unknowns as equations).
+Instead, when using this model in version 3.0 and later versions,
+the force in the length constraint component (Joints.SphericalSpherical or
+Joints.UniversalSpherical) must be calculated such that the driving torque
+in direction of the rotation
+axis is (RC shall be the name of the instance of RevoluteWithLengthConstraint):
+</p>
+<pre>
+    0 = RC.axis.tau + RC.e*RC.frame_b.t;
+</pre>
+<p>
+If this equation is used, usually the force in the length constraint
+and the second derivative of the revolute angle will be part of a linear
+algebraic system of equations. In some cases it is possible to solve
+this system of equations locally, i.e., provide the rod force directly
+as function of the revolute constraint torque. In any case, this projection
+equation or an equivalent one has to be provided via variable \"constraintResidue\" in the \"Advanced\"
+menu of \"Joints.SphericalSpherical\" or \"Joints.UniversalSpherical\".
+</p>
+
+</html>"));
+    end RevoluteWithLengthConstraint;
+
+    model PrismaticWithLengthConstraint
+      "Prismatic joint where the translational distance is computed from a length constraint (1 degree-of-freedom, no potential state)"
+
+      extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+      Modelica.Mechanics.Translational.Interfaces.Flange_a axis
+        "1-dim. translational flange that drives the joint"
+        annotation (Placement(transformation(extent={{70,80},{90,60}})));
+      Modelica.Mechanics.Translational.Interfaces.Flange_b bearing
+        "1-dim. translational flange of the drive bearing"
+        annotation (Placement(transformation(extent={{-30,80},{-50,60}})));
+      Modelica.Blocks.Interfaces.RealInput position_a[3](each final quantity="Length", each final unit="m")
+        "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of prismatic joint"
+        annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
+      Modelica.Blocks.Interfaces.RealInput position_b[3](each final quantity="Length", each final unit="m")
+        "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of prismatic joint"
+        annotation (Placement(transformation(extent={{140,-80},{100,-40}})));
+
+      parameter Boolean animation=true "= true, if animation shall be enabled";
+      parameter SI.Position length(start=1) "Fixed length of length constraint";
+      parameter Modelica.Mechanics.MultiBody.Types.Axis n={1,0,0}
+        "Axis of translation resolved in frame_a (= same as in frame_b)"
+        annotation (Evaluate=true);
+      parameter SI.Position s_offset=0
+        "Relative distance offset (distance between frame_a and frame_b = s(t) + s_offset)";
+      parameter SI.Position s_guess=0
+        "Select the configuration such that at initial time |s(t0)-s_guess| is minimal";
+      parameter Types.Axis boxWidthDirection={0,1,0}
+        "Vector in width direction of box, resolved in frame_a"
+        annotation (Evaluate=true, Dialog(tab="Animation", group=
+              "if animation = true", enable=animation));
+      parameter SI.Distance boxWidth=world.defaultJointWidth
+        "Width of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      parameter SI.Distance boxHeight=boxWidth "Height of prismatic joint box"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+      input Types.Color boxColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+        "Color of prismatic joint box"
+        annotation (Dialog(colorSelector=true, tab="Animation", group="if animation = true", enable=animation));
+      input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+        "Reflection of ambient light (= 0: light is completely absorbed)"
+        annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+      final parameter Boolean positiveBranch(fixed=false)
+        "Selection of one of the two solutions of the non-linear constraint equation";
+      final parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalizeWithAssert(n)
+        "Unit vector in direction of translation axis, resolved in frame_a";
+      SI.Position s
+        "Relative distance between frame_a and frame_b along axis n = s + s_offset)";
+      SI.Position distance
+        "Relative distance between frame_a and frame_b along axis n";
+      SI.Position r_rel_a[3]
+        "Position vector from frame_a to frame_b resolved in frame_a";
+      SI.Force f "= axis.f (driving force in the axis)";
+
+    protected
+      SI.Position r_a[3]=position_a
+        "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of prismatic joint";
+      SI.Position r_b[3]=position_b
+        "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of prismatic joint";
+      Modelica.SIunits.Position rbra[3] "= rb - ra";
+      Real B "Coefficient B of equation: s*s + B*s + C = 0";
+      Real C "Coefficient C of equation: s*s + B*s + C = 0";
+      Real k1 "Constant of quadratic equation solution";
+      Real k2 "Constant of quadratic equation solution";
+      Real k1a(start=1);
+      Real k1b;
+
+      Visualizers.Advanced.Shape box(
+        shapeType="box",
+        color=boxColor,
+        specularCoefficient=specularCoefficient,
+        length=if noEvent(abs(s + s_offset) > 1.e-6) then s + s_offset else 1.e-6,
+        width=boxWidth,
+        height=boxHeight,
+        lengthDirection=e,
+        widthDirection=boxWidthDirection,
+        r=frame_a.r_0,
+        R=frame_a.R) if world.enableAnimation and animation;
+
+      function selectBranch
+        "Determine branch which is closest to initial angle=0"
+        extends Modelica.Icons.Function;
+        input SI.Length L "Length of length constraint";
+        input Real e[3](each final unit="1")
+          "Unit vector along axis of translation, resolved in frame_a (= same in frame_b)";
+        input SI.Position d_guess
+          "Select the configuration such that at initial time |d-d_guess| is minimal (d: distance between origin of frame_a and origin of frame_b)";
+        input SI.Position r_a[3]
+          "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of prismatic joint";
+        input SI.Position r_b[3]
+          "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of prismatic joint";
+        output Boolean positiveBranch "Branch of the initial solution";
+      protected
+        Modelica.SIunits.Position rbra[3] "= rb - ra";
+        Real B "Coefficient B of equation: d*d + B*d + C = 0";
+        Real C "Coefficient C of equation: d*d + B*d + C = 0";
+        Real k1 "Constant of quadratic equation solution";
+        Real k2 "Constant of quadratic equation solution";
+        Real k1a;
+        Real k1b;
+        Real d1 "solution 1 of quadratic equation";
+        Real d2 "solution 2 of quadratic equation";
+      algorithm
+        /* The position vector r_rel from frame_a to frame_b of the length constraint
+       element, resolved in frame_b of the prismatic joint (frame_a and frame_b
+       of the prismatic joint are parallel to each other) is given by:
+          r_rel = d*e + r_b - r_a
+       The length constraint can therefore be formulated as:
+          r_rel*r_rel = L*L
+       with
+          (d*e + r_b - r_a)*(d*e + r_b - r_a)
+                   = d*d + 2*d*e*(r_b - r_a) + (r_b - r_a)*(r_b - r_a)
+       follows
+          (1)  0 = d*d + d*2*e*(r_b - r_a) + (r_b - r_a)*(r_b - r_a) - L*L
+       The vectors r_a, r_b and parameter L are NOT a function of
+       the distance d of the prismatic joint. Therefore, (1) is a quadratic
+       equation in the single unknown "d":
+          (2) d*d + B*d + C = 0
+              with   B = 2*e*(r_b - r_a)
+                     C = (r_b - r_a)*(r_b - r_a) - L*L
+       The solution is
+          (3) d = - B/2 +/- sqrt(B*B/4 - C)
+    */
+        rbra := r_b - r_a;
+        B := 2*(e*rbra);
+        C := rbra*rbra - L*L;
+        k1 := B/2;
+        k1a :=k1*k1 - C;
+      assert(noEvent(k1a > 1.e-10), "
+Singular position of loop (either no or two analytic solutions;
+the mechanism has lost one-degree-of freedom in this position).
+Try first to use another Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXXX component.
+If this also lead to singular positions, it could be that this
+kinematic loop cannot be solved analytically with a fixed state
+selection. In this case you have to build up the loop with
+basic joints (NO aggregation JointXXX components) and rely on
+dynamic state selection, i.e., during simulation the states will
+be dynamically selected in such a way that in no position a
+degree of freedom is lost.
+");
+        k1b :=max(k1a, 1.0e-12);
+        k2 :=sqrt(k1b);
+        d1 := -k1 + k2;
+        d2 := -k1 - k2;
+        if abs(d1 - d_guess) <= abs(d2 - d_guess) then
+          positiveBranch := true;
+        else
+          positiveBranch := false;
+        end if;
+      end selectBranch;
+    initial equation
+      positiveBranch = selectBranch(length, e, s_offset + s_guess, r_a, r_b);
+    equation
+      Connections.branch(frame_a.R, frame_b.R);
+
+      axis.f = f;
+      axis.s = s;
+      bearing.s = 0;
+      distance = s_offset + s;
+
+      // relationships of frame_a and frame_b quantities
+      r_rel_a = e*distance;
+      frame_b.r_0 = frame_a.r_0 + Frames.resolve1(frame_a.R, r_rel_a);
+      frame_b.R = frame_a.R;
+      zeros(3) = frame_a.f + frame_b.f;
+      zeros(3) = frame_a.t + frame_b.t + cross(r_rel_a, frame_b.f);
+
+      // Compute translational distance (details, see function "selectBranch")
+      rbra = r_b - r_a;
+      B = 2*(e*rbra);
+      C = rbra*rbra - length*length;
+      k1 = B/2;
+      k1a = k1*k1 - C;
+      assert(noEvent(k1a > 1.e-10), "
+Singular position of loop (either no or two analytic solutions;
+the mechanism has lost one-degree-of freedom in this position).
+Try first to use another Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXXX component.
+If this also lead to singular positions, it could be that this
+kinematic loop cannot be solved analytically with a fixed state
+selection. In this case you have to build up the loop with
+basic joints (NO aggregation JointXXX components) and rely on
+dynamic state selection, i.e., during simulation the states will
+be dynamically selected in such a way that in no position a
+degree of freedom is lost.
+");
+      k1b = Frames.Internal.maxWithoutEvent(k1a, 1.0e-12);
+      k2 = sqrt(k1b);
+      distance = -k1 + (if positiveBranch then k2 else -k2);
+      annotation (
+        Icon(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}}), graphics={
+            Rectangle(
+              extent={{-30,-40},{100,30}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(extent={{-30,40},{100,-40}}, lineColor={0,0,0}),
+            Rectangle(
+              extent={{-100,-60},{-30,50}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-100,50},{-30,60}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-30,30},{100,40}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Text(
+              extent={{-136,-170},{140,-113}},
+              textString="%name",
+              lineColor={0,0,255}),
+            Rectangle(extent={{-100,60},{-30,-60}}, lineColor={0,0,0}),
+            Line(points={{100,-40},{100,-60}}, color={0,0,255}),
+            Rectangle(
+              extent={{100,40},{90,80}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-136,-116},{153,-77}},
+              lineColor={0,0,0},
+              textString="n=%n")}),
+        Diagram(coordinateSystem(
+            preserveAspectRatio=true,
+            extent={{-100,-100},{100,100}}), graphics={
+            Line(points={{-30,-50},{-30,50}}),
+            Line(points={{0,-67},{90,-67}}, color={128,128,128}),
+            Text(
+              extent={{31,-68},{68,-81}},
+              lineColor={128,128,128},
+              textString="s"),
+            Line(points={{-100,-67},{0,-67}}, color={128,128,128}),
+            Polygon(
+              points={{-39,-64},{-29,-67},{-39,-70},{-39,-64}},
+              lineColor={128,128,128},
+              fillColor={128,128,128},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-77,-70},{-43,-85}},
+              lineColor={128,128,128},
+              textString="s_offset"),
+            Line(points={{-100,-71},{-100,-51}}, color={128,128,128}),
+            Line(points={{-30,-73},{-30,-33}}, color={128,128,128}),
+            Line(points={{100,-70},{100,-30}}, color={128,128,128}),
+            Polygon(
+              points={{90,-64},{100,-67},{90,-70},{90,-64}},
+              lineColor={128,128,128},
+              fillColor={128,128,128},
+              fillPattern=FillPattern.Solid),
+            Rectangle(
+              extent={{-100,50},{-30,60}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-100,-60},{-30,50}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(extent={{-30,40},{100,-40}}, lineColor={0,0,0}),
+            Rectangle(
+              extent={{-30,-40},{100,30}},
+              pattern=LinePattern.None,
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(
+              extent={{-30,30},{100,40}},
+              pattern=LinePattern.None,
+              fillColor={0,0,0},
+              fillPattern=FillPattern.Solid,
+              lineColor={0,0,255}),
+            Rectangle(extent={{-100,60},{-30,-60}}, lineColor={0,0,0}),
+            Line(points={{100,-40},{100,-60}}, color={0,0,255}),
+            Text(
+              extent={{42,91},{57,76}},
+              textString="f",
+              lineColor={0,0,255}),
+            Line(points={{40,75},{70,75}}, color={0,0,255}),
+            Polygon(
+              points={{-21,78},{-31,75},{-21,72},{-21,78}},
+              lineColor={0,0,255},
+              fillColor={0,0,255},
+              fillPattern=FillPattern.Solid),
+            Line(points={{-8,75},{-31,75}}, color={0,0,255}),
+            Text(
+              extent={{-21,90},{-6,75}},
+              textString="f",
+              lineColor={0,0,255}),
+            Polygon(
+              points={{60,78},{70,75},{60,72},{60,78}},
+              lineColor={0,0,255},
+              fillColor={0,0,255},
+              fillPattern=FillPattern.Solid),
+            Line(points={{-30,64},{70,64}}, color={128,128,128}),
+            Polygon(
+              points={{60,67},{70,64},{60,61},{60,67}},
+              lineColor={128,128,128},
+              fillColor={128,128,128},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{0,63},{37,50}},
+              lineColor={128,128,128},
+              textString="s"),
+            Rectangle(
+              extent={{100,40},{90,80}},
+              lineColor={0,0,0},
+              fillColor={192,192,192},
+              fillPattern=FillPattern.Solid)}),
+        Documentation(info="<html>
+<p>
+Joint where frame_b is translated along axis n which is fixed in frame_a.
+The two frames coincide when \"s + s_offset = 0\", where
+\"s_offset\" is a parameter with a zero default
+and \"s\" is the relative distance.
+</p>
+<p>
+This variant of the prismatic joint is designed to work together
+with a length constraint in a kinematic loop. This means that the
+relative distance \"s\" of the joint is computed such that the
+length constraint is fulfilled.
+</p>
+<p>
+<b>Usually, this joint should not be used by a user of the MultiBody
+library. It is only provided to built-up the Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXYZ
+joints.</b>
+</p>
+
+<p>
+In releases before version 3.0 of the Modelica Standard Library, it was possible
+to activate the force projection equation (= cut-force projected to the translation
+axis must be identical to the driving force of flange axis) via parameter
+<b>axisForceBalance</b>. This is no longer possible, since otherwise this
+model would not be \"balanced\" (= same number of unknowns as equations).
+Instead, when using this model in version 3.0 and later versions,
+the force in the length constraint component (Joints.SphericalSpherical or
+Joints.UniversalSpherical) must be calculated such that the driving force
+in direction of the translation
+axis is (RC shall be the name of the instance of PrismaticWithLengthConstraint):
+</p>
+<pre>
+    0 = RC.axis.f + RC.e*RC.frame_b.f;
+</pre>
+<p>
+If this equation is used, usually the force in the length constraint
+and the second derivative of the prismatic distance will be part of a linear
+algebraic system of equations. In some cases it is possible to solve
+this system of equations locally, i.e., provide the rod force directly
+as function of the prismatic constraint force. In any case, this projection
+equation or an equivalent one has to be provided via variable \"constraintResidue\" in the \"Advanced\"
+menu of \"Joints.SphericalSpherical\" or \"Joints.UniversalSpherical\".
+</p>
+
+</html>"));
+    end PrismaticWithLengthConstraint;
+
+     model RollingConstraintVerticalWheel
+      "Rolling constraint for wheel that is always perpendicular to x-y plane"
+      import Modelica.Mechanics.MultiBody.Frames;
+
+        Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_a
+        "Frame fixed in wheel center point. x-Axis: upwards, y-axis: along wheel axis"
+          annotation (Placement(transformation(extent={{-16,4},{16,36}}),
+              iconTransformation(extent={{-16,4},{16,36}})));
+
+        parameter SI.Radius radius "Wheel radius";
+
+        parameter Boolean lateralSlidingConstraint = true
+        "= true, if lateral sliding constraint taken into account, = false if lateral force = 0 (needed to avoid overconstraining if two ideal rolling wheels are connect on one axis)"
+                                                                                                            annotation(choices(checkBox=true),Evaluate=true);
+
+        // Contact force
+        SI.Force f_wheel_0[3]
+        "Contact force acting on wheel, resolved in world frame";
+        SI.Force f_lat "Contact force acting on wheel in lateral direction";
+        SI.Force f_long
+        "Contact force acting on wheel in longitudinal direction";
+    protected
+         Real e_axis_0[3]
+        "Unit vector along wheel axis, resolved in world frame";
+         SI.Position rContact_0[3]
+        "Distance vector from wheel center to contact point, resolved in world frame";
+
+         // Coordinate system at contact point
+         Real e_n_0[3]
+        "Unit vector in normal direction of road at contact point, resolved in world frame";
+         Real e_lat_0[3]
+        "Unit vector in lateral direction of wheel at contact point, resolved in world frame";
+         Real e_long_0[3]
+        "Unit vector in longitudinal direction of wheel at contact point, resolved in world frame";
+
+         // Slip velocities
+         SI.Velocity v_0[3] "Velocity of wheel center, resolved in world frame";
+         SI.AngularVelocity w_0[3]
+        "Angular velocity of wheel, resolved in world frame";
+
+         SI.Velocity vContact_0[3]
+        "Velocity of wheel contact point, resolved in world frame";
+
+         // Utility vectors
+         Real aux[3];
+
+     equation
+         // Coordinate system at contact point (e_long_0, e_lat_0, e_n_0)
+         e_n_0    = {0,0,1};
+         e_axis_0 = Frames.resolve1(frame_a.R, {0,1,0});
+         aux      = cross(e_n_0, e_axis_0);
+         e_long_0 = aux / Modelica.Math.Vectors.length(aux);
+         e_lat_0  = cross(e_long_0, e_n_0);
+
+         // Slip velocities
+         rContact_0 = {0,0,-radius};
+         v_0 = der(frame_a.r_0);
+         w_0 = Frames.angularVelocity1(frame_a.R);
+         vContact_0 = v_0 + cross(w_0, rContact_0);
+
+         // Two non-holonomic constraint equations on velocity level (ideal rolling, no slippage)
+         0 = vContact_0*e_long_0;
+         if lateralSlidingConstraint then
+            0 = vContact_0*e_lat_0;
+            f_wheel_0 = f_lat*e_lat_0 + f_long*e_long_0;
+         else
+            0 = f_lat;
+            f_wheel_0 = f_long*e_long_0;
+         end if;
+
+         // Force and torque balance at the wheel center
+         zeros(3) = frame_a.f + Frames.resolve2(frame_a.R, f_wheel_0);
+         zeros(3) = frame_a.t + Frames.resolve2(frame_a.R, cross(rContact_0, f_wheel_0));
+        annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
+                  -100},{100,100}}), graphics={
+              Rectangle(
+                extent={{-100,-60},{100,-80}},
+                lineColor={0,0,0},
+                fillColor={175,175,175},
+                fillPattern=FillPattern.Solid),
+              Text(
+                extent={{-148,-86},{152,-126}},
+                lineColor={0,0,255},
+                textString="%name"),
+              Line(
+                points={{0,-60},{0,4}},
+                pattern=LinePattern.Dot),
+              Line(
+                visible=lateralSlidingConstraint,
+                points={{-98,-30},{-16,-30}}),
+              Polygon(
+                visible=lateralSlidingConstraint,
+                points={{-40,-16},{-40,-42},{-6,-30},{-40,-16}},
+                lineColor={0,0,0},
+                fillColor={255,255,255},
+                fillPattern=FillPattern.Solid)}));
+     end RollingConstraintVerticalWheel;
+
+     model InitPosition
+      "Internal model to initialize r_rel_a for Joints.FreeMotionScalarInit"
+       extends Modelica.Blocks.Icons.Block;
+
+       import SI = Modelica.SIunits;
+       import Modelica.Mechanics.MultiBody.Frames;
+
+       input SI.Position r_a_0[3] annotation(Dialog);
+       input SI.Position r_b_0[3] annotation(Dialog);
+       input Frames.Orientation R_a annotation(Dialog);
+
+       Modelica.Blocks.Interfaces.RealOutput r_rel_a[3](each final quantity="Length", each final unit="m") annotation (Placement(transformation(extent={{100,-10},
+                 {120,10}})));
+
+     equation
+       r_b_0 = r_a_0 + Frames.resolve1(R_a, {r_rel_a[1], r_rel_a[2], r_rel_a[3]});
+
+       annotation ( Icon(coordinateSystem(
+              preserveAspectRatio=false, extent={{-100,-100},{100,100}}),
+            graphics={Text(
+              extent={{-88,16},{82,-12}},
+              lineColor={0,0,0},
+              textString="r_rel_a")}));
+     end InitPosition;
+
+     model InitAngle
+      "Internal model to initialize the angels for Joints.FreeMotionScalarInit"
+       extends Modelica.Blocks.Icons.Block;
+
+       import SI = Modelica.SIunits;
+       import Modelica.Mechanics.MultiBody.Frames;
+
+       parameter Modelica.Mechanics.MultiBody.Types.RotationSequence sequence_start={1,2,3}
+        "Sequence of angle rotations";
+
+       Interfaces.Frame_a frame_a
+         annotation (Placement(transformation(extent={{-116,-16},{-84,16}})));
+       Interfaces.Frame_b frame_b
+         annotation (Placement(transformation(extent={{84,-16},{116,16}})));
+
+       Frames.Orientation R_rel
+        "Relative orientation object to rotate from frame_a to frame_b";
+       Frames.Orientation R_rel_inv
+        "Relative orientation object to rotate from frame_b to frame_a";
+
+       Blocks.Interfaces.RealOutput angle[3](each final quantity="Angle", each final unit="rad") annotation (Placement(transformation(
+             extent={{-10,-10},{10,10}},
+             rotation=-90,
+             origin={0,-110})));
+     equation
+       Connections.branch(frame_a.R, frame_b.R);
+       R_rel = Frames.axesRotations(sequence_start,
+                                    {angle[1], angle[2], angle[3]},
+                                    {der(angle[1]), der(angle[2]), der(angle[3])});
+       if Connections.rooted(frame_a.R) then
+          R_rel_inv = Frames.nullRotation();
+          frame_b.R = Frames.absoluteRotation(frame_a.R, R_rel);
+       else
+          R_rel_inv = Frames.inverseRotation(R_rel);
+          frame_a.R = Frames.absoluteRotation(frame_b.R, R_rel_inv);
+       end if;
+
+       frame_a.f = zeros(3);
+       frame_a.t = zeros(3);
+       frame_b.f = zeros(3);
+       frame_b.t = zeros(3);
+
+       annotation ( Icon(graphics={Text(
+              extent={{-84,-58},{86,-86}},
+              lineColor={0,0,0},
+              textString="angle")}));
+     end InitAngle;
+
+     model InitAngularVelocity
+      "Internal model to initialize w_rel_b for Joints.FreeMotionScalarInit"
+       extends Modelica.Blocks.Icons.Block;
+
+       import SI = Modelica.SIunits;
+       import Modelica.Mechanics.MultiBody.Frames;
+
+       input Frames.Orientation R_a annotation(Dialog);
+       input Frames.Orientation R_b annotation(Dialog);
+
+       Modelica.Blocks.Interfaces.RealOutput w_rel_b[3](each final quantity="AngularVelocity", each final unit="rad/s") annotation (Placement(transformation(extent={{100,-10},
+                 {120,10}})));
+     equation
+      Frames.angularVelocity2(R_b) = Frames.resolve2(R_b,Frames.angularVelocity1(R_a)) + w_rel_b;
+
+       annotation ( Icon(graphics={Text(
+              extent={{-86,16},{84,-12}},
+              lineColor={0,0,0},
+              textString="w_rel_b")}));
+     end InitAngularVelocity;
+    annotation (Documentation(info="<html>
+<p>
+The models in this package should not be used by the user.
+They are designed to build up other models in the MultiBody library
+and some of them cannot be used in an arbitrary way and require
+particular knowledge how to set the options in the parameter menu.
+Don't use the models of this package.
+</p>
+</html>"));
+  end Internal;
+
+  annotation ( Documentation(info="<html>
+<p>
+This package contains <b>joint components</b>,
+that is, idealized, massless elements that constrain
+the motion between frames. In subpackage <b>Assemblies</b>
+aggregation joint components are provided to handle
+kinematic loops analytically (this means that non-linear systems
+of equations occurring in these joint aggregations are analytically
+solved, i.e., robustly and efficiently).
+</p>
+<h4>Content</h4>
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><th><b><i>Model</i></b></th><th><b><i>Description</i></b></th></tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Prismatic\">Prismatic</a>
+      <td valign=\"top\">Prismatic joint and actuated prismatic joint
+          (1 translational degree-of-freedom, 2 potential states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Prismatic.png\">
+      </td></td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Revolute\">Revolute</a>
+ </td>
+      <td valign=\"top\">Revolute and actuated revolute joint
+          (1 rotational degree-of-freedom, 2 potential states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Revolute.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Cylindrical\">Cylindrical</a></td>
+      <td valign=\"top\">Cylindrical joint (2 degrees-of-freedom, 4 potential states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Cylindrical.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Universal\">Universal</a></td>
+      <td valign=\"top\">Universal joint (2 degrees-of-freedom, 4 potential states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Universal.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Planar\">Planar</a></td>
+      <td valign=\"top\">Planar joint (3 degrees-of-freedom, 6 potential states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Planar.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Spherical\">Spherical</a></td>
+      <td valign=\"top\">Spherical joint (3 constraints and no potential states, or 3 degrees-of-freedom and 3 states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/Spherical.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.FreeMotion\">FreeMotion</a></td>
+      <td valign=\"top\">Free motion joint (6 degrees-of-freedom, 12 potential states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/FreeMotion.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.SphericalSpherical\">SphericalSpherical</a></td>
+      <td valign=\"top\">Spherical - spherical joint aggregation (1 constraint,
+          no potential states) with an optional point mass in the middle<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/SphericalSpherical.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.UniversalSpherical\">UniversalSpherical</a></td>
+      <td valign=\"top\">Universal - spherical joint aggregation (1 constraint, no potential states)<br>
+      <IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Joints/UniversalSpherical.png\">
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.GearConstraint\">GearConstraint</a></td>
+      <td valign=\"top\">Ideal 3-dim. gearbox (arbitrary shaft directions)
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Assemblies\">MultiBody.Joints.Assemblies</a></td>
+      <td valign=\"top\"><b>Package</b> of joint aggregations for analytic loop handling.
+      </td>
+  </tr>
+  <tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Joints.Constraints\">MultiBody.Joints.Constraints</a></td>
+      <td valign=\"top\"><b>Package</b> of components that define joints by constraints
+      </td>
+  </tr>
+</table>
+</html>"), Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+            {100,100}}), graphics={
+        Polygon(
+          points={{6,6},{28,-2},{54,80},{32,86},{6,6}},
+          lineColor={95,95,95},
+          fillPattern=FillPattern.Sphere,
+          fillColor={255,255,255}),
+        Polygon(
+          points={{-12,-18},{0,-36},{-70,-84},{-82,-66},{-12,-18}},
+          lineColor={95,95,95},
+          fillPattern=FillPattern.Sphere,
+          fillColor={255,255,255}),
+        Ellipse(
+          extent={{-12,8},{34,-38}},
+          lineColor={95,95,95},
+          fillPattern=FillPattern.Sphere,
+          fillColor={95,95,95})}));
+end Joints;

--- a/modelica/examples/ObsoleteModelica3.mo
+++ b/modelica/examples/ObsoleteModelica3.mo
@@ -1,0 +1,3531 @@
+within ;
+package ObsoleteModelica3
+  "Library that contains components from Modelica Standard Library 2.2.2 that have been removed from version 3.0"
+
+  package Blocks
+    "Library of basic input/output control blocks (continuous, discrete, logical, table blocks)"
+    package Interfaces
+      "Library of connectors and partial models for input/output blocks"
+    connector RealSignal = Real "Real port (both input/output possible)"
+        annotation (obsolete="Connector is not valid according to Modelica 3, since input/output prefixes are missing. When using this connector, it is not possible to check for balanced models.",
+    Documentation(info="<html>
+<p>
+Connector with one signal of type Real (no icon, no input/output prefix).
+</p>
+</html>"));
+    connector BooleanSignal = Boolean
+        "Boolean port (both input/output possible)"
+        annotation (obsolete="Connector is not valid according to Modelica 3, since input/output prefixes are missing. When using this connector, it is not possible to check for balanced models.",
+    Documentation(info="<html>
+<p>
+Connector with one signal of type Boolean (no icon, no input/output prefix).
+</p>
+</html>"));
+    connector IntegerSignal = Integer
+        "Integer port (both input/output possible)"
+        annotation (obsolete="Connector is not valid according to Modelica 3, since input/output prefixes are missing. When using this connector, it is not possible to check for balanced models.",
+    Documentation(info="<html>
+<p>
+Connector with one signal of type .
+</p>
+</html>"));
+      package Adaptors
+        "Obsolete package with components to send signals to a bus or receive signals from a bus (only for backward compatibility)"
+      model AdaptorReal
+          "Completely obsolete adaptor between 'old' and 'new' Real signal connectors (only for backward compatibility)"
+        extends ObsoleteModelica3.Icons.ObsoleteBlock;
+        ObsoleteModelica3.Blocks.Interfaces.RealSignal newReal
+            "Connector of Modelica version 2.1"                annotation (                            Hide=true,
+              Placement(transformation(extent={{100,-10},{120,10}})));
+        RealPort oldReal(final n=1) "Connector of Modelica version 1.6" annotation (Placement(
+                transformation(extent={{-120,-10},{-100,10}})));
+
+        protected
+        connector RealPort "Connector with signals of type Real"
+          parameter Integer n=1 "Dimension of signal vector" annotation (Hide=true);
+          replaceable type SignalType = Real "type of signal";
+          SignalType signal[n] "Real signals" annotation (Hide=true);
+
+        end RealPort;
+      equation
+        newReal = oldReal.signal[1];
+        annotation(defaultConnectionStructurallyInconsistent=true,
+          obsolete="Model is not balanced, so equation check will not work. This model is no longer needed",
+          Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Rectangle(
+                  extent={{-100,40},{100,-40}},
+                  lineColor={0,0,255},
+                  fillColor={255,255,255},
+                  fillPattern=FillPattern.Solid),
+                Text(
+                  extent={{-144,96},{144,46}},
+                  lineColor={0,0,0},
+                  textString=""),
+                Text(
+                  extent={{-88,22},{88,-24}},
+                  lineColor={0,0,255},
+                  textString="adaptor"),
+                Text(
+                  extent={{-216,-58},{36,-80}},
+                  lineColor={0,0,0},
+                  textString="port.signal")}),
+                                      Documentation(info="<html>
+<p>
+Completely obsolete adaptor between the Real signal connector
+of version 1.6 and version &ge; 2.1 of the Modelica Standard Library.
+This block is only provided for backward compatibility.
+</p>
+</html>"));
+      end AdaptorReal;
+
+      model AdaptorBoolean
+          "Completely obsolete adaptor between 'old' and 'new' Boolean signal connectors (only for backward compatibility)"
+        extends ObsoleteModelica3.Icons.ObsoleteBlock;
+        ObsoleteModelica3.Blocks.Interfaces.BooleanSignal newBoolean
+            "Connector of Modelica version 2.1"
+          annotation (                            Hide=true, Placement(
+                transformation(extent={{100,-10},{120,10}})));
+        BooleanPort oldBoolean(final n=1) "Connector of Modelica version 1.6" annotation (Placement(
+                transformation(extent={{-120,-10},{-100,10}})));
+
+        protected
+        connector BooleanPort "Connector with signals of type Boolean"
+          parameter Integer n=1 "Dimension of signal vector" annotation (Hide=true);
+          replaceable type SignalType = Boolean "type of signal";
+          SignalType signal[n] "Boolean signals" annotation (Hide=true);
+
+        end BooleanPort;
+      equation
+
+        newBoolean = oldBoolean.signal[1];
+
+        annotation(defaultConnectionStructurallyInconsistent=true,
+          obsolete="Model is not balanced, so equation check will not work. This model is no longer needed",
+          Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Rectangle(
+                  extent={{-100,40},{100,-40}},
+                  lineColor={255,0,255},
+                  fillColor={255,255,255},
+                  fillPattern=FillPattern.Solid),
+                Text(
+                  extent={{-144,96},{144,46}},
+                  lineColor={0,0,0},
+                  textString=""),
+                Text(
+                  extent={{-88,22},{88,-24}},
+                  lineColor={255,0,255},
+                  textString="adaptor"),
+                Text(
+                  extent={{-216,-58},{36,-80}},
+                  lineColor={0,0,0},
+                  textString="port.signal")}),
+                                      Documentation(info="<html>
+<p>
+Completely obsolete adaptor between the Real signal connector
+of version 1.6 and version &ge; 2.1 of the Modelica Standard Library.
+This block is only provided for backward compatibility.
+</p>
+</html>"));
+      end AdaptorBoolean;
+
+      model AdaptorInteger
+          "Completely obsolete adaptor between 'old' and 'new' Integer signal connectors (only for backward compatibility)"
+        extends ObsoleteModelica3.Icons.ObsoleteBlock;
+        ObsoleteModelica3.Blocks.Interfaces.IntegerSignal newInteger
+            "Connector of Modelica version 2.1"
+          annotation (                            Hide=true, Placement(
+                transformation(extent={{100,-10},{120,10}})));
+        IntegerPort oldInteger(final n=1) "Connector of Modelica version 1.6"  annotation (Placement(
+                transformation(extent={{-120,-10},{-100,10}})));
+
+        protected
+        connector IntegerPort "Connector with signals of type Integer"
+          parameter Integer n=1 "Dimension of signal vector" annotation (Hide=true);
+          replaceable type SignalType = Integer "type of signal";
+          SignalType signal[n] "Integer signals" annotation (Hide=true);
+
+        end IntegerPort;
+      equation
+
+        newInteger = oldInteger.signal[1];
+
+        annotation(defaultConnectionStructurallyInconsistent=true,
+          obsolete="Model is not balanced, so equation check will not work. This model is no longer needed",
+           Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Rectangle(
+                  extent={{-100,40},{100,-40}},
+                  lineColor={255,127,0},
+                  fillColor={255,255,255},
+                  fillPattern=FillPattern.Solid),
+                Text(
+                  extent={{-144,96},{144,46}},
+                  lineColor={0,0,0},
+                  textString=""),
+                Text(
+                  extent={{-88,22},{88,-24}},
+                  lineColor={255,127,0},
+                  textString="adaptor"),
+                Text(
+                  extent={{-216,-58},{36,-80}},
+                  lineColor={0,0,0},
+                  textString="port.signal")}),
+                                      Documentation(info="<html>
+<p>
+Completely obsolete adaptor between the Real signal connector
+of version 1.6 and version &ge; 2.1 of the Modelica Standard Library.
+This block is only provided for backward compatibility.
+</p>
+</html>"));
+      end AdaptorInteger;
+      end Adaptors;
+    end Interfaces;
+
+    package Math "Library of mathematical functions as input/output blocks"
+      package UnitConversions
+        "Conversion blocks to convert between SI and non-SI unit signals"
+        block ConvertAllUnits
+          "Obsolete block. Use one of Modelica.Blocks.Math.UnitConversions.XXX instead"
+          replaceable block ConversionBlock =
+              Modelica.Blocks.Interfaces.PartialConversionBlock
+            "Conversion block"
+            annotation (choicesAllMatching=true,
+            Documentation(info=
+                           "<html>
+<p>
+Internal replaceable block that is used to construct the
+\"pull down menu\" of the available unit conversions.
+</p>
+</html>"));
+          extends ConversionBlock;
+          extends ObsoleteModelica3.Icons.ObsoleteBlock;
+
+          annotation (
+            obsolete="Model is not according to Modelica Language 3.0 since replaceable base class present. " +
+                              "Use instead one of Modelica.Blocks.Math.UnitConversions.XXX",
+            defaultComponentName="convert",
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={Line(points={{-90,0},{30,0}}, color=
+                      {191,0,0}), Polygon(
+                  points={{90,0},{30,20},{30,-20},{90,0}},
+                  lineColor={191,0,0},
+                  fillColor={191,0,0},
+                  fillPattern=FillPattern.Solid)}),
+            Documentation(info="<html>
+<p>This block implements the Modelica.SIunits.Conversions functions as a fixed causality block to
+simplify their use. The block contains a replaceable block class <b>ConversionBlock</b> that can be
+changed to be any of the blocks defined in Modelica.Blocks.Math.UnitConversions, and more generally, any
+blocks that extend from Modelica.Blocks.Interfaces.PartialConversionBlock.
+</p>
+
+<p>
+The desired conversion can be selected in the parameter menu
+(the selected units are then displayed in the icon):
+</p>
+
+<p>
+<img src=\"modelica://Modelica/Resources/Images/Blocks/ConvertAllUnits.png\">
+</p>
+
+</html>"));
+        end ConvertAllUnits;
+      end UnitConversions;
+
+      block TwoInputs
+        "Obsolete block. Use instead Modelica.Blocks.Math.InverseBlockConstraints"
+        extends Modelica.Blocks.Interfaces.BlockIcon;
+        extends ObsoleteModelica3.Icons.ObsoleteBlock;
+            Modelica.Blocks.Interfaces.RealInput u1
+          "Connector of first Real input signal"
+              annotation (                                       layer="icon",
+            Placement(transformation(extent={{-139.742,-19.0044},{-100,20}})));
+            Modelica.Blocks.Interfaces.RealInput u2
+          "Connector of second Real input signal (u1=u2)"
+                                           annotation (
+              layer="icon", Placement(transformation(
+              origin={120,0},
+              extent={{-20,-20},{20,20}},
+              rotation=180)));
+      equation
+            u1 = u2;
+            annotation(defaultConnectionStructurallyInconsistent=true,
+              obsolete="Model is not balanced, i.e., not according to Modelica Language 3.0. Use instead Modelica.Blocks.Math.InverseBlockConstraints",
+              Documentation(info="<HTML>
+<p>
+This block is used to enable assignment of values to variables preliminary
+defined as outputs (e.g., useful for inverse model generation).
+</p>
+
+</html>"),           Icon(coordinateSystem(
+              preserveAspectRatio=false,
+              extent={{-100,-100},{100,100}}),
+                graphics={Text(
+                extent={{-95,50},{95,-50}},
+                lineColor={0,0,127},
+                textString="=")}));
+      end TwoInputs;
+
+          block TwoOutputs
+        "Obsolete block. Use instead Modelica.Blocks.Math.InverseBlockConstraints"
+            extends Modelica.Blocks.Interfaces.BlockIcon;
+            extends ObsoleteModelica3.Icons.ObsoleteBlock;
+            output Modelica.Blocks.Interfaces.RealOutput y1
+          "Connector of first Real output signal"
+              annotation (Placement(transformation(extent={{100,-10},{120,10}})));
+            output Modelica.Blocks.Interfaces.RealOutput y2
+          "Connector of second Real output signal (y1=y2)"
+                                                   annotation (Placement(
+              transformation(
+              origin={-110.366,-0.90289},
+              extent={{-10.0005,-10},{10.0005,10}},
+              rotation=180)));
+          equation
+            y1 = y2;
+            annotation(defaultConnectionStructurallyInconsistent=true,
+              obsolete="Model is not balanced, i.e., not according to Modelica Language 3.0. Use instead Modelica.Blocks.Math.InverseBlockConstraints",
+              Documentation(info="<html>
+<p>
+This block is used to enable calculation of values preliminary defined as inputs.
+(e.g., useful for inverse model generation).
+</p>
+
+</html>"),           Icon(coordinateSystem(
+              preserveAspectRatio=false,
+              extent={{-100,-100},{100,100}}),
+                graphics={Text(
+                extent={{-95,50},{95,-50}},
+                lineColor={0,0,127},
+                textString="=")}));
+          end TwoOutputs;
+    end Math;
+
+  end Blocks;
+
+  package Electrical
+    "Library of electrical models (analog, digital, machines, multi-phase)"
+    package Analog "Library for analog electrical models"
+      package Basic
+        "Basic electrical components such as resistor, capacitor, transformer"
+        model HeatingResistor
+          "Obsolete model. Use Modelica.Electrical.Analog.Basic.HeatingResistor instead"
+          extends Modelica.Electrical.Analog.Interfaces.OnePort;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          parameter Modelica.SIunits.Resistance R_ref=1
+            "Resistance at temperature T_ref";
+          parameter Modelica.SIunits.Temperature T_ref=300
+            "Reference temperature";
+          parameter Real alpha(unit="1/K") = 0
+            "Temperature coefficient of resistance";
+
+          Modelica.SIunits.Resistance R
+            "Resistance = R_ref*(1 + alpha*(heatPort.T - T_ref));";
+
+          Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort annotation (Placement(
+                transformation(
+                origin={0,-100},
+                extent={{10,-10},{-10,10}},
+                rotation=270)));
+        equation
+          v = R*i;
+
+          if cardinality(heatPort) > 0 then
+            R = R_ref*(1 + alpha*(heatPort.T - T_ref));
+            heatPort.Q_flow = -v*i;
+          else
+            /* heatPort is not connected resulting in the
+         implicit equation 'heatPort.Q_flow = 0'
+      */
+            R = R_ref;
+            heatPort.T = T_ref;
+          end if;
+          annotation (
+            obsolete="Model equations depend on cardinality(..) which will become obsolete in the Modelica language. Use instead Modelica.Electrical.Analog.Basic.HeatingResistor",
+            Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                    -100},{100,100}}), graphics={
+                Line(points={{-110,20},{-85,20}}, color={160,160,164}),
+                Polygon(
+                  points={{-95,23},{-85,20},{-95,17},{-95,23}},
+                  lineColor={160,160,164},
+                  fillColor={160,160,164},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{90,20},{115,20}}, color={160,160,164}),
+                Line(points={{-125,0},{-115,0}}, color={160,160,164}),
+                Line(points={{-120,-5},{-120,5}}, color={160,160,164}),
+                Text(
+                  extent={{-110,25},{-90,45}},
+                  lineColor={160,160,164},
+                  textString="i"),
+                Polygon(
+                  points={{105,23},{115,20},{105,17},{105,23}},
+                  lineColor={160,160,164},
+                  fillColor={160,160,164},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{115,0},{125,0}}, color={160,160,164}),
+                Text(
+                  extent={{90,45},{110,25}},
+                  lineColor={160,160,164},
+                  textString="i"),
+                Rectangle(extent={{-70,30},{70,-30}}),
+                Line(points={{-96,0},{-70,0}}),
+                Line(points={{70,0},{96,0}}),
+                Line(points={{0,-30},{0,-90}}, color={191,0,0}),
+                Line(points={{-52,-50},{48,50}}, color={0,0,255}),
+                Polygon(
+                  points={{40,52},{50,42},{54,56},{40,52}},
+                  lineColor={0,0,255},
+                  fillColor={0,0,255},
+                  fillPattern=FillPattern.Solid)}),
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Text(extent={{-142,60},{143,118}}, textString="%name"),
+                Line(points={{-90,0},{-70,0}}),
+                Line(points={{70,0},{90,0}}),
+                Rectangle(
+                  extent={{-70,30},{70,-30}},
+                  lineColor={0,0,255},
+                  fillColor={255,255,255},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{0,-30},{0,-91}}, color={191,0,0}),
+                Line(points={{-52,-50},{48,50}}, color={0,0,255}),
+                Polygon(
+                  points={{40,52},{50,42},{54,56},{40,52}},
+                  lineColor={0,0,255},
+                  fillColor={0,0,255},
+                  fillPattern=FillPattern.Solid)}),
+            Documentation(info="<HTML>
+<p>This is a model for an electrical resistor where the generated heat
+is dissipated to the environment via connector <b>heatPort</b> and where
+the resistance R is temperature dependent according to the following
+equation:</p>
+<pre>    R = R_ref*(1 + alpha*(heatPort.T - T_ref))
+</pre>
+<p><b>alpha</b> is the <b>temperature coefficient of resistance</b>, which
+is often abbreviated as <b>TCR</b>. In resistor catalogues, it is usually
+defined as <b>X [ppm/K]</b> (parts per million, similarly to percentage)
+meaning <b>X*1.e-6 [1/K]</b>. Resistors are available for 1 .. 7000 ppm/K,
+i.e., alpha = 1e-6 .. 7e-3 1/K;</p>
+<p>When connector <b>heatPort</b> is <b>not</b> connected, the temperature
+dependent behaviour is switched off by setting heatPort.T = T_ref.
+Additionally, the equation <code>heatPort.Q_flow = 0</code> is implicitly present
+due to a special rule in Modelica that flow variables of not connected
+connectors are set to zero.</p>
+</html>",         revisions=
+                 "<html>
+<ul>
+<li><i> 2002   </i>
+       by Anton Haumer<br> initially implemented<br>
+       </li>
+</ul>
+</html>"));
+        end HeatingResistor;
+      end Basic;
+    end Analog;
+  end Electrical;
+
+  package Icons "Library of icons"
+    partial block ObsoleteBlock
+      "Icon for an obsolete block (use only for this case)"
+
+      annotation (obsolete="Only used to mark an obsolete block. Do not use otherwise.",
+              Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                -100},{100,100}}), graphics={Rectangle(
+              extent={{-102,102},{102,-102}},
+              lineColor={255,0,0},
+              pattern=LinePattern.Dash,
+              lineThickness=0.5)}),        Documentation(info="<html>
+<p>
+This partial block is intended to provide a <u>default icon
+for an obsolete block</u> that will be removed from the
+corresponding library in a future release.
+</p>
+</html>"));
+    end ObsoleteBlock;
+
+    partial model ObsoleteModel
+      "Icon for an obsolete model (use only for this case)"
+
+      annotation (obsolete="Only used to mark an obsolete model. Do not use otherwise.",
+              Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                -100},{100,100}}), graphics={Rectangle(
+              extent={{-102,102},{102,-102}},
+              lineColor={255,0,0},
+              pattern=LinePattern.Dash,
+              lineThickness=0.5)}),        Documentation(info="<html>
+<p>
+This partial model is intended to provide a <u>default icon
+for an obsolete model</u> that will be removed from the
+corresponding library in a future release.
+</p>
+</html>"));
+    end ObsoleteModel;
+
+    partial class Enumeration
+      "Obsolete class (icon for an enumeration emulated by a package). Use a real enumeration instead"
+
+      annotation (obsolete="Icon for an emulated enumeration. Emulated enumerations are no longer used (only real enumerations)",
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                {100,100}}), graphics={
+            Text(extent={{-138,164},{138,104}}, textString="%name"),
+            Ellipse(
+              extent={{-100,100},{100,-100}},
+              lineColor={255,0,127},
+              fillColor={255,255,255},
+              fillPattern=FillPattern.Solid),
+            Text(
+              extent={{-100,100},{100,-100}},
+              lineColor={255,0,127},
+              textString="e")}),
+                          Documentation(info="<html>
+<p>
+This icon is designed for an <b>enumeration</b>
+(that is emulated by a package).
+</p>
+</html>"));
+    end Enumeration;
+  end Icons;
+
+  package Mechanics
+    "Library of 1-dim. and 3-dim. mechanical components (multi-body, rotational, translational)"
+
+    package MultiBody "Library to model 3-dimensional mechanical systems"
+      package Forces
+        "Components that exert forces and/or torques between frames"
+        model WorldForceAndTorque
+          "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Forces.WorldForceAndTorque"
+
+          import SI = Modelica.SIunits;
+          import Modelica.Mechanics.MultiBody.Types;
+          extends Modelica.Mechanics.MultiBody.Interfaces.PartialOneFrame_b;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          Modelica.Blocks.Interfaces.RealInput load[6]
+            "[1:6] = x-, y-, z-coordinates of force and x-, y-, z-coordiantes of torque resolved in world frame"
+            annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
+          parameter Boolean animation=true
+            "= true, if animation shall be enabled";
+          parameter Real N_to_m(unit="N/m") = world.defaultN_to_m
+            " Force arrow scaling (length = force/N_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          parameter Real Nm_to_m(unit="N.m/m") = world.defaultNm_to_m
+            " Torque arrow scaling (length = torque/Nm_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter forceDiameter=world.defaultArrowDiameter
+            " Diameter of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter torqueDiameter=forceDiameter
+            " Diameter of torque arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color forceColor=Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
+            " Color of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color torqueColor=Modelica.Mechanics.MultiBody.Types.Defaults.TorqueColor
+            " Color of torque arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+            "Reflection of ambient light (= 0: light is completely absorbed)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+
+        protected
+          SI.Position f_in_m[3]=frame_b.f/N_to_m
+            "Force mapped from N to m for animation";
+          SI.Position t_in_m[3]=frame_b.t/Nm_to_m
+            "Torque mapped from Nm to m for animation";
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow forceArrow(
+            diameter=forceDiameter,
+            color=forceColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=f_in_m,
+            r_head=-f_in_m) if world.enableAnimation and animation;
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow
+            torqueArrow(
+            diameter=torqueDiameter,
+            color=torqueColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=t_in_m,
+            r_head=-t_in_m) if world.enableAnimation and animation;
+        equation
+          frame_b.f = -Modelica.Mechanics.MultiBody.Frames.resolve2(frame_b.R, load[1
+            :3]);
+          frame_b.t = -Modelica.Mechanics.MultiBody.Frames.resolve2(frame_b.R, load[4
+            :6]);
+          annotation (
+            obsolete="Based on a packed result signal which is not a good design. Use instead Modelica.Mechanics.MultiBody.Forces.WorldForceAndTorque",
+            preferredView="info",
+            Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                    -100},{100,100}}), graphics={
+                Polygon(
+                  points={{-100,10},{50,10},{50,31},{97,0},{50,-31},{50,-10},{-100,
+                      -10},{-100,10}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Line(
+                  points={{-100,11},{-94,24},{-86,39},{-74,59},{-65,71},{-52,83},
+                      {-35,92},{-22,95},{-8,95},{7,91},{19,84},{32,76},{44,66},
+                      {52,58},{58,51}},
+                  thickness=0.5),
+                Polygon(
+                  points={{97,18},{72,77},{38,42},{97,18}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid)}),
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Text(
+                  extent={{-74,62},{44,24}},
+                  lineColor={192,192,192},
+                  textString="world"),
+                Polygon(
+                  points={{-100,10},{50,10},{50,31},{94,0},{50,-31},{50,-10},{-100,
+                      -10},{-100,10}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Text(extent={{-137,-47},{148,-108}}, textString="%name"),
+                Line(
+                  points={{-98,14},{-92,27},{-84,42},{-72,62},{-63,74},{-50,86},
+                      {-33,95},{-20,98},{-6,98},{9,94},{21,87},{34,79},{46,69},
+                      {54,61},{60,54}},
+                  thickness=0.5),
+                Polygon(
+                  points={{99,21},{74,80},{40,45},{99,21}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid)}),
+            Documentation(info="<HTML>
+<p>
+The <b>6</b> signals of the <b>load</b> connector are interpreted
+as the x-, y- and z-coordinates of a <b>force</b> and as
+the x-, y-, and z-coordinates of a <b>torque</b> resolved in the
+<b>world frame</b> and acting at the frame connector to which this
+component is attached. The input signals are mapped to the force
+and torque in the following way:
+</p>
+<pre>
+   force  = load[1:3]
+   torque = load[4:6]
+</pre>
+<p>
+The force and torque are by default visualized as an arrow (force)
+and as a double arrow (torque) acting at the connector to which
+they are connected. The diameters
+and colors of the arrows are fixed and can be defined via
+parameters <b>forceDiameter</b>, <b>torqueDiameter</b>,
+<b>forceColor</b> and <b>torqueColor</b>. The arrows
+point in the directions defined by the
+inPort.signal signals. The lengths of the arrows are proportional
+to the length of the force and torque vectors, respectively, using parameters
+<b>N_to_m</b> and <b>Nm_to_m</b> as scaling factors. For example, if N_to_m = 100 N/m,
+then a force of 350 N is displayed as an arrow of length 3.5 m.
+</p>
+<p>
+An example how to use this model is given in the
+following figure:
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/WorldForceAndTorque1.png\">
+
+<p>
+This leads to the following animation
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/WorldForceAndTorque2.png\">
+</html>"));
+        end WorldForceAndTorque;
+
+        model FrameForceAndTorque
+          "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Forces.ForceAndTorque"
+
+          import SI = Modelica.SIunits;
+          import Modelica.Mechanics.MultiBody.Types;
+          extends Modelica.Mechanics.MultiBody.Interfaces.PartialOneFrame_b;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+          Modelica.Mechanics.MultiBody.Interfaces.Frame_resolve frame_resolve
+            "If connected, the input signals are resolved in this frame"
+            annotation (Placement(transformation(
+                origin={0,100},
+                extent={{16,-16},{-16,16}},
+                rotation=270)));
+          Modelica.Blocks.Interfaces.RealInput load[6]
+            "[1:6] = x-, y-, z-coordinates of force and x-, y-, z-coordiantes of torque resolved in frame_b or frame_resolved (if connected)"
+            annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
+          parameter Boolean animation=true
+            "= true, if animation shall be enabled";
+          parameter Real N_to_m(unit="N/m") = world.defaultN_to_m
+            " Force arrow scaling (length = force/N_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          parameter Real Nm_to_m(unit="N.m/m") = world.defaultNm_to_m
+            " Torque arrow scaling (length = torque/Nm_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter forceDiameter=world.defaultArrowDiameter
+            " Diameter of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter torqueDiameter=forceDiameter
+            " Diameter of torque arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color forceColor=Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
+            " Color of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color torqueColor=Modelica.Mechanics.MultiBody.Types.Defaults.TorqueColor
+            " Color of torque arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+            "Reflection of ambient light (= 0: light is completely absorbed)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+
+        protected
+          SI.Position f_in_m[3]=frame_b.f/N_to_m
+            "Force mapped from N to m for animation";
+          SI.Position t_in_m[3]=frame_b.t/Nm_to_m
+            "Torque mapped from Nm to m for animation";
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow forceArrow(
+            diameter=forceDiameter,
+            color=forceColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=f_in_m,
+            r_head=-f_in_m) if world.enableAnimation and animation;
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow
+            torqueArrow(
+            diameter=torqueDiameter,
+            color=torqueColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=t_in_m,
+            r_head=-t_in_m) if world.enableAnimation and animation;
+        equation
+          if cardinality(frame_resolve) == 0 then
+            frame_b.f = -load[1:3];
+            frame_b.t = -load[4:6];
+            frame_resolve.r_0 = zeros(3);
+            frame_resolve.R = Modelica.Mechanics.MultiBody.Frames.nullRotation();
+          else
+            frame_b.f = -Modelica.Mechanics.MultiBody.Frames.resolveRelative(
+                load[1:3],
+                frame_resolve.R,
+                frame_b.R);
+            frame_b.t = -Modelica.Mechanics.MultiBody.Frames.resolveRelative(
+                load[4:6],
+                frame_resolve.R,
+                frame_b.R);
+            frame_resolve.f = zeros(3);
+            frame_resolve.t = zeros(3);
+          end if;
+          annotation (
+            obsolete="Based on a packed result signal which is not a good design. Use instead Modelica.Mechanics.MultiBody.Forces.ForceAndTorque",
+            preferredView="info",
+            Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                    -100},{100,100}}), graphics={
+                Polygon(
+                  points={{-100,10},{50,10},{50,31},{97,0},{50,-31},{50,-10},{-100,
+                      -10},{-100,10}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{-100,11},{-94,24},{-86,39},{-74,59},{-65,71},{-52,
+                      83},{-35,92},{-22,95},{-8,95},{7,91},{19,84},{32,76},{44,
+                      66},{52,58},{58,51}}),
+                Polygon(
+                  points={{97,18},{72,77},{38,42},{97,18}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Line(
+                  points={{0,97},{0,10}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot)}),
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Text(
+                  extent={{-74,62},{44,24}},
+                  lineColor={192,192,192},
+                  textString="resolve"),
+                Polygon(
+                  points={{-100,10},{50,10},{50,31},{94,0},{50,-31},{50,-10},{-100,
+                      -10},{-100,10}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Text(extent={{-137,-47},{148,-108}}, textString="%name"),
+                Line(points={{-100,10},{-92,26},{-84,42},{-76,52},{-60,68},{-46,
+                      76},{-31,82},{-17,85},{-2,87},{14,86},{26,82},{37,75},{46,
+                      69},{54,61},{60,54}}),
+                Polygon(
+                  points={{99,21},{74,80},{40,45},{99,21}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Line(
+                  points={{0,95},{0,10}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot)}),
+            Documentation(info="<HTML>
+<p>
+The <b>6</b> signals of the <b>load</b> connector are interpreted
+as the x-, y- and z-coordinates of a <b>force</b> and as
+the x-, y-, and z-coordinates of a <b>torque</b> acting at the frame
+connector to which this component is attached. If connector
+<b>frame_resolve</b> is <b>not</b> connected, the force and torque coordinates
+are with respect to <b>frame_b</b>. If connector
+<b>frame_resolve</b> is connected, the force and torque coordinates
+are with respect to <b>frame_resolve</b>. In this case the
+force and torque in connector frame_resolve are set to zero,
+i.e., this connector is solely used to provide the information
+of the coordinate system, in which the force coordinates
+are defined. The input signals are mapped to the force
+and torque in the following way:
+</p>
+<pre>
+   force  = load[1:3]
+   torque = load[4:6]
+</pre>
+<p>
+The force and torque are by default visualized as an arrow (force)
+and as a double arrow (torque) acting at the connector to which
+they are connected. The diameters
+and colors of the arrows are fixed and can be defined via
+parameters <b>forceDiameter</b>, <b>torqueDiameter</b>,
+<b>forceColor</b> and <b>torqueColor</b>. The arrows
+point in the directions defined by the
+inPort.signal signals. The lengths of the arrows are proportional
+to the length of the force and torque vectors, respectively, using parameters
+<b>N_to_m</b> and <b>Nm_to_m</b> as scaling factors. For example,
+if N_to_m = 100 N/m,
+then a force of 350 N is displayed as an arrow of length 3.5 m.
+</p>
+<p>
+An example how to use this model is given in the
+following figure:
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/FrameForceAndTorque1.png\">
+
+<p>
+This leads to the following animation
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/FrameForceAndTorque2.png\">
+</html>"));
+        end FrameForceAndTorque;
+
+        model ForceAndTorque
+          "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Forces.ForceAndTorque"
+
+          import SI = Modelica.SIunits;
+          import Modelica.Mechanics.MultiBody.Types;
+          extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+          Modelica.Mechanics.MultiBody.Interfaces.Frame_resolve frame_resolve
+            "If connected, the input signals are resolved in this frame"
+            annotation (Placement(transformation(
+                origin={40,100},
+                extent={{-16,-16},{16,16}},
+                rotation=90)));
+
+          Modelica.Blocks.Interfaces.RealInput load[6]
+            "[1:6] = x-, y-, z-coordinates of force and x-, y-, z-coordiantes of torque resolved in frame_b or frame_resolved (if connected)"
+            annotation (Placement(transformation(
+                origin={-60,120},
+                extent={{-20,-20},{20,20}},
+                rotation=270)));
+          parameter Boolean animation=true
+            "= true, if animation shall be enabled";
+          parameter Real N_to_m(unit="N/m") = world.defaultN_to_m
+            " Force arrow scaling (length = force/N_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          parameter Real Nm_to_m(unit="N.m/m") = world.defaultNm_to_m
+            " Torque arrow scaling (length = torque/Nm_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter forceDiameter=world.defaultArrowDiameter
+            " Diameter of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter torqueDiameter=forceDiameter
+            " Diameter of torque arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter connectionLineDiameter=forceDiameter
+            " Diameter of line connecting frame_a and frame_b"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color forceColor=Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
+            " Color of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color torqueColor=Modelica.Mechanics.MultiBody.Types.Defaults.TorqueColor
+            " Color of torque arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color connectionLineColor=Modelica.Mechanics.MultiBody.Types.Defaults.SensorColor
+            " Color of line connecting frame_a and frame_b"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+            "Reflection of ambient light (= 0: light is completely absorbed)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          SI.Position r_0[3]
+            "Position vector from origin of frame_a to origin of frame_b resolved in world frame";
+          SI.Force f_b_0[3] "frame_b.f resolved in world frame";
+          SI.Torque t_b_0[3] "frame_b.t resolved in world frame";
+
+        protected
+          SI.Position f_in_m[3]=frame_b.f/N_to_m
+            "Force mapped from N to m for animation";
+          SI.Position t_in_m[3]=frame_b.t/Nm_to_m
+            "Torque mapped from Nm to m for animation";
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow forceArrow(
+            diameter=forceDiameter,
+            color=forceColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=f_in_m,
+            r_head=-f_in_m) if world.enableAnimation and animation;
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow
+            torqueArrow(
+            diameter=torqueDiameter,
+            color=torqueColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=t_in_m,
+            r_head=-t_in_m) if world.enableAnimation and animation;
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape
+            connectionLine(
+            shapeType="cylinder",
+            lengthDirection=r_0,
+            widthDirection={0,1,0},
+            length=Modelica.Math.Vectors.length(              r_0),
+            width=connectionLineDiameter,
+            height=connectionLineDiameter,
+            color=connectionLineColor,
+            specularCoefficient=specularCoefficient,
+            r=frame_a.r_0) if world.enableAnimation and animation;
+        equation
+          if cardinality(frame_resolve) == 0 then
+            frame_b.f = -load[1:3];
+            frame_b.t = -load[4:6];
+            f_b_0 = Modelica.Mechanics.MultiBody.Frames.resolve1(frame_b.R, frame_b.f);
+            t_b_0 = Modelica.Mechanics.MultiBody.Frames.resolve1(frame_b.R, frame_b.t);
+            frame_resolve.r_0 = zeros(3);
+            frame_resolve.R = Modelica.Mechanics.MultiBody.Frames.nullRotation();
+          else
+            f_b_0 = -Modelica.Mechanics.MultiBody.Frames.resolve1(frame_resolve.R,
+              load[1:3]);
+            t_b_0 = -Modelica.Mechanics.MultiBody.Frames.resolve1(frame_resolve.R,
+              load[4:6]);
+            frame_b.f = Modelica.Mechanics.MultiBody.Frames.resolve2(frame_b.R, f_b_0);
+            frame_b.t = Modelica.Mechanics.MultiBody.Frames.resolve2(frame_b.R, t_b_0);
+            frame_resolve.f = zeros(3);
+            frame_resolve.t = zeros(3);
+          end if;
+
+          // Force and torque balance
+          r_0 = frame_b.r_0 - frame_a.r_0;
+          zeros(3) = frame_a.f + Modelica.Mechanics.MultiBody.Frames.resolve2(frame_a.R,
+            f_b_0);
+          zeros(3) = frame_a.t + Modelica.Mechanics.MultiBody.Frames.resolve2(frame_a.R,
+            t_b_0 + cross(r_0, f_b_0));
+          annotation (
+            obsolete="Based on a packed result signal which is not a good design. Use instead Modelica.Mechanics.MultiBody.Forces.ForceAndTorque",
+            preferredView="info",
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Rectangle(
+                  extent={{-98,99},{99,-98}},
+                  lineColor={255,255,255},
+                  fillColor={255,255,255},
+                  fillPattern=FillPattern.Solid),
+                Text(
+                  extent={{-59,55},{72,30}},
+                  lineColor={192,192,192},
+                  textString="resolve"),
+                Text(extent={{-136,-52},{149,-113}}, textString="%name"),
+                Polygon(
+                  points={{100,21},{84,55},{69,39},{100,21}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Line(
+                  points={{40,100},{40,0}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot),
+                Polygon(
+                  points={{-95,1},{-64,11},{-64,-10},{-95,1}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Polygon(
+                  points={{-100,20},{-86,53},{-70,42},{-100,20}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Line(
+                  points={{-60,100},{40,100}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot),
+                Polygon(
+                  points={{94,0},{65,12},{65,-11},{94,0}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{-64,0},{-20,0}}),
+                Line(points={{20,0},{65,0}}),
+                Line(points={{-79,47},{-70,61},{-59,72},{-45,81},{-32,84},{-20,
+                      85}}),
+                Line(points={{76,47},{66,60},{55,69},{49,74},{41,80},{31,84},{
+                      20,85}})}),
+            Documentation(info="<HTML>
+<p>
+The <b>6</b> signals of the <b>load</b> connector are interpreted
+as the x-, y- and z-coordinates of a <b>force</b> and as
+the x-, y-, and z-coordinates of a <b>torque</b> acting at the frame
+connector to which frame_b of this component is attached. If connector
+<b>frame_resolve</b> is <b>not</b> connected, the force and torque coordinates
+are with respect to <b>frame_b</b>. If connector
+<b>frame_resolve</b> is connected, the force and torque coordinates
+are with respect to <b>frame_resolve</b>. In this case the
+force and torque in connector frame_resolve are set to zero,
+i.e., this connector is solely used to provide the information
+of the coordinate system, in which the force/torque coordinates
+are defined. The input signals are mapped to the force
+and torque in the following way:
+</p>
+<pre>
+   force  = load[1:3]
+   torque = load[4:6]
+</pre>
+<p>
+Additionally, a force and torque acts on frame_a in such a way that
+the force and torque balance between frame_a and frame_b is fulfilled.
+</p>
+<p>
+An example how to use this model is given in the
+following figure:
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ForceAndTorque1.png\">
+
+<p>
+This leads to the following animation (the yellow cylinder
+characterizes the line between frame_a and frame_b of the
+ForceAndTorque component, i.e., the force and torque acts with
+negative sign
+also on the opposite side of this cylinder, but for
+clarity this is not shown in the animation):
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Forces/ForceAndTorque2.png\">
+</html>"));
+        end ForceAndTorque;
+      end Forces;
+
+      package Interfaces
+        "Connectors and partial models for 3-dim. mechanical components"
+        partial model PartialCutForceSensor
+          "Obsolete model. Use instead instead a model from Modelica.Mechanics.MultiBody.Sensors"
+
+          extends Modelica.Icons.RotationalSensor;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+          Modelica.Mechanics.MultiBody.Interfaces.Frame_a frame_a
+            "Coordinate system with one cut-force and cut-torque"                          annotation (Placement(
+                transformation(extent={{-116,-16},{-84,16}})));
+          Modelica.Mechanics.MultiBody.Interfaces.Frame_b frame_b
+            "Coordinate system with one cut-force and cut-torque"                          annotation (Placement(
+                transformation(extent={{84,-16},{116,16}})));
+          Modelica.Mechanics.MultiBody.Interfaces.Frame_resolve frame_resolve
+            "If connected, the output signals are resolved in this frame (cut-force/-torque are set to zero)"
+            annotation (Placement(transformation(
+                origin={80,-100},
+                extent={{-16,-16},{16,16}},
+                rotation=270)));
+
+        protected
+          outer Modelica.Mechanics.MultiBody.World world;
+        equation
+          defineBranch(frame_a.R, frame_b.R);
+          assert(cardinality(frame_a) > 0,
+            "Connector frame_a of cut-force/-torque sensor object is not connected");
+          assert(cardinality(frame_b) > 0,
+            "Connector frame_b of cut-force/-torque sensor object is not connected");
+
+          // frame_a and frame_b are identical
+          frame_a.r_0 = frame_b.r_0;
+          frame_a.R = frame_b.R;
+
+          // force and torque balance
+          zeros(3) = frame_a.f + frame_b.f;
+          zeros(3) = frame_a.t + frame_b.t;
+
+          // deduce cut-force
+          if cardinality(frame_resolve) == 1 then
+            // frame_resolve is connected
+            frame_resolve.f = zeros(3);
+            frame_resolve.t = zeros(3);
+          else
+            // frame_resolve is NOT connected
+            frame_resolve.r_0 = zeros(3);
+            frame_resolve.R = Modelica.Mechanics.MultiBody.Frames.nullRotation();
+          end if;
+          annotation (
+            obsolete="Model equations depend on cardinality(..) which will become obsolete in the Modelica language. Use instead a model from Modelica.Mechanics.MultiBody.Sensors",
+            Documentation(info="<html>
+<p>
+This is a base class for 3-dim. mechanical components with two frames
+and one output port in order to measure the cut-force and/or
+cut-torque acting between the two frames and
+to provide the measured signals as output for further processing
+with the blocks of package Modelica.Blocks.
+</p>
+</html>"),         Icon(coordinateSystem(
+                preserveAspectRatio=true,
+                extent={{-100,-100},{100,100}}),
+                graphics={
+                Line(points={{-70,0},{-101,0}}),
+                Line(points={{70,0},{100,0}}),
+                Line(points={{-80,-100},{-80,0}}, color={0,0,127}),
+                Text(
+                  extent={{-132,76},{129,124}},
+                  textString="%name",
+                  lineColor={0,0,255}),
+                Text(
+                  extent={{-118,55},{-82,30}},
+                  lineColor={128,128,128},
+                  textString="a"),
+                Text(
+                  extent={{83,55},{119,30}},
+                  lineColor={128,128,128},
+                  textString="b"),
+                Text(
+                  extent={{-31,-72},{100,-97}},
+                  lineColor={192,192,192},
+                  textString="resolve"),
+                Line(
+                  points={{80,0},{80,-100}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot)}),
+            Diagram(coordinateSystem(
+                preserveAspectRatio=true,
+                extent={{-100,-100},{100,100}}),
+                graphics={
+                Line(points={{-70,0},{-100,0}}),
+                Line(points={{70,0},{100,0}}),
+                Line(points={{-80,-100},{-80,0}}, color={0,0,127}),
+                Line(
+                  points={{80,0},{80,-100}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot)}));
+        end PartialCutForceSensor;
+      end Interfaces;
+
+      package Joints
+        package Internal
+          model RevoluteWithLengthConstraint
+            "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Joints.Internal.RevoluteWithLengthConstraint"
+
+            import SI = Modelica.SIunits;
+            import Cv = Modelica.SIunits.Conversions;
+            extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+            extends ObsoleteModelica3.Icons.ObsoleteModel;
+            Modelica.Mechanics.Rotational.Interfaces.Flange_a axis
+              "1-dim. rotational flange that drives the joint"
+              annotation (Placement(transformation(extent={{10,90},{-10,110}})));
+            Modelica.Mechanics.Rotational.Interfaces.Flange_b bearing
+              "1-dim. rotational flange of the drive bearing"
+              annotation (Placement(transformation(extent={{-50,90},{-70,110}})));
+
+            Modelica.Blocks.Interfaces.RealInput position_a[3]
+              "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint"
+              annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
+            Modelica.Blocks.Interfaces.RealInput position_b[3]
+              "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint"
+              annotation (Placement(transformation(extent={{140,-80},{100,-40}})));
+
+            parameter Boolean animation=true
+              "= true, if animation shall be enabled";
+            parameter SI.Position lengthConstraint=1
+              "Fixed length of length constraint";
+            parameter Modelica.Mechanics.MultiBody.Types.Axis n={0,0,1}
+              "Axis of rotation resolved in frame_a (= same as in frame_b)"
+              annotation (Evaluate=true);
+            parameter Cv.NonSIunits.Angle_deg phi_offset=0
+              "Relative angle offset (angle = phi + from_deg(phi_offset))";
+            parameter Cv.NonSIunits.Angle_deg phi_guess=0
+              "Select the configuration such that at initial time |phi - from_deg(phi_guess)|is minimal";
+            parameter SI.Distance cylinderLength=world.defaultJointLength
+              "Length of cylinder representing the joint axis"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+            parameter SI.Distance cylinderDiameter=world.defaultJointWidth
+              "Diameter of cylinder representing the joint axis"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+            input Modelica.Mechanics.MultiBody.Types.Color cylinderColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+              "Color of cylinder representing the joint axis"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+            input Modelica.Mechanics.MultiBody.Types.SpecularCoefficient
+              specularCoefficient=world.defaultSpecularCoefficient
+              "Reflection of ambient light (= 0: light is completely absorbed)"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+            parameter Boolean axisTorqueBalance=true
+              "= true, if torque balance of flange axis with the frame_b connector (axis.tau = -e*frame_b.t) shall be defined. Otherwise this equation has to be provided outside of this joint"
+              annotation (Dialog(tab="Advanced"));
+            final parameter Boolean positiveBranch(fixed=false)
+              "Based on phi_guess, selection of one of the two solutions of the non-linear constraint equation";
+            final parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalize(              n)
+              "Unit vector in direction of rotation axis, resolved in frame_a";
+
+            SI.Angle phi "Rotation angle of revolute joint";
+            Modelica.Mechanics.MultiBody.Frames.Orientation R_rel
+              "Relative orientation object from frame_a to frame_b";
+            SI.Angle angle
+              "= phi + from_deg(phi_offset) (relative rotation angle between frame_a and frame_b)";
+            SI.Torque tau "= axis.tau (driving torque in the axis)";
+
+          protected
+            SI.Position r_a[3]=position_a
+              "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint";
+            SI.Position r_b[3]=position_b
+              "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint";
+            Real e_r_a "Projection of r_a on e";
+            Real e_r_b "Projection of r_b on e";
+            Real A "Coefficient A of equation: A*cos(phi) + B*sin(phi) + C = 0";
+            Real B "Coefficient B of equation: A*cos(phi) + B*sin(phi) + C = 0";
+            Real C "Coefficient C of equation: A*cos(phi) + B*sin(phi) + C = 0";
+            Real k1 "Constant of quadratic equation";
+            Real k2 "Constant of quadratic equation";
+            Real k1a(start=1);
+            Real k1b;
+            Real kcos_angle "= k1*cos(angle)";
+            Real ksin_angle "= k1*sin(angle)";
+
+            Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape cylinder(
+              shapeType="cylinder",
+              color=cylinderColor,
+              specularCoefficient=specularCoefficient,
+              length=cylinderLength,
+              width=cylinderDiameter,
+              height=cylinderDiameter,
+              lengthDirection=e,
+              widthDirection={0,1,0},
+              r_shape=-e*(cylinderLength/2),
+              r=frame_a.r_0,
+              R=frame_a.R) if world.enableAnimation and animation;
+
+            function selectBranch
+              "Determine branch which is closest to initial angle=0"
+
+              import Modelica.Math.*;
+              input SI.Length L "Length of length constraint";
+              input Real e[3](each final unit="1")
+                "Unit vector along axis of rotation, resolved in frame_a (= same in frame_b)";
+              input SI.Angle angle_guess
+                "Select the configuration such that at initial time |angle-angle_guess|is minimal (angle=0: frame_a and frame_b coincide)";
+              input SI.Position r_a[3]
+                "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint";
+              input SI.Position r_b[3]
+                "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint";
+              output Boolean positiveBranch "Branch of the initial solution";
+            protected
+              Real e_r_a "Projection of r_a on e";
+              Real e_r_b "Projection of r_b on e";
+              Real A
+                "Coefficient A of equation: A*cos(phi) + B*sin(phi) + C = 0";
+              Real B
+                "Coefficient B of equation: A*cos(phi) + B*sin(phi) + C = 0";
+              Real C
+                "Coefficient C of equation: A*cos(phi) + B*sin(phi) + C = 0";
+              Real k1 "Constant of quadratic equation";
+              Real k2 "Constant of quadratic equation";
+              Real kcos1 "k1*cos(angle1)";
+              Real ksin1 "k1*sin(angle1)";
+              Real kcos2 "k2*cos(angle2)";
+              Real ksin2 "k2*sin(angle2)";
+              SI.Angle angle1 "solution 1 of nonlinear equation";
+              SI.Angle angle2 "solution 2 of nonlinear equation";
+            algorithm
+              /* The position vector r_rel from frame_a to frame_b of the length constraint
+       element, resolved in frame_b of the revolute joint is given by
+       (T_rel is the planar transformation matrix from frame_a to frame_b of
+        the revolute joint):
+          r_rel = r_b - T_rel*r_a
+       The length constraint can therefore be formulated as:
+          r_rel*r_rel = L*L
+       with
+          (r_b - T_rel*r_a)*(r_b - T_rel*r_a)
+             = r_b*r_b - 2*r_b*T_rel*r_a + r_a*transpose(T_rel)*T_rel*r_a
+             = r_b*r_b + r_a*r_a - 2*r_b*T_rel*r_a
+       follows
+          (1) 0 = r_a*r_a + r_b*r_b - 2*r_b*T_rel*r_a - L*L
+       The vectors r_a, r_b and parameter L are NOT a function of
+       the angle of the revolute joint. Since T_rel = T_rel(angle) is a function
+       of the unknown angle of the revolute joint, this is a non-linear
+       equation in this angle.
+          T_rel = [e]*transpose([e]) + (identity(3) - [e]*transpose([e]))*cos(angle)
+                  - skew(e)*sin(angle);
+       with
+          r_b*T_rel*r_a
+             = r_b*(e*(e*r_a) + (r_a - e*(e*r_a))*cos(angle) - cross(e,r_a)*sin(angle)
+             = (e*r_b)*(e*r_a) + (r_b*r_a - (e*r_b)*(e*r_a))*cos(angle) - r_b*cross(e,r_a)*sin(angle)
+       follows for the constraint equation (1)
+          (2) 0 = r_a*r_a + r_b*r_b - L*L
+                  - 2*(e*r_b)*(e*r_a)
+                  - 2*(r_b*r_a - (e*r_b)*(e*r_a))*cos(angle)
+                  + 2*r_b*cross(e,r_a)*sin(angle)
+       or
+          (3) A*cos(angle) + B*sin(angle) + C = 0
+       with
+              A = -2*(r_b*r_a - (e*r_b)*(e*r_a))
+              B = 2*r_b*cross(e,r_a)
+              C = r_a*r_a + r_b*r_b - L*L - 2*(e*r_b)*(e*r_a)
+       Equation (3) is solved by computing sin(angle) and cos(angle)
+       independently from each other. This allows to compute
+       angle in the range: -180 deg <= angle <= 180 deg
+    */
+              e_r_a := e*r_a;
+              e_r_b := e*r_b;
+              A := -2*(r_b*r_a - e_r_b*e_r_a);
+              B := 2*r_b*cross(e, r_a);
+              C := r_a*r_a + r_b*r_b - L*L - 2*e_r_b*e_r_a;
+              k1 := A*A + B*B;
+              k2 := sqrt(k1 - C*C);
+
+              kcos1 := -A*C + B*k2;
+              ksin1 := -B*C - A*k2;
+              angle1 := atan2(ksin1, kcos1);
+
+              kcos2 := -A*C - B*k2;
+              ksin2 := -B*C + A*k2;
+              angle2 := atan2(ksin2, kcos2);
+
+              if abs(angle1 - angle_guess) <= abs(angle2 - angle_guess) then
+                positiveBranch := true;
+              else
+                positiveBranch := false;
+              end if;
+            end selectBranch;
+          initial equation
+            positiveBranch = selectBranch(lengthConstraint, e, Cv.from_deg(phi_offset
+               + phi_guess), r_a, r_b);
+          equation
+            Connections.branch(frame_a.R, frame_b.R);
+            axis.tau = tau;
+            axis.phi = phi;
+            bearing.phi = 0;
+
+            angle = Cv.from_deg(phi_offset) + phi;
+
+            // transform kinematic quantities from frame_a to frame_b
+            frame_b.r_0 = frame_a.r_0;
+
+            R_rel = Modelica.Mechanics.MultiBody.Frames.planarRotation(
+              e,
+              angle,
+              der(angle));
+            frame_b.R = Modelica.Mechanics.MultiBody.Frames.absoluteRotation(frame_a.R,
+              R_rel);
+
+            // Transform the force and torque acting at frame_b to frame_a
+            zeros(3) = frame_a.f + Modelica.Mechanics.MultiBody.Frames.resolve1(R_rel,
+              frame_b.f);
+            zeros(3) = frame_a.t + Modelica.Mechanics.MultiBody.Frames.resolve1(R_rel,
+              frame_b.t);
+
+            if axisTorqueBalance then
+              /* Note, if axisTorqueBalance is false, the force in the
+       length constraint must be calculated such that the driving
+       Torque in direction of the rotation axis is:
+          axis.tau = -e*frame_b.t;
+       If axisTorqueBalance=true, this equation is provided here.
+       As a consequence, the force in the length constraint and the second
+       derivative of 'angle' will be part of a linear algebraic system of
+       equations (otherwise, it might be possible to remove this force
+       from the linear system).
+    */
+              tau = -e*frame_b.t;
+            end if;
+
+            // Compute rotation angle (details, see function "selectBranch")
+            e_r_a = e*r_a;
+            e_r_b = e*r_b;
+            A = -2*(r_b*r_a - e_r_b*e_r_a);
+            B = 2*r_b*cross(e, r_a);
+            C = r_a*r_a + r_b*r_b - lengthConstraint*lengthConstraint - 2*e_r_b*e_r_a;
+            k1 = A*A + B*B;
+            k1a = k1 - C*C;
+
+            assert(k1a > 1.e-10, "
+Singular position of loop (either no or two analytic solutions;
+the mechanism has lost one-degree-of freedom in this position).
+Try first to use another Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXXX component.
+In most cases it is best that the joints outside of the JointXXX
+component are revolute and NOT prismatic joints. If this also
+lead to singular positions, it could be that this kinematic loop
+cannot be solved analytically. In this case you have to build
+up the loop with basic joints (NO aggregation JointXXX components)
+and rely on dynamic state selection, i.e., during simulation
+the states will be dynamically selected in such a way that in no
+position a degree of freedom is lost.
+");
+
+            k1b = Modelica.Mechanics.MultiBody.Frames.Internal.maxWithoutEvent(k1a,
+              1.0e-12);
+            k2 = sqrt(k1b);
+            kcos_angle = -A*C + (if positiveBranch then B else -B)*k2;
+            ksin_angle = -B*C + (if positiveBranch then -A else A)*k2;
+
+            angle = Modelica.Math.atan2(ksin_angle, kcos_angle);
+            annotation (
+              defaultConnectionStructurallyInconsistent=true,
+              preferredView="info",
+              obsolete="Obsolete model that is not balanced. Use instead Modelica.Mechanics.MultiBody.Joints.Internal.RevoluteWithLengthConstraint",
+              Icon(coordinateSystem(
+                  preserveAspectRatio=false,
+                  extent={{-100,-100},{100,100}}),
+                  graphics={
+                  Rectangle(
+                    extent={{-30,10},{10,-10}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-100,-60},{-30,60}},
+                    lineColor={0,0,0},
+                    fillPattern=FillPattern.HorizontalCylinder,
+                    fillColor={192,192,192}),
+                  Rectangle(
+                    extent={{30,-60},{100,60}},
+                    lineColor={0,0,0},
+                    fillPattern=FillPattern.HorizontalCylinder,
+                    fillColor={192,192,192}),
+                  Text(extent={{-139,-168},{137,-111}}, textString="%name"),
+                  Rectangle(extent={{-100,60},{-30,-60}}, lineColor={0,0,0}),
+                  Rectangle(extent={{30,60},{100,-60}}, lineColor={0,0,0}),
+                  Text(
+                    extent={{-142,-108},{147,-69}},
+                    lineColor={0,0,0},
+                    textString="n=%n"),
+                  Line(points={{-60,60},{-60,90}}),
+                  Line(points={{-20,70},{-60,70}}),
+                  Line(points={{-20,80},{-20,60}}),
+                  Line(points={{20,80},{20,60}}),
+                  Line(points={{20,70},{41,70}}),
+                  Polygon(
+                    points={{-9,30},{10,30},{30,50},{-29,50},{-9,30}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Polygon(
+                    points={{10,30},{30,50},{30,-51},{10,-31},{10,30}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-10,90},{10,50}},
+                    lineColor={0,0,0},
+                    fillPattern=FillPattern.VerticalCylinder,
+                    fillColor={192,192,192})}),
+              Diagram(coordinateSystem(
+                  preserveAspectRatio=false,
+                  extent={{-100,-100},{100,100}}),
+                  graphics={
+                  Rectangle(
+                    extent={{-100,-60},{-30,60}},
+                    lineColor={0,0,0},
+                    fillPattern=FillPattern.HorizontalCylinder,
+                    fillColor={192,192,192}),
+                  Rectangle(
+                    extent={{-30,10},{10,-10}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{30,-60},{100,60}},
+                    lineColor={0,0,0},
+                    fillPattern=FillPattern.HorizontalCylinder,
+                    fillColor={192,192,192}),
+                  Line(points={{-60,60},{-60,96}}),
+                  Line(points={{-20,70},{-60,70}}),
+                  Line(points={{-20,80},{-20,60}}),
+                  Line(points={{20,80},{20,60}}),
+                  Line(points={{20,70},{41,70}}),
+                  Polygon(
+                    points={{-9,30},{10,30},{30,50},{-29,50},{-9,30}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Polygon(
+                    points={{10,30},{30,50},{30,-51},{10,-31},{10,30}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-10,50},{10,100}},
+                    lineColor={0,0,0},
+                    fillPattern=FillPattern.VerticalCylinder,
+                    fillColor={192,192,192})}),
+              Documentation(info="<HTML>
+<p>
+Joint where frame_b rotates around axis n which is fixed in frame_a.
+The two frames coincide when \"phi + phi_offset = 0\", where
+\"phi_offset\" is a parameter with a zero default
+and \"phi\" is the rotation angle.
+</p>
+<p>
+This variant of the revolute joint is designed to work together
+with a length constraint in a kinematic loop. This means that the
+angle of the revolute joint, phi, is computed such that the
+length constraint is fulfilled.
+</p>
+<p>
+<b>Usually, this joint should not be used by a user of the MultiBody
+library. It is only provided to built-up the Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXYZ
+joints.</b>
+</p>
+</html>"));
+          end RevoluteWithLengthConstraint;
+
+          model PrismaticWithLengthConstraint
+            "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Joints.Internal.PrismaticWithLengthConstraint"
+
+            import SI = Modelica.SIunits;
+            import Cv = Modelica.SIunits.Conversions;
+            extends Modelica.Mechanics.MultiBody.Interfaces.PartialTwoFrames;
+            extends ObsoleteModelica3.Icons.ObsoleteModel;
+            Modelica.Mechanics.Translational.Interfaces.Flange_a axis
+              "1-dim. translational flange that drives the joint"
+              annotation (Placement(transformation(extent={{70,80},{90,60}})));
+            Modelica.Mechanics.Translational.Interfaces.Flange_b bearing
+              "1-dim. translational flange of the drive bearing"
+              annotation (Placement(transformation(extent={{-30,80},{-50,60}})));
+            Modelica.Blocks.Interfaces.RealInput position_a[3]
+              "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint"
+              annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
+            Modelica.Blocks.Interfaces.RealInput position_b[3]
+              "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint"
+              annotation (Placement(transformation(extent={{140,-80},{100,-40}})));
+
+            parameter Boolean animation=true
+              "= true, if animation shall be enabled";
+            parameter SI.Position length=1 "Fixed length of length constraint";
+            parameter Modelica.Mechanics.MultiBody.Types.Axis n={1,0,0}
+              "Axis of translation resolved in frame_a (= same as in frame_b)"
+              annotation (Evaluate=true);
+            parameter SI.Position s_offset=0
+              "Relative distance offset (distance between frame_a and frame_b = s(t) + s_offset)";
+            parameter SI.Position s_guess=0
+              "Select the configuration such that at initial time |s(t0)-s_guess|is minimal";
+            parameter Modelica.Mechanics.MultiBody.Types.Axis boxWidthDirection={0,1,0}
+              "Vector in width direction of box, resolved in frame_a"
+              annotation (Evaluate=true, Dialog(tab="Animation", group=
+                    "if animation = true", enable=animation));
+            parameter SI.Distance boxWidth=world.defaultJointWidth
+              "Width of prismatic joint box"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+            parameter SI.Distance boxHeight=boxWidth
+              "Height of prismatic joint box"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+            input Modelica.Mechanics.MultiBody.Types.Color boxColor=Modelica.Mechanics.MultiBody.Types.Defaults.JointColor
+              "Color of prismatic joint box"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+            input Modelica.Mechanics.MultiBody.Types.SpecularCoefficient
+              specularCoefficient=world.defaultSpecularCoefficient
+              "Reflection of ambient light (= 0: light is completely absorbed)"
+              annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+            parameter Boolean axisForceBalance=true
+              "= true, if force balance of flange axis with the frame_b connector (axis.f = -e*frame_b.f) shall be defined. Otherwise this equation has to be provided outside of this joint"
+              annotation (Dialog(tab="Advanced"));
+            final parameter Boolean positiveBranch(fixed=false)
+              "Selection of one of the two solutions of the non-linear constraint equation";
+            final parameter Real e[3](each final unit="1")=Modelica.Math.Vectors.normalize(              n)
+              "Unit vector in direction of translation axis, resolved in frame_a";
+            SI.Position s
+              "Relative distance between frame_a and frame_b along axis n = s + s_offset)";
+            SI.Position distance
+              "Relative distance between frame_a and frame_b along axis n";
+            SI.Position r_rel_a[3]
+              "Position vector from frame_a to frame_b resolved in frame_a";
+            SI.Force f "= axis.f (driving force in the axis)";
+
+          protected
+            SI.Position r_a[3]=position_a
+              "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of revolute joint";
+            SI.Position r_b[3]=position_b
+              "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of revolute joint";
+            Modelica.SIunits.Position rbra[3] "= rb - ra";
+            Real B "Coefficient B of equation: s*s + B*s + C = 0";
+            Real C "Coefficient C of equation: s*s + B*s + C = 0";
+            Real k1 "Constant of quadratic equation solution";
+            Real k2 "Constant of quadratic equation solution";
+            Real k1a(start=1);
+            Real k1b;
+
+            Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape box(
+              shapeType="box",
+              color=boxColor,
+              specularCoefficient=specularCoefficient,
+              length=if noEvent(abs(s + s_offset) > 1.e-6) then s + s_offset else 1.e-6,
+              width=boxWidth,
+              height=boxHeight,
+              lengthDirection=e,
+              widthDirection=boxWidthDirection,
+              r=frame_a.r_0,
+              R=frame_a.R) if world.enableAnimation and animation;
+
+            function selectBranch
+              "Determine branch which is closest to initial angle=0"
+              import Modelica.Math.*;
+              input SI.Length L "Length of length constraint";
+              input Real e[3](each final unit="1")
+                "Unit vector along axis of translation, resolved in frame_a (= same in frame_b)";
+              input SI.Position d_guess
+                "Select the configuration such that at initial time |d-d_guess|is minimal (d: distance between origin of frame_a and origin of frame_b)";
+              input SI.Position r_a[3]
+                "Position vector from frame_a to frame_a side of length constraint, resolved in frame_a of prismatic joint";
+              input SI.Position r_b[3]
+                "Position vector from frame_b to frame_b side of length constraint, resolved in frame_b of prismatic joint";
+              output Boolean positiveBranch "Branch of the initial solution";
+            protected
+              Modelica.SIunits.Position rbra[3] "= rb - ra";
+              Real B "Coefficient B of equation: d*d + B*d + C = 0";
+              Real C "Coefficient C of equation: d*d + B*d + C = 0";
+              Real k1 "Constant of quadratic equation solution";
+              Real k2 "Constant of quadratic equation solution";
+              Real d1 "solution 1 of quadratic equation";
+              Real d2 "solution 2 of quadratic equation";
+            algorithm
+              /* The position vector r_rel from frame_a to frame_b of the length constraint
+       element, resolved in frame_b of the prismatic joint (frame_a and frame_b
+       of the prismatic joint are parallel to each other) is given by:
+          r_rel = d*e + r_b - r_a
+       The length constraint can therefore be formulated as:
+          r_rel*r_rel = L*L
+       with
+          (d*e + r_b - r_a)*(d*e + r_b - r_a)
+                   = d*d + 2*d*e*(r_b - r_a) + (r_b - r_a)*(r_b - r_a)
+       follows
+          (1)  0 = d*d + d*2*e*(r_b - r_a) + (r_b - r_a)*(r_b - r_a) - L*L
+       The vectors r_a, r_b and parameter L are NOT a function of
+       the distance d of the prismatic joint. Therefore, (1) is a quadratic
+       equation in the single unknown "d":
+          (2) d*d + B*d + C = 0
+              with   B = 2*e*(r_b - r_a)
+                     C = (r_b - r_a)*(r_b - r_a) - L*L
+       The solution is
+          (3) d = - B/2 +/- sqrt(B*B/4 - C)
+    */
+              rbra := r_b - r_a;
+              B := 2*(e*rbra);
+              C := rbra*rbra - L*L;
+              k1 := B/2;
+              k2 := sqrt(k1*k1 - C);
+              d1 := -k1 + k2;
+              d2 := -k1 - k2;
+              if abs(d1 - d_guess) <= abs(d2 - d_guess) then
+                positiveBranch := true;
+              else
+                positiveBranch := false;
+              end if;
+            end selectBranch;
+          initial equation
+            positiveBranch = selectBranch(length, e, s_offset + s_guess, r_a, r_b);
+          equation
+            Connections.branch(frame_a.R, frame_b.R);
+            axis.f = f;
+            axis.s = s;
+            bearing.s = 0;
+            distance = s_offset + s;
+
+            // relationships of frame_a and frame_b quantities
+            r_rel_a = e*distance;
+            frame_b.r_0 = frame_a.r_0 + Modelica.Mechanics.MultiBody.Frames.resolve1(
+              frame_a.R, r_rel_a);
+            frame_b.R = frame_a.R;
+            zeros(3) = frame_a.f + frame_b.f;
+            zeros(3) = frame_a.t + frame_b.t + cross(r_rel_a, frame_b.f);
+
+            if axisForceBalance then
+              /* Note, if axisForceBalance is false, the force in the
+       length constraint must be calculated such that the driving
+       force in direction of the translation axis is:
+          axis.f = -e*frame_b.f;
+       If axisForceBalance=true, this equation is provided here.
+       As a consequence, the force in the length constraint will be
+       part of a linear algebraic system of equations (otherwise, it
+       might be possible to remove this force from the linear system).
+    */
+              f = -e*frame_b.f;
+            end if;
+
+            // Compute translational distance (details, see function "selectBranch")
+            rbra = r_b - r_a;
+            B = 2*(e*rbra);
+            C = rbra*rbra - length*length;
+            k1 = B/2;
+            k1a = k1*k1 - C;
+            assert(noEvent(k1a > 1.e-10), "
+Singular position of loop (either no or two analytic solutions;
+the mechanism has lost one-degree-of freedom in this position).
+Try first to use another Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXXX component.
+If this also lead to singular positions, it could be that this
+kinematic loop cannot be solved analytically with a fixed state
+selection. In this case you have to build up the loop with
+basic joints (NO aggregation JointXXX components) and rely on
+dynamic state selection, i.e., during simulation the states will
+be dynamically selected in such a way that in no position a
+degree of freedom is lost.
+");
+            k1b = Modelica.Mechanics.MultiBody.Frames.Internal.maxWithoutEvent(k1a,
+            1.0e-12);
+            k2 = sqrt(k1b);
+            distance = -k1 + (if positiveBranch then k2 else -k2);
+            annotation (
+              defaultConnectionStructurallyInconsistent=true,
+              preferredView="info",
+              obsolete="Obsolete model that is not balanced. Use instead Modelica.Mechanics.MultiBody.Joints.Internal.PrismaticWithLengthConstraint",
+              Icon(coordinateSystem(
+                  preserveAspectRatio=false,
+                  extent={{-100,-100},{100,100}}),
+                  graphics={
+                  Rectangle(
+                    extent={{-30,-40},{100,30}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(extent={{-30,40},{100,-40}}, lineColor={0,0,0}),
+                  Rectangle(
+                    extent={{-100,-60},{-30,50}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-100,50},{-30,60}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={0,0,0},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-30,30},{100,40}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={0,0,0},
+                    fillPattern=FillPattern.Solid),
+                  Text(extent={{-136,-170},{140,-113}}, textString="%name"),
+                  Rectangle(extent={{-100,60},{-30,-60}}, lineColor={0,0,0}),
+                  Line(points={{100,-40},{100,-60}}),
+                  Rectangle(
+                    extent={{100,40},{90,80}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Text(
+                    extent={{-136,-116},{153,-77}},
+                    lineColor={0,0,0},
+                    textString="n=%n")}),
+              Diagram(coordinateSystem(
+                  preserveAspectRatio=false,
+                  extent={{-100,-100},{100,100}}),
+                  graphics={
+                  Line(points={{-30,-50},{-30,50}}),
+                  Line(points={{0,-67},{90,-67}}, color={128,128,128}),
+                  Text(
+                    extent={{31,-68},{68,-81}},
+                    lineColor={128,128,128},
+                    textString="s"),
+                  Line(points={{-100,-67},{0,-67}}, color={128,128,128}),
+                  Polygon(
+                    points={{-39,-64},{-29,-67},{-39,-70},{-39,-64}},
+                    lineColor={128,128,128},
+                    fillColor={128,128,128},
+                    fillPattern=FillPattern.Solid),
+                  Text(
+                    extent={{-77,-70},{-43,-85}},
+                    lineColor={128,128,128},
+                    textString="s_offset"),
+                  Line(points={{-100,-71},{-100,-51}}, color={128,128,128}),
+                  Line(points={{-30,-73},{-30,-33}}, color={128,128,128}),
+                  Line(points={{100,-70},{100,-30}}, color={128,128,128}),
+                  Polygon(
+                    points={{90,-64},{100,-67},{90,-70},{90,-64}},
+                    lineColor={128,128,128},
+                    fillColor={128,128,128},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-100,50},{-30,60}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={0,0,0},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-100,-60},{-30,50}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(extent={{-30,40},{100,-40}}, lineColor={0,0,0}),
+                  Rectangle(
+                    extent={{-30,-40},{100,30}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(
+                    extent={{-30,30},{100,40}},
+                    lineColor={0,0,255},
+                    pattern=LinePattern.None,
+                    fillColor={0,0,0},
+                    fillPattern=FillPattern.Solid),
+                  Rectangle(extent={{-100,60},{-30,-60}}, lineColor={0,0,0}),
+                  Line(points={{100,-40},{100,-60}}),
+                  Text(extent={{42,91},{57,76}}, textString="f"),
+                  Line(points={{40,75},{70,75}}, color={0,0,255}),
+                  Polygon(
+                    points={{-21,78},{-31,75},{-21,72},{-21,78}},
+                    lineColor={0,0,255},
+                    fillColor={0,0,255},
+                    fillPattern=FillPattern.Solid),
+                  Line(points={{-8,75},{-31,75}}, color={0,0,255}),
+                  Text(extent={{-21,90},{-6,75}}, textString="f"),
+                  Polygon(
+                    points={{60,78},{70,75},{60,72},{60,78}},
+                    lineColor={0,0,255},
+                    fillColor={0,0,255},
+                    fillPattern=FillPattern.Solid),
+                  Line(points={{-30,64},{70,64}}, color={128,128,128}),
+                  Polygon(
+                    points={{60,67},{70,64},{60,61},{60,67}},
+                    lineColor={128,128,128},
+                    fillColor={128,128,128},
+                    fillPattern=FillPattern.Solid),
+                  Text(
+                    extent={{0,63},{37,50}},
+                    lineColor={128,128,128},
+                    textString="s"),
+                  Rectangle(
+                    extent={{100,40},{90,80}},
+                    lineColor={0,0,0},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid)}),
+              Documentation(info="<HTML>
+<p>
+Joint where frame_b is translated along axis n which is fixed in frame_a.
+The two frames coincide when \"s + s_offset = 0\", where
+\"s_offset\" is a parameter with a zero default
+and \"s\" is the relative distance.
+</p>
+<p>
+This variant of the prismatic joint is designed to work together
+with a length constraint in a kinematic loop. This means that the
+relative distance \"s\" of the joint is computed such that the
+length constraint is fulfilled.
+</p>
+<p>
+<b>Usually, this joint should not be used by a user of the MultiBody
+library. It is only provided to built-up the Modelica.Mechanics.MultiBody.Joints.Assemblies.JointXYZ
+joints.</b>
+</p>
+</html>"));
+          end PrismaticWithLengthConstraint;
+        end Internal;
+      end Joints;
+
+      package Sensors "Sensors to measure variables"
+        model AbsoluteSensor
+          "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Sensors.AbsoluteSensor"
+          import SI = Modelica.SIunits;
+          import Modelica.Mechanics.MultiBody.Frames;
+          import Modelica.Mechanics.MultiBody.Types;
+          extends Modelica.Mechanics.MultiBody.Interfaces.PartialAbsoluteSensor(final
+              n_out=3*((if get_r_abs then 1 else 0) + (if get_v_abs then 1 else 0) + (
+                if get_a_abs then 1 else 0) + (if get_angles then 1 else 0) + (if
+                get_w_abs then 1 else 0) + (if get_z_abs then 1 else 0)));
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          Modelica.Mechanics.MultiBody.Interfaces.Frame_resolve frame_resolve
+            "If connected, the output signals are resolved in this frame"
+            annotation (Placement(transformation(
+                origin={0,100},
+                extent={{-16,-16},{16,16}},
+                rotation=270)));
+          parameter Boolean animation=true
+            "= true, if animation shall be enabled (show arrow)";
+          parameter Boolean resolveInFrame_a=false
+            "= true, if vectors are resolved in frame_a, otherwise in the world frame (if connector frame_resolve is connected, vectors are resolved in frame_resolve)";
+          parameter Boolean get_r_abs=true
+            "= true, to measure the position vector from the origin of the world frame to the origin of frame_a in [m]";
+          parameter Boolean get_v_abs=false
+            "= true, to measure the absolute velocity of the origin of frame_a in [m/s]";
+          parameter Boolean get_a_abs=false
+            "= true, to measure the absolute acceleration of the origin of frame_a in [m/s^2]";
+          parameter Boolean get_angles=false
+            "= true, to measure the 3 rotation angles to rotate the world frame into frame_a along the axes defined in 'sequence' below in [rad]";
+          parameter Boolean get_w_abs=false
+            "= true, to measure the absolute angular velocity of frame_a in [rad/s]";
+          parameter Boolean get_z_abs=false
+            "= true, to measure the absolute angular acceleration to frame_a in [rad/s^2]";
+          parameter Types.RotationSequence sequence(
+            min={1,1,1},
+            max={3,3,3}) = {1,2,3}
+            " Angles are returned to rotate world frame around axes sequence[1], sequence[2] and finally sequence[3] into frame_a"
+            annotation (Evaluate=true, Dialog(group="if get_angles = true", enable=get_angles));
+          parameter SI.Angle guessAngle1=0
+            " Select angles[1] such that abs(angles[1] - guessAngle1) is a minimum"
+            annotation (Dialog(group="if get_angles = true", enable=get_angles));
+          input SI.Diameter arrowDiameter=world.defaultArrowDiameter
+            " Diameter of arrow from world frame to frame_a"
+            annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+          input Types.Color arrowColor=Modelica.Mechanics.MultiBody.Types.Defaults.SensorColor
+            " Color of arrow from world frame to frame_a"
+            annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+          input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+            "Reflection of ambient light (= 0: light is completely absorbed)"
+            annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+        protected
+          SI.Position r_abs[3]
+            "Dummy or position vector from origin of the world frame to origin of frame_a (resolved in frame_resolve, frame_a or world frame)";
+          SI.Velocity v_abs[3]
+            "Dummy or velocity of origin of frame_a with respect to origin of world frame (resolved in frame_resolve, frame_a or world frame)";
+          SI.Acceleration a_abs[3]
+            "Dummy or acceleration of origin of frame_a with respect to origin of word frame (resolved in frame_resolve, frame_a or world frame)";
+          SI.Angle angles[3]
+            "Dummy or angles to rotate world frame into frame_a via 'sequence'";
+          SI.AngularVelocity w_abs[3]
+            "Dummy or angular velocity of frame_a with respect to world frame (resolved in frame_resolve, frame_a or world frame)";
+          SI.AngularAcceleration z_abs[3]
+            "Dummy or angular acceleration of frame_a with respect to world frame (resolved in frame_resolve, frame_a or world frame)";
+
+          SI.Velocity v_abs_0[3]
+            "Dummy or absolute velocity of origin of frame_a resolved in world frame";
+          SI.AngularVelocity w_abs_0[3]
+            "Dummy or absolute angular velocity of frame_a resolved in world frame";
+          parameter Integer i1=1;
+          parameter Integer i2=if get_r_abs then i1 + 3 else i1;
+          parameter Integer i3=if get_v_abs then i2 + 3 else i2;
+          parameter Integer i4=if get_a_abs then i3 + 3 else i3;
+          parameter Integer i5=if get_angles then i4 + 3 else i4;
+          parameter Integer i6=if get_w_abs then i5 + 3 else i5;
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow arrow(
+            r_head=frame_a.r_0,
+            diameter=arrowDiameter,
+            specularCoefficient=specularCoefficient,
+            color=arrowColor) if world.enableAnimation and animation;
+        equation
+          if get_angles then
+            angles = Frames.axesRotationsAngles(frame_a.R, sequence, guessAngle1);
+          else
+            angles = zeros(3);
+          end if;
+
+          if cardinality(frame_resolve) == 1 then
+            // frame_resolve is connected
+            frame_resolve.f = zeros(3);
+            frame_resolve.t = zeros(3);
+
+            if get_r_abs then
+              r_abs = Frames.resolve2(frame_resolve.R, frame_a.r_0);
+            else
+              r_abs = zeros(3);
+            end if;
+
+            if get_v_abs or get_a_abs then
+              v_abs_0 = der(frame_a.r_0);
+              v_abs = Frames.resolve2(frame_resolve.R, v_abs_0);
+            else
+              v_abs_0 = zeros(3);
+              v_abs = zeros(3);
+            end if;
+
+            if get_a_abs then
+              a_abs = Frames.resolve2(frame_resolve.R, der(v_abs_0));
+            else
+              a_abs = zeros(3);
+            end if;
+
+            if get_w_abs or get_z_abs then
+              w_abs_0 = Modelica.Mechanics.MultiBody.Frames.angularVelocity1(frame_a.R);
+              w_abs = Frames.resolve2(frame_resolve.R, w_abs_0);
+            else
+              w_abs_0 = zeros(3);
+              w_abs = zeros(3);
+            end if;
+
+            if get_z_abs then
+              z_abs = Frames.resolve2(frame_resolve.R, der(w_abs_0));
+            else
+              z_abs = zeros(3);
+            end if;
+          else
+            // frame_resolve is NOT connected
+            frame_resolve.r_0 = zeros(3);
+            frame_resolve.R = Frames.nullRotation();
+
+            if get_r_abs then
+              if resolveInFrame_a then
+                r_abs = Modelica.Mechanics.MultiBody.Frames.resolve2(frame_a.R, frame_a.r_0);
+              else
+                r_abs = frame_a.r_0;
+              end if;
+            else
+              r_abs = zeros(3);
+            end if;
+
+            if get_v_abs or get_a_abs then
+              v_abs_0 = der(frame_a.r_0);
+              if resolveInFrame_a then
+                v_abs = Modelica.Mechanics.MultiBody.Frames.resolve2(frame_a.R, v_abs_0);
+              else
+                v_abs = v_abs_0;
+              end if;
+            else
+              v_abs_0 = zeros(3);
+              v_abs = zeros(3);
+            end if;
+
+            if get_a_abs then
+              if resolveInFrame_a then
+                a_abs = Modelica.Mechanics.MultiBody.Frames.resolve2(frame_a.R, der(v_abs_0));
+              else
+                a_abs = der(v_abs_0);
+              end if;
+            else
+              a_abs = zeros(3);
+            end if;
+
+            w_abs_0 = zeros(3);
+            if get_w_abs or get_z_abs then
+              if resolveInFrame_a then
+                w_abs = Modelica.Mechanics.MultiBody.Frames.angularVelocity2(frame_a.R);
+              else
+                w_abs = Modelica.Mechanics.MultiBody.Frames.angularVelocity1(frame_a.R);
+              end if;
+            else
+              w_abs = zeros(3);
+            end if;
+
+            if get_z_abs then
+              /* if w_abs and z_abs are resolved in the world frame, we have
+            z_abs = der(w_abs)
+         if w_abs and z_abs are resolved in frame_a, we have
+            z_abs = R*der(transpose(R)*w_abs)
+                  = R*(der(transpose(R))*w_abs + transpose(R)*der(w_abs)))
+                  = R*(transpose(R)*R*der(transpose(R))*w_abs + transpose(R)*der(w_abs)))
+                  = skew(w_abs)*w_abs + der(w_abs)
+                  = der(w_abs)  // since cross(w_abs, w_abs) = 0
+      */
+              z_abs = der(w_abs);
+            else
+              z_abs = zeros(3);
+            end if;
+          end if;
+
+          frame_a.f = zeros(3);
+          frame_a.t = zeros(3);
+
+          if get_r_abs then
+            y[i1:i1 + 2] = r_abs;
+          end if;
+
+          if get_v_abs then
+            y[i2:i2 + 2] = v_abs;
+          end if;
+
+          if get_a_abs then
+            y[i3:i3 + 2] = a_abs;
+          end if;
+
+          if get_angles then
+            y[i4:i4 + 2] = angles;
+          end if;
+
+          if get_w_abs then
+            y[i5:i5 + 2] = w_abs;
+          end if;
+
+          if get_z_abs then
+            y[i6:i6 + 2] = z_abs;
+          end if;
+          annotation (
+            obsolete="Based on a packed result signal which is not a good design. Use instead Modelica.Mechanics.MultiBody.Sensors.AbsoluteSensor",
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Text(
+                  extent={{19,109},{150,84}},
+                  lineColor={192,192,192},
+                  textString="resolve"),
+                Line(
+                  points={{-84,0},{-84,84},{0,84},{0,100}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot),
+                Text(
+                  extent={{-132,52},{-96,27}},
+                  lineColor={128,128,128},
+                  textString="a")}),
+            Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                    -100},{100,100}}), graphics={Line(
+                  points={{-84,0},{-84,82},{0,82},{0,98}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot)}),
+            Documentation(info="<HTML>
+<p>
+Absolute kinematic quantities of frame_a are
+computed and provided at the output signal connector <b>y</b>
+in packed format in the order
+</p>
+<ol>
+<li> absolute position vector (= r_abs)</li>
+<li> absolute velocity vector (= v_abs)</li>
+<li> absolute acceleration vector (= a_abs)</li>
+<li> 3 angles to rotate the world frame into frame_a (= angles)</li>
+<li> absolute angular velocity vector (= w_abs)</li>
+<li> absolute angular acceleration vector (= z_abs)</li>
+</ol>
+<p>
+For example, if parameters <b>get_v</b> and <b>get_w</b>
+are <b>true</b> and all other get_XXX parameters are <b>false</b>, then
+y contains 6 elements:
+</p>
+<pre>
+ y[1:3] = absolute velocity
+ y[4:6] = absolute angular velocity
+</pre>
+<p>
+In the following figure the animation of an AbsoluteSensor
+component is shown. The light blue coordinate system is
+frame_a and the yellow arrow is the animated sensor.
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Sensors/AbsoluteSensor.png\">
+
+<p>
+If <b>frame_resolve</b> is connected to another frame, then the
+provided absolute kinematic vectors are resolved in this frame.
+If <b>frame_resolve</b> is <b>not</b> connected then the
+coordinate system in which the relative quantities are
+resolved is defined by parameter <b>resolveInFrame_a</b>.
+If this parameter is <b>true</b>, then the
+provided kinematic vectors are resolved in frame_a of this
+component. Otherwise, the kinematic vectors are resolved in
+the world frame. For example, if frame_resolve is not
+connected and if resolveInFrame_a = <b>false</b>, and
+get_v = <b>true</b>, then
+</p>
+<pre>
+  y = <b>der</b>(frame_a.r) // resolved in world frame
+</pre>
+<p>
+is returned, i.e., the derivative of the distance frame_a.r_0
+from the origin of the world frame to the origin of frame_a,
+resolved in the world frame.
+</p>
+<p>
+Note, the cut-force and the cut-torque in frame_resolve are
+always zero, whether frame_resolve is connected or not.
+</p>
+<p>
+If <b>get_angles</b> = <b>true</b>, the 3 angles to rotate the world
+frame into frame_a along the axes defined by parameter <b>sequence</b>
+are returned. For example, if sequence = {3,1,2} then the world frame is
+rotated around angles[1] along the z-axis, afterwards it is rotated
+around angles[2] along the x-axis, and finally it is rotated around
+angles[3] along the y-axis and is then identical to frame_a.
+The 3 angles are returned in the range
+</p>
+<pre>
+    -<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+</pre>
+<p>
+There are <b>two solutions</b> for \"angles[1]\" in this range.
+Via parameter <b>guessAngle1</b> (default = 0) the
+returned solution is selected such that |angles[1] - guessAngle1| is
+minimal. The transformation matrix between the world frame and
+frame_a may be in a singular configuration with respect to \"sequence\", i.e.,
+there is an infinite number of angle values leading to the same
+transformation matrix. In this case, the returned solution is
+selected by setting angles[1] = guessAngle1. Then angles[2]
+and angles[3] can be uniquely determined in the above range.
+</p>
+<p>
+Note, that parameter <b>sequence</b> has the restriction that
+only values 1,2,3 can be used and that sequence[1] &ne; sequence[2]
+and sequence[2] &ne; sequence[3]. Often used values are:
+</p>
+<pre>
+  sequence = <b>{1,2,3}</b>  // Cardan angle sequence
+           = <b>{3,1,3}</b>  // Euler angle sequence
+           = <b>{3,2,1}</b>  // Tait-Bryan angle sequence
+</pre>
+<p>
+Exact definition of the returned quantities:
+</p>
+<ol>
+<li>r_abs is vector frame_a.r_0, resolved according to table below.</li>
+<li>v_abs is vector <b>der</b>(frame_a.r_0), resolved according to table below.</li>
+<li>a_abs is vector <b>der</b>(<b>der</b>(frame_a.r_0)), resolved according to
+            table below.</li>
+<li>angles is a vector of 3 angles such that
+    frame_a.R = Frames.axesRotations(sequence, angles).</li>
+<li>w_abs is vector Modelica.Mechanics.MultiBody.Frames.angularVelocity1(frame_a.R, <b>der</b>(frame_a.R)),
+            resolved according to table below.</li>
+<li>z_abs is vector <b>der</b>(w_abs) (= derivative of absolute angular
+            velocity of frame_a with respect to the world frame,
+            resolved according to table below).</li>
+</ol>
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><th><b><i>frame_resolve is</i></b></th>
+      <th><b><i>resolveInFrame_a =</i></b></th>
+      <th><b><i>vector is resolved in</i></b></th>
+  </tr>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><b>frame_resolve</b></td>
+  </tr>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><b>frame_resolve</b></td>
+  </tr>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><b>frame_a</b></td>
+  </tr>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><b>world frame</b></td>
+  </tr>
+</table><br>
+</html>"));
+        end AbsoluteSensor;
+
+        model RelativeSensor
+          "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Sensors.RelativeSensor"
+
+          import SI = Modelica.SIunits;
+          import Modelica.Mechanics.MultiBody.Frames;
+          import Modelica.Mechanics.MultiBody.Types;
+          extends Modelica.Mechanics.MultiBody.Interfaces.PartialRelativeSensor(final
+              n_out=3*((if get_r_rel then 1 else 0) + (if get_v_rel then 1 else 0) + (
+                if get_a_rel then 1 else 0) + (if get_angles then 1 else 0) + (if
+                get_w_rel then 1 else 0) + (if get_z_rel then 1 else 0)));
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          Modelica.Mechanics.MultiBody.Interfaces.Frame_resolve frame_resolve
+            "If connected, the output signals are resolved in this frame"
+            annotation (Placement(transformation(
+                origin={-60,-100},
+                extent={{-16,-16},{16,16}},
+                rotation=270)));
+
+          parameter Boolean animation=true
+            "= true, if animation shall be enabled (show arrow)";
+          parameter Boolean resolveInFrame_a=true
+            "= true, if relative vectors from frame_a to frame_b are resolved before differentiation in frame_a, otherwise in frame_b. If frame_resolve is connected, the vector and its derivatives are resolved in frame_resolve";
+          parameter Boolean get_r_rel=true
+            "= true, to measure the relative position vector from the origin of frame_a to the origin of frame_b in [m]";
+          parameter Boolean get_v_rel=false
+            "= true, to measure the relative velocity of the origin of frame_b with respect to frame_a in [m/s]";
+          parameter Boolean get_a_rel=false
+            "= true, to measure the relative acceleration of the origin of frame_b with respect to frame_a in [m/s^2]";
+          parameter Boolean get_angles=false
+            "= true, to measure the 3 rotation angles to rotate frame_a into frame_b along the axes defined in 'sequence' below in [rad]";
+          parameter Boolean get_w_rel=false
+            "= true, to measure the relative angular velocity of frame_b with respect to frame_a in [rad/s]";
+          parameter Boolean get_z_rel=false
+            "= true, to measure the relative angular acceleration of frame_b with respect to frame_a in [rad/s^2]";
+          parameter Types.RotationSequence sequence(
+            min={1,1,1},
+            max={3,3,3}) = {1,2,3}
+            " Angles are returned to rotate frame_a around axes sequence[1], sequence[2] and finally sequence[3] into frame_b"
+            annotation (Evaluate=true, Dialog(group="if get_angles = true", enable=get_angles));
+          parameter SI.Angle guessAngle1=0
+            " Select angles[1] such that abs(angles[1] - guessAngle1) is a minimum"
+            annotation (Dialog(group="if get_angles = true", enable=get_angles));
+          input SI.Diameter arrowDiameter=world.defaultArrowDiameter
+            " Diameter of relative arrow from frame_a to frame_b"
+            annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+          input Types.Color arrowColor=Modelica.Mechanics.MultiBody.Types.Defaults.SensorColor
+            " Color of relative arrow from frame_a to frame_b"
+            annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+          input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+            "Reflection of ambient light (= 0: light is completely absorbed)"
+            annotation (Dialog(tab="Animation", group="if animation = true", enable=animation));
+
+          SI.Position r_rel[3]
+            "Dummy or relative position vector (resolved in frame_a, frame_b or frame_resolve)";
+          SI.Velocity v_rel[3]
+            "Dummy or relative velocity vector (resolved in frame_a, frame_b or frame_resolve";
+          SI.Acceleration a_rel[3]
+            "Dummy or relative acceleration vector (resolved in frame_a, frame_b or frame_resolve";
+          SI.Angle angles[3]
+            "Dummy or angles to rotate frame_a into frame_b via 'sequence'";
+          SI.AngularVelocity w_rel[3]
+            "Dummy or relative angular velocity vector (resolved in frame_a, frame_b or frame_resolve";
+          SI.AngularAcceleration z_rel[3]
+            "Dummy or relative angular acceleration vector (resolved in frame_a, frame_b or frame_resolve";
+          Frames.Orientation R_rel
+            "Dummy or relative orientation object from frame_a to frame_b";
+        protected
+          SI.Position r_rel_ab[3]
+            "Dummy or relative position vector resolved in frame_a or frame_b";
+          SI.Velocity der_r_rel_ab[3]
+            "Dummy or derivative of relative position vector (resolved in frame_a, frame_b or frame_resolve)";
+          SI.AngularVelocity w_rel_ab[3]
+            "Dummy or angular velocity of frame_b with respect to frame_a (resolved in frame_a or frame_b)";
+          Frames.Orientation R_resolve
+            "Dummy or relative orientation of frame_a or frame_b with respect to frame_resolve";
+
+          parameter Integer i1=1;
+          parameter Integer i2=if get_r_rel then i1 + 3 else i1;
+          parameter Integer i3=if get_v_rel then i2 + 3 else i2;
+          parameter Integer i4=if get_a_rel then i3 + 3 else i3;
+          parameter Integer i5=if get_angles then i4 + 3 else i4;
+          parameter Integer i6=if get_w_rel then i5 + 3 else i5;
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow arrow(
+            r=frame_a.r_0,
+            r_head=frame_b.r_0 - frame_a.r_0,
+            diameter=arrowDiameter,
+            color=arrowColor,
+            specularCoefficient) if world.enableAnimation and animation;
+        equation
+          if get_angles or get_w_rel or get_z_rel then
+            R_rel = Modelica.Mechanics.MultiBody.Frames.relativeRotation(frame_a.R, frame_b.R);
+          else
+            R_rel = Modelica.Mechanics.MultiBody.Frames.nullRotation();
+          end if;
+
+          if get_angles then
+            angles = Frames.axesRotationsAngles(R_rel, sequence, guessAngle1);
+          else
+            angles = zeros(3);
+          end if;
+
+          if cardinality(frame_resolve) == 1 then
+            // frame_resolve is connected
+            frame_resolve.f = zeros(3);
+            frame_resolve.t = zeros(3);
+
+            if resolveInFrame_a then
+              R_resolve = Frames.relativeRotation(frame_a.R, frame_resolve.R);
+            else
+              R_resolve = Frames.relativeRotation(frame_b.R, frame_resolve.R);
+            end if;
+
+            if get_r_rel or get_v_rel or get_a_rel then
+              if resolveInFrame_a then
+                r_rel_ab = Frames.resolve2(frame_a.R, frame_b.r_0 - frame_a.r_0);
+              else
+                r_rel_ab = Frames.resolve2(frame_b.R, frame_b.r_0 - frame_a.r_0);
+              end if;
+              r_rel = Frames.resolve2(R_resolve, r_rel_ab);
+            else
+              r_rel_ab = zeros(3);
+              r_rel = zeros(3);
+            end if;
+
+            if get_v_rel or get_a_rel then
+              der_r_rel_ab = der(r_rel_ab);
+            else
+              der_r_rel_ab = zeros(3);
+            end if;
+
+            if get_v_rel then
+              v_rel = Frames.resolve2(R_resolve, der_r_rel_ab);
+            else
+              v_rel = zeros(3);
+            end if;
+
+            if get_a_rel then
+              a_rel = Frames.resolve2(R_resolve, der(der_r_rel_ab));
+            else
+              a_rel = zeros(3);
+            end if;
+
+            if get_w_rel or get_z_rel then
+              if resolveInFrame_a then
+                w_rel_ab = Modelica.Mechanics.MultiBody.Frames.angularVelocity1(R_rel);
+              else
+                w_rel_ab = Modelica.Mechanics.MultiBody.Frames.angularVelocity2(R_rel);
+              end if;
+              w_rel = Frames.resolve2(R_resolve, w_rel_ab);
+            else
+              w_rel = zeros(3);
+              w_rel_ab = zeros(3);
+            end if;
+
+            if get_z_rel then
+              z_rel = Frames.resolve2(R_resolve, der(w_rel_ab));
+            else
+              z_rel = zeros(3);
+            end if;
+
+          else
+            // frame_resolve is NOT connected
+            frame_resolve.r_0 = zeros(3);
+            frame_resolve.R = Frames.nullRotation();
+            R_resolve = Frames.nullRotation();
+            r_rel_ab = zeros(3);
+            der_r_rel_ab = zeros(3);
+            w_rel_ab = zeros(3);
+
+            if get_r_rel or get_v_rel or get_a_rel then
+              if resolveInFrame_a then
+                r_rel = Frames.resolve2(frame_a.R, frame_b.r_0 - frame_a.r_0);
+              else
+                r_rel = Frames.resolve2(frame_b.R, frame_b.r_0 - frame_a.r_0);
+              end if;
+            else
+              r_rel = zeros(3);
+            end if;
+
+            if get_v_rel or get_a_rel then
+              v_rel = der(r_rel);
+            else
+              v_rel = zeros(3);
+            end if;
+
+            if get_a_rel then
+              a_rel = der(v_rel);
+            else
+              a_rel = zeros(3);
+            end if;
+
+            if get_w_rel or get_z_rel then
+              if resolveInFrame_a then
+                w_rel = Frames.angularVelocity1(R_rel);
+              else
+                w_rel = Frames.angularVelocity2(R_rel);
+              end if;
+            else
+              w_rel = zeros(3);
+            end if;
+
+            if get_z_rel then
+              z_rel = der(w_rel);
+            else
+              z_rel = zeros(3);
+            end if;
+          end if;
+
+          frame_a.f = zeros(3);
+          frame_a.t = zeros(3);
+          frame_b.f = zeros(3);
+          frame_b.t = zeros(3);
+
+          if get_r_rel then
+            y[i1:i1 + 2] = r_rel;
+          end if;
+
+          if get_v_rel then
+            y[i2:i2 + 2] = v_rel;
+          end if;
+
+          if get_a_rel then
+            y[i3:i3 + 2] = a_rel;
+          end if;
+
+          if get_angles then
+            y[i4:i4 + 2] = angles;
+          end if;
+
+          if get_w_rel then
+            y[i5:i5 + 2] = w_rel;
+          end if;
+
+          if get_z_rel then
+            y[i6:i6 + 2] = z_rel;
+          end if;
+          annotation (
+            obsolete="Based on a packed result signal which is not a good design. Use instead Modelica.Mechanics.MultiBody.Sensors.RelativeSensor",
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={Line(
+                  points={{-60,-94},{-60,-76},{0,-76},{0,-76}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot), Text(
+                  extent={{-157,-49},{-26,-74}},
+                  lineColor={192,192,192},
+                  pattern=LinePattern.Dot,
+                  textString="resolve")}),
+            Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                    -100},{100,100}}), graphics={Line(
+                  points={{-60,-98},{-60,-76},{0,-76},{0,-76}},
+                  color={95,95,95},
+                  pattern=LinePattern.Dot)}),
+            Documentation(info="<HTML>
+<p>
+Relative kinematic quantities between frame_a and frame_b are
+determined and provided at the output signal connector <b>y</b>
+in packed format in the order
+</p>
+<ol>
+<li> relative position vector (= r_rel)</li>
+<li> relative velocity vector (= v_rel)</li>
+<li> relative acceleration vector (= a_rel))</li>
+<li> 3 angles to rotate frame_a into frame_b (= angles)</li>
+<li> relative angular velocity vector (= w_rel)</li>
+<li> relative angular acceleration vector (= z_rel)</li>
+</ol>
+<p>
+For example, if parameters <b>get_v_rel</b> and <b>get_w_rel</b>
+are <b>true</b> and all other get_XXX parameters are <b>false</b>, then
+y contains 6 elements:
+</p>
+<pre>
+ y = relative velocity
+ y = relative angular velocity
+</pre>
+<p>
+In the following figure the animation of a RelativeSensor
+component is shown. The light blue coordinate system is
+frame_a, the dark blue coordinate system is frame_b, and
+the yellow arrow is the animated sensor.
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Sensors/RelativeSensor.png\">
+
+<p>
+If parameter <b>resolveInFrame_a</b> = <b>true</b>, then the
+provided relative kinematic vectors of frame_b with respect to
+frame_a are resolved before differentiation in frame_a. If this
+parameter is <b>false</b>, the relative kinematic vectors are
+resolved before differentiation in frame_b.
+If <b>frame_resolve</b> is connected to another frame, then the
+kinematic vector as defined above and/or its required derivatives
+are resolved in frame_resolve. Note, derivatives
+of relative kinematic quantities are always performed with
+respect to frame_a (<b>resolveInFrame_a</b> = <b>true</b>)
+or with respect to frame_b (<b>resolveInFrame_a</b> = <b>false</b>).
+The resulting vector is then resolved in frame_resolve, if this
+connector is connected.
+</p>
+<p>
+For example, if frame_resolve is not
+connected and if resolveInFrame_a = <b>false</b>, and
+get_v = <b>true</b>, then
+</p>
+<pre>
+  y = v_rel
+    = <b>der</b>(r_rel)
+</pre>
+<p>
+is returned (r_rel = resolve2(frame_b.R, frame_b.r_0 - frame_a.r0)), i.e.,
+the derivative of the relative distance from frame_a to frame_b,
+resolved in frame_b. If frame_resolve is connected, then
+</p>
+<pre>
+  y = v_rel
+    = resolve2(frame_resolve.R, <b>der</b>(r_rel))
+</pre>
+<p>
+is returned, i.e., the previous relative velocity vector is
+additionally resolved in frame_resolve.
+</p>
+<p>
+Note, the cut-force and the cut-torque in frame_resolve are
+always zero, whether frame_resolve is connected or not.
+</p>
+<p>
+If <b>get_angles</b> = <b>true</b>, the 3 angles to rotate frame_a
+into frame_b along the axes defined by parameter <b>sequence</b>
+are returned. For example, if sequence = {3,1,2} then frame_a is
+rotated around angles[1] along the z-axis, afterwards it is rotated
+around angles[2] along the x-axis, and finally it is rotated around
+angles[3] along the y-axis and is then identical to frame_b.
+The 3 angles are returned in the range
+</p>
+<pre>
+    -<font face=\"Symbol\">p</font> &lt;= angles[i] &lt;= <font face=\"Symbol\">p</font>
+</pre>
+<p>
+There are <b>two solutions</b> for \"angles[1]\" in this range.
+Via parameter <b>guessAngle1</b> (default = 0) the
+returned solution is selected such that |angles[1] - guessAngle1| is
+minimal. The relative transformation matrix between frame_a and
+frame_b may be in a singular configuration with respect to \"sequence\", i.e.,
+there is an infinite number of angle values leading to the same relative
+transformation matrix. In this case, the returned solution is
+selected by setting angles[1] = guessAngle1. Then angles[2]
+and angles[3] can be uniquely determined in the above range.
+</p>
+<p>
+Note, that parameter <b>sequence</b> has the restriction that
+only values 1,2,3 can be used and that sequence[1] &ne; sequence[2]
+and sequence[2] &ne; sequence[3]. Often used values are:
+</p>
+<pre>
+  sequence = <b>{1,2,3}</b>  // Cardan angle sequence
+           = <b>{3,1,3}</b>  // Euler angle sequence
+           = <b>{3,2,1}</b>  // Tait-Bryan angle sequence
+</pre>
+<p>
+Exact definition of the returned quantities
+(r_rel_ab, R_rel_ab, w_rel_ab are defined below the enumeration):
+</p>
+<ol>
+<li>r_rel is vector r_rel_ab, resolved according to table below.</li>
+<li>v_rel is vector <b>der</b>(r_rel_ab), resolved according to table below.</li>
+<li>a_rel is vector <b>der</b>(<b>der</b>(r_rel_ab)), resolved according to
+            table below.</li>
+<li>angles is a vector of 3 angles such that
+    R_rel_ab = Frames.axesRotations(sequence, angles).</li>
+<li>w_rel is vector w_rel_ab, resolved according to table below.</li>
+<li>z_rel is vector <b>der</b>(w_rel_ab), resolved according to table below.</li>
+</ol>
+<p>
+using the auxiliary quantities
+</p>
+<ol>
+<li> r_rel_ab is vector frame_b.r_0 - frame_a.r_0, resolved either in frame_a or
+     frame_b according to parameter resolveInFrame_a.</li>
+<li> R_rel_ab is orientation object Frames.relativeRotation(frame_a.R, frame_b.R).</li>
+<li> w_rel_ab is vector Frames.angularVelocity1(R_rel_ab, der(R_rel_ab)), resolved either
+     in frame_a or frame_b according to parameter resolveInFrame_a.</li>
+</ol>
+<p>
+and resolved in the following frame
+</p>
+<table border=1 cellspacing=0 cellpadding=2>
+  <tr><th><b><i>frame_resolve is</i></b></th>
+      <th><b><i>resolveInFrame_a =</i></b></th>
+      <th><b><i>vector is resolved in</i></b></th>
+  </tr>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><b>frame_resolve</b></td>
+  </tr>
+  <tr><td valign=\"top\">connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><b>frame_resolve</b></td>
+  </tr>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">true</td>
+      <td valign=\"top\"><b>frame_a</b></td>
+  </tr>
+  <tr><td valign=\"top\">not connected</td>
+      <td valign=\"top\">false</td>
+      <td valign=\"top\"><b>frame_b</b></td>
+  </tr>
+</table>
+</HTML>"));
+        end RelativeSensor;
+
+        model CutForceAndTorque
+          "Obsolete model. Use instead Modelica.Mechanics.MultiBody.Sensors.CutForceAndTorque"
+
+          import SI = Modelica.SIunits;
+          import Modelica.Mechanics.MultiBody.Types;
+
+          extends
+            ObsoleteModelica3.Mechanics.MultiBody.Interfaces.PartialCutForceSensor;
+          Modelica.Blocks.Interfaces.RealOutput load[6]
+            "Cut force and cut torque resolved in frame_a/frame_b or in frame_resolved, if connected"
+               annotation (Placement(transformation(
+                origin={-80,-110},
+                extent={{10,-10},{-10,10}},
+                rotation=90)));
+
+          parameter Boolean animation=true
+            "= true, if animation shall be enabled (show force and torque arrow)";
+          parameter Boolean positiveSign=true
+            "= true, if force and torque with positive sign is returned (= frame_a.f/.t), otherwise with negative sign (= frame_b.f/.t)";
+          parameter Boolean resolveInFrame_a=true
+            "= true, if force and torque are resolved in frame_a/frame_b, otherwise in the world frame (if connector frame_resolve is connected, the force/torque is resolved in frame_resolve)";
+          input Real N_to_m(unit="N/m") = 1000
+            " Force arrow scaling (length = force/N_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input Real Nm_to_m(unit="N.m/m") = 1000
+            " Torque arrow scaling (length = torque/Nm_to_m)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter forceDiameter=world.defaultArrowDiameter
+            " Diameter of force arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input SI.Diameter torqueDiameter=forceDiameter
+            " Diameter of torque arrow" annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color forceColor=Modelica.Mechanics.MultiBody.Types.Defaults.ForceColor
+            " Color of force arrow"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.Color torqueColor=Modelica.Mechanics.MultiBody.Types.Defaults.TorqueColor
+            " Color of torque arrow"
+            annotation (Dialog(group="if animation = true", enable=animation));
+          input Types.SpecularCoefficient specularCoefficient = world.defaultSpecularCoefficient
+            "Reflection of ambient light (= 0: light is completely absorbed)"
+            annotation (Dialog(group="if animation = true", enable=animation));
+
+          SI.Force force[3]
+            "Cut force resolved in frame_a/frame_b or in frame_resolved, if connected";
+          SI.Torque torque[3]
+            "Cut torque resolved in frame_a/frame_b or in frame_resolved, if connected";
+        protected
+          outer Modelica.Mechanics.MultiBody.World world;
+          parameter Integer csign=if positiveSign then +1 else -1;
+          SI.Position f_in_m[3]=frame_a.f*csign/N_to_m
+            "Force mapped from N to m for animation";
+          SI.Position t_in_m[3]=frame_a.t*csign/Nm_to_m
+            "Torque mapped from Nm to m for animation";
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.Arrow forceArrow(
+            diameter=forceDiameter,
+            color=forceColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=f_in_m,
+            r_head=-f_in_m) if world.enableAnimation and animation;
+          Modelica.Mechanics.MultiBody.Visualizers.Advanced.DoubleArrow
+            torqueArrow(
+            diameter=torqueDiameter,
+            color=torqueColor,
+            specularCoefficient=specularCoefficient,
+            R=frame_b.R,
+            r=frame_b.r_0,
+            r_tail=t_in_m,
+            r_head=-t_in_m) if world.enableAnimation and animation;
+        equation
+          if cardinality(frame_resolve) == 1 then
+            force = Modelica.Mechanics.MultiBody.Frames.resolve2(frame_resolve.R,
+              Modelica.Mechanics.MultiBody.Frames.resolve1(frame_a.R, frame_a.f))*csign;
+            torque = Modelica.Mechanics.MultiBody.Frames.resolve2(frame_resolve.R,
+              Modelica.Mechanics.MultiBody.Frames.resolve1(frame_a.R, frame_a.t))*csign;
+          elseif resolveInFrame_a then
+            force = frame_a.f*csign;
+            torque = frame_a.t*csign;
+          else
+            force = Modelica.Mechanics.MultiBody.Frames.resolve1(frame_a.R, frame_a.f)*
+              csign;
+            torque = Modelica.Mechanics.MultiBody.Frames.resolve1(frame_a.R, frame_a.t)
+              *csign;
+          end if;
+
+          load[1:3] = force;
+          load[4:6] = torque;
+          annotation (
+            obsolete="Based on a packed result signal which is not a good design. Use instead Modelica.Mechanics.MultiBody.Sensors.CutForceAndTorque",
+            preferredView="info",
+            Documentation(info="<HTML>
+<p>
+The cut-force and cut-torque acting at the component to which frame_b is
+connected are determined and provided at the output signal connector
+<b>load</b>:
+</p>
+<pre>
+  load[1:3] = frame_a.f;
+  load[4:6] = frame_a.t;
+</pre>
+<p>
+If parameter <b>positiveSign</b> =
+<b>false</b>, the negative cut-force and negative
+cut-torque is provided (= frame_b.f and frame_b.t).
+If <b>frame_resolve</b> is connected to another frame, then the
+cut-force and cut-torque are resolved in frame_resolve.
+If <b>frame_resolve</b> is <b>not</b> connected then the
+coordinate system in which the cut-force and cut-torque is resolved
+is defined by parameter <b>resolveInFrame_a</b>.
+If this parameter is <b>true</b>, then the
+cut-force and cut-torque is resolved in frame_a, otherwise it is
+resolved in the world frame.
+</p>
+<p>
+In the following figure the animation of a CutForceAndTorque
+sensor is shown. The dark blue coordinate system is frame_b,
+and the green arrows are the cut force and the cut torque,
+respectively, acting at frame_b and
+with negative sign at frame_a.
+</p>
+
+<IMG src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Sensors/CutForceAndTorque.png\">
+</HTML>"));
+        end CutForceAndTorque;
+      end Sensors;
+
+      package Types
+        "Constants and types with choices, especially to build menus"
+        type AngularVelocity_degs = Modelica.Icons.TypeReal(final quantity="AngularVelocity", final unit=
+                   "deg/s")
+          "Obsolete type. Use Modelica.SIunits.AngularVelocity instead with an appropriate displayUnit"
+              annotation (obsolete="Non SI-units should no longer be used. Use Modelica.SIunits.AngularVelocity instead with an appropriate displayUnit");
+        type AngularAcceleration_degs2 = Modelica.Icons.TypeReal (final
+              quantity =                                                         "AngularAcceleration",
+              final unit="deg/s2")
+          "Obsolete type. Use Modelica.SIunits.AngularAcceleration instead with an appropriate displayUnit"
+              annotation (obsolete="Non SI-units should no longer be used. Use Modelica.SIunits.AngularAcceleration instead with an appropriate displayUnit");
+        package Init
+          "Obsolete type. This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu"
+
+          extends ObsoleteModelica3.Icons.Enumeration;
+
+          constant Integer Free=1;
+          constant Integer PositionVelocity=2;
+          constant Integer SteadyState=3;
+          constant Integer Position=4;
+          constant Integer Velocity=5;
+          constant Integer VelocityAcceleration=6;
+          constant Integer PositionVelocityAcceleration=7;
+
+          type Temp
+            "Obsolete type. This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu"
+
+            extends Modelica.Icons.TypeInteger;
+            annotation (
+                obsolete="This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu",
+                choices(
+                choice=Modelica.Mechanics.MultiBody.Types.Init.Free
+                  "free (no initialization)",
+                choice=Modelica.Mechanics.MultiBody.Types.Init.PositionVelocity
+                  "initialize generalized position and velocity variables",
+                choice=Modelica.Mechanics.MultiBody.Types.Init.SteadyState
+                  "initialize in steady state (velocity and acceleration are zero)",
+                choice=Modelica.Mechanics.MultiBody.Types.Init.Position
+                  "initialize only generalized position variable(s)",
+                choice=Modelica.Mechanics.MultiBody.Types.Init.Velocity
+                  "initialize only generalized velocity variable(s)",
+                choice=Modelica.Mechanics.MultiBody.Types.Init.VelocityAcceleration
+                  "initialize generalized velocity and acceleration variables",
+                choice=Modelica.Mechanics.MultiBody.Types.Init.PositionVelocityAcceleration
+                  "initialize generalized position, velocity and acceleration variables"),
+                Documentation(info="<html>
+
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><th><b>Types.Init.</b></th><th><b>Meaning</b></th></tr>
+<tr><td valign=\"top\">Free</td>
+    <td valign=\"top\">No initialization</td></tr>
+
+<tr><td valign=\"top\">PositionVelocity</td>
+    <td valign=\"top\">Initialize generalized position and velocity variables</td></tr>
+
+<tr><td valign=\"top\">SteadyState</td>
+    <td valign=\"top\">Initialize in steady state (velocity and acceleration are zero)</td></tr>
+
+<tr><td valign=\"top\">Position </td>
+    <td valign=\"top\">Initialize only generalized position variable(s)</td></tr>
+
+<tr><td valign=\"top\">Velocity</td>
+    <td valign=\"top\">Initialize only generalized velocity variable(s)</td></tr>
+
+<tr><td valign=\"top\">VelocityAcceleration</td>
+    <td valign=\"top\">Initialize generalized velocity and acceleration variables</td></tr>
+
+<tr><td valign=\"top\">PositionVelocityAcceleration</td>
+    <td valign=\"top\">Initialize generalized position, velocity and acceleration variables</td></tr>
+
+</table>
+
+</html>"));
+
+          end Temp;
+          annotation (obsolete="This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu",
+        Documentation(info="<html>
+
+</html>"));
+        end Init;
+      end Types;
+
+    end MultiBody;
+
+    package Rotational
+      "Library to model 1-dimensional, rotational mechanical systems"
+
+      package Interfaces
+        "Connectors and partial models for 1D rotational mechanical components"
+        partial model Rigid
+          "Base class for the rigid connection of two rotational 1D flanges"
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          Modelica.SIunits.Angle phi
+            "Absolute rotation angle of component (= flange_a.phi = flange_b.phi)";
+
+          Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a
+            "(left) driving flange (flange axis directed INTO cut plane)"
+            annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+          Modelica.Mechanics.Rotational.Interfaces.Flange_b flange_b
+            "(right) driven flange (flange axis directed OUT OF cut plane)"
+            annotation (Placement(transformation(extent={{90,-10},{110,10}})));
+        equation
+          flange_a.phi = phi;
+          flange_b.phi = phi;
+          annotation (
+            Documentation(info="<html>
+<p>
+This is a 1D rotational component with two rigidly connected flanges,
+i.e., flange_a.phi = flange_b.phi. It is used e.g., to built up components
+with inertia.
+</p>
+
+</html>"));
+        end Rigid;
+
+        partial model Bearing
+          "Obsolete model. Use one of Modelica.Mechanics.Rotational.Interfaces.PartialXXX instead"
+          extends Modelica.Mechanics.Rotational.Interfaces.PartialTwoFlanges;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          Modelica.SIunits.Torque tau_support;
+
+          Modelica.Mechanics.Rotational.Interfaces.Flange_a bearing
+            "Flange of bearing"
+                           annotation (Placement(transformation(extent={{-10,-110},
+                    {10,-90}})));
+          annotation (
+            obsolete=
+                "The Rotational library has now a new improved design with optional support connectors. Use Modelica.Mechanics.Rotational.Interfaces.PartialXXX instead.",
+            Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
+                    -100},{100,100}}), graphics={Rectangle(
+                  extent={{-20,-80},{20,-120}},
+                  lineColor={192,192,192},
+                  fillColor={192,192,192},
+                  fillPattern=FillPattern.Solid)}),
+            Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
+                    {100,100}}), graphics={Rectangle(
+                  extent={{-20,-80},{20,-120}},
+                  lineColor={192,192,192},
+                  fillColor={192,192,192},
+                  fillPattern=FillPattern.Solid)}),
+            Documentation(info="<html>
+<p>
+This is a 1D rotational component with two flanges and an additional bearing flange.
+It is a superclass for the two components TwoFlangesAndBearing and TwoFlangesAndBearingH.</p>
+
+</html>"));
+
+        end Bearing;
+
+        partial model TwoFlangesAndBearing
+          "Obsolete model. Use one of Modelica.Mechanics.Rotational.Interfaces.PartialXXX instead"
+
+          extends ObsoleteModelica3.Mechanics.Rotational.Interfaces.Bearing;
+
+          Modelica.SIunits.Angle phi_a;
+          Modelica.SIunits.Angle phi_b;
+
+        equation
+          if cardinality(bearing) == 0 then
+            bearing.phi = 0;
+          else
+            bearing.tau = tau_support;
+          end if;
+
+          0 = flange_a.tau + flange_b.tau + tau_support;
+
+          phi_a = flange_a.phi - bearing.phi;
+          phi_b = flange_b.phi - bearing.phi;
+          annotation (
+            obsolete=
+                "The Rotational library has now a new improved design with optional support connectors. Use Modelica.Mechanics.Rotational.Interfaces.PartialXXX instead.",
+          Documentation(info="<html>
+<p>
+This is a 1D rotational component with two flanges and an additional bearing flange.
+It is used e.g., to build up equation-based parts of a drive train.</p>
+
+</html>"));
+        end TwoFlangesAndBearing;
+
+        partial model TwoFlangesAndBearingH
+          "Obsolete model. Use one of Modelica.Mechanics.Rotational.Interfaces.PartialXXX instead"
+
+          extends ObsoleteModelica3.Mechanics.Rotational.Interfaces.Bearing;
+
+          Adapter adapter(bearingConnected=cardinality(bearing) > 1)
+            annotation (Placement(transformation(
+                origin={0,-60},
+                extent={{-10,-10},{10,10}},
+                rotation=90)));
+        protected
+          encapsulated model Adapter
+            import Modelica;
+            import ObsoleteModelica3;
+            import TwoFlanges =
+              Modelica.Mechanics.Rotational.Interfaces.PartialTwoFlanges;
+            extends Modelica.Mechanics.Rotational.Interfaces.PartialTwoFlanges;
+            extends ObsoleteModelica3.Icons.ObsoleteModel;
+            parameter Boolean bearingConnected;
+
+          equation
+            flange_a.phi = flange_b.phi;
+
+            if bearingConnected then
+              0 = flange_a.tau + flange_b.tau;
+            else
+              0 = flange_a.phi;
+            end if;
+            annotation (Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
+                      -100},{100,100}}), graphics={Rectangle(
+                    extent={{-90,10},{90,-10}},
+                    lineColor={192,192,192},
+                    fillColor={192,192,192},
+                    fillPattern=FillPattern.Solid), Text(
+                    extent={{-150,60},{150,20}},
+                    textString="%name",
+                    lineColor={0,0,255})}));
+          end Adapter;
+        equation
+          tau_support = -adapter.flange_b.tau;
+          connect(adapter.flange_a, bearing) annotation (Line(points={{
+                  0,-70},{0,-70},{0,-100}}));
+          annotation (obsolete=
+                "The Rotational library has now a new improved design with optional support connectors. Use Modelica.Mechanics.Rotational.Interfaces.PartialXXX instead.",
+        Documentation(info="<html>
+<p>
+This is a 1D rotational component with two flanges and an additional bearing flange.
+It is used e.g., to build up parts of a drive train consisting
+of several base components.</p>
+
+</html>"));
+        end TwoFlangesAndBearingH;
+
+        partial model PartialSpeedDependentTorque
+          "Partial model of a torque acting at the flange (accelerates the flange)"
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+          Modelica.SIunits.AngularVelocity w = der(flange.phi)
+            "Angular velocity at flange";
+          Modelica.SIunits.Torque tau = flange.tau
+            "accelerating torque acting at flange";
+          Modelica.Mechanics.Rotational.Interfaces.Flange_b flange
+            "Flange on which torque is acting"
+            annotation (Placement(transformation(extent={{110,-10},{90,10}})));
+          Modelica.Mechanics.Rotational.Interfaces.Flange_a bearing
+            "Bearing at which the reaction torque (i.e., -flange.tau) is acting"
+               annotation (Placement(transformation(extent={{-10,-130},{10,-110}})));
+        equation
+          if cardinality(bearing) == 0 then
+            bearing.phi = 0;
+          else
+            bearing.tau = -flange.tau;
+          end if;
+          annotation (
+            Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+                    {100,100}}), graphics={
+                Rectangle(
+                  extent={{-96,96},{96,-96}},
+                  lineColor={255,255,255},
+                  fillColor={255,255,255},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{-30,-70},{30,-70}}),
+                Line(points={{-30,-90},{-10,-70}}),
+                Line(points={{-10,-90},{10,-70}}),
+                Rectangle(
+                  extent={{-20,-100},{20,-140}},
+                  lineColor={192,192,192},
+                  fillColor={192,192,192},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{10,-90},{30,-70}}),
+                Line(points={{0,-70},{0,-110}}),
+                Line(points={{-92,0},{-76,36},{-54,62},{-30,80},{-14,88},{10,92},
+                      {26,90},{46,80},{64,62}}),
+                Text(
+                  extent={{-150,140},{150,100}},
+                  lineColor={0,0,255},
+                  textString=
+                       "%name"),
+                Polygon(
+                  points={{94,16},{80,74},{50,52},{94,16}},
+                  lineColor={0,0,0},
+                  fillColor={0,0,0},
+                  fillPattern=FillPattern.Solid)}),
+            Documentation(info="<HTML>
+<p>
+Partial model of torque dependent on speed that accelerates the flange.
+</p>
+</HTML>"));
+        end PartialSpeedDependentTorque;
+
+        partial model AbsoluteSensor
+          "Obsolete model. Use Modelica.Mechanics.Rotational.Interfaces.PartialAbsoluteSensor instead and define a meaningful name for the output signal"
+
+          extends Modelica.Icons.RotationalSensor;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a
+            "(left) flange to be measured (flange axis directed INTO cut plane)"
+            annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+          Modelica.Blocks.Interfaces.RealOutput y "Sensor signal"
+            annotation (Placement(transformation(extent={{100,-10},{120,10}})));
+          annotation (
+            obsolete=
+                "Use Modelica.Mechanics.Rotational.Interfaces.PartialAbsoluteSensor instead and define a meaningful name for the output signal.",
+            Documentation(info="<html>
+<p>
+This is the base class of a 1D rotational component with one flange and one
+output signal y in order to measure an absolute kinematic quantity in the flange
+and to provide the measured signal as output signal for further processing
+with the blocks of package Modelica.Blocks.
+</p>
+
+</html>"),         Icon(coordinateSystem(
+                preserveAspectRatio=true,
+                extent={{-100,-100},{100,100}}),
+                graphics={
+                Line(points={{-70,0},{-90,0}}),
+                Line(points={{70,0},{100,0}}, color={0,0,127}),
+                Text(
+                  extent={{150,80},{-150,120}},
+                  textString="%name",
+                  lineColor={0,0,255})}),
+            Diagram(coordinateSystem(
+                preserveAspectRatio=true,
+                extent={{-100,-100},{100,100}}),
+                graphics={Line(points={{-70,0},{-90,0}}, color={0,
+                      0,0}), Line(points={{70,0},{100,0}}, color={0,0,255})}));
+        end AbsoluteSensor;
+
+        partial model RelativeSensor
+          "Obsolete model. Use Modelica.Mechanics.Rotational.Interfaces.PartialRelativbeSensor instead and define a meaningful name for the output signal"
+
+          extends Modelica.Icons.RotationalSensor;
+          extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+          Modelica.Mechanics.Rotational.Interfaces.Flange_a flange_a
+            "(left) driving flange (flange axis directed INTO cut plane)"
+            annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
+          Modelica.Mechanics.Rotational.Interfaces.Flange_b flange_b
+            "(right) driven flange (flange axis directed OUT OF cut plane)"
+            annotation (Placement(transformation(extent={{90,-10},{110,10}})));
+          Modelica.Blocks.Interfaces.RealOutput y "Sensor signal"
+            annotation (Placement(transformation(
+                origin={0,-110},
+                extent={{10,-10},{-10,10}},
+                rotation=90)));
+          annotation (
+            obsolete=
+                "Use Modelica.Mechanics.Rotational.Interfaces.PartialRelativeSensor instead and define a meaningful name for the output signal.",
+            Documentation(info="<html>
+<p>
+This is a base class for 1D rotational components with two rigidly connected
+flanges and one output signal y in order to measure relative kinematic quantities
+between the two flanges or the cut-torque in the flange and
+to provide the measured signal as output signal for further processing
+with the blocks of package Modelica.Blocks.
+</p>
+
+</html>"),         Icon(coordinateSystem(
+                preserveAspectRatio=true,
+                extent={{-100,-100},{100,100}}),
+                graphics={
+                Line(points={{-70,0},{-90,0}}),
+                Line(points={{70,0},{90,0}}),
+                Line(points={{0,-100},{0,-70}}, color={0,0,127}),
+                Text(
+                  extent={{-150,70},{150,110}},
+                  textString="%name",
+                  lineColor={0,0,255})}),
+            Diagram(coordinateSystem(
+                preserveAspectRatio=true,
+                extent={{-100,-100},{100,100}}),
+                graphics={
+                Line(points={{-70,0},{-90,0}}),
+                Line(points={{70,0},{90,0}}),
+                Line(points={{0,-100},{0,-70}}, color={0,0,255})}));
+        end RelativeSensor;
+      end Interfaces;
+
+      package Types
+        "Constants and types with choices, especially to build menus"
+        extends Modelica.Icons.Library;
+
+        package Init
+          "Obsolete type. This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu"
+          extends ObsoleteModelica3.Icons.Enumeration;
+          constant Integer NoInit=1
+            "no initialization (phi_start, w_start are guess values)";
+          constant Integer SteadyState=2
+            "steady state initialization (der(phi)=der(w)=0)";
+          constant Integer InitialState=3
+            "initialization with phi_start, w_start";
+          constant Integer InitialAngle=4 "initialization with phi_start";
+          constant Integer InitialSpeed=5 "initialization with w_start";
+          constant Integer InitialAcceleration=6 "initialization with a_start";
+          constant Integer InitialAngleAcceleration=7
+            "initialization with phi_start, a_start";
+          constant Integer InitialSpeedAcceleration=8
+            "initialization with w_start, a_start";
+          constant Integer InitialAngleSpeedAcceleration=9
+            "initialization with phi_start, w_start, a_start";
+
+          type Temp
+            "Obsolete type. This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu"
+            extends Modelica.Icons.TypeInteger(min=1,max=9);
+
+            annotation (
+                  obsolete="This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu",
+                Evaluate=true, choices(
+                choice=Modelica.Mechanics.Rotational.Types.Init.NoInit
+                  "no initialization (phi_start, w_start are guess values)",
+                choice=Modelica.Mechanics.Rotational.Types.Init.SteadyState
+                  "steady state initialization (der(phi)=der(w)=0)",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialState
+                  "initialization with phi_start, w_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialAngle
+                  "initialization with phi_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialSpeed
+                  "initialization with w_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialAcceleration
+                  "initialization with a_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialAngleAcceleration
+                  "initialization with phi_start, a_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialSpeedAcceleration
+                  "initialization with w_start, a_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialAngleSpeedAcceleration
+                  "initialization with phi_start, w_start, a_start"));
+          end Temp;
+
+          annotation (Documentation(info="<html>
+<p>
+Type <b>Init</b> defines initialization of absolute rotational
+quantities.
+</p>
+
+</html>"));
+        end Init;
+
+        package InitRel
+          "Obsolete type. This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu"
+          extends ObsoleteModelica3.Icons.Enumeration;
+          constant Integer NoInit=1
+            "no initialization (phi_rel_start, w_rel_start are guess values)";
+          constant Integer SteadyState=2
+            "steady state initialization (der(phi_rel)=der(w_rel)=0)";
+          constant Integer InitialState=3
+            "initialization with phi_rel_start, w_rel_start";
+          constant Integer InitialAngle=4 "initialization with phi_rel_start";
+          constant Integer InitialSpeed=5 "initialization with w_rel_start";
+
+          type Temp
+            "Obsolete type. This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu"
+            extends Modelica.Icons.TypeInteger(min=1,max=5);
+
+            annotation (
+                 obsolete="This is an emulated enumeration for initialization. Initialization is now defined with start/fixed values and appropriate support in the parameter menu",
+                Evaluate=true, choices(
+                choice=Modelica.Mechanics.Rotational.Types.Init.NoInit
+                  "no initialization (phi_rel_start, w_rel_start are guess values)",
+                choice=Modelica.Mechanics.Rotational.Types.Init.SteadyState
+                  "steady state initialization (der(phi)=der(w)=0)",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialState
+                  "initialization with phi_rel_start, w_rel_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialAngle
+                  "initialization with phi_rel_start",
+                choice=Modelica.Mechanics.Rotational.Types.Init.InitialSpeed
+                  "initialization with w_rel_start"));
+          end Temp;
+
+          annotation (Documentation(info="<html>
+<p>
+Type <b>Init</b> defines initialization of relative rotational
+quantities.
+</p>
+
+</html>"));
+        end InitRel;
+        annotation (preferredView="info", Documentation(info="<HTML>
+<p>
+In this package <b>types</b> and <b>constants</b> are defined that are used
+in library Modelica.Blocks. The types have additional annotation choices
+definitions that define the menus to be built up in the graphical
+user interface when the type is used as parameter in a declaration.
+</p>
+</HTML>"));
+      end Types;
+
+      model GearEfficiency
+        "Obsolete model. Use Modelica.Mechanics.Rotational.Components.LossyGear instead"
+        extends
+          ObsoleteModelica3.Mechanics.Rotational.Interfaces.TwoFlangesAndBearing;
+        extends ObsoleteModelica3.Icons.ObsoleteModel;
+
+        parameter Real eta(
+          min=Modelica.Constants.small,
+          max=1) = 1 "Efficiency";
+        Modelica.SIunits.Angle phi;
+        Modelica.SIunits.Power power_a "Energy flowing into flange_a (= power)";
+        Boolean driving_a
+          "True, if energy is flowing INTO and not out of flange flange_a";
+
+      equation
+        phi = phi_a;
+        phi = phi_b;
+        power_a = flange_a.tau*der(phi);
+        driving_a = power_a >= 0;
+        flange_b.tau = -(if driving_a then eta*flange_a.tau else flange_a.tau/eta);
+        annotation (
+          obsolete=
+              "This model can get stuck due when the torque direction varies, use Modelica.Mechanics.Rotational.Components.LossyGear instead.",
+          Icon(coordinateSystem(
+              preserveAspectRatio=true,
+              extent={{-100,-100},{100,100}}),
+              graphics={
+              Text(
+                extent={{-150,100},{150,60}},
+                textString="%name",
+                lineColor={0,0,255}),
+              Rectangle(
+                extent={{-100,20},{100,-20}},
+                lineColor={0,0,0},
+                fillPattern=FillPattern.HorizontalCylinder,
+                fillColor={192,192,192}),
+              Line(points={{-30,-40},{30,-40}}),
+              Line(points={{0,-40},{0,-90}}),
+              Polygon(
+                points={{-30,-20},{60,-20},{60,-80},{70,-80},{50,-100},{30,-80},
+                    {40,-80},{40,-30},{-30,-30},{-30,-20},{-30,-20}},
+                lineColor={0,0,0},
+                fillColor={255,0,0},
+                fillPattern=FillPattern.Solid),
+              Text(
+                extent={{-150,60},{150,20}},
+                lineColor={0,0,0},
+                textString="eta=%eta"),
+              Line(points={{30,-50},{20,-60}}),
+              Line(points={{30,-40},{10,-60}}),
+              Line(points={{20,-40},{0,-60}}),
+              Line(points={{10,-40},{-10,-60}}),
+              Line(points={{0,-40},{-20,-60}}),
+              Line(points={{-10,-40},{-30,-60}}),
+              Line(points={{-20,-40},{-30,-50}})}),
+          Documentation(info="<html>
+<p>
+THIS COMPONENT IS <b>OBSOLETE</b> and should <b>no longer be used</b>. It is only
+kept for <b>backward compatibility</b> purposes. Use model
+Modelica.Mechanics.Rotational.LossyGear instead which implements
+gear efficiency in a much more reliable way.
+</p>
+<p>
+This component consists of two rigidly connected flanges flange_a and flange_b without
+inertia where an <b>efficiency</b> coefficient <b>eta</b> reduces the driven
+torque as function of the driving torque depending on the direction
+of the energy flow, i.e., energy is always lost. This can be seen as a
+simple model of the Coulomb friction acting between the teeth of a
+gearbox.
+</p>
+<p>
+Note, that most gearbox manufacturers provide tables of the
+efficiency of a gearbox as function of the angular velocity
+(efficiency becomes zero, if the angular velocity is zero).
+However, such a table is practically useless for simulation purposes,
+because in gearboxes always two types of friction is present:
+(1) Friction in the <b>bearings</b> and (2) friction between
+the teeth of the gear. (1) leads to a velocity dependent, additive
+loss-torque, whereas (2) leads to a torque-dependent reduction of the
+driving torque. The gearbox manufacturers measure both effects
+together and determine the gear efficiency from it, although for
+simulation purposes the two effects need to be separated.
+Assume for example that only constant bearing friction, i.e.,
+bearingTorque=const., is present, i.e.,
+</p>
+<pre>
+   (1)  loadTorque = motorTorque - sign(w)*bearingTorque
+</pre>
+<p>
+Gearbox manufacturers use the loss-formula
+</p>
+<pre>
+   (2)  loadTorque = eta*motorTorque
+</pre>
+<p>
+Comparing (1) and (2) gives a formula for the efficiency eta:
+</p>
+<pre>
+   eta = (1 - sign(w)*bearingTorque/motorTorque)
+</pre>
+<p>
+When the motorTorque becomes smaller as the bearingTorque,
+(2) is useless, because the efficiency is zero. To summarize,
+be careful to determine the gear <b>efficiency</b> of this element
+from tables of the gear manufacturers.
+</p>
+
+</html>"),       Diagram(coordinateSystem(
+              preserveAspectRatio=true,
+              extent={{-100,-100},{100,100}}),
+              graphics={
+              Rectangle(
+                extent={{-96,20},{96,-21}},
+                lineColor={0,0,0},
+                fillPattern=FillPattern.HorizontalCylinder,
+                fillColor={192,192,192}),
+              Line(points={{-30,-40},{30,-40}}),
+              Line(points={{0,60},{0,40}}),
+              Line(points={{-30,40},{29,40}}),
+              Line(points={{0,-40},{0,-90}}),
+              Polygon(
+                points={{-30,-20},{60,-20},{60,-80},{70,-80},{50,-100},{30,-80},
+                    {40,-80},{40,-30},{-30,-30},{-30,-20},{-30,-20}},
+                lineColor={0,0,0},
+                fillColor={255,0,0},
+                fillPattern=FillPattern.Solid),
+              Text(
+                extent={{16,83},{84,70}},
+                lineColor={128,128,128},
+                textString="rotation axis"),
+              Polygon(
+                points={{12,76},{-8,81},{-8,71},{12,76}},
+                lineColor={128,128,128},
+                fillColor={128,128,128},
+                fillPattern=FillPattern.Solid),
+              Line(points={{-78,76},{-7,76}}, color={128,128,128}),
+              Line(points={{30,-50},{20,-60}}),
+              Line(points={{30,-40},{10,-60}}),
+              Line(points={{20,-40},{0,-60}}),
+              Line(points={{10,-40},{-10,-60}}),
+              Line(points={{0,-40},{-20,-60}}),
+              Line(points={{-10,-40},{-30,-60}}),
+              Line(points={{-20,-40},{-30,-50}})}));
+      end GearEfficiency;
+
+      model Gear
+        "Obsolete model. Use Modelica.Mechanics.Rotational.Components.Gearbox instead"
+        extends
+          ObsoleteModelica3.Mechanics.Rotational.Interfaces.TwoFlangesAndBearingH;
+
+        parameter Real ratio=1 "transmission ratio (flange_a.phi/flange_b.phi)";
+        parameter Real eta(
+          min=Modelica.Constants.small,
+          max=1) = 1 "Gear efficiency";
+        parameter Real friction_pos[:, 2]=[0, 1]
+          "[w,tau] positive sliding friction characteristic (w>=0)";
+        parameter Real peak(final min=1) = 1
+          "peak*friction_pos[1,2] = maximum friction torque at zero velocity";
+        parameter Real c(
+          final unit="N.m/rad",
+          final min=Modelica.Constants.small) = 1.e5
+          "Gear elasticity (spring constant)";
+        parameter Real d(
+          final unit="N.m.s/rad",
+          final min=0) = 0 "(relative) gear damping";
+        parameter Modelica.SIunits.Angle b(final min=0)=0 "Total backlash";
+
+        Modelica.Mechanics.Rotational.Components.IdealGear gearRatio(final
+            ratio =                                                              ratio)
+          annotation (Placement(transformation(extent={{-70,-10},{-50,10}})));
+        ObsoleteModelica3.Mechanics.Rotational.GearEfficiency gearEfficiency(
+                                      final eta=eta)
+          annotation (Placement(transformation(extent={{-30,-10},{-10,10}})));
+        Modelica.Mechanics.Rotational.Components.ElastoBacklash elastoBacklash(
+          final b=b,
+          final c=c,
+          final phi_rel0=0,
+          final d=d) annotation (Placement(transformation(extent={{50,-10},{70,10}})));
+        Modelica.Mechanics.Rotational.Components.BearingFriction
+          bearingFriction(                                                       final
+            tau_pos=friction_pos, final peak=peak)
+          annotation (Placement(transformation(extent={{10,-10},{30,10}})));
+      equation
+        connect(flange_a, gearRatio.flange_a)
+          annotation (Line(points={{-100,0},{-70,0}}));
+        connect(gearRatio.flange_b, gearEfficiency.flange_a)
+          annotation (Line(points={{-50,0},{-30,0}}));
+        connect(gearEfficiency.flange_b, bearingFriction.flange_a)
+          annotation (Line(points={{-10,0},{10,0}}));
+        connect(bearingFriction.flange_b, elastoBacklash.flange_a)
+          annotation (Line(points={{30,0},{50,0}}));
+        connect(elastoBacklash.flange_b, flange_b)
+          annotation (Line(points={{70,0},{100,0}}));
+        connect(gearEfficiency.bearing, adapter.flange_b) annotation (Line(points={{-20,-10},
+                {-20,-40},{0,-40},{0,-50}},           color={
+                0,0,0}));
+        connect(bearingFriction.support, adapter.flange_b) annotation (Line(
+            points={{20,-10},{20,-40},{0,-40},{0,-50}}));
+        connect(gearRatio.support, adapter.flange_b) annotation (Line(
+            points={{-60,-10},{-60,-40},{0,-40},{0,-50}}));
+
+        annotation (
+          obsolete=
+              "This model can get stuck due when the torque direction varies, use Modelica.Mechanics.Rotational.Components.Gearbox instead.",
+          Documentation(info="<html>
+<p>
+This component models the essential effects of a gearbox, in particular
+gear <b>efficiency</b> due to friction between the teeth, <b>bearing friction</b>,
+gear <b>elasticity</b> and <b>damping</b>, <b>backlash</b>.
+The inertia of the gear wheels is not modeled. If necessary, inertia
+has to be taken into account by connecting components of model Inertia
+to the left and/or the right flange.
+</p>
+
+</html>"),       Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
+                  100,100}}), graphics={
+              Rectangle(
+                extent={{-40,60},{40,-60}},
+                lineColor={0,0,0},
+                lineThickness=0.25,
+                fillPattern=FillPattern.HorizontalCylinder,
+                fillColor={192,192,192}),
+              Polygon(
+                points={{-60,-80},{-46,-80},{-20,-20},{20,-20},{46,-80},{60,-80},
+                    {60,-90},{-60,-90},{-60,-80}},
+                lineColor={0,0,0},
+                fillColor={0,0,0},
+                fillPattern=FillPattern.Solid),
+              Rectangle(
+                extent={{-100,10},{-60,-10}},
+                lineColor={0,0,0},
+                fillPattern=FillPattern.HorizontalCylinder,
+                fillColor={192,192,192}),
+              Rectangle(
+                extent={{60,10},{100,-10}},
+                lineColor={0,0,0},
+                fillPattern=FillPattern.HorizontalCylinder,
+                fillColor={192,192,192}),
+              Polygon(
+                points={{-60,10},{-60,20},{-40,40},{-40,-40},{-60,-20},{-60,10}},
+                lineColor={0,0,0},
+                fillPattern=FillPattern.HorizontalCylinder,
+                fillColor={128,128,128}),
+              Polygon(
+                points={{60,20},{40,40},{40,-40},{60,-20},{60,20}},
+                lineColor={128,128,128},
+                fillColor={128,128,128},
+                fillPattern=FillPattern.Solid),
+              Text(
+                extent={{-150,110},{150,70}},
+                textString="%name=%ratio",
+                lineColor={0,0,255}),
+              Text(
+                extent={{-150,-160},{150,-120}},
+                lineColor={0,0,0},
+                textString="c=%c")}),
+          Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
+                  {100,100}}), graphics={
+              Text(
+                extent={{2,29},{46,22}},
+                lineColor={128,128,128},
+                textString="rotation axis"),
+              Polygon(
+                points={{4,25},{-4,27},{-4,23},{4,25}},
+                lineColor={128,128,128},
+                fillColor={128,128,128},
+                fillPattern=FillPattern.Solid),
+              Line(points={{-36,25},{-3,25}}, color={128,128,128})}));
+      end Gear;
+    end Rotational;
+  end Mechanics;
+  annotation (uses(Modelica(version="3.2.2")),
+Documentation(info="<html>
+<p>
+This package contains models and blocks from the Modelica Standard Library
+version 2.2.2 that are no longer available in version 3.0.
+The conversion script for version 3.0 changes references in existing
+user models automatically to the models and blocks of package
+ObsoleteModelica3. The user should <b>manually</b> replace all
+references to ObsoleteModelica3 in his/her models to the models
+that are recommended in the documentation of the respective model.
+</p>
+
+<p>
+In most cases, this means that a model with the name
+\"ObsoleteModelica3.XXX\" should be renamed to \"Modelica.XXX\" (version 3.0)
+and then a manual adaptation is needed. For example, a reference to
+ObsoleteModelica3.Mechanics.MultiBody.Sensors.AbsoluteSensor
+should be replaced by
+Modelica.Mechanics.MultiBody.Sensors.AbsoluteSensor (version 3.0).
+Since the design of the component has changed (e.g., several
+optional connectors, and no longer one connector where all signals
+are packed together), this requires some changes at the place where
+the model is used (besides the renaming of the underlying class).
+</p>
+
+<p>
+The models in ObsoleteModelica3 are either not according to the Modelica Language
+version 3.0 and higher, or the model was changed to get a better design.
+In all cases, an automatic conversion to the new implementation
+was not feasible, since too complicated.
+</p>
+
+<p>
+In order to easily detect obsolete models and blocks, all of them are specially
+marked in the icon layer with a red box.
+</p>
+
+<p>
+Copyright &copy; 2007-2016, Modelica Association.
+</p>
+<p>
+<i>This Modelica package is <u>free</u> software and the use is completely at <u>your own risk</u>; it can be redistributed and/or modified under the terms of the Modelica License 2. For license conditions (including the disclaimer of warranty) see <a href=\"modelica://Modelica.UsersGuide.ModelicaLicense2\">Modelica.UsersGuide.ModelicaLicense2</a> or visit <a href=\"https://www.modelica.org/licenses/ModelicaLicense2\"> https://www.modelica.org/licenses/ModelicaLicense2</a>.</i>
+</p>
+</html>"));
+end ObsoleteModelica3;

--- a/modelica/examples/package.mo
+++ b/modelica/examples/package.mo
@@ -1,0 +1,8207 @@
+within ;
+package Modelica "Modelica Standard Library - Version 3.2.2"
+extends Modelica.Icons.Package;
+
+
+package UsersGuide "User's Guide"
+  extends Modelica.Icons.Information;
+
+class Overview "Overview of Modelica Library"
+  extends Modelica.Icons.Information;
+
+ annotation (Documentation(info="<html>
+<p>
+The Modelica Standard Library consists of the following
+main sub-libraries:
+</p>
+
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><th>Library Components</th> <th>Description</th></tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Electrical.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Electrical.Analog\">Analog</a><br>
+ Analog electric and electronic components, such as
+ resistor, capacitor, transformers, diodes, transistors,
+ transmission lines, switches, sources, sensors.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Digital.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Electrical.Digital\">Digital</a><br>
+ Digital electrical components based on the VHDL standard,
+ like basic logic blocks with 9-value logic, delays, gates,
+ sources, converters between 2-, 3-, 4-, and 9-valued logic.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Machines.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Electrical.Machines\">Machines</a><br>
+            Electrical asynchronous-, synchronous-, and DC-machines
+ (motors and generators) as well as 3-phase transformers.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-FluxTubes.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Magnetic.FluxTubes\">FluxTubes</a><br>
+Based on magnetic flux tubes concepts. Especially to model electro-magnetic actuators. Nonlinear shape, force, leakage, and material models. Material data for steel, electric sheet, pure iron, Cobalt iron, Nickel iron, NdFeB, Sm2Co17, and more.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Translational.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Mechanics.Translational\">Translational</a><br>
+ 1-dim. mechanical, translational systems, e.g.,
+ sliding mass, mass with stops, spring, damper.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Rotational.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Mechanics.Rotational\">Rotational</a><br>
+ 1-dim. mechanical, rotational systems, e.g., inertias, gears,
+ planetary gears, convenient definition of speed/torque dependent friction
+ (clutches, brakes, bearings, ..)
+ </td>
+</tr>
+
+<tr><td valign=\"top\" width=100>
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-MultiBody1.png\"><br>
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-MultiBody2.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Mechanics.MultiBody\">MultiBody</a>
+ 3-dim. mechanical systems consisting of joints, bodies, force and
+ sensor elements. Joints can be driven by drive trains defined by
+ 1-dim. mechanical system library (Rotational).
+ Every component has a default animation.
+ Components can be arbitrarily connected together.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Fluid.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Fluid\">Fluid</a><br>
+        1-dim. thermo-fluid flow in networks of vessels, pipes,
+        fluid machines, valves and fittings. All media from the
+        Modelica.Media library can be used (so incompressible or compressible,
+        single or multiple substance, one or two phase medium).
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Media.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Media\">Media</a><br>
+ Large media library providing models and functions
+ to compute media properties, such as h = h(p,T), d = d(p,T),
+ for the following media:
+ <ul>
+ <li> 1240 gases and mixtures between these gases.</li>
+ <li> incompressible, table based liquids (h = h(T), etc.).</li>
+ <li> compressible liquids</li>
+ <li> dry and moist air</li>
+ <li> high precision model for water (IF97).</li>
+ </ul>
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Thermal.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Thermal.FluidHeatFlow\">FluidHeatFlow</a>,
+ <a href=\"modelica://Modelica.Thermal.HeatTransfer\">HeatTransfer</a>
+ Simple thermo-fluid pipe flow, especially to model cooling of machines
+ with air or water (pipes, pumps, valves, ambient, sensors, sources) and
+ lumped heat transfer with heat capacitors, thermal conductors, convection,
+ body radiation, sources and sensors.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Blocks1.png\"><br>
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-Blocks2.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Blocks\">Blocks</a><br>
+ Input/output blocks to model block diagrams and logical networks, e.g.,
+ integrator, PI, PID, transfer function, linear state space system,
+ sampler, unit delay, discrete transfer function, and/or blocks,
+ timer, hysteresis, nonlinear and routing blocks, sources, tables.
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Lib-StateGraph.png\">
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.StateGraph\">StateGraph</a><br>
+ Hierarchical state machines with a similar modeling power as Statecharts.
+ Modelica is used as synchronous action language, i.e., deterministic
+ behavior is guaranteed
+ </td>
+</tr>
+
+<tr><td valign=\"top\">
+ <pre>
+ A = [1,2,3;
+   3,4,5;
+   2,1,4];
+ b = {10,22,12};
+ x = Matrices.solve(A,b);
+ Matrices.eigenValues(A);
+ </pre>
+ </td>
+ <td valign=\"top\">
+ <a href=\"modelica://Modelica.Math\">Math</a>,
+ <a href=\"modelica://Modelica.Utilities\">Utilities</a><br>
+ Functions operating on vectors and matrices, such as for solving
+ linear systems, eigen and singular values etc.,  and
+ functions operating on strings, streams, files, e.g.,
+ to copy and remove a file or sort a vector of strings.
+ </td>
+</tr>
+
+</table>
+
+</html>"));
+end Overview;
+
+class Connectors "Connectors"
+  extends Modelica.Icons.Information;
+
+ annotation (Documentation(info="<html>
+
+<p>
+The Modelica standard library defines the most important
+<b>elementary connectors</b> in various domains. If any possible,
+a user should utilize these connectors in order that components
+from the Modelica Standard Library and from other libraries
+can be combined without problems.
+The following elementary connectors are defined
+(the meaning of potential, flow, and stream
+variables is explained in section \"Connector Equations\" below):
+</p>
+
+<table border=1 cellspacing=0 cellpadding=1>
+<tr><td valign=\"top\"><b>domain</b></td>
+   <td valign=\"top\"><b>potential<br>variables</b></td>
+   <td valign=\"top\"><b>flow<br>variables</b></td>
+   <td valign=\"top\"><b>stream<br>variables</b></td>
+   <td valign=\"top\"><b>connector definition</b></td>
+   <td valign=\"top\"><b>icons</b></td></tr>
+
+<tr><td valign=\"top\"><b>electrical<br>analog</b></td>
+   <td valign=\"top\">electrical potential</td>
+   <td valign=\"top\">electrical current</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Analog.Interfaces\">Modelica.Electrical.Analog.Interfaces</a>
+     <br>Pin, PositivePin, NegativePin</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ElectricalPins.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>electrical<br>multi-phase</b></td>
+   <td colspan=\"3\">vector of electrical pins</td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.MultiPhase.Interfaces\">Modelica.Electrical.MultiPhase.Interfaces</a>
+     <br>Plug, PositivePlug, NegativePlug</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ElectricalPlugs.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>electrical <br>space phasor</b></td>
+   <td valign=\"top\">2 electrical potentials</td>
+   <td valign=\"top\">2 electrical currents</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Machines.Interfaces\">Modelica.Electrical.Machines.Interfaces</a>
+     <br>SpacePhasor</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/SpacePhasor.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>quasi<br>stationary<br>single phase</b></td>
+   <td valign=\"top\">complex electrical potential</td>
+   <td valign=\"top\">complex electrical current</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces\">
+                                       Modelica.Electrical.QuasiStationary.SinglePhase.Interfaces</a>
+     <br>Pin, PositivePin, NegativePin</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/QuasiStationarySinglePhasePins.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>quasi<br>stationary<br>multi-phase</b></td>
+   <td colspan=\"3\">vector of quasi stationary single phase pins</td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.QuasiStationary.MultiPhase.Interfaces\">Modelica.Electrical.QuasiStationary.MultiPhase.Interfaces</a>
+     <br>Plug, PositivePlug, NegativePlug</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/QuasiStationaryMultiPhasePlugs.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>electrical <br>digital</b></td>
+   <td valign=\"top\">Integer (1..9)</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Digital.Interfaces\">Modelica.Electrical.Digital.Interfaces</a>
+     <br>DigitalSignal, DigitalInput, DigitalOutput</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/Digital.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>magnetic<br>flux tubes</b></td>
+   <td valign=\"top\">magnetic potential</td>
+   <td valign=\"top\">magnetic flux</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\">
+<a href=\"modelica://Modelica.Magnetic.FluxTubes.Interfaces\">Modelica.Magnetic.FluxTubes.Interfaces</a>
+     <br>MagneticPort, PositiveMagneticPort, <br>NegativeMagneticPort</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/MagneticPorts.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>magnetic<br>fundamental<br>wave</b></td>
+   <td valign=\"top\">complex magnetic potential</td>
+   <td valign=\"top\">complex magnetic flux</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\">
+<a href=\"modelica://Modelica.Magnetic.FundamentalWave.Interfaces\">Modelica.Magnetic.FundamentalWave.Interfaces</a>
+     <br>MagneticPort, PositiveMagneticPort, <br>NegativeMagneticPort</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FundamentalWavePorts.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>translational</b></td>
+   <td valign=\"top\">distance</td>
+   <td valign=\"top\">cut-force</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.Interfaces\">Modelica.Mechanics.Translational.Interfaces</a>
+     <br>Flange_a, Flange_b</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/TranslationalFlanges.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>rotational</b></td>
+   <td valign=\"top\">angle</td>
+   <td valign=\"top\">cut-torque</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.Interfaces\">Modelica.Mechanics.Rotational.Interfaces</a>
+     <br>Flange_a, Flange_b</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/RotationalFlanges.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>3-dim.<br>mechanics</b></td>
+   <td valign=\"top\">position vector<br>
+    orientation object</td>
+   <td valign=\"top\">cut-force vector<br>
+    cut-torque vector</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.Interfaces\">Modelica.Mechanics.MultiBody.Interfaces</a>
+     <br>Frame, Frame_a, Frame_b, Frame_resolve</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/MultiBodyFrames.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>simple<br>fluid flow</b></td>
+   <td valign=\"top\">pressure<br>
+    specific enthalpy</td>
+   <td valign=\"top\">mass flow rate<br>
+    enthalpy flow rate</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Thermal.FluidHeatFlow.Interfaces\">Modelica.Thermal.FluidHeatFlow.Interfaces</a>
+     <br>FlowPort, FlowPort_a, FlowPort_b</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FluidHeatFlowPorts.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>thermo<br>fluid flow</b></td>
+   <td valign=\"top\">pressure</td>
+   <td valign=\"top\">mass flow rate</td>
+   <td valign=\"top\">specific enthalpy<br>mass fractions</td>
+   <td valign=\"top\">
+<a href=\"modelica://Modelica.Fluid.Interfaces\">Modelica.Fluid.Interfaces</a>
+     <br>FluidPort, FluidPort_a, FluidPort_b</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/FluidPorts.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>heat<br>transfer</b></td>
+   <td valign=\"top\">temperature</td>
+   <td valign=\"top\">heat flow rate</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Thermal.HeatTransfer.Interfaces\">Modelica.Thermal.HeatTransfer.Interfaces</a>
+     <br>HeatPort, HeatPort_a, HeatPort_b</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ThermalHeatPorts.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>blocks</b></td>
+   <td valign=\"top\">
+    Real variable<br>
+    Integer variable<br>
+    Boolean variable</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Interfaces\">Modelica.Blocks.Interfaces</a>
+     <br>
+      RealSignal, RealInput, RealOutput<br>
+      IntegerSignal, IntegerInput, IntegerOutput<br>
+      BooleanSignal, BooleanInput, BooleanOutput</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/Signals.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>complex<br>blocks</b></td>
+   <td valign=\"top\">
+    Complex variable</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.ComplexBlocks.Interfaces\">Modelica.ComplexBlocks.Interfaces</a>
+     <br>ComplexSignal, ComplexInput, ComplexOutput</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/ComplexSignals.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>state<br>machine</b></td>
+   <td valign=\"top\">Boolean variables<br>
+    (occupied, set, <br>
+     available, reset)</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\"><a href=\"modelica://Modelica.StateGraph.Interfaces\">Modelica.StateGraph.Interfaces</a>
+     <br>Step_in, Step_out, Transition_in, Transition_out</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/StateGraphPorts.png\"></td></tr>
+
+<tr><td colspan=\"5\">&nbsp;<br><b>Connectors from other libraries</b></td></tr>
+
+<tr><td valign=\"top\"><b>hydraulic</b></td>
+   <td valign=\"top\">pressure</td>
+   <td valign=\"top\">volume flow rate</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\">HyLibLight.Interfaces
+     <br>Port_A, Port_b</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/HydraulicPorts.png\"></td></tr>
+
+<tr><td valign=\"top\"><b>pneumatic</b></td>
+   <td valign=\"top\">pressure</td>
+   <td valign=\"top\">mass flow rate</td>
+   <td valign=\"top\"></td>
+   <td valign=\"top\">PneuLibLight.Interfaces
+     <br>Port_1, Port_2</td>
+   <td valign=\"top\"><img src=\"modelica://Modelica/Resources/Images/UsersGuide/PneumaticPorts.png\"></td></tr>
+</table>
+
+<p>
+In all domains, usually 2 connectors are defined. The variable declarations
+are <b>identical</b>, only the icons are different in order that it is easy
+to distinguish connectors of the same domain that are attached at the same
+component.
+</p>
+
+<h4>Hierarchical Connectors </h4>
+<p>
+Modelica supports also hierarchical connectors, in a similar way as hierarchical models.
+As a result, it is, e.g., possible, to collect elementary connectors together.
+For example, an electrical plug consisting of two electrical pins can be defined as:
+</p>
+
+<blockquote>
+<pre>
+<b>connector</b> Plug
+   <b>import</b> Modelica.Electrical.Analog.Interfaces;
+   Interfaces.PositivePin phase;
+   Interfaces.NegativePin ground;
+<b>end</b> Plug;
+</pre>
+</blockquote>
+
+<p>
+With one connect(..) equation, either two plugs can be connected
+(and therefore implicitly also the phase and ground pins) or a
+Pin connector can be directly connected to the phase or ground of
+a Plug connector, such as \"connect(resistor.p, plug.phase)\".
+</p>
+
+<h4 id=\"ConnectorEquations\">Connector Equations</h4>
+
+<p>
+The connector variables listed above have been basically determined
+with the following strategy:
+</p>
+
+<ol>
+<li> State the relevant balance equations and boundary
+     conditions of a volume for the particular physical domain.</li>
+<li> Simplify the balance equations and boundary conditions
+     of (1) by taking the
+     limit of an infinitesimal small volume
+     (e.g., thermal domain:
+      temperatures are identical and heat flow rates
+      sum up to zero).
+</li>
+<li> Use the variables needed for the balance equations
+     and boundary conditions of (2)
+     in the connector and select appropriate Modelica
+     <b>prefixes</b>, so that these equations
+     are generated by the Modelica connection semantics.
+</li>
+</ol>
+
+<p>
+The Modelica connection semantics is sketched at hand
+of an example: Three connectors c1, c2, c3 with the definition
+</p>
+
+<pre>
+<b>connector</b> Demo
+  Real        p;  // potential variable
+  <b>flow</b>   Real f;  // flow variable
+  <b>stream</b> Real s;  // stream variable
+<b>end</b> Demo;
+</pre>
+
+<p>
+are connected together with
+</p>
+
+<pre>
+   <b>connect</b>(c1,c2);
+   <b>connect</b>(c1,c3);
+</pre>
+
+<p>
+then this leads to the following equations:
+</p>
+
+<pre>
+  // Potential variables are identical
+  c1.p = c2.p;
+  c1.p = c3.p;
+
+  // The sum of the flow variables is zero
+  0 = c1.f + c2.f + c3.f;
+
+  /* The sum of the product of flow variables and upstream stream variables is zero
+     (this implicit set of equations is explicitly solved when generating code;
+     the \"&lt;undefined&gt;\" parts are defined in such a way that
+     inStream(..) is continuous).
+  */
+  0 = c1.f*(<b>if</b> c1.f > 0 <b>then</b> s_mix <b>else</b> c1.s) +
+      c2.f*(<b>if</b> c2.f > 0 <b>then</b> s_mix <b>else</b> c2.s) +
+      c3.f*(<b>if</b> c3.f > 0 <b>then</b> s_mix <b>else</b> c3.s);
+
+  <b>inStream</b>(c1.s) = <b>if</b> c1.f > 0 <b>then</b> s_mix <b>else</b> &lt;undefined&gt;;
+  <b>inStream</b>(c2.s) = <b>if</b> c2.f > 0 <b>then</b> s_mix <b>else</b> &lt;undefined&gt;;
+  <b>inStream</b>(c3.s) = <b>if</b> c3.f > 0 <b>then</b> s_mix <b>else</b> &lt;undefined&gt;;
+</pre>
+
+</html>"));
+end Connectors;
+
+  package Conventions "Conventions"
+    extends Modelica.Icons.Information;
+    package Documentation "HTML documentation"
+      extends Modelica.Icons.Information;
+
+      package Format "Format"
+        extends Modelica.Icons.Information;
+
+        class Cases "Cases"
+          extends Modelica.Icons.Information;
+          annotation (Documentation(info="<html>
+
+<p>In the Modelica documentation sometimes different cases have to be distinguished. If the case distinction refers to Modelica parameters or variables (Boolean expressions) the comparisons should be written in the style of Modelica code within <code>&lt;code&gt;</code> and <code>&lt;/code&gt;</code>
+</p>
+
+<h5>Example 1</h5>
+
+<code>&lt;p&gt;If &lt;code&gt;useCage == true&lt;/code&gt;, a damper cage is considered in the model...&lt;/p&gt;</code>
+
+<p>appears as</p>
+
+<p>If <code>useCage == true</code>, a damper cage is considered in the model...</p>
+
+<p>
+For more complex case scenarios a unordered list should be used. In this case only Modelica specific code segments and Boolean expressions.
+</p>
+
+<h5>Example 2</h5>
+
+<pre>
+&lt;ul&gt;
+  &lt;li&gt; If &lt;code&gt;useCage == true&lt;/code&gt;, a damper cage is considered in the model.
+       Cage parameters must be specified in this case.&lt;/li&gt;
+  &lt;li&gt; If &lt;code&gt;useCage == false&lt;/code&gt;, the damper cage is omitted.&lt;/li&gt;
+&lt;/ul&gt;</pre>
+
+<p>appears as</p>
+
+<ul>
+  <li> If <code>useCage == true</code>, a damper cage is considered in the model.
+       Cage parameters must be specified in this case.</li>
+  <li> If <code>useCage == false</code>, the damper cage is omitted.</li>
+</ul>
+
+<p>
+In a more equation oriented case additional equations or code segments can be added.
+</p>
+
+<h5>Example 3</h5>
+
+<pre>
+&lt;ul&gt;
+  &lt;li&gt;if &lt;code&gt;usePolar == true&lt;/code&gt;, assign magnitude and angle to output &lt;br&gt;
+  &lt;!-- insert graphical representation of equations --&gt;
+  y[i,1] = sqrt( a[i]^2 + b[i]^2 ) &lt;br&gt;
+  y[i,2] = atan2( b[i], a[i] )
+  &lt;/li&gt;
+  &lt;li&gt;if &lt;code&gt;usePolar == false&lt;/code&gt;, assign cosine and sine to output &lt;br&gt;
+  &lt;!-- insert graphical representation of equations --&gt;
+  y[i,1] = a[i] &lt;br&gt;
+  y[i,2] = b[i]
+  &lt;/li&gt;
+&lt;/ul&gt;</pre>
+
+<p>appears as</p>
+
+<ul>
+  <li>if <code>usePolar == true</code>, assign magnitude and angle to output <br>
+
+  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Cases/y_i1_polar.png\"
+       alt=\"y[i,1] = sqrt( a[i]^2 + b[i]^2 )\"> <br>
+  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Cases/y_i2_polar.png\"
+       alt=\"y[i,2] = atan2( b[i], a[i] )\">
+  </li>
+  <li>if <code>usePolar == false</code>, assign cosine and sine to output <br>
+  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Cases/y_i1_rect.png\"
+       alt=\"y[i,1] = a[i]\"> <br>
+  <img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Cases/y_i2_rect.png\"
+       alt=\" y[i,2] = b[i]\">
+  </li>
+</ul>
+
+</html>"));
+        end Cases;
+
+        class Code "Code"
+          extends Modelica.Icons.Information;
+
+          annotation (Documentation(info="<html>
+<p>
+<a href=\"modelica://Modelica.UsersGuide.Conventions.ModelicaCode\">Modelica code</a> conventions of class and instance names,
+parameters and variables are specified separately. In this section it is summarized how to refer to
+Modelica code in the HTML documentation.
+</p>
+
+<ol>
+<li> For constants, parameters and variables in code segments <code>&lt;code&gt;</code> and <code>&lt;/code&gt;</code>
+     should to be used, e.g., <br>
+     <code><b>parameter</b> Modelica.SIunits.Time tStart \"Start time\"</code></li>
+<li> Write multi or single line code segments using <code>&lt;pre&gt;</code> and <code>&lt;/pre&gt;</code>.</li>
+<li> Multi line or single line code shall not be indented.</li>
+<li> Inline code segments may be typeset with <code>&lt;code&gt;</code> and <code>&lt;/code&gt;</code>.</li>
+<li> In code segments use bold to emphasize Modelica keywords.</li>
+</ol>
+
+<h5>Example 1</h5>
+
+<pre>
+&lt;pre&gt;
+&lt;b&gt;connector&lt;/b&gt; Frame
+   ...
+   &lt;b&gt;flow&lt;/b&gt; SI.Force f[Woehrnschimmel1998] &lt;b&gt;annotation&lt;/b&gt;(unassignedMessage=\"...\");
+&lt;b&gt;end&lt;/b&gt; Frame;
+&lt;/pre&gt;</pre>
+
+<p>appears as</p>
+
+<pre>
+<b>connector</b> Frame
+   ...
+   <b>flow</b> SI.Force f[Woehrnschimmel1998] <b>annotation</b>(unassignedMessage=\"...\");
+<b>end</b> Frame;
+</pre>
+
+<h5>Example 2</h5>
+
+<pre>
+&lt;pre&gt;
+&lt;b&gt;parameter&lt;/b&gt; Modelica.SIunits.Conductance G=1 &quot;Conductance&quot;;
+&lt;/pre&gt;
+</pre>
+
+<p>appears as</p>
+
+<pre>
+<b>parameter</b> Modelica.SIunits.Conductance G=1 &quot;Conductance&quot;;
+</pre>
+</html>"));
+        end Code;
+
+        class Equations "Equations"
+          extends Modelica.Icons.Information;
+
+          annotation (Documentation(info="<html>
+
+<p>
+In the context of <a href=\"http://www.w3c.org/\">HTML</a> documentation
+equations should have a graphical representation in PNG format. For that purpose tool
+specific math typing capabilities can be used. Alternatively the LaTeX to HTML translator
+<a href=\"http://www.latex2html.org\">LaTeX2HTML</a>, or the
+<a href=\"http://www.homeschoolmath.net/worksheets/equation_editor.php\">Online Equation Editor</a>
+or <a href=\"http://www.codecogs.com/latex/eqneditor.php\">codecogs</a> can be used.
+</p>
+
+<p>
+A typical equation, e.g., of a Fourier synthesis, could look like<br>
+<img
+ src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Equations/fourier.png\"> <br>
+or <br>
+<img
+ src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Equations/sample.png\"
+ alt=\"y=a_1+a_2\"><br>
+In an <code>alt</code> tag the original equation should be stored, e.g.,</p>
+<pre>
+&lt;img
+&nbsp;src=&quot;modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Equations/sample.png&quot;
+&nbsp;alt=&quot;y=a_1+a_2&quot;&gt;
+</pre>
+
+<p>
+If one wants to refer to particular variables and parameters in the documentation text, either a
+graphical representation (PNG file) or italic fonts for regular physical symbols and lower case
+<a href=\"http://www.w3.org/TR/html4/sgml/entities.html\">Greek letters</a>
+should be used. Full word variables and full word indices should be spelled within &lt;code&gt; and &lt;/code&gt;.
+Vector and array indices should be typeset as subscripts using the &lt;sub&gt; and &lt;/sub&gt; tags.
+</p>
+
+<p> Examples for such variables and parameters are:
+<i>&phi;</i>, <i>&phi;</i><sub>ref</sub>, <i>v<sub>2</sub></i>, <code>useDamperCage</code>.
+</p>
+
+<h4>Numbered equations</h4>
+
+<p>For numbering equations a one row table with two columns should be used. The equation number should be placed in the right column:</p>
+
+<pre>
+&lt;table border=\"0\" cellspacing=\"10\" cellpadding=\"2\"&gt;
+  &lt;tr&gt;
+      &lt;td&gt;&lt;img
+      src=&quot;modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Equations/sample.png&quot;
+      alt=&quot;y=a_1+a_2&quot;&gt; &lt;/td&gt;
+      &lt;td&gt;(1)&lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+<p>appears as:</p>
+
+<table border=\"0\" cellspacing=\"10\" cellpadding=\"2\">
+  <tr>
+    <td><img
+         src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Documentation/Format/Equations/sample.png\"
+         alt=\"y=a_1+a_2\"></td>
+    <td>(1)</td>
+  </tr>
+</table>
+
+</html>"));
+        end Equations;
+
+        class Figures "Figures"
+          extends Modelica.Icons.Information;
+
+          annotation (Documentation(info="<html>
+<p>
+Figures should in particular be included to examples to discuss the problems and results of the respective model. The library developers are yet encouraged to add figures to the documentation of other components to support the understanding of the users of the library.
+</p>
+
+<ol>
+<li> Figures have to be placed <strong>outside</strong> of paragraphs to be HTML compliant.</li>
+<li> Figures need to have <strong>at least</strong> a <code>src</code> and an <code>alt</code> attribute defined to be HTML compliant.</li>
+<li> Technical figures should be placed within a table environment. Each technical figure should then also have a caption. The figure caption starts with a capital letter.</li>
+<li> Illustration can be embedded without table environment.</li>
+</ol>
+
+<h4>Location of files</h4>
+
+The <code>PNG</code> files should be placed in a folder which exactly represents the package structure.
+
+<h5>Example 1</h5>
+
+<p>This example shows how an illustration should be embedded in the Example
+<a href=\"modelica://Modelica.Blocks.Examples.PID_Controller\">PID_Controller</a> of the
+<a href=\"modelica://Modelica.Blocks\">Blocks</a> package.</p>
+
+<pre>
+&lt;img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Images/Blocks/Examples/PID_controller.png\"
+     alt=\"PID_controller.png\"&gt;
+</pre>
+
+<h5>Example 2</h5>
+
+<p>This is a simple example of a technical figure with caption.</p>
+
+<pre>
+&lt;table border=\"0\" cellspacing=\"0\" cellpadding=\"2\"&gt;
+  &lt;caption align=\"bottom\"&gt;Caption starts with a capital letter&lt;/caption&gt;
+  &lt;tr&gt;
+    &lt;td&gt;
+      &lt;img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Images/Blocks/Examples/PID_controller.png\"
+           alt=\"PID_controller.png\"&gt;
+    &lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+<h5>Example 3</h5>
+
+<p>To refer to a certain figure, a figure number may be added. In such case the figure name (Fig.) including the figure enumeration (1,2,...) have to be displayed bold using <code>&lt;strong&gt;</code> and <code>&lt;/strong&gt;</code>.</p>
+<p>The figure name and enumeration should look like this: <strong>Fig. 1:</strong></p>
+<p>Figures have to be enumerated manually. </p>
+
+<pre>
+&lt;table border=\"0\" cellspacing=\"0\" cellpadding=\"2\"&gt;
+  &lt;caption align=\"bottom\"&gt;&lt;strong&gt;Fig. 2: &lt;/strong&gt;Caption starts with a capital letter&lt;/caption&gt;
+  &lt;tr&gt;
+    &lt;td&gt;
+      &lt;img src=\"modelica://Modelica/Resources/Images/UsersGuide/Conventions/Images/Blocks/Examples/PID_controller.png\"
+           alt=\"PID_controller.png\"&gt;
+    &lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+</html>"));
+        end Figures;
+
+        class Hyperlinks "Hyperlinks"
+          extends Modelica.Icons.Information;
+
+          annotation (Documentation(info="<html>
+<ol>
+<li> Hyperlinks should always be made when referring to a component or package.</li>
+<li> The hyperlink text in between <code>&lt;a href=&quot;...&quot;&gt;</code> and <code>&lt;/a&gt;</code> should include the full main package name.</li>
+<li> A link to an external component should include the full name of the package that it is referred to.</li>
+<li> Modelica hyperlinks have to use the scheme <code>&quot;modelica://...&quot;</code></li>
+<li> For hyperlinks referring to a Modelica component, see Example 1 and 2.</li>
+<li> No links to commercial web sites are allowed.</li>
+</ol>
+<h5>Example 1</h5>
+<pre>
+&lt;a href=\"modelica://Modelica.Mechanics.MultiBody.UsersGuide.Tutorial.LoopStructures.PlanarLoops\"&gt;
+         Modelica.Mechanics.MultiBody.UsersGuide.Tutorial.LoopStructures.PlanarLoops&lt;/a&gt;</pre>
+<p>appears as</p>
+<a href=\"modelica://Modelica.Mechanics.MultiBody.UsersGuide.Tutorial.LoopStructures.PlanarLoops\">
+         Modelica.Mechanics.MultiBody.UsersGuide.Tutorial.LoopStructures.PlanarLoops</a>
+<h5>Example 2</h5>
+<pre>
+&lt;p&gt;
+  The feeder cables are connected to an
+  &lt;a href=\"modelica://Modelica.Electrical.Machines.BasicMachines.AsynchronousInductionMachines.AIM_SquirrelCage\"&gt;
+  induction machine&lt;/a&gt;.
+&lt;/p&gt;</pre>
+<p>appears as</p>
+<p>
+  The feeder cables are connected to an
+  <a href=\"modelica://Modelica.Electrical.Machines.BasicMachines.AsynchronousInductionMachines.AIM_SquirrelCage\">
+  induction machine</a>.
+</p>
+</html>"));
+        end Hyperlinks;
+
+        class Lists "Lists"
+          extends Modelica.Icons.Information;
+
+          annotation (Documentation(info="<html>
+<p>
+Lists have to be placed <strong>outside</strong> of paragraphs to be HTML compliant.
+</p>
+
+<ol>
+<li> Items of a list shall start with
+<ul>
+    <li> a capital letter if each item is a full sentence</li>
+    <li> a small letter, if only text fragments are used or the list is fragment of a sentence</li>
+</ul></li>
+</ol>
+
+<h5>Example 1</h5>
+
+<p>This is a simple example of an enumerated (ordered) list</p>
+
+<pre>
+&lt;ol&gt;
+  &lt;li&gt;item 1&lt;/li&gt;
+  &lt;li&gt;item 2&lt;/li&gt;
+&lt;/ol&gt;
+</pre>
+<p>appears as</p>
+<ol>
+  <li>item 1</li>
+  <li>item 2</li>
+</ol>
+
+<h5>Example 2</h5>
+
+<p>This is a simple example of an unnumbered list.</p>
+
+<pre>
+&lt;ul&gt;
+  &lt;li&gt;item 1&lt;/li&gt;
+  &lt;li&gt;item 2&lt;/li&gt;
+&lt;/ul&gt;
+</pre>
+<p>appears as</p>
+<ul>
+  <li>item 1</li>
+  <li>item 2</li>
+</ul>
+</html>"));
+        end Lists;
+
+        class References "References"
+          extends Modelica.Icons.Information;
+
+          annotation (Documentation(info="<html>
+
+<h4>General</h4>
+<ol>
+<li> Refer to references by [1], [Andronov1973], etc. by hyperlink and summarize literature in the references subsection of
+     <a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide.References\">Conventions.UsersGuide.References</a>.</li>
+<li> There has to be made at least one citation to each reference.</li>
+</ol>
+
+<h5>Example</h5>
+
+<pre>
+&lt;p&gt;
+  More details about sensorless rotor temperature estimation
+  can be found in &lt;a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide.References\"&gt;[Gao2008]&lt;/a.&gt;
+&lt;/p&gt;</pre>
+<p>appears as</p>
+<p>
+  More details about sensorless rotor temperature estimation can be found in <a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide.References\">[Gao2008]</a>.
+</p>
+
+</html>"));
+        end References;
+
+        class Tables "Tables"
+          extends Modelica.Icons.Information;
+
+          annotation (Documentation(info="<html>
+<ol>
+<li> Tables should always be typeset with <code>&lt;table&gt;</code> and <code>&lt;/table&gt;</code>,
+     not with <code>&lt;pre&gt;</code> and <code>&lt;/pre&gt;</code>.</li>
+<li> Tables have to be placed <strong>outside</strong> of paragraphs to be HTML compliant.</li>
+<li> Each table must have a table caption.</li>
+<li> Table headers and entries start with capital letters.</li>
+</ol>
+
+<h5>Example 1</h5>
+
+<p>This is a simple example of a table.</p>
+
+<pre>
+&lt;table border=\"1\" cellspacing=\"0\" cellpadding=\"2\"&gt;
+  &lt;caption align=\"bottom\"&gt;Caption starts with a capital letter&lt;/caption&gt;
+  &lt;tr&gt;
+    &lt;th&gt;Head 1&lt;/th&gt;
+    &lt;th&gt;Head 2&lt;/th&gt;
+  &lt;/tr&gt;
+  &lt;tr&gt;
+    &lt;td&gt;Entry 1&lt;/td&gt;
+    &lt;td&gt;Entry 2&lt;/td&gt;
+  &lt;/tr&gt;
+  &lt;tr&gt;
+    &lt;td&gt;Entry 3&lt;/td&gt;
+    &lt;td&gt;Entry 4&lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+<p>appears as</p>
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+  <caption align=\"bottom\">Caption starts with a capital letter</caption>
+  <tr>
+    <th><b>Head 1</b></th>
+    <th><b>Head 2</b></th>
+  </tr>
+  <tr>
+    <td>Entry 1</td>
+    <td>Entry 2</td>
+  </tr>
+  <tr>
+    <td>Entry 3</td>
+    <td>Entry 4</td>
+  </tr>
+</table>
+
+<h5>Example 2</h5>
+
+<p>In this case of table captions, the table name (Tab.) including the table enumeration (1,2,...)
+has to be displayed bold using <code>&lt;b&gt;</code> and <code>&lt;/b&gt;</code>. The table name
+and enumeration should look like this: <b>Tab. 1:</b> Tables have to be enumerated manually.</p>
+
+<pre>
+&lt;table border=\"1\" cellspacing=\"0\" cellpadding=\"2\"&gt;
+  &lt;caption align=\"bottom\"&gt;&lt;b&gt;Tab 2: &lt;/b&gt;Caption starts with a capital letter&lt;/caption&gt;
+  &lt;tr&gt;
+    &lt;th&gt;Head 1&lt;/th&gt;
+    &lt;th&gt;Head 2&lt;/th&gt;
+  &lt;/tr&gt;
+  &lt;tr&gt;
+    &lt;td&gt;Entry 1&lt;/td&gt;
+    &lt;td&gt;Entry 2&lt;/td&gt;
+  &lt;/tr&gt;
+  &lt;tr&gt;
+    &lt;td&gt;Entry 3&lt;/td&gt;
+    &lt;td&gt;Entry 4&lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+<p>appears as</p>
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+  <caption align=\"bottom\"><b>Tab. 2: </b>Caption starts with a capital letter</caption>
+  <tr>
+    <th>Head 1</th>
+    <th>Head 2</th>
+  </tr>
+  <tr>
+    <td>Entry 1</td>
+    <td>Entry 2</td>
+  </tr>
+  <tr>
+    <td>Entry 3</td>
+    <td>Entry 4</td>
+  </tr>
+</table>
+
+</html>"));
+        end Tables;
+        annotation (Documentation(info="<html>
+
+<p>
+In this section the format UsersGuide of the HTML documentation are specified.
+The <a href=\"modelica://Modelica.UsersGuide.Conventions.Documentation.Structure\">structure</a> of the documentation is specified separately.
+</p>
+
+<h4>Paragraphs</h4>
+
+<ol>
+<li> In each section the paragraphs should start with <code>&lt;p&gt;</code>
+     and terminate with <code>&lt;/p&gt;</code>.</li>
+<li> Do not write plain text without putting it in a paragraph.</li>
+<li> No artificial line breaks <code>&lt;br&gt;</code> should be added within text paragraphs if possible.
+     Use separate paragraphs instead.</li>
+<li> After a colon (:) continue with capital letter if new sentence starts;
+     for text fragments continue with lower case letter</li>
+</ol>
+
+<h4>Emphasis</h4>
+
+<ol>
+<li> For setting text in <strong>strong font</strong> (normally interpreted as <strong>boldface</strong>) the tags <code>&lt;strong&gt;</code> and <code>&lt;/strong&gt;</code> have to be used.</li>
+<li> For <em>emphasizing</em> text fragments <code>&lt;em&gt;</code> and <code>&lt;/em&gt;</code> has to be used.</li>
+<li> Modelica terms such as expandable bus, array, etc. should not be emphasized anyhow.</li>
+</ol>
+
+<h4>Capitalization of Text</h4>
+
+<ol>
+<li> Table headers and entries should start with capital letters</li>
+<li> Table entries should start with lower case letter if only text fragments are used.</li>
+<li> Table and figure captions start with a capital letter</li>
+</ol>
+
+</html>"));
+      end Format;
+
+      class Structure "Structure"
+        extends Modelica.Icons.Information;
+
+        annotation (Documentation(info="<html>
+
+<h4>General</h4>
+
+<ol>
+<li> In the HTML documentation of any Modelica library, the headings <code>&lt;h1&gt;</code>,
+     <code>&lt;h2&gt;</code> and <code>&lt;h3&gt;</code> should not be used, because they are utilized by
+     the automatically generated documentation.</li>
+<li> The utilized heading format starts with <code>&lt;h4&gt;</code> and terminates with <code>&lt;/h4&gt;</code>, e.g.,
+     <code>&lt;h4&gt;Description&lt;/h4&gt;</code> </li>
+<li> The  <code>&lt;h4&gt;</code> and  <code>&lt;h5&gt;</code> headings must not be terminated by a colon (:).</li>
+<li> For additional structuring <code>&lt;h5&gt;</code> and <code>&lt;/h5&gt;</code> may be used as demonstrated below.</li>
+</ol>
+
+<h4>Structure</h4>
+<p>
+The following parts should be added to the documentation of each component:
+</p>
+
+<ol>
+<li> General information without additional subsection explains how the class works</li>
+<li> <b>Syntax</b> (for functions only): shows syntax of function call with minimum and full input parameters</li>
+<li> <b>Implementation</b> (optional): explains how the implementation is made </li>
+<li> <b>Limitations</b> (optional): explains the limitations of the component</li>
+<li> <b>Notes</b> (optional): if required/useful </li>
+<li> <b>Examples</b> (optional): if required/useful </li>
+<li> <b>Acknowledgments</b> (optional): if required </li>
+<li> <b>See also</b>: shows hyperlinks to related models </li>
+<li> <b>Revision history</b> (optional): if required/intended for a package/model, the revision history
+        should be placed in <code>annotation(Documentation(revisions=&quot;...&quot;));</code></li>
+</ol>
+
+<p>
+These sections should appear in the listed order. The only exceptions are hierarchically structured notes and examples as explained in the following.
+</p>
+
+<h4>Additional notes and examples</h4>
+
+<p>Some additional notes or examples may require additional <code>&lt;h5&gt;</code> headings. For either notes or examples the following cases may be applied:</p>
+
+<h5>Example 1</h5>
+<p>
+This is an example of a single note.
+</p>
+
+<pre>
+&lt;h5&gt;Note&lt;/h5&gt;
+&lt;p&gt;This is the note.&lt;/p&gt;
+</pre>
+
+<h5>Example 2</h5>
+<p>
+This is an example of a very simple structure.
+</p>
+
+<pre>
+&lt;h5&gt;Notes&lt;/h5&gt;
+&lt;p&gt;This is the first note.&lt;/p&gt;
+&lt;p&gt;This is the second note.&lt;/p&gt;
+</pre>
+
+<h5>Example 3</h5>
+
+<p>
+This example shows a more complex structure with enumeration.
+</p>
+
+<pre>
+&lt;h5&gt;Note 1&lt;/h5&gt;
+...
+&lt;h5&gt;Note 2&lt;/h5&gt;
+...
+</pre>
+<h4>Automatically created documentation</h4>
+<p>
+For parameters, connectors, as well as inputs and outputs of function automatic documentation is generated by the tool from the quoted comments.
+</p>
+</html>"));
+      end Structure;
+      annotation (Documentation(info="<html>
+<a href=\"http://www.w3c.org/\">HTML</a> documentation of Modelica classes.
+</html>"));
+    end Documentation;
+
+    package ModelicaCode "Modelica code"
+      extends Modelica.Icons.Information;
+
+       class Format "Format"
+         extends Modelica.Icons.Information;
+
+        annotation (Documentation(info="<html>
+
+<ol>
+<li> In the <b>icon</b> of a component the instance name is displayed
+     (text string <code>%name</code>) in <b>blue color</b>.
+     Parameter values, e.g., resistance, mass, gear ratio, are displayed
+     in the icon in <b>black color</b> in a smaller font size as the instance name.</li>
+<li> Comments and annotations should start with a capital letter, for example: <br>
+     <code><b>parameter</b> Real a = 1 \"Arbitrary factor\";</code>.<br>
+     For Boolean parameters, the description string should start with \"= true: ..\", for example:<br>
+     <code><b>parameter</b> Boolean useHeatPort = false \"= true, if heatPort is enabled\";</code>.</li>
+</ol>
+
+</html>"));
+       end Format;
+
+      class Naming "Naming convention"
+        extends Modelica.Icons.Information;
+
+        annotation (Documentation(info="<html>
+
+<ol>
+<li> <b>Class and instance names</b> are usually written in upper and lower case
+     letters, e.g., \"ElectricCurrent\". An underscore may be used in names.
+     However, it has to be taken into account that the last underscore in a
+     name might indicate that the following characters are rendered as a subscript.
+     Example: \"pin_a\" may be rendered as \"pin<sub>a</sub>\".</li>
+
+<li> <b>Class names</b> start always with an upper case letter,
+     with the exception of functions, that start with a lower case letter.</li>
+
+<li> <b>Instance names</b>, i.e., names of component instances and
+     of variables (with the exception of constants),
+     start usually with a lower case letter with only
+     a few exceptions if this is common sense
+     (such as <code>T</code> for a temperature variable).</li>
+
+<li> <b>Constant names</b>, i.e., names of variables declared with the
+     \"constant\" prefix, follow the usual naming conventions
+     (= upper and lower case letters) and start usually with an
+     upper case letter, e.g., UniformGravity, SteadyState.</li>
+
+<li> The two <b>connectors</b> of a domain that have identical declarations
+     and different icons are usually distinguished by <code>_a</code>, <code>_b</code>
+     or <code>_p</code>, <code>_n</code>, e.g., <code>Flange_a</code>, <code>Flange_b</code>,
+     <code>HeatPort_a</code>, <code>HeatPort_b</code>.</li>
+
+<li> A <b>connector class</b> has the instance
+     name definition in the diagram layer and not in the icon layer.</li>
+</ol>
+
+<h4>Variable names</h4>
+<p>In the following table typical variable names are listed. This list should be completed.</p>
+
+<table border=\"1\" cellpadding=\"2\" cellspacing=\"0\" >
+   <caption align=\"bottom\">Variables and names</caption>
+   <tr>
+      <th>Variable</th>
+      <th>Quantity</th>
+    </tr>
+     <tr>
+      <td>a</td>
+      <td>acceleration</td>
+    </tr>
+    <tr>
+      <td>A</td>
+      <td>area</td>
+    </tr>
+    <tr>
+      <td>C</td>
+      <td>capacitance</td>
+    </tr>
+    <tr>
+      <td>d</td>
+      <td>damping, density, diameter</td>
+    </tr>
+    <tr>
+      <td>dp</td>
+      <td>pressureDrop</td>
+    </tr>
+    <tr>
+      <td>e</td>
+      <td>specificEntropy</td>
+    </tr>
+    <tr>
+      <td>E</td>
+      <td>energy, entropy</td>
+    </tr>
+    <tr>
+      <td>eta</td>
+      <td>efficiency</td>
+    </tr>
+    <tr>
+      <td>f</td>
+      <td>force, frequency</td>
+    </tr>
+    <tr>
+      <td>G</td>
+      <td>conductance</td>
+    </tr>
+    <tr>
+      <td>H</td>
+      <td>enthalpy</td>
+    </tr>
+    <tr>
+      <td>h</td>
+      <td>height, specificEnthalpy</td>
+    </tr>
+    <tr>
+      <td>HFlow</td>
+      <td>enthalpyFlow</td>
+    </tr>
+    <tr>
+      <td>i</td>
+      <td>current</td>
+    </tr>
+    <tr>
+      <td>J</td>
+      <td>inertia</td>
+    </tr>
+    <tr>
+      <td>l</td>
+      <td>length</td>
+    </tr>
+    <tr>
+      <td>L</td>
+      <td>Inductance</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>mass</td>
+    </tr>
+    <tr>
+      <td>M</td>
+      <td>mutualInductance</td>
+    </tr>
+    <tr>
+      <td>mFlow</td>
+      <td>massFlow</td>
+    </tr>
+    <tr>
+      <td>P</td>
+      <td>power</td>
+    </tr>
+    <tr>
+      <td>p</td>
+      <td>pressure</td>
+    </tr>
+    <tr>
+      <td>Q</td>
+      <td>heat</td>
+    </tr>
+    <tr>
+      <td>Qflow</td>
+      <td>heatFlow</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>radius</td>
+    </tr>
+    <tr>
+      <td>R</td>
+      <td>radius, resistance</td>
+    </tr>
+    <tr>
+      <td>t</td>
+      <td>time</td>
+    </tr>
+    <tr>
+      <td>T</td>
+      <td>temperature</td>
+    </tr>
+    <tr>
+      <td>tau</td>
+      <td>torque</td>
+    </tr>
+    <tr>
+      <td>U</td>
+      <td>internalEnergy</td>
+    </tr>
+    <tr>
+      <td>v</td>
+      <td>electricPotential, specificVolume, velocity, voltage</td>
+    </tr>
+    <tr>
+      <td>V</td>
+      <td>volume</td>
+    </tr>
+    <tr>
+      <td>w</td>
+      <td>angularVelocity</td>
+    </tr>
+    <tr>
+      <td>X</td>
+      <td>reactance</td>
+    </tr>
+    <tr>
+      <td>Z</td>
+      <td>impedance</td>
+    </tr>
+</table>
+</html>"));
+      end Naming;
+
+      annotation (Documentation(info="<html>
+
+<p>In this section the
+<a href=\"modelica://Modelica.UsersGuide.Conventions.ModelicaCode.Naming\">naming conventions</a> of class and instance names, parameters and variables are specified. Additionally some
+<a href=\"modelica://Modelica.UsersGuide.Conventions.ModelicaCode.Format\">format UsersGuide</a> are stated.</p>
+
+</html>"));
+    end ModelicaCode;
+
+    package UsersGuide "User's Guide"
+      extends Modelica.Icons.Information;
+
+      class Implementation "Implementation notes"
+        extends Modelica.Icons.Information;
+
+        annotation (Documentation(info="<html>
+<p>
+This class summarizes general information about the implementation which is not stated elsewhere.
+</p>
+<ol>
+<li>The <code>&lt;caption&gt;</code> tag is currently not supported in some tools.</li>
+<li>The <code>&amp;sim;</code> symbol (i.e., '&sim;' ) is currently not supported in some tools.</li>
+<li>The <code>&amp;prop;</code> symbol (i.e., '&prop;' ) is currently not supported in some tools.</li>
+</ol>
+</html>"));
+      end Implementation;
+
+      class References "References"
+        extends Modelica.Icons.References;
+
+        annotation (Documentation(info="<html>
+
+<ol>
+<li> Citation formats should be unified according to IEEE Transactions style.</li>
+<li> Reference should be formatted as tables with two columns.</li>
+</ol>
+
+<p>In the following the reference formats will be explained based on five examples:</p>
+
+<ul>
+<li> Journal (or conference) [Gao2008] </li>
+<li> Book [Andronov1973]</li>
+<li> Master's thesis [Woehrnschimmel1998]</li>
+<li> PhD thesis [Farnleitner1999]</li>
+<li> Technical report [Marlino2005]</li>
+</ul>
+
+<p>The <a href=\"modelica://Modelica.UsersGuide.Conventions.Documentation.Format.References\">citation</a> is also explained.</p>
+
+<h4>Example</h4>
+
+<pre>
+&lt;table border=\"0\" cellspacing=\"0\" cellpadding=\"2\"&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;[Gao2008]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
+        &quot;A sensorless  rotor temperature estimator for induction
+                 machines based on a current harmonic spectral
+                 estimation scheme,&quot;
+        &lt;i&gt;IEEE Transactions on Industrial Electronics&lt;/i&gt;,
+        vol. 55, no. 1, pp. 407-416, Jan. 2008.&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;[Andronov1973]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
+        &lt;i&gt;Theory of  Bifurcations of Dynamic Systems on a plane&lt;/i&gt;,
+        1st ed. New York: J. Wiley &amp; Sons, 1973.&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;[Woehrnschimmel1998]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;R. W&ouml;hrnschimmel,
+        &quot;Simulation, modeling and fault detection for vector
+              controlled induction machines,&quot;
+        Master&#39;s thesis, Vienna University of Technology,
+        Vienna, Austria, 1998.&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;[Farnleitner1999]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;E. Farnleitner,
+        &quot;Computational Fluid dynamics analysis for rotating
+              electrical machinery,&quot;
+        Ph.D. dissertation, University of Leoben,
+        Department  of Applied Mathematics, Leoben, Austria, 1999.&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;[Marlino2005]&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;L. D. Marlino,
+        &quot;Oak ridge national laboratory annual progress report for the
+              power electronics and electric machinery program,&quot;
+      Oak Ridge National Laboratory, prepared for the U.S. Department of Energy,
+      Tennessee, USA, Tech. Rep. FY2004 Progress Report, January 2005.&lt;/td&gt;
+    &lt;/tr&gt;
+&lt;/table&gt;</pre>
+
+<p>appears as</p>
+
+<table border=\"0\" cellspacing=\"0\" cellpadding=\"2\">
+    <tr>
+      <td valign=\"top\">[Gao08]</td>
+      <td valign=\"top\">Z. Gao, T. G. Habetler, R. G. Harley, and R. S. Colby,
+        &quot;A sensorless  rotor temperature estimator for induction
+                 machines based on a current harmonic spectral
+                 estimation scheme,&quot;
+        <i>IEEE Transactions on Industrial Electronics</i>,
+        vol. 55, no. 1, pp. 407-416, Jan. 2008.</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">[Andronov1973]</td>
+      <td valign=\"top\">A. Andronov, E. Leontovich, I. Gordon, and A. Maier,
+        <i>Theory of  Bifurcations of Dynamic Systems on a plane</i>,
+        1st ed. New York: J. Wiley &amp; Sons, 1973.</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">[Woehrnschimmel1998]</td>
+      <td valign=\"top\">R. W&ouml;hrnschimmel,
+        &quot;Simulation, modeling and fault detection for vector
+              controlled induction machines,&quot;
+        Master&#39;s thesis, Vienna University of Technology,
+        Vienna, Austria, 1998.</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">[Farnleitner1999]</td>
+      <td valign=\"top\">E. Farnleitner,
+        &quot;Computational Fluid dynamics analysis for rotating
+              electrical machinery,&quot;
+        Ph.D. dissertation, University of Leoben,
+        Department  of Applied Mathematics, Leoben, Austria, 1999.</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">[Marlino2005]</td>
+      <td valign=\"top\">L. D. Marlino,
+        &quot;Oak ridge national laboratory annual progress report for the
+              power electronics and electric machinery program,&quot;
+      Oak Ridge National Laboratory, prepared for the U.S. Department of Energy,
+      Tennessee, USA, Tech. Rep. FY2004 Progress Report, January 2005.</td>
+    </tr>
+</table>
+
+</html>"));
+      end References;
+
+      class Contact "Contact"
+        extends Modelica.Icons.Contact;
+
+        annotation (Documentation(info="<html>
+
+<p>
+This class summarizes contact information of the contributing persons.
+</p>
+
+<h5>Example</h5>
+
+<pre>
+&lt;p&gt;This package is developed and maintained by the following contributors&lt;/p&gt;
+  &lt;table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+    &lt;tr&gt;
+      &lt;th&gt;&lt;/th&gt;
+      &lt;th&gt;Name&lt;/th&gt;
+      &lt;th&gt;Affiliation&lt;/th&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;Library officer&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;
+      &lt;a href=\"mailto:a.haumer@haumer.at\"&gt;A. Haumer&lt;/a&gt;
+      &lt;/td&gt;
+      &lt;td valign=\"top\"&gt;
+        &lt;a href=\"http://www.haumer.at\"&gt;Technical Consulting &amp;amp; Electrical Engineering&lt;/a&gt;&lt;br&gt;
+        3423 St.Andrae-Woerdern&lt;br&gt;
+        Austria
+      &lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;Contributor&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;
+        &lt;a href=\"mailto:dr.christian.kral@gmail.com\"&gt;C. Kral&lt;/a&gt;
+      &lt;/td&gt;
+      &lt;td valign=\"top\"&gt;
+        &lt;a href=\"http://christiankral.net\"&gt;Electric Machines, Drives and Systems&lt;/a&gt;&lt;br&gt;
+        1060 Vienna&lt;br&gt;
+        Austria
+      &lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/table&gt;</pre>
+
+<p>appears as</p>
+
+<p>This package is developed and maintained by the following contributors</p>
+  <table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+    <tr>
+      <th></th>
+      <th>Name</th>
+      <th>Affiliation</th>
+    </tr>
+    <tr>
+      <td valign=\"top\">Library officer</td>
+      <td valign=\"top\">
+      <a href=\"mailto:a.haumer@haumer.at\">A. Haumer</a>
+      </td>
+      <td valign=\"top\">
+        <a href=\"http://www.haumer.at\">Technical Consulting &amp; Electrical Engineering</a><br>
+        3423 St.Andrae-Woerdern<br>
+        Austria
+      </td>
+    </tr>
+    <tr>
+      <td valign=\"top\">Contributor</td>
+      <td valign=\"top\">
+        <a href=\"mailto:dr.christian.kral@gmail.com\">C. Kral</a>
+      </td>
+      <td valign=\"top\">
+        <a href=\"http://christiankral.net\">Electric Machines, Drives and Systems</a><br>
+        1060 Vienna<br>
+        Austria
+      </td>
+    </tr>
+    <tr>
+      <td valign=\"top\">Contributor</td>
+      <td valign=\"top\">
+        <a href=\"http://www.linkedin.com/in/dietmarw\">D. Winkler</a>
+      </td>
+      <td valign=\"top\">
+        DWE, Norway
+      </td>
+    </tr>
+  </table>
+
+</html>"));
+      end Contact;
+
+      class RevisionHistory "Revision History"
+        extends Modelica.Icons.ReleaseNotes;
+
+        annotation (Documentation(info="<html>
+
+<ol>
+<li> The revision history needs to answer the question:
+     What has changed and what are the improvements over the previous versions and revision.</li>
+<li> The revision history includes the documentation of the development history of each class and/or package.</li>
+<li> Version number, revision number, date, author and comments shall be included.</li>
+</ol>
+
+<h5>Example</h5>
+
+<pre>
+&lt;table border=\"1\" cellspacing=\"0\" cellpadding=\"2\"&gt;
+    &lt;tr&gt;
+      &lt;th&gt;Version&lt;/th&gt;
+      &lt;th&gt;Revision&lt;/th&gt;
+      &lt;th&gt;Date&lt;/th&gt;
+      &lt;th&gt;Author&lt;/th&gt;
+      &lt;th&gt;Comment&lt;/th&gt;
+    &lt;/tr&gt;
+    ...
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;1.0.1&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;828&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;2008-05-26&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;A. Haumer&lt;br&gt;C. Kral&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;Fixed bug in documentation&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td valign=\"top\"&gt;1.0.0&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;821&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;2008-05-21&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;A. Haumer&lt;/td&gt;
+      &lt;td valign=\"top\"&gt;&lt;/td&gt;
+    &lt;/tr&gt;
+&lt;/table&gt;</pre>
+
+<p>This code appears then as in the \"Revisions\" section below.</p>
+
+</html>",
+      revisions="<html>
+<table border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+    <tr>
+      <th>Version</th>
+      <th>Revision</th>
+      <th>Date</th>
+      <th>Author</th>
+      <th>Comment</th>
+    </tr>
+    <tr>
+      <td valign=\"top\">1.1.0</td>
+      <td valign=\"top\"></td>
+      <td valign=\"top\">2010-04-22</td>
+      <td valign=\"top\">C. Kral</td>
+      <td valign=\"top\">Migrated Conventions to UsersGuide of MSL</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">1.0.5</td>
+      <td valign=\"top\">3540</td>
+      <td valign=\"top\">2010-03-11</td>
+      <td valign=\"top\">D. Winkler</td>
+      <td valign=\"top\">Updated image links guide to new 'modelica://' URIs, added contact details</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">1.0.4</td>
+      <td valign=\"top\">2960</td>
+      <td valign=\"top\">2009-09-28</td>
+      <td valign=\"top\">C. Kral</td>
+      <td valign=\"top\">Applied new rules for equations as discussed on the 63rd Modelica Design Meeting</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">1.0.3</td>
+      <td valign=\"top\">2579</td>
+      <td valign=\"top\">2008-05-26</td>
+      <td valign=\"top\">D. Winkler</td>
+      <td valign=\"top\">Layout fixes and enhancements</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">1.0.1</td>
+      <td valign=\"top\">828</td>
+      <td valign=\"top\">2008-05-26</td>
+      <td valign=\"top\">A. Haumer<br>C. Kral</td>
+      <td valign=\"top\">Fixed bug in documentation</td>
+    </tr>
+    <tr>
+      <td valign=\"top\">1.0.0</td>
+      <td valign=\"top\">821</td>
+      <td valign=\"top\">2008-05-21</td>
+      <td valign=\"top\">A. Haumer</td>
+      <td valign=\"top\"></td>
+    </tr>
+</table>
+</html>"));
+      end RevisionHistory;
+
+    annotation (Documentation(info="<html>
+<p>The UsersGuide of each package should consist of the following classes</p>
+<ol>
+<li> <a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide.Contact\">Contact</a> information of
+     the library officer and the co-authors </li>
+<li> Optional <a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide.Implementation\">Implementation Notes</a> to give general information about the implementation</li>
+<li> <a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide.References\">References</a> for summarizing the literature of the package</li>
+<li> <a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide.RevisionHistory\">Revision history </a> to summarize the most important changes and improvements of the package</li>
+</ol>
+</html>"));
+    end UsersGuide;
+    annotation (DocumentationClass=true,Documentation(info="<html>
+<p>A Modelica main package should be compliant with the UsersGuide stated in this documentation:</p>
+<ol>
+<li> Conventions of the <a href=\"modelica://Modelica.UsersGuide.Conventions.ModelicaCode\">Modelica code</a> </li>
+<li> Consistent HTML documentation <a href=\"modelica://Modelica.UsersGuide.Conventions.Documentation\">UsersGuide</a> </li>
+<li> Structure to be provided by a main package
+<ul>
+     <li> <a href=\"modelica://Modelica.UsersGuide.Conventions.UsersGuide\">User's Guide</a></li>
+     <li> <b>Examples</b> containing models demonstrating the usage of the library.</li>
+     <li> <b>Components</b> -- in case of a complex library a more detailed structure can be established.</li>
+     <li> <b>Sensors</b></li>
+     <li> <b>Sources</b></li>
+     <li> <b>Interfaces</b> containing connectors and partial models.</li>
+     <li> <b>Types</b> containing type, enumeration and choice definitions.</li>
+</ul></li>
+<li> These packages should appear in the listed order.</li>
+</ol>
+</html>"));
+  end Conventions;
+
+class ParameterDefaults "Parameter defaults"
+  extends Modelica.Icons.Information;
+
+ annotation (Documentation(info="<html>
+
+<p>
+In this section the convention is summarized how default parameters are
+handled in the Modelica Standard Library (since version 3.0).
+</p>
+
+<p>
+Many models in this library have parameter declarations to define
+constants of a model that might be changed before simulation starts.
+Example:
+</p>
+
+<blockquote>
+<pre>
+<b>model</b> SpringDamper
+<b>parameter</b> Real c(final unit=\"N.m/rad\")    = 1e5 \"Spring constant\";
+<b>parameter</b> Real d(final unit=\"N.m.s/rad\")  = 0   \"Damping constant\";
+<b>parameter</b> Modelica.SIunits.Angle phi_rel0 = 0   \"Unstretched spring angle\";
+...
+<b>end</b> SpringDamper;
+</pre>
+</blockquote>
+
+<p>
+In Modelica it is possible to define a default value of a parameter in
+the parameter declaration. In the example above, this is performed for
+all parameters. Providing default values for all parameters can lead to
+errors that are difficult to detect, since a modeler may have forgotten
+to provide a meaningful value (the model simulates but gives wrong
+results due to wrong parameter values). In general the following basic
+situations are present:
+</p>
+
+<ol>
+<li> The parameter value could be anything (e.g., a spring constant or
+  a resistance value) and therefore the user should provide a value in
+  all cases. A Modelica translator should warn, if no value is provided.
+</li>
+
+<li> The parameter value is not changed in &gt; 95 % of the cases
+  (e.g., initialization or visualization parameters, or parameter phi_rel0
+  in the example above). In this case a default parameter value should be
+  provided, in order that the model or function can be conveniently
+  used by a modeler.
+</li>
+
+<li> A modeler would like to quickly utilize a model, e.g.,
+  <ul>
+  <li> to automatically check that the model still translates and/or simulates
+    (after some changes in the library),</li>
+  <li> to make a quick demo of a library by drag-and-drop of components,</li>
+  <li> to implement a simple test model in order to get a better understanding
+    of the desired component.</li>
+  </ul>
+  In all these cases, it would be not practical, if the modeler would
+  have to provide explicit values for all parameters first.
+  </li>
+</ol>
+
+<p>
+To handle the conflicting goals of (1) and (3), the Modelica Standard Library
+uses two approaches to define default parameters, as demonstrated with the
+following example:
+</p>
+
+<blockquote>
+<pre>
+<b>model</b> SpringDamper
+<b>parameter</b> Real c(final unit=\"N.m/rad\"  , start=1e5) \"Spring constant\";
+<b>parameter</b> Real d(final unit=\"N.m.s/rad\", start=  0) \"Damping constant\";
+<b>parameter</b> Modelica.SIunits.Angle phi_rel0 = 0       \"Unstretched spring angle\";
+...
+<b>end</b> SpringDamper;
+
+SpringDamper sp1;              // warning for \"c\" and \"d\"
+SpringDamper sp2(c=1e4, d=0);  // fine, no warning
+</pre>
+</blockquote>
+
+<p>
+Both definition forms, using a \"start\" value (for \"c\" and \"d\") and providing
+a declaration equation (for \"phi_rel0\"), are valid Modelica and define the value
+of the parameter. By convention, it is expected that Modelica translators will
+trigger a warning message for parameters that are <b>not</b> defined by a declaration
+equation, by a modifier equation or in an initial equation/algorithm section.
+A Modelica translator might have options to change this behavior, especially,
+that no messages are printed in such cases and/or that an error is triggered
+instead of a warning.
+</p>
+
+</html>"));
+end ParameterDefaults;
+
+class ModelicaLicense2 "Modelica License 2"
+  extends Modelica.Icons.Information;
+
+  annotation (Documentation(info="<html>
+<head>
+    <title>The Modelica License 2</title>
+    <style type=\"text/css\">
+    *       { font-size: 10pt; font-family: Arial,sans-serif; }
+    code    { font-size:  9pt; font-family: Courier,monospace;}
+    h6      { font-size: 10pt; font-weight: bold; color: green; }
+    h5      { font-size: 11pt; font-weight: bold; color: green; }
+    h4      { font-size: 13pt; font-weight: bold; color: green; }
+    address {                  font-weight: normal}
+    td      { solid #000; vertical-align:top; }
+    th      { solid #000; vertical-align:top; font-weight: bold; }
+    table   { solid #000; border-collapse: collapse;}
+    </style>
+</head>
+<body lang=\"en-US\">
+    <p>All files in this directory (&quot;Modelica&quot;) and in all
+    subdirectories, especially all files that build package
+    &quot;Modelica&quot; and the contents of the directory
+    &quot;Modelica/Resources&quot; are licensed by the <strong>Modelica
+    Association</strong> under the &quot;Modelica License&nbsp;2&quot; (with
+    exception of the contents of the directory
+    &quot;Modelica/Resources/C-Sources&quot;).</p>
+    <p style=\"margin-left: 40px;\"><strong>Licensor:</strong><br>
+    Modelica Association<br>
+    (Ideella F&ouml;reningar 822003-8858 in Link&ouml;ping)<br>
+    c/o PELAB, IDA, Link&ouml;pings Universitet<br>
+    S-58183 Link&ouml;ping<br>
+    Sweden<br>
+    email: Board@Modelica.org<br>
+    web: <a href=\"https://www.Modelica.org\">https://www.Modelica.org</a></p>
+    <p style=\"margin-left: 40px;\"><strong>Copyright notices of the
+    files:</strong><br>
+    Copyright &copy; 1998-2016, ABB, Austrian Institute of Technology,
+    T.&nbsp;B&ouml;drich, DLR, Dassault Syst&egrave;mes AB, Fraunhofer,
+    A.&nbsp;Haumer, ITI, Modelon, TU Hamburg-Harburg, Politecnico di Milano,
+    XRG Simulation</p>
+    <p><a href=\"#The_Modelica_License_2-outline\">The Modelica
+    License&nbsp;2</a><br>
+    <a href=\"#Frequently_Asked_Questions-outline\">Frequently Asked
+    Questions</a><br></p>
+    <hr>
+    <h4><a name=\"The_Modelica_License_2-outline\" id=
+    \"The_Modelica_License_2-outline\"></a>The Modelica License&nbsp;2</h4>
+    <p><strong>Preamble.</strong> The goal of this license is that Modelica
+    related model libraries, software, images, documents, data files etc. can
+    be used freely in the original or a modified form, in open source and in
+    commercial environments (as long as the license conditions below are
+    fulfilled, in particular sections&nbsp;2c) and 2d). The Original Work is
+    provided free of charge and the use is completely at your own risk.
+    Developers of free Modelica packages are encouraged to utilize this license
+    for their work.</p>
+    <p>The Modelica License applies to any Original Work that contains the
+    following licensing notice adjacent to the copyright notice(s) for this
+    Original Work:</p>
+    <p><strong>Licensed by the Modelica Association under the Modelica
+    License&nbsp;2</strong></p>
+    <p><strong>1. Definitions.</strong></p>
+    <ol type=\"a\">
+        <li>&quot;License&quot; is this Modelica License.</li>
+        <li>&quot;Original Work&quot; is any work of authorship, including
+        software, images, documents, data files, that contains the above
+        licensing notice or that is packed together with a licensing notice
+        referencing it.</li>
+        <li>&quot;Licensor&quot; is the provider of the Original Work who has
+        placed this licensing notice adjacent to the copyright notice(s) for
+        the Original Work. The Original Work is either directly provided by the
+        owner of the Original Work, or by a licensee of the owner.</li>
+        <li>&quot;Derivative Work&quot; is any modification of the Original
+        Work which represents, as a whole, an original work of authorship. For
+        the matter of clarity and as examples:
+            <ol type=\"a\">
+                <li>Derivative Work shall not include work that remains
+                separable from the Original Work, as well as merely extracting
+                a part of the Original Work without modifying it.</li>
+                <li>Derivative Work shall not include (a) fixing of errors
+                and/or (b) adding vendor specific Modelica annotations and/or
+                (c) using a subset of the classes of a Modelica package, and/or
+                (d) using a different representation, e.g., a binary
+                representation.</li>
+                <li>Derivative Work shall include classes that are copied from
+                the Original Work where declarations, equations or the
+                documentation are modified.</li>
+                <li>Derivative Work shall include executables to simulate the
+                models that are generated by a Modelica translator based on the
+                Original Work (of a Modelica package).</li>
+            </ol>
+        </li>
+        <li>&quot;Modified Work&quot; is any modification of the Original
+        Work with the following exceptions: (a) fixing of errors and/or (b)
+        adding vendor specific Modelica annotations and/or (c) using a subset
+        of the classes of a Modelica package, and/or (d) using a different
+        representation, e.g., a binary representation.</li>
+        <li>&quot;Source Code&quot; means the preferred form of the Original
+        Work for making modifications to it and all available documentation
+        describing how to modify the Original Work.</li>
+        <li>&quot;You&quot; means an individual or a legal entity exercising
+        rights under, and complying with all of the terms of, this
+        License.</li>
+        <li>&quot;Modelica package&quot; means any Modelica library that is
+        defined with the
+        &quot;<code><strong>package</strong>&nbsp;&lt;Name&gt;&nbsp;...&nbsp;<strong>end</strong>&nbsp;&lt;Name&gt;;</code>&quot;
+        Modelica language element.</li>
+    </ol>
+    <p><strong>2. Grant of Copyright License.</strong> Licensor grants You a
+    worldwide, royalty-free, non-exclusive, sublicensable license, for the
+    duration of the copyright, to do the following:</p>
+    <ol type=\"a\">
+        <li>
+            <p>To reproduce the Original Work in copies, either alone or as
+            part of a collection.</p>
+        </li>
+        <li>
+            <p>To create Derivative Works according to Section&nbsp;1d) of this
+            License.</p>
+        </li>
+        <li>
+            <p>To distribute or communicate to the public copies of the
+            <u>Original Work</u> or a <u>Derivative Work</u> under <u>this
+            License</u>. No fee, neither as a copyright-license fee, nor as a
+            selling fee for the copy as such may be charged under this License.
+            Furthermore, a verbatim copy of this License must be included in
+            any copy of the Original Work or a Derivative Work under this
+            License.<br>
+            For the matter of clarity, it is permitted A) to distribute or
+            communicate such copies as part of a (possible commercial)
+            collection where other parts are provided under different licenses
+            and a license fee is charged for the other parts only and B) to
+            charge for mere printing and shipping costs.</p>
+        </li>
+        <li>
+            <p>To distribute or communicate to the public copies of a
+            <u>Derivative Work</u>, alternatively to Section&nbsp;2c), under
+            <u>any other license</u> of your choice, especially also under a
+            license for commercial/proprietary software, as long as You comply
+            with Sections&nbsp;3, 4 and 8 below.<br>
+            For the matter of clarity, no restrictions regarding fees, either
+            as to a copyright-license fee or as to a selling fee for the copy
+            as such apply.</p>
+        </li>
+        <li>
+            <p>To perform the Original Work publicly.</p>
+        </li>
+        <li>
+            <p>To display the Original Work publicly.</p>
+        </li>
+    </ol>
+    <p><strong>3. Acceptance.</strong> Any use of the Original Work or a
+    Derivative Work, or any action according to either Section&nbsp;2a) to 2f)
+    above constitutes Your acceptance of this License.</p>
+    <p><strong>4. Designation of Derivative Works and of Modified
+    Works.</strong> The identifying designation of Derivative Work and of
+    Modified Work must be different to the corresponding identifying
+    designation of the Original Work. This means especially that the
+    (root-level) name of a Modelica package under this license must be changed
+    if the package is modified (besides fixing of errors, adding vendor
+    specific Modelica annotations, using a subset of the classes of a Modelica
+    package, or using another representation, e.g. a binary
+    representation).</p>
+    <p><strong>5. Grant of Patent License.</strong> Licensor grants You a
+    worldwide, royalty-free, non-exclusive, sublicensable license, under patent
+    claims owned by the Licensor or licensed to the Licensor by the owners of
+    the Original Work that are embodied in the Original Work as furnished by
+    the Licensor, for the duration of the patents, to make, use, sell, offer
+    for sale, have made, and import the Original Work and Derivative Works
+    under the conditions as given in Section&nbsp;2. For the matter of clarity,
+    the license regarding Derivative Works covers patent claims to the extent
+    as they are embodied in the Original Work only.</p>
+    <p><strong>6. Provision of Source Code.</strong> Licensor agrees to provide
+    You with a copy of the Source Code of the Original Work but reserves the
+    right to decide freely on the manner of how the Original Work is
+    provided.<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For the matter of clarity, Licensor
+    might provide only a binary representation of the Original Work. In that
+    case, You may (a) either reproduce the Source Code from the binary
+    representation if this is possible (e.g., by performing a copy of an
+    encrypted Modelica package, if encryption allows the copy operation) or (b)
+    request the Source Code from the Licensor who will provide it to You.</p>
+    <p><strong>7. Exclusions from License Grant.</strong> Neither the names of
+    Licensor, nor the names of any contributors to the Original Work, nor any
+    of their trademarks or service marks, may be used to endorse or promote
+    products derived from this Original Work without express prior permission
+    of the Licensor. Except as otherwise expressly stated in this License and
+    in particular in Sections&nbsp;2 and 5, nothing in this License grants any
+    license to Licensor&apos;s trademarks, copyrights, patents, trade secrets or any
+    other intellectual property, and no patent license is granted to make, use,
+    sell, offer for sale, have made, or import embodiments of any patent
+    claims.<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;No license is granted to the trademarks
+    of Licensor even if such trademarks are included in the Original Work,
+    except as expressly stated in this License. Nothing in this License shall
+    be interpreted to prohibit Licensor from licensing under terms different
+    from this License any Original Work that Licensor otherwise would have a
+    right to license.</p>
+    <p><strong>8. Attribution Rights.</strong> You must retain in the Source
+    Code of the Original Work and of any Derivative Works that You create, all
+    author, copyright, patent, or trademark notices, as well as any descriptive
+    text identified therein as an &quot;Attribution Notice&quot;. The same
+    applies to the licensing notice of this License in the Original Work. For
+    the matter of clarity, &quot;author notice&quot; means the notice that
+    identifies the original author(s).<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;You must cause the Source Code for any
+    Derivative Works that You create to carry a prominent Attribution Notice
+    reasonably calculated to inform recipients that You have modified the
+    Original Work.<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;In case the Original Work or Derivative
+    Work is not provided in Source Code, the Attribution Notices shall be
+    appropriately displayed, e.g., in the documentation of the Derivative
+    Work.</p>
+    <p><strong>9. Disclaimer of Warranty.<br></strong> <u><strong>The Original
+    Work is provided under this License on an &quot;as is&quot; basis and
+    without warranty, either express or implied, including, without limitation,
+    the warranties of non-infringement, merchantability or fitness for a
+    particular purpose. The entire risk as to the quality of the Original Work
+    is with You.</strong></u> This disclaimer of warranty constitutes an
+    essential part of this License. No license to the Original Work is granted
+    by this License except under this disclaimer.</p>
+    <p><strong>10. Limitation of Liability.</strong> Under no circumstances and
+    under no legal theory, whether in tort (including negligence), contract, or
+    otherwise, shall the Licensor, the owner or a licensee of the Original Work
+    be liable to anyone for any direct, indirect, general, special, incidental,
+    or consequential damages of any character arising as a result of this
+    License or the use of the Original Work including, without limitation,
+    damages for loss of goodwill, work stoppage, computer failure or
+    malfunction, or any and all other commercial damages or losses. This
+    limitation of liability shall not apply to the extent applicable law
+    prohibits such limitation.</p>
+    <p><strong>11. Termination.</strong> This License conditions your rights to
+    undertake the activities listed in Section&nbsp;2 and 5, including your
+    right to create Derivative Works based upon the Original Work, and doing so
+    without observing these terms and conditions is prohibited by copyright law
+    and international treaty. Nothing in this License is intended to affect
+    copyright exceptions and limitations. This License shall terminate
+    immediately and You may no longer exercise any of the rights granted to You
+    by this License upon your failure to observe the conditions of this
+    license.</p>
+    <p><strong>12. Termination for Patent Action.</strong> This License shall
+    terminate automatically and You may no longer exercise any of the rights
+    granted to You by this License as of the date You commence an action,
+    including a cross-claim or counterclaim, against Licensor, any owners of
+    the Original Work or any licensee alleging that the Original Work infringes
+    a patent. This termination provision shall not apply for an action alleging
+    patent infringement through combinations of the Original Work under
+    combination with other software or hardware.</p>
+    <p><strong>13. Jurisdiction.</strong> Any action or suit relating to this
+    License may be brought only in the courts of a jurisdiction wherein the
+    Licensor resides and under the laws of that jurisdiction excluding its
+    conflict-of-law provisions. The application of the United Nations
+    Convention on Contracts for the International Sale of Goods is expressly
+    excluded. Any use of the Original Work outside the scope of this License or
+    after its termination shall be subject to the requirements and penalties of
+    copyright or patent law in the appropriate jurisdiction. This section shall
+    survive the termination of this License.</p>
+    <p><strong>14. Attorneys&apos; Fees.</strong> In any action to enforce the terms
+    of this License or seeking damages relating thereto, the prevailing party
+    shall be entitled to recover its costs and expenses, including, without
+    limitation, reasonable attorneys&apos; fees and costs incurred in connection
+    with such action, including any appeal of such action. This section shall
+    survive the termination of this License.</p>
+    <p><strong>15. Miscellaneous.</strong></p>
+    <ol type=\"a\">
+        <li>If any provision of this License is held to be unenforceable, such
+        provision shall be reformed only to the extent necessary to make it
+        enforceable.</li>
+        <li>No verbal ancillary agreements have been made. Changes and
+        additions to this License must appear in writing to be valid. This also
+        applies to changing the clause pertaining to written form.</li>
+        <li>You may use the Original Work in all ways not otherwise restricted
+        or conditioned by this License or by law, and Licensor promises not to
+        interfere with or be responsible for such uses by You.</li>
+    </ol>
+    <hr>
+    <h5><a name=\"Frequently_Asked_Questions-outline\" id=
+    \"Frequently_Asked_Questions-outline\"></a> Frequently Asked Questions</h5>
+    <p>This section contains questions/answer to users and/or distributors of
+    Modelica packages and/or documents under Modelica License&nbsp;2. Note, the
+    answers to the questions below are not a legal interpretation of the
+    Modelica License&nbsp;2. In case of a conflict, the language of the license
+    shall prevail.</p>
+    <h6>Using or Distributing a Modelica <u>Package</u> under the Modelica
+    License&nbsp;2</h6>
+    <p><strong>What are the main differences to the previous version of the
+    Modelica License?</strong></p>
+    <ol>
+        <li>
+            <p>Modelica License&nbsp;1 is unclear whether the licensed Modelica
+            package can be distributed under a different license.
+            Version&nbsp;2 explicitly allows that &quot;Derivative Work&quot;
+            can be distributed under any license of Your choice, see examples
+            in Section&nbsp;1d) as to what qualifies as Derivative Work (so,
+            version&nbsp;2 is clearer).</p>
+        </li>
+        <li>
+            <p>If You modify a Modelica package under Modelica License&nbsp;2
+            (besides fixing of errors, adding vendor specific Modelica
+            annotations, using a subset of the classes of a Modelica package,
+            or using another representation, e.g., a binary representation),
+            you must rename the root-level name of the package for your
+            distribution. In version&nbsp;1 you could keep the name (so,
+            version&nbsp;2 is more restrictive). The reason of this restriction
+            is to reduce the risk that Modelica packages are available that
+            have identical names, but different functionality.</p>
+        </li>
+        <li>
+            <p>Modelica License&nbsp;1 states that &quot;It is not allowed to
+            charge a fee for the original version or a modified version of the
+            software, besides a reasonable fee for distribution and
+            support&quot;. Version&nbsp;2 has a similar intention for all
+            Original Work under <u>Modelica License&nbsp;2</u> (to remain free
+            of charge and open source) but states this more clearly as
+            &quot;No fee, neither as a copyright-license fee, nor as a selling
+            fee for the copy as such may be charged&quot;. Contrary to
+            version&nbsp;1, Modelica License&nbsp;2 has no restrictions on fees
+            for Derivative Work that is provided under a different license (so,
+            version&nbsp;2 is clearer and has fewer restrictions).</p>
+        </li>
+        <li>
+            <p>Modelica License&nbsp;2 introduces several useful provisions for
+            the licensee (articles&nbsp;5, 6, 12), and for the licensor
+            (articles&nbsp;7, 12, 13, 14) that have no counter part in
+            version&nbsp;1.</p>
+        </li>
+        <li>
+            <p>Modelica License&nbsp;2 can be applied to all type of work,
+            including documents, images and data files, contrary to
+            version&nbsp;1 that was dedicated for software only (so,
+            version&nbsp;2 is more general).</p>
+        </li>
+    </ol>
+    <p><strong>Can I distribute a Modelica package (under Modelica
+    License&nbsp;2) as part of my commercial Modelica modeling and simulation
+    environment?</strong></p>
+    <p>Yes, according to Section&nbsp;2c). However, you are not allowed to
+    charge a fee for this part of your environment. Of course, you can charge
+    for your part of the environment.</p>
+    <p><strong>Can I distribute a Modelica package (under Modelica
+    License&nbsp;2) under a different license?</strong></p>
+    <p>No. The license of an unmodified Modelica package cannot be changed
+    according to Sections&nbsp;2c) and 2d). This means that you cannot
+    <u>sell</u> copies of it, any distribution has to be free of charge.</p>
+    <p><strong>Can I distribute a Modelica package (under Modelica
+    License&nbsp;2) under a different license when I first encrypt the
+    package?</strong></p>
+    <p>No. Merely encrypting a package does not qualify for Derivative Work and
+    therefore the encrypted package has to stay under Modelica
+    License&nbsp;2.</p>
+    <p><strong>Can I distribute a Modelica package (under Modelica
+    License&nbsp;2) under a different license when I first add classes to the
+    package?</strong></p>
+    <p>No. The package itself remains unmodified, i.e., it is Original Work,
+    and therefore the license for this part must remain under Modelica
+    License&nbsp;2. The newly added classes can be, however, under a different
+    license.</p>
+    <p><strong>Can I copy a class out of a Modelica package (under Modelica
+    License&nbsp;2) and include it</strong> <u><strong>unmodified</strong></u>
+    <strong>in a Modelica package under a</strong>
+    <u><strong>commercial/proprietary</strong></u>
+    <strong>license?</strong></p>
+    <p>No, according to article&nbsp;2c). However, you can include model,
+    block, function, package, record and connector classes in your Modelica
+    package under <u>Modelica License&nbsp;2</u>. This means that your Modelica
+    package could be under a commercial/proprietary license, but one or more
+    classes of it are under Modelica License&nbsp;2.<br>
+    Note, a &quot;type&quot; class (e.g., type Angle =
+    Real(unit=&quot;rad&quot;)) can be copied and included unmodified under a
+    commercial/proprietary license (for details, see the next question).</p>
+    <p><strong>Can I copy a type class or</strong> <u><strong>part</strong></u>
+    <strong>of a model, block, function, record, connector class, out of a
+    Modelica package (under Modelica License&nbsp;2) and include it modified or
+    unmodified in a Modelica package under a</strong>
+    <u><strong>commercial/proprietary</strong></u>
+    <strong>license?</strong></p>
+    <p>Yes, according to article&nbsp;2d), since this will in the end usually
+    qualify as Derivative Work. The reasoning is the following: A type class or
+    part of another class (e.g., an equation, a declaration, part of a class
+    description) cannot be utilized &quot;by its own&quot;. In order to make
+    this &quot;usable&quot;, you have to add additional code in order that
+    the class can be utilized. This is therefore usually Derivative Work and
+    Derivative Work can be provided under a different license. Note, this only
+    holds, if the additional code introduced is sufficient to qualify for
+    Derivative Work. Merely, just copying a class and changing, say, one
+    character in the documentation of this class would be no Derivative Work
+    and therefore the copied code would have to stay under Modelica
+    License&nbsp;2.</p>
+    <p><strong>Can I copy a class out of a Modelica package (under Modelica
+    License&nbsp;2) and include it in</strong> <u><strong>modified</strong></u>
+    <strong>form in a</strong> <u><strong>commercial/proprietary</strong></u>
+    <strong>Modelica package?</strong></p>
+    <p>Yes. If the modification can be seen as a &quot;Derivative Work&quot;,
+    you can place it under your commercial/proprietary license. If the
+    modification does not qualify as &quot;Derivative Work&quot; (e.g., bug
+    fixes, vendor specific annotations), it must remain under Modelica
+    License&nbsp;2. This means that your Modelica package could be under a
+    commercial/proprietary license, but one or more parts of it are under
+    Modelica License&nbsp;2.</p>
+    <p><strong>Can I distribute a &quot;save total model&quot; under my
+    commercial/proprietary license, even if classes under Modelica
+    License&nbsp;2 are included?</strong></p>
+    <p>Your classes of the &quot;save total model&quot; can be distributed
+    under your commercial/proprietary license, but the classes under Modelica
+    License&nbsp;2 must remain under Modelica License&nbsp;2. This means you
+    can distribute a &quot;save total model&quot;, but some parts might be
+    under Modelica License&nbsp;2.</p>
+    <p><strong>Can I distribute a Modelica package (under Modelica
+    License&nbsp;2) in encrypted form?</strong></p>
+    <p>Yes. Note, if the encryption does not allow &quot;copying&quot; of
+    classes (in to unencrypted Modelica source code), you have to send the
+    Modelica source code of this package to your customer, if he/she wishes it,
+    according to article&nbsp;6.</p>
+    <p><strong>Can I distribute an executable under my commercial/proprietary
+    license, if the model from which the executable is generated uses models
+    from a Modelica package under Modelica License&nbsp;2?</strong></p>
+    <p>Yes, according to article&nbsp;2d), since this is seen as Derivative
+    Work. The reasoning is the following: An executable allows the simulation
+    of a concrete model, whereas models from a Modelica package (without
+    pre-processing, translation, tool run-time library) are not able to be
+    simulated without tool support. By the processing of the tool and by its
+    run-time libraries, significant new functionality is added (a model can be
+    simulated whereas previously it could not be simulated) and functionality
+    available in the package is removed (e.g., to build up a new model by
+    dragging components of the package is no longer possible with the
+    executable).</p>
+    <p><strong>Is my modification to a Modelica package (under Modelica
+    License&nbsp;2) a Derivative Work?</strong></p>
+    <p>It is not possible to give a general answer to it. To be regarded as
+    &quot;an original work of authorship&quot;, a derivative work must be
+    different enough from the original or must contain a substantial amount of
+    new material. Making minor changes or additions of little substance to a
+    preexisting work will not qualify the work as a new version for such
+    purposes.</p>
+    <h6>Using or Distributing a Modelica <u>Document</u> under the Modelica
+    License&nbsp;2</h6>
+    <p>This section is devoted especially for the following applications:</p>
+    <ol type=\"a\">
+        <li>
+            <p>A Modelica tool extracts information out of a Modelica package
+            and presents the result in form of a &quot;manual&quot; for this
+            package in, e.g., html, doc, or pdf format.</p>
+        </li>
+        <li>
+            <p>The Modelica language specification is a document defining the
+            Modelica language. It will be licensed under Modelica
+            License&nbsp;2.</p>
+        </li>
+        <li>
+            <p>Someone writes a book about the Modelica language and/or
+            Modelica packages and uses information which is available in the
+            Modelica language specification and/or the corresponding Modelica
+            package.</p>
+        </li>
+    </ol>
+    <p><strong>Can I sell a manual that was basically derived by extracting
+    information automatically from a Modelica package under Modelica
+    License&nbsp;2 (e.g., a &quot;reference guide&quot; of the Modelica
+    Standard Library)?</strong></p>
+    <p>Yes. Extracting information from a Modelica package, and providing it in
+    a human readable, suitable format, like html, doc or pdf format, where the
+    content is significantly modified (e.g. tables with interface information
+    are constructed from the declarations of the public variables) qualifies as
+    Derivative Work and there are no restrictions to charge a fee for
+    Derivative Work under alternative&nbsp;2d).</p>
+    <p><strong>Can I copy a text passage out of a Modelica document (under
+    Modelica License&nbsp;2) and use it</strong>
+    <u><strong>unmodified</strong></u> <strong>in my document (e.g. the
+    Modelica syntax description in the Modelica Specification)?</strong></p>
+    <p>Yes. In case you distribute your document, the copied parts are still
+    under Modelica License&nbsp;2 and you are not allowed to charge a license
+    fee for this part. You can, of course, charge a fee for the rest of your
+    document.</p>
+    <p><strong>Can I copy a text passage out of a Modelica document (under
+    Modelica License&nbsp;2) and use it in</strong>
+    <u><strong>modified</strong></u> <strong>form in my document?</strong></p>
+    <p>Yes, the creation of Derivative Works is allowed. In case the content is
+    significantly modified this qualifies as Derivative Work and there are no
+    restrictions to charge a fee for Derivative Work under
+    alternative&nbsp;2d).</p>
+    <p><strong>Can I sell a printed version of a Modelica document (under
+    Modelica License&nbsp;2), e.g., the Modelica Language
+    Specification?</strong></p>
+    <p>No, if you are not the copyright-holder, since article&nbsp;2c) does not
+    allow a selling fee for a (in this case physical) copy. However, mere
+    printing and shipping costs may be recovered.</p>
+</body>
+</html>"));
+end ModelicaLicense2;
+
+package ReleaseNotes "Release notes"
+class VersionManagement "Version Management"
+  extends Modelica.Icons.ReleaseNotes;
+
+      annotation (Documentation(info="<html>
+<p>
+Maintenance of the Modelica Standard Library is performed with
+three branches on the subversion server of the Modelica Association
+(<a href=\"https://svn.modelica.org/projects/Modelica\">https://svn.modelica.org/projects/Modelica</a>):
+</p>
+
+<h4>Released branch</h4>
+<p>
+Example: \"/tags/v3.0.1/Modelica\"
+</p>
+
+<p>
+This branch contains the released Modelica versions (e.g., version 3.0.1),
+where all available test cases and compatibility checks with other Modelica
+libraries have been performed on the respective release. This version is
+usually shipped with a Modelica modeling and simulation environment and
+utilized by a Modelica user.
+</p>
+
+<h4>Development branch</h4>
+<p>
+Example: \"/trunk/Modelica\"
+</p>
+
+<p>
+This branch contains the actual development version, i.e., all bug fixes
+and new features based on the last Modelica release.
+New features should have been tested before including them.
+However, the exhaustive tests for a new version are (usually) not performed.
+This version is usually only be used by the developers of the
+Modelica Standard Library and is not utilized by Modelica users.
+</p>
+
+<h4>Maintenance branch</h4>
+<p>
+Example: \"/branches/maintenance/3.0.1/Modelica\"
+</p>
+
+<p>
+This branch contains the released Modelica version (e.g., version 3.0.1)
+where all bug fixes since this release date are included (up to a  new release,
+when becoming available; i.e., after a new release, the previous maintenance
+versions are no longer changed).
+These bug fixes might be not yet tested with all test cases or with
+other Modelica libraries. The goal is that a vendor may take this version at
+any time for a new release of its software, in order to incorporate the latest
+bug fixes, without changing the version number of the Modelica Standard Library.
+</p>
+
+<p>
+Incorporation of bug fixes (subversion \"commit\") shall be performed in the following way:
+</p>
+
+<ul>
+<li> One person is fixing the bug and another person is checking whether the
+         fix is fine.</li>
+<li> It is up to the library developer, whether he opens a new branch for
+         testing and then merges it with the \"head\" maintenance branch or not.</li>
+<li> Every change to the maintenance branch has to be done at the development
+         branch (see above) as well. One exception are pure changes to the
+         \"versionBuild\" annotation as these have no meaning in the development trunk.</li>
+<li> Every change to the maintenance branch requires introducing a
+         description of the bug fix under
+         Modelica.UsersGuide.ReleaseNotes.Version_&lt;release-number&gt;_BugFixes.</li>
+<li> Annotations \"version\" and \"versionDate\" must <u>not</u> be changed in a maintenance release.</li>
+<li> Every change to the maintenance branch requires changing the \"versionBuild\" number (incrementing it by one),
+     as well as the \"dateModified\" field.<br>
+     Example:
+         <pre>  annotation(version      = \"3.1\",
+             versionDate  = \"2009-06-22\",
+             versionBuild = 3,
+             dateModified = \"2009-08-28 07:40:19Z\",
+             revisionId   = \"$I&#8203;d::                                       $\")</pre>
+     The \"revisionId\" field is a bit special though. If written like in the example above it will be automatically
+     expanded to:
+        <pre>             revisionId   = \"$I&#8203;d:: package.mo 2879 2009-08-28 07:40:19Z #$\"</pre>
+     by the subversion checkout procedure.</li>
+<li> If time does not permit, a vendor makes the bug fix in its local version
+         and then has to include it in the maintenance version. It would be best to make these
+         changes at a new branch in order to get a unique release number.</li>
+</ul>
+
+<p>
+A valid \"commit\" to the maintenance branch may contain one or
+more of the following changes.
+</p>
+
+<ul>
+<li> Correcting an equation.</li>
+<li> Correcting attributes quantity/unit/defaultUnit in a declaration.</li>
+<li> Improving/fixing the documentation.</li>
+<li> Introducing a new name in the public section of a class
+         (model, package, ...) or in any section of a partial class is <b>not</b> allowed.
+         Since otherwise, a user might use this new name and when storing its model
+         and loading it with an older build-version, an error would occur.</li>
+<li> Introducing a new name in the protected section of a non-partial
+         class should only be done if absolutely necessary to fix a bug.
+         The problem is that this might be non-backward compatible,
+         because a user might already extend from this class and already using the same name.</li>
+</ul>
+</html>"));
+end VersionManagement;
+
+class Version_3_2_2 "Version 3.2.2 (April 3, 2016)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+<p>
+Version 3.2.2 is backward compatible to version 3.2.1, that is models developed with
+versions 3.0, 3.0.1, 3.1, 3.2, or 3.2.1 will work without any changes also with version 3.2.2
+(with exception of the, usually uncritical, non-backwards compatible changes listed below with regards to
+external object libraries, and one bug fix introduced in 3.2.1 Build.3 for non-circular pipes
+that can be non-backwards compatible if a user constructed a new pipe model based on
+Modelica.Fluid.Pipes.BaseClasses.WallFriction.PartialWallFriction, see details below).
+</p>
+
+<ul>
+<li> This version of the Modelica package is <b>fully compatible</b> to
+     Modelica Specification <b>3.2 revision 2</b>.<br>&nbsp;
+     </li>
+
+<li> About <b>240</b> tickets have been fixed in this release and the previous maintenance releases:
+     <ul>
+     <li> <b>Version 3.2.1 Build.3</b> (July 30, 2015) with respect to 3.2.1 Build.2 (August 14, 2013):<br>
+          About <a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.1/ResolvedTracTickets-build-3.html\">103 tickets</a>
+          have been fixed for this maintenance release.<br>&nbsp; </li>
+
+     <li> <b>Version 3.2.1 Build.4</b> (September 30, 2015) with respect to 3.2.1 Build.3 (July 30, 2015):
+          <ul>
+            <li> About <a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.1/ResolvedTracTickets-build-4.html\">10 tickets</a>
+                 have been fixed for this maintenance release. Critical tickets:</li>
+
+            <li> Ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1768\">1768</a>
+                 fixes an issue with block <a href=\"modelica://Modelica.Blocks.Sources.CombiTimeTable\">CombiTimeTable</a>
+                 (wrong output when using fixed time step integrator with time step greater than table resolution).</li>
+
+            <li> Ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1758\">1758</a>
+                 states that simulation of
+                 <a href=\"modelica://Modelica.Fluid.Examples.HeatingSystem\">Modelica.Fluid.Examples.HeatingSystem</a>
+                 fails in Dymola 2016 if option \"pedantic mode for checking Modelica semantics\" is set.
+                 This issue was not fixed in the library due to the following reasons:<br>
+                 The Modelica.Fluid library uses a particular pattern to define some parameters resulting
+                 in a cyclic dependency of parameters if only incident information is taken into account.
+                 According to Modelica Specification 3.2 revision 2 this is not allowed
+                 (and therefore Dymola 2016 correctly reports errors if the pedantic flag is set).
+                 In ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1320\">1320</a>
+                 this issue was resolved for Modelica Specification 3.3 revision 1 by allowing
+                 cyclic parameter definitions if the cycles disappear when evaluating parameters
+                 that have annotation Evaluate=true. Modelica.Fluid is correct with respect
+                 to Modelica Specification 3.3 revision 1.
+                 Changing the Modelica.Fluid library for 3.2.1 build.4 so that no cyclic parameter dependencies
+                 would be present anymore would (a) result in a non-backwards compatible
+                 change and (b) make the usage of Modelica.Fluid less convenient. For this
+                 reason Modelica.Fluid is not changed. (Practically, this means for example that
+                 the pedantic flag in Dymola 2016 needs to be switched off, when using the
+                 Modelica.Fluid library in version 3.2.1 build 4 and any previous version).</li>
+
+            <li> In ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1757\">1757</a> it is (correctly) stated
+                 that the example model <a href=\"modelica://Modelica.Media.Air.MoistAir.PsychrometricData\">PsychrometricData</a>
+                 was moved to another location and that this is a non-backwards compatible change.
+                 This non-backwards compatible change is accepted, because it fixes a circular depedency (a model references
+                 a package in which it resides), for details see ticket
+                 <a href=\"https://trac.modelica.org/Modelica/ticket/1679\">1679</a>.
+                 Fixing this ticket is seen as of much higher priority, as the small drawback that
+                 an example model is moved (and the probability is very high that this moved model is not
+                 used in any user model).<br>&nbsp;
+                </li>
+          </ul>
+     </li>
+     <li> <b>Version 3.2.2 Build.2</b> (March 16, 2016) with respect to 3.2.1 Build.4 (September 30, 2015):<br>
+          About <a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.2/ResolvedTracTickets.html\">130 tickets</a>
+          have been fixed for this release.<br>
+          The ModelicaStandardTables object library (.lib, .dll, .a, .so, depending on tool) has
+          been split into the libraries <b>ModelicaStandardTables</b>, <b>ModelicaMatIO</b>, <b>zlib</b> and the new
+          object library <b>ModelicaIO</b> has been added.<br>
+          For a <b>tool vendor</b> this can be a non-backwards compatible change if the same object libraries have been used in the past
+          for different releases of package Modelica.
+          In <a href=\"modelica://Modelica/Resources/C-sources/_readme.txt\">Resources/C-sources/_readme.txt</a>
+          the issue is explained in detail and how to resolve it.
+          For a <b>user</b> this might be a non-backwards compatible change if he/she implemented an
+          own external C interface function to one of the functions in the ModelicaStandardTables,
+          ModelicaMatIO or zlib libraries. In this case, the library annotations to these functions need to be
+          adapted.<br>&nbsp;</li>
+     </ul>
+</li>
+<li> In version 3.2.1 Build.3 a new argument crossArea was introduced in the functions of
+Modelica.Fluid.Pipes.BaseClasses.WallFriction.PartialWallFriction to fix a subtle bug for the
+calculation of pipe friction for non-circular pipes, see <a href=\"https://trac.modelica.org/Modelica/ticket/1601\">#1601</a>
+and <a href=\"https://trac.modelica.org/Modelica/ticket/1656\">#1656</a>.
+If a user utilized a pipe model of Modelica.Fluid.Pipes, this does not matter because the pipe models have been
+improved in a fully backwards compatible way. However, if the user constructed an own pipe model based on
+the partial package PartialWallFriction and calls the functions defined in PartialWallFriction with
+positional (and not named) arguments, then a unit warning or error will occur (depending on the tool
+and tool-specific settings) because the new argument crossArea has unit [m2] and the previous
+argument at this place, roughness, has unit [m]. If the warning is ignored, the simulation result
+will be wrong, because the crossArea is used as roughness. The user needs to fix this by
+adapting his/her pipe model so that the crossArea is used in the function calls,
+or by using named function arguments.
+</li>
+</ul>
+
+<p>
+The exact difference between package Modelica version 3.2.2 and version 3.2.1 is
+summarized in the following two comparison tables:
+</p>
+<ul>
+<li><a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.2/Differences322To321Build4.html\">Difference 3.2.2 to 3.2.1 Build 4</a>, </li>
+<li><a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.2/Differences321Build4toBuild2.html\">Difference 3.2.1 Build 4 to 3.2.1 Build 2</a>.</li>
+</ul>
+
+<p>
+This release of package Modelica, and the accompanying ModelicaTest, has been tested with the
+following tools (the tools are listed alphabetically. At the time of the test, some of the
+tools might not yet supported the complete Modelica package. For more details of the tests
+see <a href=\"https://trac.modelica.org/Modelica/ticket/1867\">#1867</a>):
+</p>
+
+<ul>
+<li> <b>Dymola 2017 Beta.1</b> (Windows 64 bit, \"Check\" with pedantic flag, that is checking strict
+     Modelica compliance, and \"Check with Simulation\").<br>
+     <a href=\"https://trac.modelica.org/Modelica/ticket/1924\">#1924</a>:
+     Regression testing of 3.2.2+build.0-beta.2 using Dymola 2017 Dev 4 with respect to
+     3.2.1+build.4 reference files<br>
+     <a href=\"https://trac.modelica.org/Modelica/ticket/1949\">#1949</a>:
+     Regression testing of 3.2.2+build.0-beta.3 using Dymola 2017 Beta 1 with respect to
+     3.2.1+build.4 reference files</li>
+<li> <b>LMS Imagine.Lab Amesim 14.2</b> and <b>LMS Imagine.Lab Amesim 15 (development build)</b>.
+     No previously unreported regressions have been detected.</li>
+<li> <b>Maplesim Parser</b></li>
+<li> <b>OpenModelica 1.9.4 Beta.2</b> (Windows, Linux, Mac)<br>
+     <a href=\"https://test.openmodelica.org/hudson/job/MSL_trunk_Compilation/\">Compilation</a> of models of 3.2.2.<br>
+     <a href=\"https://test.openmodelica.org/hudson/job/MSL_trunk_cpp_Simulation/\">Simulation</a> of models of 3.2.2.<br>
+     <a href=\"https://test.openmodelica.org/libraries/MSL_trunk/BuildModelRecursive.html\">Regression testing</a> of 3.2.2 using OpenModelica 1.9.4 with respect
+     to 3.2.1+build.4 reference files.</li>
+     </li>
+</ul>
+
+<p>
+The following Modelica packages have been tested that they work together with this release of package Modelica
+(alphabetical list):
+</p>
+
+<ul>
+<li>AirConditioning Library 1.12 (Modelon)</li>
+<li>Buildings 2.1.0 (LBNL)</li>
+<li>Electric Power Library 2.2.3 (Modelon)</li>
+<li>Engine Dynamics Library 1.2.5 (Modelon)</li>
+<li>FlexibleBodies 2.2 (DLR)</li>
+<li>FlightDynamics 1.0.1 (DLR)</li>
+<li>FluidDissipation 1.1.8 (XRG Simulation)</li>
+<li>Fuel Cell Library 1.3.3 (Modelon)</li>
+<li>Heat Exchanger Library 1.4.1 (Modelon)</li>
+<li>Human Comfort Library 2.1.0 (XRG Simulation)</li>
+<li>HVAC Library 2.1.0 (XRG Simulation)</li>
+<li>Hydraulics Library 4.4 (Modelon)</li>
+<li>Hydronics Library 2.1.0 (XRG Simulation)</li>
+<li>Hydro Power Library 2.6 (Modelon)</li>
+<li>Liquid Cooling Library 1.5 (Modelon)</li>
+<li>Modelica_Synchronous 0.92.1</li>
+<li>Modelica_LinearSystems2 2.3.4 </li>
+<li>Modelica_StateGraph2 2.0.3</li>
+<li>Optimization 2.2.2 (DLR)</li>
+<li>PowerTrain 2.4.0 (DLR)</li>
+<li>Pneumatics Library 2.0 (Modelon)</li>
+<li>Thermal Power Library 1.12 (Modelon)</li>
+<li>Vapor Cycle Library 1.3 (Modelon)</li>
+<li>Vehicle Dynamics Library 2.3 (Modelon)</li>
+</ul>
+
+
+<p><br>
+The following <b style=\"color:blue\">new libraries</b> have been added:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.PowerConverters\">Modelica.Electrical.PowerConverters</a></td>
+    <td valign=\"top\">
+    This library offers models for rectifiers, inverters and DC/DC-converters.<br>
+    (This library was developed by Christian Kral and Anton Haumer).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.QuasiStatic.FundamentalWave\">Modelica.Magnetic.QuasiStatic.FundamentalWave</a></td>
+    <td valign=\"top\">
+    This library provides quasi-static models of multiphase machines (induction machines, synchronous machines) in parallel (with the same parameters but different electric connectors)
+    to the transient models in <a href=\"modelica://Modelica.Magnetic.FundamentalWave\">Modelica.Magnetic.FundamentalWave</a>.<br>
+    Quasistatic means that electric transients are neglected, voltages and currents are supposed to be sinusoidal. Mechanical and thermal transients are taken into account.<br>
+    This library is especially useful in combination with the <a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a>
+    library in order to build up very fast simulations of electrical circuits with sinusoidal currents and voltages.<br>
+    (This library was developed by Christian Kral and Anton Haumer).
+    </td></tr>
+
+<tr><td valign=\"top\">Sublibraries of <a href=\"modelica://Modelica.Magnetic.FluxTubes\">Modelica.Magnetic.FluxTubes</a></td>
+    <td valign=\"top\">
+   New elements for modeling ferromagnetic (static) and eddy current (dynamic) hysteresis effects and permanent magnets have been added.
+   The FluxTubes.Material package is also extended to provide hysteresis data for several magnetic materials. These data is partly based on own measurements.
+   For modeling of ferromagnetic hysteresis, two different hystereses models have been implemented: The simple Tellinen model and the considerably
+   more detailed Preisach hysteresis model. The following packages have been added:
+  <ul>
+  <li><a href=\"Modelica.Magnetic.FluxTubes.UsersGuide.Hysteresis\">FluxTubes.UsersGuide.Hysteresis</a></li>
+  <li><a href=\"Modelica.Magnetic.FluxTubes.Examples.Hysteresis\">Fluxtubes.Examples.Hysteresis</a></li>
+  <li><a href=\"Modelica.Magnetic.FluxTubes.Shapes.HysteresisAndMagnets\">FluxTubes.Shapes.HysteresisAndMagnets</a></li>
+  <li><a href=\"Modelica.Magnetic.FluxTubes.Material.HysteresisEverettParameter\">FluxTubes.Material.HysteresisEverettParameter</a></li>
+  <li><a href=\"Modelica.Magnetic.FluxTubes.Material.HysteresisTableData\">FluxTubes.Material.HysteresisTableData</a></li>
+  </ul>
+    (These extensions have been developed by Johannes Ziske and Thomas B&ouml;drich as part of the <a href=\"http://www.cleansky.eu/\">Clean Sky</a> JTI project;
+     project number: 296369; Theme:
+   <a href=\"http://cordis.europa.eu/project/rcn/101194_en.html\">JTI-CS-2011-1-SGO-02-026</a>;
+   MOMOLIB - Modelica Model Library Development for Media, Magnetic Systems and Wavelets.
+     The partial financial support by the European Union for this development is highly appreciated.).
+    </td></tr>
+
+<tr><td valign=\"top\">Sublibraries for <b>noise</b> modeling</td>
+    <td valign=\"top\">
+   Several new sublibraries have been added allowing the modeling of reproducible noise.
+   The most important new sublibraries are (for more details see below):
+  <ul>
+  <li><a href=\"modelica://Modelica.Blocks.Noise\">Modelica.Blocks.Noise</a></li>
+  <li><a href=\"modelica://Modelica.Math.Random\">Modelica.Math.Random</a></li>
+  <li><a href=\"modelica://Modelica.Math.Distributions\">Modelica.Math.Distributions</a></li>
+  <li><a href=\"modelica://Modelica.Math.Special\">Modelica.Math.Special</a></li>
+  </ul>
+  (These extensions have been developed by  Andreas Kl&ouml;ckner, Frans van der Linden, Dirk Zimmer, and Martin Otter from
+  DLR Institute of System Dynamics and Control).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities\">Modelica.Utilities</a> functions for <b>matrix read/write</b></td>
+    <td valign=\"top\">
+   New functions are provided in the <a href=\"modelica://Modelica.Utilities.Streams\">Modelica.Utilities.Streams</a>
+   sublibrary to write matrices in MATLAB MAT format on file and read matrices in this format from file.
+   The MATLAB MAT formats v4, v6, v7 and v7.3 (in case the tool supports HDF) are supported by these functions.
+   Additionally, example models are provided under
+   <a href=\"modelica://Modelica.Utilities.Examples\">Modelica.Utilities.Examples</a>
+   to demonstrate the usage of these functions in models. For more details see below.<br>
+   (These extensions have been developed by Thomas Beutlich from ITI GmbH).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Math\">Modelica.Math</a> sublibrary for <b>FFT</b></td>
+    <td valign=\"top\">
+   The new sublibrary <a href=\"modelica://Modelica.Math.FastFourierTransform\">FastFourierTransform</a>
+   provides utility and convenience functions to compute the Fast Fourier Transform (FFT).
+   Additionally two examples are present to demonstrate how to compute an FFT during continuous-time
+   simulation and store the result on file. For more details see below.<br>
+  (These extensions have been developed by Martin Kuhn and Martin Otter from
+   DLR Institute of System Dynamics and Control).
+    </td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries:<br>
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Examples</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">NoiseExamples</td>
+    <td valign=\"top\"> Several examples to demonstrate the usage of the blocks in the
+                      new sublibrary Blocks.Noise.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Interfaces</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">PartialNoise</td>
+    <td valign=\"top\"> Partial noise generator (base class of the noise generators in Blocks.Noise)</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Math</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">ContinuousMean</td>
+    <td valign=\"top\"> Calculates the empirical expectation (mean) value of its input signal</td></tr>
+<tr><td valign=\"top\" width=\"150\">Variance</td>
+    <td valign=\"top\"> Calculates the empirical variance of its input signal</td></tr>
+<tr><td valign=\"top\" width=\"150\">StandardDeviation</td>
+    <td valign=\"top\"> Calculates the empirical standard deviation of its input signal</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Noise</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">GlobalSeed</td>
+    <td valign=\"top\"> Defines global settings for the blocks of sublibrary Noise,
+                      especially a global seed value is defined</td></tr>
+<tr><td valign=\"top\" width=\"150\">UniformNoise</td>
+    <td valign=\"top\"> Noise generator with uniform distribution</td></tr>
+<tr><td valign=\"top\" width=\"150\">NormalNoise</td>
+    <td valign=\"top\"> Noise generator with normal distribution</td></tr>
+<tr><td valign=\"top\" width=\"150\">TruncatedNormalNoise</td>
+    <td valign=\"top\"> Noise generator with truncated normal distribution</td></tr>
+<tr><td valign=\"top\" width=\"150\">BandLimitedWhiteNoise</td>
+    <td valign=\"top\"> Noise generator to produce band-limited white noise with normal distribution</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.ComplexBlocks.Examples</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">ShowTransferFunction</td>
+    <td valign=\"top\"> Example to demonstrate the usage of the block TransferFunction.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.ComplexBlocks.ComplexMath</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">TransferFunction</td>
+    <td valign=\"top\"> This block allows to define a complex transfer function (depending on frequency input w) to obtain the complex output y.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.ComplexBlocks.Sources</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">LogFrequencySweep</td>
+    <td valign=\"top\"> The logarithm of w performs a linear ramp from log10(wMin) to log10(wMax), the output is the decimal power of this logarithmic ramp.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.Examples.Utilities.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">SpringDamperNoRelativeStates</td>
+    <td valign=\"top\">Introduced to fix ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1375\">1375</a></td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.Components.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">ElastoBacklash2</td>
+    <td valign=\"top\">Alternative model of backlash. The difference to the existing ElastoBacklash
+    component is that an event is generated when contact occurs and that the contact torque
+    changes discontinuously in this case. For some user models, this variant of a backlash model
+    leads to significantly faster simulations.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Examples.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">NonCircularPipes</td>
+    <td valign=\"top\">Introduced to check the fix of ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1601\">1681</a></td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Media.Examples.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">PsychrometricData</td>
+    <td valign=\"top\">Introduced to fix ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1679\">1679</a></td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">balanceABC</td>
+    <td valign=\"top\"> Return a balanced form of a system [A,B;C,0]
+                      to improve its condition by a state transformation</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Random.Generators.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">Xorshift64star</td>
+    <td valign=\"top\"> Random number generator xorshift64*</td></tr>
+<tr><td valign=\"top\" width=\"150\">Xorshift128plus </td>
+    <td valign=\"top\"> Random number generator xorshift128+</td></tr>
+<tr><td valign=\"top\" width=\"150\">Xorshift1024star</td>
+    <td valign=\"top\"> Random number generator xorshift1024*</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Random.Utilities.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">initialStateWithXorshift64star</td>
+    <td valign=\"top\"> Return an initial state vector for a random number generator (based on xorshift64star algorithm)</td></tr>
+<tr><td valign=\"top\" width=\"150\">automaticGlobalSeed </td>
+    <td valign=\"top\"> Creates an automatic integer seed from the current time and process id (= impure function)</td></tr>
+<tr><td valign=\"top\" width=\"150\">initializeImpureRandom </td>
+    <td valign=\"top\"> Initializes the internal state of the impure random number generator</td></tr>
+<tr><td valign=\"top\" width=\"150\">impureRandom</td>
+    <td valign=\"top\"> Impure random number generator (with hidden state vector)</td></tr>
+<tr><td valign=\"top\" width=\"150\">impureRandomInteger </td>
+    <td valign=\"top\"> Impure random number generator for integer values (with hidden state vector)</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Distributions.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">Uniform</td>
+    <td valign=\"top\"> Library of uniform distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">Normal</td>
+    <td valign=\"top\"> Library of normal distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">TruncatedNormal </td>
+    <td valign=\"top\"> Library of truncated normal distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">Weibull</td>
+    <td valign=\"top\"> Library of Weibull distribution functions (functions: density, cumulative, quantile)</td></tr>
+<tr><td valign=\"top\" width=\"150\">TruncatedWeibull </td>
+    <td valign=\"top\"> Library of truncated Weibull distribution functions (functions: density, cumulative, quantile)</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Special.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">erf</td>
+    <td valign=\"top\">Error function erf(u) = 2/sqrt(pi)*Integral_0_u exp(-t^2)*d</td></tr>
+<tr><td valign=\"top\" width=\"150\">erfc</td>
+    <td valign=\"top\">Complementary error function erfc(u) = 1 - erf(u)</td></tr>
+<tr><td valign=\"top\" width=\"150\">erfInv</td>
+    <td valign=\"top\">Inverse error function: u = erf(erfInv(u))</td></tr>
+<tr><td valign=\"top\" width=\"150\">erfcInv </td>
+    <td valign=\"top\">Inverse complementary error function: u = erfc(erfcInv(u))</td></tr>
+<tr><td valign=\"top\" width=\"150\">sinc </td>
+    <td valign=\"top\">Unnormalized sinc function: sinc(u) = sin(u)/u</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.FastFourierTransform.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">realFFTinfo </td>
+    <td valign=\"top\">Print information about real FFT for given f_max and f_resolution</td></tr>
+<tr><td valign=\"top\" width=\"150\">realFFTsamplePoints </td>
+    <td valign=\"top\">Return number of sample points for a real FFT</td></tr>
+<tr><td valign=\"top\" width=\"150\">realFFT</td>
+    <td valign=\"top\">Return amplitude and phase vectors for a real FFT</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Utilities.Streams.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">readMatrixSize</td>
+    <td valign=\"top\">Read dimensions of a Real matrix from a MATLAB MAT file</td></tr>
+<tr><td valign=\"top\" width=\"150\">readRealMatrix</td>
+    <td valign=\"top\">Read Real matrix from MATLAB MAT file</td></tr>
+<tr><td valign=\"top\" width=\"150\">writeRealMatrix</td>
+    <td valign=\"top\">Write Real matrix to a MATLAB MAT file</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Utilities.Strings.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">hashString</td>
+    <td valign=\"top\">Creates a hash value of a String</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Utilities.System.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">getTime</td>
+    <td valign=\"top\">Retrieves the local time (in the local time zone)</td></tr>
+<tr><td valign=\"top\" width=\"150\">getPid</td>
+    <td valign=\"top\">Retrieves the current process id</td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">existing components</b> have been <b style=\"color:blue\">changed</b> in a <b style=\"color:blue\">non-backward compatible</b> way:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Electrical.Analog.Semiconductors.</b></td></tr>
+<tr><td valign=\"top\"> HeatingDiode </td>
+          <td valign=\"top\"> Removed protected variable k \"Boltzmann's constant\".<br>
+                            Calculate protected constant q \"Electron charge\" from already known constants instead of defining a protected variable q.</td></tr>
+<tr><td valign=\"top\"> HeatingNPN<br>
+                      HeatingPNP </td>
+          <td valign=\"top\"> Removed parameter K \"Boltzmann's constant\" and q \"Elementary electronic charge\".<br>
+                            Calculate instead protected constant q \"Electron charge\" from already known constants.<br>
+                            Users that have used these parameters might have broken their models;
+                            the (although formal non-backwards compatible) change offers the users a safer use.</td></tr>
+</table>
+
+</html>"));
+end Version_3_2_2;
+
+  extends Modelica.Icons.ReleaseNotes;
+
+class Version_3_2_1 "Version 3.2.1 (August 14, 2013)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+<p>
+Version 3.2.1 is backward compatible to version 3.2, that is models developed with
+versions 3.0, 3.0.1, 3.1, or 3.2 will work without any changes also with version 3.2.1.
+This version is a \"clean-up\" with major emphasis on quality improvement and
+tool compatibility. The goal is that all
+<a href=\"https://www.modelica.org/tools\">Modelica tools</a> will support this package
+and will interpret it in the same way. Short Overview:
+</p>
+
+<ul>
+<li> This version of the Modelica package is <b>fully compatible</b> to
+     Modelica Specification <b>3.2 revision 2</b>.<br>
+     (Especially, some operators used in package Modelica,
+     such as \"rooted\", have been standardized in 3.2 rev. 2,
+     as well as vendor specific annotations. Furthermore,
+     ambiguous/unclear descriptions in the specification have
+     been corrected/improved. One important improvement in packages
+     Modelica and ModelicaTest is that the initialization has been fully defined
+     in all example models, in order that all tools can produce the same result
+     without relying on tool heuristics).
+     </li>
+
+<li> About <a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.1/ResolvedTracTickets.html\">400 tickets</a>
+     have been fixed for this release, and
+     especially all compliance issues and all relevant defect issues.
+     </li>
+
+<li> An open source implementation of the <b>table blocks</b> has been provided
+     by <a href=\"http://www.itisim.com\">ITI GmbH</a>. This work has been
+     <a href=\"https://www.modelica.org/news_items/call-texts-to-improve-modelica-2012/2012-12-20-Call-for-quotation-for-MSL-tables.pdf/at_download/file\">paid by Modelica Association</a>.
+     As a result, all parts of package Modelica are now available
+     in a free implementation. Additionally new features have been added to the table blocks
+     by this implementation:
+     <ul>
+     <li>The table outputs can be differentiated once.</li>
+     <li>Support of binary MATLAB MAT-file formats v6 and v7</li>
+     <li>New option ConstantSegments for parameter Smoothness</li>
+     <li>New option NoExtrapolation for parameter Extrapolation</li>
+     <li>Support of tables provided in the C-Code (usertab.c, for realtime systems without file system)</li>
+     </ul></li>
+
+<li> <b>Icons</b> have been re-designed by Wolfram Research to provide a more modern view.</li>
+
+<li> The <b>Modelica.Media.Air.MoistAir</b> media model has been improved so that it
+     can be used in a temperature range of 190 ... 647 K (previously: 240 ... 400 K).</li>
+
+<li> New media models for air (<b>ReferenceAir</b> with a large operating range: 30 ... 2000 K,
+     0 ... 2000 MPa), for moist air (<b>ReferenceMoistAir</b> with a large operating range:
+     143.15 ... 2000 K, 0 .. 10 MPa;  but 1-2 orders of magnitude slower as
+     Modelica.Media.Air.MoistAir),
+     and the refrigerant <b>R134a</b> are included in the Modelica.Media library in order to
+     improve the modeling of air conditioning systems especially in aircraft.
+     These models have been developed by
+     <a href=\"http://www.xrg-simulation.de/\">XRG Simulation GmbH</a>
+     as part of the <a href=\"http://www.cleansky.eu/\">Clean Sky</a> JTI project
+     (Project number: 296369; Theme: JTI-CS-2011-1-SGO-02-026).
+     The partial financial support by the European Union for this development
+     is highly appreciated.</li>
+
+<li> <b>60</b> models and blocks and <b>90</b> functions are newly included, for details see below.</li>
+
+</ul>
+
+<p>
+This release of package Modelica, and the accompanying ModelicaTest, has been tested with the
+following tools (the tools are listed alphabetically. At the time of the test, some of the
+tools might not yet supported the complete Modelica package):
+</p>
+
+<ul>
+<li> CyModelica </li>
+<li> Dymola 2014 (Windows 64 bit)<br>
+     Regression test results with regards to Modelica 3.2 are available
+     in ticket <a href=\"https://trac.modelica.org/Modelica/ticket/1114\">#1114</a>.</li>
+<li> Dymola 2014 FD01 development with pedantic flag (Windows 64 bit)<br>
+     (\"pedantic flag\" means that strict Modelica compliance is checked.
+     Dymola 2014 fails with pedantic flag, e.g., because the annotation DocumentationClass
+     was not standardized when this version of Dymola was released).</li>
+<li> Maplesim Parser</li>
+<li> MWorks 3.2</li>
+<li> OpenModelica 1.9.0 Beta4+dev (Windows, Linux, Mac)<br>
+     Test reports for the daily builds are available
+     <a href=\"https://trac.openmodelica.org/OpenModelica/wiki\">here</a>.
+     Test reports of comparisons with Dymola result files are available
+     <a href=\"https://test.openmodelica.org/hudson/job/OpenModelica_TEST_CLANG/lastCompletedBuild/testReport/(root)/simulation_libraries_msl32/\">here</a>.
+     </li>
+<li> SimulationX 3.6</li>
+</ul>
+
+<p>
+The following Modelica packages have been tested that they work together with this release of package Modelica
+(alphabetical list):
+</p>
+
+<ul>
+<li> Buildings 1.4 (LBNL) </li>
+<li> FlexibleBodies 2.0.1 (DLR)</li>
+<li> Modelica_Synchronous 0.91 (DLR)</li>
+<li> Optimization 2.2 (DLR)</li>
+<li> PowerTrain 2.2.0 (DLR) </li>
+</ul>
+
+<p>
+The new open source tables have been tested by T. Beutlich (ITI):
+</p>
+
+<ul>
+<li> 193 Modelica test models for compatibility check with previous table implementation
+     (available in ModelicaTest.Tables).
+     Performed tests with SimulationX 3.5.707 (32 bit) and
+     Dymola 2013 FD01 (32 bit). Furthermore a basic check was performed in OpenModelica
+     to make sure it works in general.
+     </li>
+<li> The two C source files (Modelica/Resources/C-Sources/ModelicaStandardTables.c; ModelicaMatIO.c)
+     have been tested to successfully compile for the following platforms<br>
+     &nbsp;&nbsp;&nbsp;Windows 32 and 64 bit<br>
+     &nbsp;&nbsp;&nbsp;Linux 32 and 64 bit<br>
+     &nbsp;&nbsp;&nbsp;dSPACE SCALEXIO<br>
+     &nbsp;&nbsp;&nbsp;dSPACE DS1005 (no file system)<br>
+     &nbsp;&nbsp;&nbsp;dSPACE DS1006 (no file system)<br>
+     &nbsp;&nbsp;&nbsp;dSPACE DS1401 (no file system)
+     </li>
+<li> The following compilers/environments have been used for the platform evaluation<br>
+     &nbsp;&nbsp;&nbsp;Microsoft compilers (VC6 and &ge; VS2005 (Win32 and x64)) <br>
+     &nbsp;&nbsp;&nbsp;MinGW (GCC 4.4.0 and GCC 4.7.2)<br>
+     &nbsp;&nbsp;&nbsp;Cygwin (GCC 4.3.0)<br>
+     &nbsp;&nbsp;&nbsp;Open WATCOM 1.3<br>
+     &nbsp;&nbsp;&nbsp;LCC 2.4.1<br>
+     &nbsp;&nbsp;&nbsp;Borland C/C++ (free command line tools) 5.5<br>
+     &nbsp;&nbsp;&nbsp;GCC 4.x on Linux<br>
+     &nbsp;&nbsp;&nbsp;GCC 3.3.5 (for DS1006)<br>
+     &nbsp;&nbsp;&nbsp;Microtec PowerPC Compiler 3.7 (for DS1005)
+     </li>
+</ul>
+
+<p>
+The exact difference between package Modelica version 3.2 and version 3.2.1 is
+summarized in a
+<a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.1/DifferencesTo32.html\">comparison table</a>.
+</p>
+
+<p>
+About <b>400</b> trac tickets have been fixed for this release. An overview is given
+<a href=\"modelica://Modelica/Resources/Documentation/Version-3.2.1/ResolvedTracTickets.html\">here</a>.
+Clicking on a ticket gives all information about it.
+</p>
+
+
+<p><br>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Logical.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> RSFlipFlop</td>
+    <td valign=\"top\"> Basic RS flip flop</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> MinMax</td>
+    <td valign=\"top\">Output the minimum and the maximum element of the input vector </td></tr>
+<tr><td valign=\"top\" width=\"150\"> LinearDependency </td>
+    <td valign=\"top\">Output a linear combination of the two inputs </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Nonlinear.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> SlewRateLimiter</td>
+    <td valign=\"top\"> Limit the slew rate of a signal </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Memories</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> DLATRAM</td>
+    <td valign=\"top\"> Level sensitive Random Access Memory </td></tr>
+<tr><td valign=\"top\" width=\"150\"> DLATROM</td>
+    <td valign=\"top\"> Level sensitive Read Only Memory </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Multiplexers</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> MUX2x1</td>
+    <td valign=\"top\"> A two inputs MULTIPLEXER for multiple value logic (2 data inputs, 1 select input, 1 output) </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Examples.AsynchronousInductionMachines.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> AIMC_Initialize </td>
+    <td valign=\"top\"> Steady-State Initialization example of AsynchronousInductionMachineSquirrelCage </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> SMPM_VoltageSource </td>
+    <td valign=\"top\"> PermanentMagnetSynchronousInductionMachine example fed by FOC </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Examples.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> TestSensors </td>
+    <td valign=\"top\"> Example for multiphase quasiRMS sensors: A sinusoidal source feeds a load consisting of resistor and inductor </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Sensors.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> VoltageQuasiRMSSensor </td>
+    <td valign=\"top\"> Continuous quasi voltage RMS sensor for multi phase system </td></tr>
+<tr><td valign=\"top\" width=\"150\"> CurrentQuasiRMSSensor </td>
+    <td valign=\"top\"> Continuous quasi current RMS sensor for multi phase system </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Blocks.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> QuasiRMS </td>
+    <td valign=\"top\"> Determine quasi RMS value of a multi-phase system </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Functions.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> quasiRMS </td>
+    <td valign=\"top\"> Calculate continuous quasi RMS value of input </td></tr>
+<tr><td valign=\"top\" width=\"150\"> activePower </td>
+    <td valign=\"top\"> Calculate active power of voltage and current input </td></tr>
+<tr><td valign=\"top\" width=\"150\"> symmetricOrientation </td>
+    <td valign=\"top\"> Orientations of the resulting fundamental wave field phasors </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Spice3.Examples.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> CoupledInductors<br>
+                                      CascodeCircuit<br>
+                                      Spice3BenchmarkDifferentialPair<br>
+                                      Spice3BenchmarkMosfetCharacterization<br>
+                                      Spice3BenchmarkRtlInverter<br>
+                                      Spice3BenchmarkFourBitBinaryAdder</td>
+    <td valign=\"top\"> Spice3 examples and benchmarks from the SPICE3 Version e3 User's Manual </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Spice3.Basic.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> K_CoupledInductors</td>
+    <td valign=\"top\"> Inductive coupling via coupling factor K </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Spice3.Semiconductors.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> M_NMOS2 <br>
+                                      M_PMOS2 <br>
+                                      ModelcardMOS2</td>
+    <td valign=\"top\">  N/P channel MOSFET transistor with fixed level 2 </td></tr>
+<tr><td valign=\"top\" width=\"150\"> J_NJFJFE <br>
+                                      J_PJFJFE <br>
+                                      ModelcardJFET</td>
+    <td valign=\"top\">  N/P-channel junction field-effect transistor </td></tr>
+<tr><td valign=\"top\" width=\"150\"> C_Capacitor <br>
+                                      ModelcardCAPACITOR</td>
+    <td valign=\"top\">  Semiconductor capacitor model </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> AIMC_DOL_MultiPhase<br>
+                                      AIMS_Start_MultiPhase<br>
+                                      SMPM_Inverter_MultiPhase<br>
+                                      SMEE_Generator_MultiPhase<br>
+                                      SMR_Inverter_MultiPhase</td>
+    <td valign=\"top\"> Multi-phase machine examples </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Sensors.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> MassFractions<br>
+                                      MassFractionsTwoPort</td>
+    <td valign=\"top\"> Ideal mass fraction sensors </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Media.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\">R134a</td>
+    <td valign=\"top\"> R134a (Tetrafluoroethane) medium model in the range (0.0039 bar .. 700 bar,
+    169.85 K .. 455 K)</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Media.Air.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> ReferenceAir</td>
+    <td valign=\"top\"> Detailed dry air model with a large operating range (130 ... 2000 K, 0 ... 2000 MPa)
+                        based on Helmholtz equations of state</td></tr>
+<tr><td valign=\"top\" width=\"150\"> ReferenceMoistAir</td>
+    <td valign=\"top\"> Detailed moist air model (143.15 ... 2000 K)</td></tr>
+<tr><td valign=\"top\" width=\"150\"> MoistAir</td>
+    <td valign=\"top\"> Temperature range of functions of MoistAir medium enlarged from
+                        240 - 400 K to  190 - 647 K.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Media.Air.MoistAir.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> velocityOfSound<br>
+                                      isobaricExpansionCoefficient<br>
+                                      isothermalCompressibility<br>
+                                      density_derp_h<br>
+                                      density_derh_p<br>
+                                      density_derp_T<br>
+                                      density_derT_p<br>
+                                      density_derX<br>
+                                      molarMass<br>
+                                      T_psX<br>
+                                      setState_psX<br>
+                                      s_pTX<br>
+                                      s_pTX_der<br>
+                                      isentropicEnthalpy</td>
+    <td valign=\"top\"> Functions returning additional properties of the moist air medium model</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Thermal.HeatTransfer.Components.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> ThermalResistor</td>
+    <td valign=\"top\"> Lumped thermal element transporting heat without storing it (dT = R*Q_flow) </td></tr>
+<tr><td valign=\"top\" width=\"150\"> ConvectiveResistor</td>
+    <td valign=\"top\"> Lumped thermal element for heat convection (dT = Rc*Q_flow) </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.MultiBody.Examples.Constraints.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> PrismaticConstraint <br>
+                        RevoluteConstraint<br>
+                        SphericalConstraint<br>
+                        UniversalConstraint</td>
+    <td valign=\"top\"> Demonstrates the use of the new Joints.Constraints joints by comparing
+                        them with the standard joints.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.MultiBody.Joints.Constraints.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> Prismatic <br>
+                        Revolute<br>
+                        Spherical<br>
+                        Universal</td>
+    <td valign=\"top\"> Joint elements formulated as kinematic constraints. These elements are
+                        designed to break kinematic loops and result usually in numerically more
+                        efficient and reliable loop handling as the (standard) automatic handling.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> MultiSensor</td>
+    <td valign=\"top\"> Ideal sensor to measure the torque and power between two flanges and the absolute angular velocity </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Translational.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> MultiSensor</td>
+    <td valign=\"top\"> Ideal sensor to measure the absolute velocity, force and power between two flanges </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> isPowerOf2</td>
+    <td valign=\"top\"> Determine if the integer input is a power of 2 </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Math.Vectors.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> normalizedWithAssert</td>
+    <td valign=\"top\"> Return normalized vector such that length = 1 (trigger an assert for zero vector) </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Math.BooleanVectors.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> countTrue</td>
+    <td valign=\"top\"> Returns the number of true entries in a Boolean vector  </td></tr>
+<tr><td valign=\"top\" width=\"150\"> enumerate</td>
+    <td valign=\"top\"> Enumerates the true entries in a Boolean vector (0 for false entries) </td></tr>
+<tr><td valign=\"top\" width=\"150\"> index</td>
+    <td valign=\"top\"> Returns the indices of the true entries of a Boolean vector</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Utilities.Files.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> loadResource</td>
+    <td valign=\"top\"> Return the absolute path name of a URI or local file name  </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.SIunits.</b></td></tr>
+<tr><td valign=\"top\" width=\"150\"> PressureDifference<br>
+                        MolarDensity<br>
+                        MolarEnergy<br>
+                        MolarEnthalpy<br>
+                        TimeAging<br>
+                        ChargeAging<br>
+                        PerUnit<br>
+                        DerPressureByDensity<br>
+                        DerPressureByTemperature</td>
+    <td valign=\"top\"> New SI unit types </td></tr>
+</table>
+</html>"));
+end Version_3_2_1;
+
+class Version_3_2 "Version 3.2 (Oct. 25, 2010)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p>
+Version 3.2 is backward compatible to version 3.1, i.e., models developed with
+versions 3.0, 3.0.1, or 3.1 will work without any changes also with version 3.2.
+This version is a major improvement:
+</p>
+
+<ul>
+<li> <b>357</b> models and blocks and <b>295</b> functions are newly included.</li>
+
+<li><b>7</b> new libraries are included.</li>
+
+<li> The icons of the library are newly designed to provide a modern, unified view,
+     see <a href=\"modelica://Modelica.Icons\">Modelica.Icons</a>.</li>
+
+<li> All non-Modelica files, such as images, pdf-files, C-source files,
+     scripts are moved to the new directory \"Modelica\\Resources\".
+     Furthermore, all file references are changed to URIs as introduced in
+     Modelica 3.1 (e.g., a file with the file name
+     \"Modelica/Resources/Images/xxx\" is referenced as
+     \"modelica://Modelica/Resources/Images/xxx\").</li>
+
+<li> All physical models that dissipate heat (such as electrical elements,
+     electrical machines, bearings, dampers, etc.), have now an optional heat port
+     to which the dissipated energy is flowing, if activated.
+     This will significantly improve design studies about the thermal efficiency
+     of technical systems.</li>
+
+<li> All electrical machines in the
+     <a href=\"modelica://Modelica.Electrical.Machines\">Machines</a>
+     library have now a \"Losses\" tab in the parameter menu to optionally
+     model machines losses such as frictional losses, stator core losses
+     or stray load losses, respectively.</li>
+
+<li> All electrical machines in the
+     <a href=\"modelica://Modelica.Electrical.Machines\">Machines</a>
+     library have now a \"powerBalance\" result record,
+     summarizing converted power and losses.</li>
+</ul>
+
+<p>
+Version 3.2 is slightly based on the Modelica Specification 3.2. It uses
+the following new language elements (compared to Modelica Specification 3.1):
+</p>
+
+<ul>
+<li> Operator records and overloaded operators.</li>
+<li> Functions as input arguments to functions.</li>
+<li> Improved expandable connectors (variables declared in expandable
+     connectors are ignored if not referenced).</li>
+</ul>
+
+<p>
+A large part of the new classes have been developed with
+partial financial support by
+<a href=\"http://www.bmbf.de/en/index.php\">BMBF</a>
+(BMBF F&ouml;rderkennzeichen: 01IS07022F)
+within the <a href=\"http://www.itea2.org\">ITEA2</a> project
+EUROSYSLIB.
+We highly appreciate this funding.
+</p>
+
+<p>
+The following <b style=\"color:blue\">new libraries</b> have been added:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><a href=\"modelica://Complex\">Complex</a></td>
+    <td valign=\"top\">
+    This is a top-level record outside of the Modelica Standard Library.
+    It is used for complex numbers and contains overloaded operators.
+    From a users point of view, Complex is used in a similar way as the
+    built-in type Real. Example:<br>
+    <code>&nbsp;  Real     a    = 2;</code><br>
+    <code>&nbsp;  Complex  j    = Modelica.ComplexMath.j;</code><br>
+    <code>&nbsp;  Complex  b    = 2 + 3*j;</code><br>
+    <code>&nbsp;  Complex  c    = (2*b + a)/b;</code><br>
+    <code>&nbsp;  Complex  d    = Modelica.ComplexMath.sin(c);</code><br>
+    <code>&nbsp;  Complex  v[3] = {b/2, c, 2*d};</code><br>
+    (This library was developed by Marcus Baur, DLR).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.ComplexBlocks\">Modelica.ComplexBlocks</a></td>
+    <td valign=\"top\">
+    Library of basic input/output control blocks with Complex signals.<br>
+    This library is especially useful in combination with the new
+    <a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a>
+    library in order to build up very fast simulations of electrical circuits with periodic
+    currents and voltages.<br>
+    (This library was developed by Anton Haumer).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a></td>
+    <td valign=\"top\">
+    Library for quasi-stationary electrical singlephase and multiphase AC simulation.<br>
+    This library allows very fast simulations of electrical circuits with sinusoidal
+    currents and voltages by only taking into account the quasi-stationary, periodic part
+    and neglecting non-periodic transients.<br>
+    (This library was developed by Anton Haumer and Christian Kral).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Spice3\">Modelica.Electrical.Spice3</a></td>
+    <td valign=\"top\">
+    Library with components of the Berkeley
+    <a href=\"http://bwrc.eecs.berkeley.edu/Classes/IcBook/SPICE/\">SPICE3</a>
+    simulator:<br>
+    R, C, L, controlled and independent sources, semiconductor device models
+    (MOSFET Level 1, Bipolar junction transistor, Diode, Semiconductor resistor).
+    The components have been intensively tested with more than 1000 test models
+    and compared with results from the SPICE3 simulator. All test models give identical
+    results in Dymola 7.4 with respect to the Berkeley SPICE3 simulator up to the relative
+    tolerance of the integrators.<br>
+    This library allows detailed simulations of electronic circuits.
+    Work on Level 2 SPICE3 models, i.e., even more detailed models, is under way.
+    Furthermore, a pre-processor is under development to transform automatically
+    a SPICE netlist into a Modelica model, in order that the many available
+    SPICE3 models can be directly used in a Modelica model.<br>
+    (This library was developed by Fraunhofer Gesellschaft, Dresden).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FundamentalWave\">Modelica.Magnetic.FundamentalWave</a></td>
+    <td valign=\"top\">
+     Library for magnetic fundamental wave effects in electric machines for the
+     application in three phase electric machines.
+     The library is an alternative approach to the Modelica.Electrical.Machines library.
+     A great advantage of this library is the strict object orientation of the
+     electrical and magnetic components that the electric machines models are composed of.
+     This allows an easier incorporation of more detailed physical effects of
+     electrical machines.
+     From a didactic point of view this library is very beneficial for students in the field
+     of electrical engineering.<br>
+     (This library was developed by Christian Kral and Anton Haumer, using
+     ideas and source code of a library from Michael Beuschel from 2000).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Fluid.Dissipation\">Modelica.Fluid.Dissipation</a></td>
+    <td valign=\"top\">
+     Library with functions to compute convective heat transfer and pressure loss characteristics.<br>
+     (This library was developed by Thorben Vahlenkamp and Stefan Wischhusen from
+     XRG Simulation GmbH).
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.ComplexMath\">Modelica.ComplexMath</a></td>
+    <td valign=\"top\">
+    Library of complex mathematical functions (e.g., sin, cos) and of functions operating
+    on complex vectors.<br>
+    (This library was developed by Marcus Baur from DLR-RM, Anton Haumer, and
+     HansJ&uuml;rg Wiesmann).
+    </td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.UsersGuide</b></td></tr>
+<tr><td valign=\"top\"> Conventions
+                      </td>
+    <td valign=\"top\"> Considerably improved 'Conventions' for the Modelica Standard Library.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Examples</b></td></tr>
+<tr><td valign=\"top\"> Filter<br>
+                      FilterWithDifferentation<br>
+                      FilterWithRiseTime<br>
+                      RealNetwork1<br>
+                      IntegerNetwork1<br>
+                      BooleanNetwork1<br>
+                      Interaction1
+                      </td>
+    <td valign=\"top\"> Examples for the newly introduced block components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Continuous</b></td></tr>
+<tr><td valign=\"top\"> Filter </td>
+    <td valign=\"top\"> Continuous low pass, high pass, band pass and band stop
+                      IIR-filter of type CriticalDamping, Bessel, Butterworth and Chebyshev I.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Interaction.Show</b></td></tr>
+<tr><td valign=\"top\"> RealValue<br>
+                      IntegerValue<br>
+                      BooleanValue</td>
+    <td valign=\"top\"> Blocks to show the values of variables in a diagram animation.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Interfaces</b></td></tr>
+<tr><td valign=\"top\"> RealVectorInput<br>
+                      IntegerVectorInput<br>
+                      BooleanVectorInput<br>
+                      PartialRealMISO<br>
+                      PartialIntegerSISO<br>
+                      PartialIntegerMISO<br>
+                      PartialBooleanSISO_small<br>
+                      PartialBooleanMISO
+                      </td>
+    <td valign=\"top\"> Interfaces and partial blocks for the new block components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Math</b></td></tr>
+<tr><td valign=\"top\"> MultiSum<br>
+                      MultiProduct<br>
+                      MultiSwitch </td>
+    <td valign=\"top\"> Sum, product and switch blocks with 1,2,...,N inputs
+                      (based on connectorSizing annotation to handle vectors of
+                       connectors in a convenient way).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.MathInteger</b></td></tr>
+<tr><td valign=\"top\"> MultiSwitch<br>
+                      Sum<br>
+                      Product<br>
+                      TriggeredAdd</td>
+    <td valign=\"top\"> Mathematical blocks for Integer signals.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Boolean</b></td></tr>
+<tr><td valign=\"top\"> MultiSwitch<br>
+                      And<br>
+                      Or<br>
+                      Xor<br>
+                      Nand<br>
+                      Nor<br>
+                      Not<br>
+                      RisingEdge<br>
+                      FallingEdge<br>
+                      ChangingEdge<br>
+                      OnDelay</td>
+    <td valign=\"top\"> Mathematical blocks for Boolean signals.
+                      Some of these blocks are available also in library
+                      <a href=\"modelica://Modelica.Blocks.Logical\">Logical</a>.
+                      The new design is based on the connectorSizing annotation that allows
+                      the convenient handling of an arbitrary number of input signals
+                      (e.g., the \"And\" block has 1,2,...,N inputs, instead of only 2 inputs
+                      in the <a href=\"modelica://Modelica.Blocks.Logical\">Logical</a> library).
+                      Additionally, the icons are smaller so that the diagram area is
+                      better utilized</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Sources</b></td></tr>
+<tr><td valign=\"top\"> RadioButtonSource</td>
+    <td valign=\"top\"> Boolean signal source that mimics a radio button.</td></tr>
+<tr><td valign=\"top\"> IntegerTable</td>
+    <td valign=\"top\"> Generate an Integer output signal based on a table matrix
+                      with [time, yi] values.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Examples</b></td></tr>
+<tr><td valign=\"top\"> SimpleTriacCircuit,<br>
+                      IdealTriacCircuit,<br>
+                      AD_DA_conversion </td>
+    <td valign=\"top\"> Examples for the newly introduced Analog components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Ideal</b></td></tr>
+<tr><td valign=\"top\"> IdealTriac,<br>
+                      AD_Converter,<br>
+                      DA_Converter </td>
+    <td valign=\"top\"> AD and DA converter, ideal triac (based on ideal thyristor).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Semiconductors</b></td></tr>
+<tr><td valign=\"top\"> SimpleTriac </td>
+    <td valign=\"top\"> Simple triac based on semiconductor thyristor model.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Examples</b></td></tr>
+<tr><td valign=\"top\">  Delay_example,<br>
+                       DFFREG_example,<br>
+                       DFFREGL_example,<br>
+                       DFFREGSRH_example,<br>
+                       DFFREGSRL_example,<br>
+                       DLATREG_example,<br>
+                       DLATREGL_example,<br>
+                       DLATREGSRH_example,<br>
+                       DLATREGSRL_example,<br>
+                       NXFER_example,<br>
+                       NRXFER_example,<br>
+                       BUF3S_example,<br>
+                       INV3S_example,<br>
+                       WiredX_example </td>
+    <td valign=\"top\"> Examples for the newly introduced Digital components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Interfaces</b></td></tr>
+<tr><td valign=\"top\"> UX01,<br>
+                      Strength,<br>
+                      MIMO </td>
+    <td valign=\"top\"> Interfaces for the newly introduced Digital components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Tables</b></td></tr>
+<tr><td valign=\"top\"> ResolutionTable,<br>
+                      StrengthMap,<br>
+                      NXferTable,<br>
+                      NRXferTable,<br>
+                      PXferTable,<br>
+                      PRXferTable,<br>
+                      Buf3sTable,<br>
+                      Buf3slTable </td>
+    <td valign=\"top\"> New Digital table components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Delay</b></td></tr>
+<tr><td valign=\"top\"> InertialDelaySensitiveVector </td>
+    <td valign=\"top\"> New Digital delay component.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Registers</b></td></tr>
+<tr><td valign=\"top\"> DFFR,<br>
+                      DFFREG,<br>
+                      DFFREGL,<br>
+                      DFFSR,<br>
+                      DFFREGSRH,<br>
+                      DFFREGSRL,<br>
+                      DLATR,<br>
+                      DLATREG,<br>
+                      DLATREGL,<br>
+                      DLATSR,<br>
+                      DLATREGSRH,<br>
+                      DLATREGSRL </td>
+    <td valign=\"top\"> Various register components (collection of flipflops and latches)
+                      according to the VHDL standard.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Tristates</b></td></tr>
+<tr><td valign=\"top\"> NXFERGATE,<br>
+                      NRXFERGATE,<br>
+                      PXFERGATE,<br>
+                      PRXFERGATE,<br>
+                      BUF3S,<br>
+                      BUF3SL,<br>
+                      INV3S,<br>
+                      INV3SL,<br>
+                      WiredX </td>
+    <td valign=\"top\"> Transfer gates, buffers, inverters and wired node.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Basic</b></td></tr>
+<tr><td valign=\"top\"> MutualInductor </td>
+    <td valign=\"top\"> Multi phase inductor providing a mutual inductance matrix model.</td></tr>
+<tr><td valign=\"top\"> ZeroInductor </td>
+    <td valign=\"top\"> Multi phase zero sequence inductor.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines</b></td></tr>
+<tr><td valign=\"top\"> Examples </td>
+    <td valign=\"top\"> Structured according to machine types:<br>
+                      AsynchronousInductionMachines<br>
+                      SynchronousInductionMachines<br>
+                      DCMachines<br>
+                      Transformers </td></tr>
+<tr><td valign=\"top\"> Losses.* </td>
+    <td valign=\"top\"> Parameter records and models for losses in electrical machines and transformers (where applicable): <br>
+                      Friction losses <br>
+                      Brush losses <br>
+                      Stray Load losses <br>
+                      Core losses (only eddy current losses but no hysteresis losses; not for transformers) </td></tr>
+<tr><td valign=\"top\"> Thermal.* </td>
+    <td valign=\"top\"> Simple thermal ambients, to be connected to the thermal ports of machines, <br>
+                      as well as material constants and utility functions.</td></tr>
+<tr><td valign=\"top\"> Icons.* </td>
+    <td valign=\"top\"> Icons for transient and quasistationary electrical machines and transformers.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Examples.AsynchronousInductionMachines.</b></td></tr>
+<tr><td valign=\"top\"> AIMC_withLosses </td>
+    <td valign=\"top\"> Asynchronous induction machine with squirrel cage with losses </td></tr>
+<tr><td valign=\"top\"> AIMC_Transformer </td>
+    <td valign=\"top\"> Asynchronous induction machine with squirrel cage - transformer starting </td></tr>
+<tr><td valign=\"top\"> AIMC_withLosses </td>
+    <td valign=\"top\"> Test example of an asynchronous induction machine with squirrel cage with losses </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.</b></td></tr>
+<tr><td valign=\"top\"> SMPM_CurrentSource </td>
+    <td valign=\"top\"> Permanent magnet synchronous induction machine fed by a current source </td></tr>
+<tr><td valign=\"top\"> SMEE_LoadDump </td>
+    <td valign=\"top\"> Electrical excited synchronous induction machine with voltage controller </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Examples.DCMachines.</b></td></tr>
+<tr><td valign=\"top\"> DCSE_SinglePhase </td>
+    <td valign=\"top\"> Series excited DC machine, fed by sinusoidal voltage </td></tr>
+<tr><td valign=\"top\"> DCPM_Temperature </td>
+    <td valign=\"top\"> Permanent magnet DC machine, demonstration of varying temperature </td></tr>
+<tr><td valign=\"top\"> DCPM_Cooling </td>
+    <td valign=\"top\"> Permanent magnet DC machine, coupled with a simple thermal model </td></tr>
+<tr><td valign=\"top\"> DCPM_QuasiStationary </td>
+    <td valign=\"top\"> Permanent magnet DC machine, comparison between transient and quasistationary model </td></tr>
+<tr><td valign=\"top\"> DCPM_Losses </td>
+    <td valign=\"top\"> Permanent magnet DC machine, comparison between model with and without losses </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines.</b></td></tr>
+<tr><td valign=\"top\"> DC_PermanentMagnet <br>
+                      DC_ElectricalExcited <br>
+                      DC_SeriesExcited </td>
+    <td valign=\"top\"> QuasiStationary DC machines, i.e., neglecting electrical transients </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.BasicMachines.Components.</b></td></tr>
+<tr><td valign=\"top\"> InductorDC </td>
+    <td valign=\"top\"> Inductor model which neglects der(i) if Boolean parameter quasiStationary = true </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Interfaces.</b></td></tr>
+<tr><td valign=\"top\">  ThermalPortTransformer <br>
+                       PowerBalanceTransformer </td>
+    <td valign=\"top\"> Thermal ports and power balances for electrical machines and transformers.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Utilities</b></td></tr>
+<tr><td valign=\"top\"> SwitchedRheostat </td>
+    <td valign=\"top\"> Switched rheostat, used for starting asynchronous induction motors with slipring rotor.</td></tr>
+<tr><td valign=\"top\"> RampedRheostat </td>
+    <td valign=\"top\"> Ramped rheostat, used for starting asynchronous induction motors with slipring rotor.</td></tr>
+<tr><td valign=\"top\"> SynchronousMachineData </td>
+    <td valign=\"top\"> The parameters of the synchronous machine model with electrical excitation (and damper) are calculated
+                      from parameters normally given in a technical description,
+                      according to the standard EN 60034-4:2008 Appendix C.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Examples.Elementary.</b></td></tr>
+<tr><td valign=\"top\"> HeatLosses </td>
+    <td valign=\"top\"> Demonstrate the modeling of heat losses.</td></tr>
+<tr><td valign=\"top\"> UserDefinedGravityField </td>
+    <td valign=\"top\"> Demonstrate the modeling of a user-defined gravity field.</td></tr>
+<tr><td valign=\"top\"> Surfaces </td>
+    <td valign=\"top\"> Demonstrate the visualization of a sine surface,<br>
+                      as well as a torus and a wheel constructed from a surface.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Joints.</b></td></tr>
+<tr><td valign=\"top\"> FreeMotionScalarInit </td>
+    <td valign=\"top\"> Free motion joint that allows initialization and state selection<br>
+                      of single elements of the relevant vectors<br>
+                      (e.g., initialize r_rel_a[2] but not the other elements of r_rel_a;<br>
+                      this new component fixes ticket
+                      <a href=\"https://trac.modelica.org/Modelica/ticket/274\">#274</a>) </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Visualizers.</b></td></tr>
+<tr><td valign=\"top\"> Torus </td>
+    <td valign=\"top\"> Visualizing a torus.</td></tr>
+<tr><td valign=\"top\"> VoluminousWheel </td>
+    <td valign=\"top\"> Visualizing a voluminous wheel.</td></tr>
+<tr><td valign=\"top\"> PipeWithScalarField </td>
+    <td valign=\"top\"> Visualizing a pipe with scalar field quantities along the pipe axis.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Visualizers.ColorMaps.</b></td></tr>
+<tr><td valign=\"top\"> jet<br>
+                      hot<br>
+                      gray<br>
+                      spring<br>
+                      summer<br>
+                      autumn<br>
+                      winter </td>
+    <td valign=\"top\"> Functions returning different color maps.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Visualizers.Colors.</b></td></tr>
+<tr><td valign=\"top\"> colorMapToSvg </td>
+    <td valign=\"top\"> Save a color map on file in svg (scalable vector graphics) format.</td></tr>
+<tr><td valign=\"top\"> scalarToColor </td>
+    <td valign=\"top\"> Map a scalar to a color using a color map.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Visualizers.Advanced.</b></td></tr>
+<tr><td valign=\"top\"> Surface </td>
+    <td valign=\"top\"> Visualizing a moveable, parameterized surface;<br>
+                      the surface characteristic is provided by a function<br>
+                      (this new component fixes ticket
+                       <a href=\"https://trac.modelica.org/Modelica/ticket/181\">#181</a>)</td></tr>
+<tr><td valign=\"top\"> PipeWithScalarField </td>
+    <td valign=\"top\"> Visualizing a pipe with a scalar field.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Visualizers.Advanced.SurfaceCharacteristics.</b></td></tr>
+<tr><td valign=\"top\"> torus </td>
+    <td valign=\"top\"> Function defining the surface characteristic of a torus.</td></tr>
+<tr><td valign=\"top\"> pipeWithScalarField </td>
+    <td valign=\"top\"> Function defining the surface characteristic of a pipe<br>
+                      where a scalar field value is displayed with color along the pipe axis.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.Examples.</b></td></tr>
+<tr><td valign=\"top\"> HeatLosses </td>
+    <td valign=\"top\"> Demonstrate the modeling of heat losses.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Translational.Examples.</b></td></tr>
+<tr><td valign=\"top\"> HeatLosses </td>
+    <td valign=\"top\"> Demonstrate the modeling of heat losses.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Fittings.Bends</b></td></tr>
+<tr><td valign=\"top\"> CurvedBend<br>
+                      EdgedBend</td>
+    <td valign=\"top\"> New fitting (pressure loss) components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Fittings.Orifices.</b></td></tr>
+<tr><td valign=\"top\"> ThickEdgedOrifice</td>
+    <td valign=\"top\"> New fitting (pressure loss) component.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Fittings.GenericResistances.</b></td></tr>
+<tr><td valign=\"top\"> VolumeFlowRate</td>
+    <td valign=\"top\"> New fitting (pressure loss) component.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math</b></td></tr>
+<tr><td valign=\"top\"> isEqual </td>
+    <td valign=\"top\"> Determine if two Real scalars are numerically identical.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Vectors</b></td></tr>
+<tr><td valign=\"top\"> find </td>
+    <td valign=\"top\"> Find element in vector.</td></tr>
+<tr><td valign=\"top\"> toString </td>
+    <td valign=\"top\"> Convert a real vector to a string.</td></tr>
+<tr><td valign=\"top\"> interpolate </td>
+    <td valign=\"top\"> Interpolate in a vector.</td></tr>
+<tr><td valign=\"top\"> relNodePositions </td>
+    <td valign=\"top\"> Return vector of relative node positions (0..1).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Vectors.Utilities</b></td></tr>
+<tr><td valign=\"top\"> householderVector<br>
+                      householderReflection<br>
+                      roots </td>
+    <td valign=\"top\"> Utility functions for vectors that are used by the newly introduced functions,
+                      but are only of interested for a specialist.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices</b></td></tr>
+<tr><td valign=\"top\"> continuousRiccati<br>
+                      discreteRiccati </td>
+    <td valign=\"top\"> Return solution of continuous-time and discrete-time
+                      algebraic Riccati equation respectively.</td></tr>
+<tr><td valign=\"top\"> continuousSylvester<br>
+                      discreteSylvester </td>
+    <td valign=\"top\"> Return solution of continuous-time and discrete-time
+                      Sylvester equation respectively.</td></tr>
+<tr><td valign=\"top\"> continuousLyapunov<br>
+                      discreteLyapunov </td>
+    <td valign=\"top\"> Return solution of continuous-time and discrete-time
+                      Lyapunov equation respectively.</td></tr>
+<tr><td valign=\"top\"> trace </td>
+    <td valign=\"top\"> Return the trace of a matrix.</td></tr>
+<tr><td valign=\"top\"> conditionNumber </td>
+    <td valign=\"top\"> Compute the condition number of a matrix.</td></tr>
+<tr><td valign=\"top\"> rcond </td>
+    <td valign=\"top\"> Estimate the reciprocal condition number of a matrix.</td></tr>
+<tr><td valign=\"top\"> nullSpace </td>
+    <td valign=\"top\"> Return a orthonormal basis for the null space of a matrix.</td></tr>
+<tr><td valign=\"top\"> toString </td>
+    <td valign=\"top\"> Convert a matrix into its string representation.</td></tr>
+<tr><td valign=\"top\"> flipLeftRight </td>
+    <td valign=\"top\"> Flip the columns of a matrix in left/right direction.</td></tr>
+<tr><td valign=\"top\"> flipUpDown </td>
+    <td valign=\"top\"> Flip the rows of a matrix in up/down direction.</td></tr>
+<tr><td valign=\"top\"> cholesky </td>
+    <td valign=\"top\"> Perform Cholesky factorization of a real symmetric positive definite matrix.</td></tr>
+<tr><td valign=\"top\"> hessenberg </td>
+    <td valign=\"top\"> Transform a matrix to upper Hessenberg form.</td></tr>
+<tr><td valign=\"top\"> realSchur </td>
+    <td valign=\"top\"> Computes the real Schur form of a matrix.</td></tr>
+<tr><td valign=\"top\"> frobeniusNorm </td>
+    <td valign=\"top\"> Return the Frobenius norm of a matrix.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices.LAPACK.</b></td></tr>
+<tr><td valign=\"top\"> dtrevc<br>
+                      dpotrf<br>
+                      dtrsm<br>
+                      dgees<br>
+                      dtrsen<br>
+                      dgesvx<br>
+                      dhseqr<br>
+                      dlange<br>
+                      dgecon<br>
+                      dgehrd<br>
+                      dgeqrf<br>
+                      dggevx<br>
+                      dgesdd<br>
+                      dggev<br>
+                      dggevx<br>
+                      dhgeqz<br>
+                      dormhr<br>
+                      dormqr<br>
+                      dorghr</td>
+    <td valign=\"top\"> New interface functions for LAPACK
+                      (should usually not directly be used but only indirectly via
+                      Modelica.Math.Matrices).</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices.Utilities.</b></td></tr>
+<tr><td valign=\"top\"> reorderRSF<br>
+                      continuousRiccatiIterative<br>
+                      discreteRiccatiIterative<br>
+                      eigenvaluesHessenberg<br>
+                      toUpperHessenberg<br>
+                      householderReflection<br>
+                      householderSimilarityTransformation<br>
+                      findLokal_tk</td>
+    <td valign=\"top\"> Utility functions for matrices that are used by the newly introduced functions,
+                      but are only of interested for a specialist.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Nonlinear</b></td></tr>
+<tr><td valign=\"top\"> quadratureLobatto </td>
+    <td valign=\"top\"> Return the integral of an integrand function using an adaptive Lobatto rule.</td></tr>
+<tr><td valign=\"top\"> solveOneNonlinearEquation </td>
+    <td valign=\"top\"> Solve f(u) = 0 in a very reliable and efficient way
+                      (f(u_min) and f(u_max) must have different signs).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Nonlinear.Examples.</b></td></tr>
+<tr><td valign=\"top\"> quadratureLobatto1<br>
+                      quadratureLobatto2<br>
+                      solveNonlinearEquations1<br>
+                      solveNonlinearEquations2 </td>
+    <td valign=\"top\"> Examples that demonstrate the usage of the Modelica.Math.Nonlinear functions
+                      to integrate over functions and to solve scalar nonlinear equations.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.BooleanVectors.</b></td></tr>
+<tr><td valign=\"top\"> allTrue </td>
+    <td valign=\"top\"> Returns true, if all elements of the Boolean input vector are true.</td></tr>
+<tr><td valign=\"top\"> anyTrue </td>
+    <td valign=\"top\"> Returns true, if at least on element of the Boolean input vector is true.</td></tr>
+<tr><td valign=\"top\"> oneTrue </td>
+    <td valign=\"top\"> Returns true, if exactly one element of the Boolean input vector is true.</td></tr>
+<tr><td valign=\"top\"> firstTrueIndex </td>
+    <td valign=\"top\"> Returns the index of the first element of the Boolean vector that
+                      is true and returns 0, if no element is true </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Icons.</b></td></tr>
+<tr><td valign=\"top\"> Information<br>
+                      Contact<br>
+                      ReleaseNotes<br>
+                      References<br>
+                      ExamplesPackage<br>
+                      Example<br>
+                      Package<br>
+                      BasesPackage<br>
+                      VariantsPackage<br>
+                      InterfacesPackage<br>
+                      SourcesPackage<br>
+                      SensorsPackage<br>
+                      MaterialPropertiesPackage<br>
+                      MaterialProperty </td>
+    <td valign=\"top\"> New icons to get a unified view on different categories
+                      of packages.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.SIunits.</b></td></tr>
+<tr><td valign=\"top\"> ComplexCurrent<br>
+                      ComplexCurrentSlope<br>
+                      ComplexCurrentDensity<br>
+                      ComplexElectricPotential<br>
+                      ComplexPotentialDifference<br>
+                      ComplexVoltage<br>
+                      ComplexVoltageSlope<br>
+                      ComplexElectricFieldStrength<br>
+                      ComplexElectricFluxDensity<br>
+                      ComplexElectricFlux<br>
+                      ComplexMagneticFieldStrength<br>
+                      ComplexMagneticPotential<br>
+                      ComplexMagneticPotentialDifference<br>
+                      ComplexMagnetomotiveForce<br>
+                      ComplexMagneticFluxDensity<br>
+                      ComplexMagneticFlux<br>
+                      ComplexReluctance<br>
+                      ComplexImpedance<br>
+                      ComplexAdmittance<br>
+                      ComplexPower</td>
+    <td valign=\"top\"> SIunits to be used in physical models using complex variables, e.g.,<br>
+                      <a href=\"modelica://Modelica.Electrical.QuasiStationary\">Modelica.Electrical.QuasiStationary</a>,
+                      <a href=\"modelica://Modelica.Magnetic.FundamentalWave\">Modelica.Magnetic.FundamentalWave</a> </td></tr>
+<tr><td valign=\"top\"> ImpulseFlowRate<br>
+                      AngularImpulseFlowRate</td>
+    <td valign=\"top\"> New SIunits for mechanics.</td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">improved</b> in a
+<b style=\"color:blue\">backward compatible</b> way:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Sources.</b></td></tr>
+<tr><td valign=\"top\"> Pulse<br>
+                      SawTooth </td>
+    <td valign=\"top\"> New parameter \"nperiod\" introduced to define the number of periods
+                      for the signal type. Default is \"infinite number of periods
+                      (nperiods=-1).</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.</b></td></tr>
+<tr><td valign=\"top\"> MultiPhase.*</td>
+    <td valign=\"top\"> All dissipative components have now an optional heatPort connector
+                      to which the dissipated losses are transported in form of heat.
+                       </td></tr>
+<tr><td valign=\"top\"> Machines.*</td>
+    <td valign=\"top\"> To all electric machines (asynchronous and synchronous induction machines, DC machines)
+                      and transformers loss models have been added (where applicable): <br>
+                      Temperature dependent resistances (ohmic losses) <br>
+                      Friction losses <br>
+                      Brush losses <br>
+                      Stray Load losses <br>
+                      Core losses (only eddy current losses but no hysteresis losses; not for transformers) <br>
+                      As default, temperature dependency and losses are set to zero. <br><br>
+                      To all electric machines (asynchronous and synchronous induction machines, DC machines)
+                      and transformers conditional thermal ports have been added,
+                      to which the dissipated losses are flowing, if activated.
+                      The thermal port contains a <a href=\"modelica://Modelica.Thermal.HeatTransfer.Interfaces.HeatPort\">HeatPort</a>
+                      for each loss source of the specific machine type. <br><br>
+                      To all electric machines (asynchronous and synchronous induction machines, DC machines)
+                      a \"powerBalance\" result record has been added, summarizing converted power and losses.
+                       </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.</b></td></tr>
+<tr><td valign=\"top\"> MultiBody.*<br>
+                      Rotational.*<br>
+                      Translational.*</td>
+    <td valign=\"top\"> All dissipative components in Modelica.Mechanics have now an
+                      optional heatPort connector to which the dissipated energy is
+                      transported in form of heat.<br>
+                      All icons in Modelica.Mechanics are unified according to the
+                      Modelica.Blocks library:<br>
+                      \"%name\": width: -150 .. 150, height: 40, color: blue<br>
+                      other text: height: 30, color: black
+                       </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.</b></td></tr>
+<tr><td valign=\"top\"> World </td>
+    <td valign=\"top\"> Function gravityAcceleration is made replaceable, so that redeclaration
+                      yields user-defined gravity fields.
+                       </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Valves.</b></td></tr>
+<tr><td valign=\"top\"> ValveIncompressible<br>
+                      ValveVaporizing<br>
+                      ValveCompressible</td>
+    <td valign=\"top\"> (a) Optional filtering of opening signal introduced to model
+                      the delay time of the opening/closing drive. In this case, an optional
+                      leakageOpening can be defined to model leakage flow and/or to
+                      improve the numerics in certain situations.
+                      (b) Improved regularization of the valve characteristics in some cases
+                      so that it is twice differentiable (smooth=2),
+                      instead of continuous (smooth=0).</td>
+                      </tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Sources.</b></td></tr>
+<tr><td valign=\"top\"> FixedBoundary<br>
+                      Boundary_pT<br>
+                      Boundary_ph</td>
+    <td valign=\"top\"> Changed the implementation so that no non-linear algebraic
+                      equation system occurs, if the given variables (e.g. p,T,X) do
+                      not correspond to the medium states (e.g. p,h,X). This is
+                      achieved by using appropriate \"setState_xxx\" calls to compute the
+                      medium state from the given variables. If a nonlinear equation
+                      system occurs, it is solved by a specialized handler inside the
+                      setState_xxx(..) function, but in the model this equation system is
+                      not visible.</td>
+                      </tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Media.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialMedium </td>
+    <td valign=\"top\"> The min/max values of types SpecificEnthalpy, SpecificEntropy,
+                      SpecificHeatCapacity increased, due to reported user problems.<br>
+                      New constant C_nominal introduced to provide nominal values for
+                      trace substances (utilized in Modelica.Fluid to avoid numerical problems;
+                      this fixes ticket
+                      <a href=\"https://trac.modelica.org/Modelica/ticket/393\">#393</a>).</td>
+                      </tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Thermal.</b></td></tr>
+<tr><td valign=\"top\"> HeatTransfer.*</td>
+    <td valign=\"top\"> All icons are unified according to the
+                      Modelica.Blocks library:<br>
+                      \"%name\": width: -150 .. 150, height: 40, color: blue<br>
+                      other text: height: 30, color: black
+                       </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices</b></td></tr>
+<tr><td valign=\"top\"> QR </td>
+    <td valign=\"top\"> A Boolean input \"pivoting\" has been added (now QR(A, pivoting)) to provide QR-decomposition without pivoting (QR(A, false)). Default is pivoting=true.</td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:red\">critical errors</b> have been fixed (i.e., errors
+that can lead to wrong simulation results):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.Delay.</b></td></tr>
+<tr><td valign=\"top\"> InertialDelaySensitive </td>
+    <td valign=\"top\"> In order to decide whether the rising delay (tLH) or
+                      the falling delay (tHL) is used, the \"previous\" value of the
+                      output y has to be used and not the \"previous\" value of the
+                      input x (delayType = delayTable[y_old, x] and not
+                      delayType = delayTable[x_old, x]). This has been corrected.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Parts.</b></td></tr>
+<tr><td valign=\"top\"> BodyBox<br>
+                      BodyCylinder </td>
+    <td valign=\"top\"> Fixes ticket
+                      <a href=\"https://trac.modelica.org/Modelica/ticket/373\">#373</a>:
+                      The \"Center of Mass\" was calculated as normalize(r)*length/2. This is
+                      only correct if the box/cylinder is attached between frame_a and frame_b.
+                      If this is not the case, the calculation is wrong.
+                      The has been fixed by using the correct formula:<br>
+                      r_shape + normalize(lengthDirection)*length/2</td></tr>
+<tr><td valign=\"top\"> BodyShape<br>
+                      BodyBox<br>
+                      BodyCylinder </td>
+    <td valign=\"top\"> Fixes ticket
+                      <a href=\"https://trac.modelica.org/Modelica/ticket/300\">#300</a>:
+                      If parameter enforceStates=true, an error occurred.
+                      This has been fixed.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.Components.</b></td></tr>
+<tr><td valign=\"top\"> LossyGear</td>
+    <td valign=\"top\"> In cases where the driving flange is not obvious, the component could
+                      lead to a non-convergent event iteration. This has been fixed
+                      (a detailed description is provided in ticket
+                      <a href=\"https://trac.modelica.org/Modelica/ticket/108\">#108</a>
+                      and in the
+                      <a href=\"modelica://Modelica/Resources/Documentation/Mechanics/Lossy-Gear-Bug_Solution.pdf\">attachment</a>
+                      of this ticket).</td></tr>
+
+<tr><td valign=\"top\"> Gearbox</td>
+    <td valign=\"top\"> If useSupport=false, the support flange of the internal LossyGear
+                      model was connected to the (disabled) support connector. As a result, the
+                      LossyGear was \"free floating\". This has been corrected.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Pipes.</b></td></tr>
+<tr><td valign=\"top\"> DynamicPipe</td>
+    <td valign=\"top\"> Bug fix for dynamic mass, energy and momentum balances
+                      for pipes with nParallel&gt;1.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Fluid.Pipes.BaseClasses.HeatTransfer.</b></td></tr>
+<tr><td valign=\"top\"> PartialPipeFlowHeatTransfer</td>
+    <td valign=\"top\"> Calculation of Reynolds numbers for the heat transfer through
+                      walls corrected, if nParallel&gt;1.
+                      This partial model is used by LocalPipeFlowHeatTransfer
+                      for laminar and turbulent forced convection in pipes.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Media.Interfaces.PartialLinearFluid</b></td></tr>
+<tr><td valign=\"top\"> setState_psX</td>
+    <td valign=\"top\"> Sign error fixed.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Media.CompressibleLiquids.</b></td></tr>
+<tr><td valign=\"top\"> LinearColdWater</td>
+    <td valign=\"top\"> Fixed wrong values for thermal conductivity and viscosity.</td></tr>
+
+</table>
+
+<p><br>
+The following <b style=\"color:red\">uncritical errors</b> have been fixed (i.e., errors
+that do <b style=\"color:red\">not</b> lead to wrong simulation results, but, e.g.,
+units are wrong or errors in documentation):
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices.LAPACK</b></td></tr>
+<tr><td valign=\"top\"> dgesv_vec<br>
+                        dgesv<br>
+                        dgetrs<br>
+                        dgetrf<br>
+                        dgetrs_vec<br>
+                        dgetri<br>
+                        dgeqpf<br>
+                        dorgqr<br>
+                        dgesvx<br>
+                        dtrsyl</td>
+    <td valign=\"top\"> Integer inputs to specify leading dimensions of matrices have got a lower bound 1 (e.g., lda=max(1,n))
+                      to avoid incorrect values (e.g., lda=0) in the case of empty matrices.<br>
+                      The Integer variable \"info\" to indicate the successful call of a LAPACK routine has been converted to an output where it had been a protected variable.</td></tr>
+</table>
+
+<p><br>
+The following
+<a href=\"http://trac.modelica.org/Modelica\">trac tickets</a>
+have been fixed:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica</b></td></tr>
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/155\">#155</a></td>
+    <td valign=\"top\">Wrong usage of \"fillColor\" and \"fillPattern\" annotations for lines</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/211\">#211</a></td>
+    <td valign=\"top\">Undefined function realString used in MSL</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/216\">#216</a></td>
+    <td valign=\"top\">Make MSL version 3.2 more Modelica 3.1 conform</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/218\">#218</a></td>
+    <td valign=\"top\">Replace `Modelica://`-URIs by `modelica://`-URIs</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/271\">#271</a></td>
+    <td valign=\"top\">Documentation URI errors in MSL 3.1</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/292\">#292</a></td>
+    <td valign=\"top\">Remove empty \"\" annotations\"</td>
+</tr>
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/294\">#294</a></td>
+    <td valign=\"top\">Typo 'w.r.t' --> 'w.r.t.'</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/296\">#296</a></td>
+    <td valign=\"top\">Unify disclaimer message and improve bad style \"here\" links</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/333\">#333</a></td>
+    <td valign=\"top\">Fix real number formats of the form `.[0-9]+`</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/347\">#347</a></td>
+    <td valign=\"top\">invalid URI in MSL 3.2</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/355\">#355</a></td>
+    <td valign=\"top\">Non-standard annotations</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Blocks</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/227\">#227</a></td>
+    <td valign=\"top\">Enhance unit deduction functionality by adding 'unit=\"1\"' to some blocks\"</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/349\">#349</a></td>
+    <td valign=\"top\">Incorrect annotation in Blocks/Continuous.mo</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/374\">#374</a></td>
+    <td valign=\"top\">Parameter with no value at all in Modelica.Blocks.Continuous.TransferFunction</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Constants</b></td></tr>
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/356\">#356</a></td>
+    <td valign=\"top\">Add Euler-Mascheroni constant to Modelica.Constants</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Electrical.Analog</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/346\">#346</a></td>
+    <td valign=\"top\">Multiple text in Modelica.Electrical.Analog.Basic.Conductor</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/363\">#363</a></td>
+    <td valign=\"top\">Mixture of Real and Integer in index expressions in Modelica.Electrical.Analog.Lines</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/384\">#384</a></td>
+    <td valign=\"top\">Incomplete annotations in some examples</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/396\">#396</a></td>
+    <td valign=\"top\">Bug in Modelica.Electrical.Analog.Ideal.ControlledIdealIntermediateSwitch</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Machines</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/276\">#276</a></td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Electrical.Machines</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/288\">#288</a></td>
+    <td valign=\"top\">Describe thermal concept of machines</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/301\">#301</a></td>
+    <td valign=\"top\">Documentation of Electrical.Machines.Examples needs update</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/306\">#306</a></td>
+    <td valign=\"top\">Merge content of `Modelica.Electrical.Machines.Icons` into `Modelica.Icons`</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/362\">#362</a></td>
+    <td valign=\"top\">Incomplete example model for DC machines</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/375\">#375</a></td>
+    <td valign=\"top\">Strangeness with final parameters with no value but a start value</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Electrical.MultiPhase</b></td></tr>
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/173\">#173</a></td>
+    <td valign=\"top\">m-phase mutual inductor</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/200\">#200</a></td>
+    <td valign=\"top\">adjust Multiphase to Analog</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/277\">#277</a></td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Electrical.Multiphase</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/352\">#352</a></td>
+    <td valign=\"top\">Odd annotation in Modelica.Electrical.MultiPhase.Sources.SignalVoltage</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Fluid</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/215\">#215</a></td>
+    <td valign=\"top\">Bug in Modelica.Fluid.Pipes.DynamicPipe</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/219\">#219</a></td>
+    <td valign=\"top\">Fluid.Examples.HeatExchanger: Heat transfer is switched off and cannot be enabled</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Math</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/348\">#348</a></td>
+    <td valign=\"top\">Small error in documentation</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/371\">#371</a></td>
+    <td valign=\"top\">Modelica.Math functions declared as \"C\" not \"builtin\"\"</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Mechanics.MultiBody</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/50\">#50</a></td>
+    <td valign=\"top\">Error in LineForce handling of potential root</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/71\">#71</a></td>
+    <td valign=\"top\">Make MultiBody.World replaceable</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/181\">#181</a></td>
+    <td valign=\"top\">3d surface visualisation</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/210\">#210</a></td>
+    <td valign=\"top\">Description of internal gear wheel missing</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/242\">#242</a></td>
+    <td valign=\"top\">Missing each qualifier for modifiers in MultiBody.</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/251\">#251</a></td>
+    <td valign=\"top\">Using enforceStates=true for BodyShape causes errors</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/255\">#255</a></td>
+    <td valign=\"top\">Error in Revolute's handling of non-normalized axis of rotations</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/268\">#268</a></td>
+    <td valign=\"top\">Non-standard annotation in MultiBody,Examples.Systems.RobotR3</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/269\">#269</a></td>
+    <td valign=\"top\">What is the purpose of MultiBody.Examples.Systems.RobotR3.Components.InternalConnectors?</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/272\">#272</a></td>
+    <td valign=\"top\">Function World.gravityAcceleration should not be protected</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/274\">#274</a></td>
+    <td valign=\"top\">Convenient and mighty  initialization of frame kinematics</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/286\">#286</a></td>
+    <td valign=\"top\">Typo in Multibody/Frames.mo</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/300\">#300</a></td>
+    <td valign=\"top\">enforceStates parameter managed incorrectly in BodyShape, BodyBox, BodyCylinder</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/320\">#320</a></td>
+    <td valign=\"top\">Replace non-standard annotation by `showStartAttribute`</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/373\">#373</a></td>
+    <td valign=\"top\">Error in Modelica Mechanics</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/389\">#389</a></td>
+    <td valign=\"top\">Shape.rxvisobj wrongly referenced in Arrow/DoubleArrow</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Mechanics.Rotational</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/108\">#108</a></td>
+    <td valign=\"top\">Problem with model \"Lossy Gear\" and approach to a solution</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/278\">#278</a></td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Mechanics.Rotational</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/381\">#381</a></td>
+    <td valign=\"top\">Bug in Modelica.Mechanics.Rotational.Gearbox</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Mechanics.Translational</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/279\">#279</a></td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Mechanics.Translational</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/310\">#310</a></td>
+    <td valign=\"top\">Erroneous image links in `Modelica.Mechanics.Translational`</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Media</b></td></tr>
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/72\">#72</a></td>
+    <td valign=\"top\">PartialMedium functions not provided for all media in  Modelica.Media</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/217\">#217</a></td>
+    <td valign=\"top\">Missing image file Air.png</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/224\">#224</a></td>
+    <td valign=\"top\">dpT calculation in waterBaseProp_dT</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/393\">#393</a></td>
+    <td valign=\"top\">Provide C_nominal in Modelica.Media to allow propagating
+                     value and avoid wrong numerical results</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.StateGraph</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/206\">#206</a></td>
+    <td valign=\"top\">Syntax error in StateGraph.mo</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/261\">#261</a></td>
+    <td valign=\"top\">Modelica.StateGraph should mention the availability of Modelica_StateGraph2</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/354\">#354</a></td>
+    <td valign=\"top\">Bad annotation in Modelica.StateGraph.Temporary.NumericValue</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Thermal.FluidHeatFlow</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/280\">#280</a></td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Thermal.FluidHeatFlow</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Thermal.HeatTransfer</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/281\">#281</a></td>
+    <td valign=\"top\">Improve/fix documentation of Modelica.Thermal.HeatTransfer</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.UsersGuide</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/198\">#198</a></td>
+    <td valign=\"top\">Name of components in MSL not according to naming conventions</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/204\">#204</a></td>
+    <td valign=\"top\">Minor correction to User's Guide's section on version management</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/244\">#244</a></td>
+    <td valign=\"top\">Update the contacts section of the User's Guide</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/267\">#267</a></td>
+    <td valign=\"top\">MSL-Documentation: Shouldn't equations be numbered on the right hand side?</td>
+</tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/299\">#299</a></td>
+    <td valign=\"top\">SVN keyword expansion messed up the User's guide section on version management</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>Modelica.Utilities</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/249\">#249</a></td>
+    <td valign=\"top\">Documentation error in ModelicaUtilities.h</td>
+</tr>
+
+<tr><td colspan=\"2\"><br><b>ModelicaServices</b></td></tr>
+
+<tr><td valign=\"top\">
+    <a href=\"https://trac.modelica.org/Modelica/ticket/248\">#248</a></td>
+    <td valign=\"top\">No uses statement on ModelicaServices in MSL 3.1</td>
+</tr>
+
+</table>
+
+<p>
+Note:
+</p>
+<ul>
+<li> Libraries
+     <a href=\"https://www.modelica.org/libraries/Modelica_FundamentalWave\">Modelica_FundamentalWave</a>
+     and
+     <a href=\"https://www.modelica.org/libraries/Modelica_QuasiStationary\">Modelica_QuasiStationary</a>
+     are included in this version in an improved form.</li>
+<li> From library
+     <a href=\"https://www.modelica.org/libraries/Modelica_LinearSystems2\">Modelica_LinearSystems2</a>,
+     the sublibraries
+     Math.Complex, Math.Vectors and Math.Matrices are included in this version
+     in an improved form.</li>
+<li> From library
+     <a href=\"https://www.modelica.org/libraries/Modelica_StateGraph2\">Modelica_StateGraph2</a>,
+     the sublibrary Blocks is included in this version in an improved form.</li>
+</ul>
+</html>"));
+end Version_3_2;
+
+class Version_3_1 "Version 3.1 (August 14, 2009)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p>
+Version 3.1 is backward compatible to version 3.0 and 3.0.1,
+i.e., models developed with version 3.0 or 3.0.1 will work without any
+changes also with version 3.1.
+</p>
+
+<p>
+Version 3.1 is slightly based on the Modelica Specification 3.1. It uses
+the following new language elements (compared to Modelica Specification 3.0):
+</p>
+
+<ul>
+<li> Prefix <u>stream</u> and built-in operators <u>inStream(..)</u>
+     and <u>actualStream(..)</u> in Modelica.Fluid.</li>
+<li> Annotation <u>connectorSizing</u> in Modelica.Fluid.</li>
+<li> Annotation <u>inverse</u> in Modelica.Media.</li>
+<li> Annotations <u>versionBuild</u>, <u>dateModified</u>,
+     <u>revisionId</u> at the root level annotation of package Modelica,
+     to improve the version handling.</li>
+<li> Modifiers can be used in connectors instances (so balanced models
+     are less restrictive). This allowed to make the implementation
+     of conditional connectors (support and heatPort) in the Rotational,
+     Translational and Electrical libraries simpler.</li>
+</ul>
+
+<p>
+The following <b style=\"color:blue\">new libraries</b> have been added:
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Fluid\">Modelica.Fluid</a></td>
+    <td valign=\"top\">
+     Components to model 1-dim. thermo-fluid flow in networks of vessels, pipes,
+     fluid machines, valves and fittings. All media from the
+     Modelica.Media library can be used (so incompressible or compressible,
+     single or multiple substance, one or two phase medium).
+    The library is using the stream-concept from Modelica Specification 3.1.
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes\">Modelica.Magnetic.FluxTubes</a></td>
+    <td valign=\"top\">
+     Components to model magnetic devices based on the magnetic flux tubes concepts.
+     Especially to model
+     electro-magnetic actuators. Nonlinear shape, force, leakage, and
+     Material models. Material data for steel, electric sheet, pure iron,
+     Cobalt iron, Nickel iron, NdFeB, Sm2Co17, and more.
+    </td></tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://ModelicaServices\">ModelicaServices</a></td>
+    <td valign=\"top\">
+     New top level package that shall contain functions and models to be used in the
+     Modelica Standard Library that requires a tool specific implementation.
+     ModelicaServices is then used in the Modelica package.
+     In this first version, the 3-dim. animation with model Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape
+     was moved to ModelicaServices. Tool vendors can now provide their own implementation
+     of the animation.
+    </td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.</b></td></tr>
+<tr><td valign=\"top\"> versionBuild<br>versionDate<br>dateModified<br>revisionId </td>
+    <td valign=\"top\"> New annotations from Modelica 3.1 for version handling added.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.UsersGuide.ReleaseNotes.</b></td></tr>
+<tr><td valign=\"top\"> VersionManagement </td>
+    <td valign=\"top\"> Copied from info layer of previous ReleaseNotes (to make it more
+                      visible) and adapted it to the new possibilities in
+                      Modelica Specification 3.1.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\"> RectangularToPolar<br>
+                      PolarToRectangular </td>
+    <td valign=\"top\"> New blocks to convert between rectangular and polar form
+                      of space phasors.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Routing.</b></td></tr>
+<tr><td valign=\"top\"> Replicator </td>
+    <td valign=\"top\"> New block to replicate an input signal to many output signals.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Examples.</b></td></tr>
+<tr><td valign=\"top\"> AmplifierWithOpAmpDetailed<br>
+                      HeatingResistor<br>
+                      CompareTransformers<br>
+                      OvervoltageProtection<br>
+                      ControlledSwitchWithArc<br>
+                      SwitchWithArc<br>
+                      ThyristorBehaviourTest</td>
+    <td valign=\"top\"> New examples to demonstrate the usage of new components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Basic.</b></td></tr>
+<tr><td valign=\"top\"> OpAmpDetailed<br>
+                      TranslationalEMF<br>
+                      M_Transformer</td>
+    <td valign=\"top\"> New detailed model of an operational amplifier. <br>
+                      New electromotoric force from electrical energy into mechanical translational energy.<br>
+                      Generic transformer with choosable number of inductors</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Ideal.</b></td></tr>
+<tr><td valign=\"top\"> OpenerWithArc<br>
+                      CloserWithArc<br>
+                      ControlledOpenerWithArc<br>
+                      ControlledCloserWithArc</td>
+    <td valign=\"top\"> New switches with simple arc model.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> ConditionalHeatPort</td>
+    <td valign=\"top\"> New partial model to add a conditional HeatPort to
+                      an electrical component.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Lines.</b></td></tr>
+<tr><td valign=\"top\"> M_Oline</td>
+    <td valign=\"top\"> New multiple line model, both the number of lines and the number of segments choosable.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Semiconductors.</b></td></tr>
+<tr><td valign=\"top\"> ZDiode<br>Thyristor</td>
+    <td valign=\"top\"> Zener Diode with 3 working areas and simple thyristor model.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Ideal.</b></td></tr>
+<tr><td valign=\"top\"> OpenerWithArc<br>CloserWithArc</td>
+    <td valign=\"top\"> New switches with simple arc model (as in Modelica.Electrical.Analog.Ideal.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Examples.Elementary.</b></td></tr>
+<tr><td valign=\"top\"> RollingWheel<br>
+                      RollingWheelSetDriving<br>
+                      RollingWheelSetPulling</td>
+    <td valign=\"top\"> New examples to demonstrate the usage of new components.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Joints.</b></td></tr>
+<tr><td valign=\"top\"> RollingWheel<br>
+                      RollingWheelSet</td>
+    <td valign=\"top\"> New joints (no mass, no inertia) that describe an
+                      ideal rolling wheel and a ideal rolling wheel set consisting
+                      of two wheels rolling on the plane z=0.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Parts.</b></td></tr>
+<tr><td valign=\"top\"> RollingWheel<br>
+                      RollingWheelSet</td>
+    <td valign=\"top\"> New ideal rolling wheel and ideal rolling wheel set consisting
+                      of two wheels rolling on the plane z=0.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Visualizers.</b></td></tr>
+<tr><td valign=\"top\"> Ground</td>
+    <td valign=\"top\"> New model to visualize the ground (box at z=0).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialElementaryOneFlangeAndSupport2<br>
+                      PartialElementaryTwoFlangesAndSupport2</td>
+    <td valign=\"top\"> New partial model with one and two flanges and the support flange
+                      with a much simpler implementation as previously.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Translational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialElementaryOneFlangeAndSupport2<br>
+                      PartialElementaryTwoFlangesAndSupport2</td>
+    <td valign=\"top\"> New partial model with one and two flanges and the support flange
+                      with a much simpler implementation as previously.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Media.IdealGases.Common.MixtureGasNasa.</b></td></tr>
+<tr><td valign=\"top\"> setSmoothState</td>
+    <td valign=\"top\"> Return thermodynamic state so that it smoothly approximates:
+                      if x &gt; 0 then state_a else state_b.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Utilities.Internal.</b></td></tr>
+<tr><td valign=\"top\"> PartialModelicaServices</td>
+    <td valign=\"top\"> New package containing the interface description of
+                      models and functions that require a tool dependent
+                      implementation (currently only \"Shape\" for 3-dim. animation,
+                      but will be extended in the future)</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Thermal.HeatTransfer.Components.</b></td></tr>
+<tr><td valign=\"top\"> ThermalCollector</td>
+    <td valign=\"top\"> New auxiliary model to collect the heat flows
+                      from m heatports to a single heatport;
+                      useful for multiphase resistors (with heatports)
+                      as a junction of the m heatports.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Icons.</b></td></tr>
+<tr><td valign=\"top\"> VariantLibrary<br>
+                      BaseClassLibrary<br>
+                      ObsoleteModel</td>
+    <td valign=\"top\"> New icons (VariantLibrary and BaseClassLibrary have been moved
+                      from Modelica_Fluid.Icons to this place).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.SIunits.</b></td></tr>
+<tr><td valign=\"top\"> ElectricalForceConstant </td>
+    <td valign=\"top\"> New type added (#190).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.SIunits.Conversions.</b></td></tr>
+<tr><td valign=\"top\"> from_Hz<br>
+                      to_Hz</td>
+    <td valign=\"top\"> New functions to convert between frequency [Hz] and
+                      angular velocity [1/s]. (#156) </td></tr>
+
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">improved</b> in a
+<b style=\"color:blue\">backward compatible</b> way:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.</b></td></tr>
+<tr><td valign=\"top\"> Blocks<br>Mechanics<br>StateGraph </td>
+    <td valign=\"top\"> Provided missing parameter values for examples
+                      (these parameters had only start values)</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Basic</b></td></tr>
+<tr><td valign=\"top\"> Resistor, Conductor, VariableResistor, VariableConductor</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Ideal</b></td></tr>
+<tr><td valign=\"top\"> Thyristors, Switches, IdealDiode</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Semiconductors</b></td></tr>
+<tr><td valign=\"top\"> Diode, ZDiode, PMOS, NMOS, NPN, PNP</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Basic</b></td></tr>
+<tr><td valign=\"top\"> Resistor, Conductor, VariableResistor, VariableConductor</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network (as in Modelica.Electrical.Analog).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase.Ideal</b></td></tr>
+<tr><td valign=\"top\"> Thyristors, Switches, IdealDiode</td>
+    <td valign=\"top\"> Conditional heatport added for coupling to thermal network (as in Modelica.Electrical.Analog).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Visualizers.Advanced.</b></td></tr>
+<tr><td valign=\"top\"> Shape </td>
+    <td valign=\"top\"> New implementation by inheriting from ModelicaServices. This allows a
+                      tool vendor to provide its own implementation of Shape.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.StateGraph.</b></td></tr>
+<tr><td valign=\"top\"> Examples </td>
+    <td valign=\"top\"> Introduced \"StateGraphRoot\" on the top level of all example models.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.StateGraph.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> StateGraphRoot<br>PartialCompositeStep<br>CompositeStepState </td>
+    <td valign=\"top\"> Replaced the wrong Modelica code \"flow output Real xxx\"
+                      by \"Real dummy; flow Real xxx;\".
+                      As a side effect, several \"blocks\" had to be changed to \"models\".</td></tr>
+<tr><td valign=\"top\"> PartialStep </td>
+    <td valign=\"top\"> Changed model by packing the protected outer connector in to a model.
+                      Otherwise, there might be differences in the sign of the flow variable
+                      in Modelica 3.0 and 3.1.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Utilities.Examples.</b></td></tr>
+<tr><td valign=\"top\"> expression </td>
+    <td valign=\"top\"> Changed local variable \"operator\" to \"opString\" since \"operator\"
+                      is a reserved keyword in Modelica 3.1 </td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:red\">uncritical errors</b> have been fixed (i.e., errors
+that do <b style=\"color:red\">not</b> lead to wrong simulation results, but, e.g.,
+units are wrong or errors in documentation):
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Modelica.</b></td></tr>
+<tr><td valign=\"top\"> Many models</td>
+    <td valign=\"top\"> Removed wrong usages of annotations fillColor and fillPattern
+                      in text annotations (#155, #185).</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines</b></td></tr>
+<tr><td valign=\"top\"> All machine models</td>
+    <td valign=\"top\"> The conditional heatports of the instantiated resistors
+                        (which are new in Modelica.Electrical.Analog and Modelica.Electrical.MultiPhase)
+                        are finally switched off until a thermal connector design for machines is implemented.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Media.Air.MoistAir</b></td></tr>
+<tr><td valign=\"top\"> saturationPressureLiquid<br>
+                      sublimationPressureIce<br>
+                      saturationPressure</td>
+          <td valign=\"top\"> For these three functions, an error in the <code>derivative</code> annotation was corrected. However, the effect of
+                            this bug was minor, as a Modelica tool was allowed to compute derivatives automatically via
+                            the <code>smoothOrder</code> annotation.</td>
+</tr>
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices.</b></td></tr>
+<tr><td valign=\"top\"> eigenValues</td>
+    <td valign=\"top\"> Wrong documentation corrected (#162)</td></tr>
+</table>
+
+</html>"));
+end Version_3_1;
+
+class Version_3_0_1 "Version 3.0.1 (Jan. 27, 2009)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p>
+This Modelica package is provided under the
+<a href=\"modelica://Modelica.UsersGuide.ModelicaLicense2\">Modelica License 2</a>
+and no longer under Modelica License 1.1. There are the following reasons
+why the Modelica Association changes from Modelica License 1.1 to this
+new license text (note, the text below is not a legal interpretation of the
+Modelica License 2. In case of a conflict, the language of the license shall prevail):
+</p>
+
+<ol>
+<li> The rights of licensor and licensee are much more clearly defined. For example:
+         <ul>
+         <li> The licensed work (Original Work) can be used in unmodified form in
+                  open source and commercial software (the licensee cannot change the
+                  license and the work must be provided without fees)</li>
+         <li> If a model component is copied out of a Modelica package under
+                  Modelica License 2 and is modified in order to adapt it to the needs
+                  of the modeler, then the result can be licensed under any license
+                  (including a commercial license).</li>
+         <li> It is practically not possible to change the license of a
+                  Modelica package under Modelica License 2 to another license, i.e., a
+                  licensee cannot change the license by adding material or changing classes,
+                  so the work must remain under Modelica License 2 (to be more precise,
+                  if the licensee makes modifications to the Original Work \"which represents,
+                  as a whole, an original work of authorship\", he/she can change the license
+                  to another license. However, for a Modelica package this would
+                  require a lot of changes which is usually unrealistic).</li>
+         <li> If an executable is constructed using a Modelica package under
+                  Modelica License 2, then this executable can be licensed under any
+                  license (including a commercial license).</li>
+         </ul>
+         We hope that this compromise between open source contributors, commercial
+         Modelica environments and Modelica users will motivate even more people to
+         provide their Modelica packages freely under the Modelica License 2.<br><br></li>
+<li> There are several new provisions that shall make law suites against licensors and licensees more unlikely (so the small risk is further reduced).</li>
+</ol>
+
+<p><br>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Electrical.Analog.Basic.</b></td></tr>
+<tr><td valign=\"top\">M_Transformer</td>
+          <td valign=\"top\"> Transformer, with the possibility to
+        choose the number of inductors. The inductances and the coupled inductances
+        can be chosen arbitrarily.</td></tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Analog.Lines.</b></td></tr>
+<tr><td valign=\"top\">M_OLine</td>
+          <td valign=\"top\"> Segmented line model that enables the use of
+        multiple lines, that means, the number of segments and the number of
+        single lines can be chosen by the user. The model allows to investigate
+        phenomena at multiple lines like mutual magnetic or capacitive influence.</td></tr>
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Components.Examples.</b></td></tr>
+<tr><td valign=\"top\">Brake</td>
+          <td valign=\"top\"> Demonstrates the usage of the translational brake component.</td></tr>
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialMedium.</b></td></tr>
+<tr><td valign=\"top\">ThermoStates</td>
+          <td valign=\"top\"> Enumeration type for independent variables to identify the independent
+                                                variables of the medium (pT, ph, phX, pTX, dTX).<br>
+                                                An implementation of this enumeration is provided for every medium.
+                                                (This is useful for fluid libraries that do not use the
+                                                PartialMedium.BaseProperties model).</td></tr>
+<tr><td valign=\"top\">setSmoothState</td>
+          <td valign=\"top\"> Function that returns the thermodynamic state which smoothly approximates:
+                                                if x > 0 then state_a else state_b.<br>
+                                                (This is useful for pressure drop components in fluid libraries
+                                                 where the upstream density and/or viscosity has to be computed
+                                                 and these properties should be smooth a zero mass flow rate)<br>
+                                                An implementation of this function is provided for every medium.</td></tr>
+<tr><td colspan=\"2\"><b>Media.Common.</b></td></tr>
+<tr><td valign=\"top\">smoothStep</td>
+          <td valign=\"top\"> Approximation of a general step, such that the characteristic
+                                                is continuous and differentiable.</td></tr>
+<tr><td colspan=\"2\"><b>Media.UsersGuide.</b></td></tr>
+<tr><td valign=\"top\">Future</td>
+          <td valign=\"top\"> Short description of goals and changes of upcoming release of Modelica.Media.</td></tr>
+<tr><td colspan=\"2\"><b>Media.Media.Air.MoistAir.</b></td></tr>
+<tr><td valign=\"top\">isentropicExponent</td>
+          <td valign=\"top\"> Implemented Missing Function from interface.</td></tr>
+<tr><td valign=\"top\">isentropicEnthalpyApproximation</td>
+<td valign=\"top\"> Implemented function that approximates the isentropic enthalpy change.
+This is only correct as long as there is no liquid in the stream.</td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">changed</b> (in a
+<b style=\"color:blue\">backward compatible</b> way):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialFriction </td>
+          <td valign=\"top\"> Improvement of friction model so that in certain situations
+                                                the number of iterations is much smaller.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Components.Examples.</b></td></tr>
+<tr><td valign=\"top\"> Friction </td>
+          <td valign=\"top\"> Added a third variant, where friction is modelled with
+                                                the SupportFriction component.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Components.</b></td></tr>
+<tr><td valign=\"top\"> MassWithStopAndFriction </td>
+          <td valign=\"top\"> Improvement of friction model so that in certain situations
+                                                the number of iterations is much smaller.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialFriction </td>
+          <td valign=\"top\"> Improvement of friction model so that in certain situations
+                                                the number of iterations is much smaller.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Examples.</b></td></tr>
+<tr><td valign=\"top\"> SimpleLiquidWater <br>
+                                                IdealGasH20 <br>
+                                                WaterIF97 <br>
+                                                MixtureGases <br>
+                                                MoistAir </td>
+          <td valign=\"top\"> Added equations to test the new setSmoothState(..) functions
+                                                including the analytic derivatives of these functions.</td></tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialLinearFluid.</b></td></tr>
+<tr><td valign=\"top\"> setState_pTX <br>
+                                                setState_phX <br>
+                                                setState_psX <br>
+                                                setState_dTX </td>
+          <td valign=\"top\"> Rewritten function in one statement so that it is usually inlined.</td></tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialLinearFluid.</b></td></tr>
+<tr><td valign=\"top\"> consistent use of reference_d instead of density(state </td>
+          <td valign=\"top\"> Change was done to achieve consistency with analytic inverse functions.</td></tr>
+
+<tr><td colspan=\"2\"><b>Media.Air.MoistAir.</b></td></tr>
+<tr><td valign=\"top\"> T_phX </td>
+          <td valign=\"top\"> Interval of nonlinear solver to compute T from p,h,X changed
+                                                from 200..6000 to 240 ..400 K.</td></tr>
+
+</table>
+
+<p><br>
+The following <b style=\"color:red\">critical errors</b> have been fixed (i.e., errors
+that can lead to wrong simulation results):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Forces</b></td></tr>
+<tr><td valign=\"top\"> WorldTorque </td>
+          <td valign=\"top\"> Parameter \"ResolveInFrame\" was not propagated and therefore
+                                                always the default (resolved in world frame) was used, independently
+                                                of the setting of this parameter.</td>
+</tr>
+<tr><td valign=\"top\"> WorldForceAndTorque </td>
+          <td valign=\"top\"> Parameter \"ResolveInFrame\" was not propagated and therefore
+                                                always the default (resolved in world frame) was used, independently
+                                                of the setting of this parameter.<br>
+                                                Furthermore, internally WorldTorque was used instead of
+                                                Internal.BasicWorldTorque and therefore the visualization of
+                                                worldTorque was performed twice.</td>
+</tr>
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Sensors</b></td></tr>
+<tr><td valign=\"top\"> AbsoluteSensor </td>
+          <td valign=\"top\"> Velocity, acceleration and angular acceleration were computed
+                                                  by differentiating in the resolveInFrame frame. This has been corrected, by
+                                                  first transforming the vectors in to the world frame, differentiating here
+                                                  and then transforming into resolveInFrame. The parameter in the Advanced menu
+                                                  resolveInFrameAfterDifferentiation is then superfluous and was removed .</td>
+</tr>
+<tr><td valign=\"top\"> AbsoluteVelocity </td>
+          <td valign=\"top\"> The velocity was computed
+                                                  by differentiating in the resolveInFrame frame. This has been corrected, by
+                                                  first transforming the velocity in to the world frame, differentiating here
+                                                  and then transforming into resolveInFrame </td>
+</tr>
+<tr><td valign=\"top\"> RelativeSensor </td>
+          <td valign=\"top\"> If resolveInFrame &lt;&gt; frame_resolve and
+                                                   resolveInFrameAfterDifferentiation = frame_resolve, a translation
+                                                error occurred, since frame_resolve was not enabled in this situation.
+                                                This has been corrected.</td>
+</tr>
+<tr><td valign=\"top\"> RelativeVelocity </td>
+          <td valign=\"top\"> The velocity has have been computed
+                                                  by differentiating in the resolveInFrame frame. This has been corrected, by
+                                                  first transforming the relative position in to frame_a, differentiating here
+                                                  and then transforming into resolveInFrame </td>
+</tr>
+<tr><td valign=\"top\"> TransformRelativeVector </td>
+          <td valign=\"top\"> The transformation was wrong, since the parameters frame_r_in and frame_r_out
+                                                have not been propagated to the submodel that performs the transformation.
+                                                This has been corrected.</td>
+</tr>
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Components.</b></td></tr>
+<tr><td valign=\"top\"> SupportFriction<br>
+                                                Brake </td>
+          <td valign=\"top\"> The sign of the friction force was wrong and therefore friction accelerated
+                                                instead of decelerated. This was fixed.</td>
+</tr>
+<tr><td valign=\"top\"> SupportFriction</td>
+          <td valign=\"top\"> The component was only correct for fixed support.
+                                                This was corrected.</td>
+</tr>
+<tr><td colspan=\"2\"><b>Media.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialSimpleMedium<br>
+                                                PartialSimpleIdealGasMedium </td>
+          <td valign=\"top\"> BaseProperties.p was not defined as preferred state and BaseProperties.T was
+                                                always defined as preferred state. This has been fixed by
+                                                Defining p,T as preferred state if parameter preferredMediumState = true.
+                                                This error had the effect that mass m is selected as state instead of p
+                                                and if default initialization is used then m=0 could give not the expected
+                                                behavior. This means, simulation is not wrong but the numerics is not as good
+                                                and if a model relies on default initial values, the result could be not
+                                                as expected.</td>
+</tr>
+
+</table>
+
+<p><br>
+The following <b style=\"color:red\">uncritical errors</b> have been fixed (i.e., errors
+that do <b style=\"color:red\">not</b> lead to wrong simulation results, but, e.g.,
+units are wrong or errors in documentation):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\"> InverseBlockConstraint </td>
+          <td valign=\"top\"> Changed annotation preserveAspectRatio from true to false.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Sources.</b></td></tr>
+<tr><td valign=\"top\"> RealExpression<br>
+                                                IntegerExpression<br>
+                                                BooleanExpression </td>
+          <td valign=\"top\"> Changed annotation preserveAspectRatio from true to false.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Analog.Basic.</b></td></tr>
+<tr><td valign=\"top\"> SaturatingInductor</td>
+          <td valign=\"top\"> Replaced non-standard \"arctan\" by \"atan\" function.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Digital.</b></td></tr>
+<tr><td valign=\"top\"> UsersGuide</td>
+          <td valign=\"top\"> Removed empty documentation placeholders and added the missing
+                                                  release comment for version 1.0.7</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Translational.Components.</b></td></tr>
+<tr><td valign=\"top\"> MassWithStopAndFriction </td>
+          <td valign=\"top\"> Changed usage of reinit(..), in order that it appears
+                                                only once for one variable according to the language specification
+                                                (if a tool could simulate the model, there is no difference).</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialSimpleMedium</b></td></tr>
+<tr><td valign=\"top\"> pressure<br>
+                                                temperature<br>
+                                                density<br>
+                                                specificEnthalpy </td>
+          <td valign=\"top\"> Missing functions added.</td>
+</tr>
+
+</table>
+
+</html>"));
+end Version_3_0_1;
+
+class Version_3_0 "Version 3.0 (March 1, 2008)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+<p>
+Version 3.0 is <b>not</b> backward compatible to previous versions.
+A conversion script is provided to transform models and libraries
+of previous versions to the new version. Therefore, conversion
+should be automatic.
+</p>
+
+<p>
+The following changes are present for the whole library:
+</p>
+
+<ul>
+<li> In the Modelica language version 3.0, several restrictions have been
+         introduced to allow better checking, e.g., models on all levels must be balanced
+         (number of equations = number of unknown variables - unknown variables that have
+         to be defined when using the component). A few models of the Modelica
+         Standard Library did not fulfill these new restrictions and had
+         either to be moved to library ObsoleteModelica3 (e.g., Blocks.Math.TwoInputs)
+         or had to be differently implemented
+         (e.g., Media.Interfaces.PartialMedium.BaseProperties).
+         The Modelica Standard Library version 3.0 fulfills all the restrictions of
+         the Modelica Language version 3.0.<br>&nbsp;
+         </li>
+
+<li> The graphical annotations describing the layout of icon and diagram layer
+         are changed from Modelica language version 1 to Modelica language version 3.
+         This gives several significant improvements:<br>Especially, the coordinate systems
+         of icon and diagram layers are no longer coupled and therefore the size of the
+         icon layer can be changed independently of the size of the diagram layer.
+         Also it can be defined that the aspect ratio of a component icon is kept when changing
+         its size in a model. This flag is set so that all icons of the Modelica
+         Standard Library keep its aspect ratios. This is slightly non-backward compatible:
+         If the aspect ratio was not kept when using a component from the Modelica
+         Standard Library, it is now resized so that the aspect ratio is maintained.<br>&nbsp; </li>
+
+<li> All non-standard annotations removed by:<br>
+         (1) Removing the annotation since without effect
+                 (e.g., \"__Dymola_experimentSetupOutput\", \"Window\", \"Terminal\" removed).<br>
+         (2) Renaming the annotation to a standard name (e.g., \"Hide\" renamed to \"HideResult\").<br>
+         (3) Renaming the annotation to a vendor specific name
+                 (e.g., \"checkBox\" renamed to \"__Dymola_checkBox\").<br>&nbsp; </li>
+
+<li> All emulated enumerations (defined via packages and constants) have been
+         replaced by \"real\" enumerations. User models are automatically correctly
+         converted, provided the user models used the package constants previously.
+         <b>Existing models that use directly literal values for enumerations, might give in
+         some cases wrong results</b> (if the first constant of the emulated enumeration
+         had value zero, whereas the first value of an enumeration is one).<br>&nbsp; </li>
+
+<li> The operator \"cardinality\" will be removed in one of the next versions of the
+         Modelica language, since it is a reflective operator and its usage significantly
+         reduces the possibilities of advanced model checks (e.g., to guarantee that a model
+         is \"balanced\", i.e., the number of equations and unknowns is identical,
+         for all valid usages of the component). As a preparation for this change, all
+         models that contain the \"cardinality(..)\" operator are rewritten: If possible
+         the operator is removed. If this is not possible, it is only used in asserts to
+         check that, e.g., a connector is connected at least once or is connected exactly
+         once. In the next Modelica language version new language elements will be introduced
+         to specify such a property check without the cardinality operator. Once these
+         language elements are available, the cardinality operator will be removed completely
+         from the Modelica Standard Library.<br>
+         The changes with respect to the cardinality(..) operator are usually not backward
+         compatible. This is the reason for the changes of the
+         Rotational and Translational library (see below).<br>&nbsp;</li>
+
+<li> The design of the <b>Rotational</b> and <b>Translational</b> libraries have been changed
+         (especially to remove the cardinality(..) operator, see above):
+         <ul>
+         <li> Components have a <b>useSupport</b> flag to enable or disable a support flange.
+                  If the support flange is enabled, it must be connected. If it is disabled, it must
+                  not be connected and the component is then internally grounded. The grounding
+                  is visualized in the icon.</li>
+         <li> The relative angle/distance and the relative speed of all force/torque elements
+                  (that need the relative speed) are by default defined with \"StateSelect.prefer\", i.e.,
+                  to use these variables as preferred states. This improves the numerics if the
+                  absolute angle or the absolute distance are continuously increasing during
+                  operation (e.g., driving shaft of the wheels of a car). The effect is that relative
+                  angles/distances and speeds are used as states and the size of these variables is
+                  limited. Previously, the default was to use the absolute angle/distance
+                  and absolute speed of every inertia/mass which has the disadvantage that the absolute
+                  angle and or distance are state variables that grow in size continuously.<br>
+                  A significant advantage is also, that default initialization is usually better,
+                  because a default value of zero for a relative angle/distance is usually what the
+                  user would like to have. Previously, say, the load was initialized to a non-zero
+                  angle and then the elastically coupled motor inertia had to be explicitly
+                  also initialized with this value. This is now, no longer needed. Since the default
+                  nominal value of 1 is usually too large for a relative quantity, the nominal
+                  values of the relative angle/distance was changed to 1e-4.</li>
+         <li> The two libraries have been restructured in sublibraries to cope
+                  with the growing number of components.</li>
+         <li> Finally, the Translational library has been
+                  made as similar as possible to the Rotational library by, e.g., adding missing
+                  components.<br>&nbsp;</li>
+         </ul></li>
+
+<li> The initialization of the MultiBody, Rotational and Translational libraries have
+         been significantly simplified by removing the \"initType\" parameters and only
+         using start/fixed values. This design assumes that a tool has special support
+         for start/fixed values in the parameter menu.<br>&nbsp;</li>
+
+<li> Nearly all parameters defined in the Modelica Standard Library had been
+         defined with a default equation, e.g.,
+         <pre>   <b>parameter</b> Modelica.SIunits.Resistance R=1; </pre>
+         Physical parameters, such as a resistance, mass, gear ratio, do not have a meaningful
+         default and in nearly all cases, the user of the corresponding component has to
+         provide values for such parameters. If the user forgets this, a tool
+         cannot provide diagnostics, since a default value is present in the library
+         (such as 1 Ohm for the resistance). In most cases the model will simulate but will
+         give wrong results due to wrong parameter values. To improve this situation, all physical
+         parameter declarations in the Modelica Standard Library have been changed, so
+         that the previous default becomes a start value. For example, the above
+         declaration is changed to:
+         <pre>   <b>parameter</b> Modelica.SIunits.Resistance R(start=1);  </pre>
+         This is a backward compatible change and completely equivalent from the perspective
+         of the Modelica language. It is, however, advised that tools will print a warning
+         or optionally an error message, if the start value of a parameter is defined, but
+         no value for the parameter is given via a modification. Furthermore, it is expected,
+         that the input field of a parameter menu is empty, if no default equation is defined,
+         but only a start value. This shows clearly to the modeler that a value has to
+         be provided.</li>
+</ul>
+
+<p><br>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries (note, the names in parentheses
+are the new sublibrary names that are introduced in version 3.0):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Blocks.Examples.</b></td></tr>
+<tr><td valign=\"top\">InverseModel</td>
+          <td valign=\"top\"> Demonstrates the construction of an inverse model.</td></tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\">InverseBlockConstraints</td>
+          <td valign=\"top\"> Construct inverse model by requiring that two inputs
+                                                and two outputs are identical (replaces the previously,
+                                                unbalanced, TwoInputs and TwoOutputs blocks).</td></tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.Utilities</b></td></tr>
+<tr><td valign=\"top\">TransformerData</td>
+          <td valign=\"top\"> A record that calculates required impedances (parameters) from nominal data of transformers.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Examples.Rotational3DEffects</b></td></tr>
+<tr><td valign=\"top\"> GyroscopicEffects<br>
+                                                ActuatedDrive<br>
+                                                MovingActuatedDrive<br>
+                                                GearConstraint </td>
+          <td valign=\"top\"> New examples to demonstrate the usage of the Rotational library
+                                                in combination with multi-body components.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Sensors</b></td></tr>
+<tr><td valign=\"top\"> AbsolutePosition<br>
+                                                AbsoluteVelocity<br>
+                                                AbsoluteAngles<br>
+                                                AbsoluteAngularVelocity<br>
+                                                RelativePosition<br>
+                                                RelativeVelocity<br>
+                                                RelativeAngles<br>
+                                                RelativeAngularVelocity</td>
+          <td valign=\"top\"> New sensors to measure one vector.</td>
+</tr>
+<tr><td valign=\"top\"> TransformAbsoluteVector<br>
+                                                TransformRelativeVector</td>
+          <td valign=\"top\"> Transform absolute and/or relative vector into another frame.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.(Components)</b></td></tr>
+<tr><td valign=\"top\"> Disc </td>
+          <td valign=\"top\"> Right flange is rotated by a fixed angle with respect to left flange</td></tr>
+<tr><td valign=\"top\"> IdealRollingWheel </td>
+          <td valign=\"top\"> Simple 1-dim. model of an ideal rolling wheel without inertia</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Sensors</b></td></tr>
+<tr><td valign=\"top\">RelPositionSensor<br>RelSpeedSensor<br>RelAccSensor<br>PowerSensor</td>
+          <td valign=\"top\"> Relative position sensor, i.e., distance between two flanges<br>
+                                                Relative speed sensor<br>
+                                                Relative acceleration sensor<br>
+                                                Ideal power sensor</td></tr>
+<tr><td colspan=\"2\"><b>Mechanics.Translational(.Components)</b></td></tr>
+<tr><td valign=\"top\">SupportFriction<br>Brake<br>InitializeFlange</td>
+          <td valign=\"top\"> Model of friction due to support<br>
+                                                Model of a brake, base on Coulomb friction<br>
+                                                Initializes a flange with pre-defined position, speed and acceleration .</td></tr>
+<tr><td colspan=\"2\"><b>Mechanics.Translational(.Sources)</b></td></tr>
+<tr><td valign=\"top\">Force2<br>LinearSpeedDependentForce<br>QuadraticSpeedDependentForce<br>
+                                           ConstantForce<br>ConstantSpeed<br>ForceStep</td>
+          <td valign=\"top\"> Force acting on 2 flanges<br>
+                                                Force linearly dependent on flange speed<br>
+                                                Force quadratic dependent on flange speed<br>
+                                                Constant force source<br>
+                                                Constant speed source<br>
+                                                Force step</td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">changed</b> in a
+<b style=\"color:blue\">non-backward compatible</b> way
+(the conversion script transforms models and libraries
+of previous versions to the new version. Therefore, conversion
+should be automatic):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Blocks.Continuous.</b></td></tr>
+<tr><td valign=\"top\"> CriticalDamping </td>
+          <td valign=\"top\"> New parameter \"normalized\" to define whether filter is provided
+                                                in normalized or non-normalized form. Default is \"normalized = true\".
+                                                The previous implementation was a non-normalized filter.
+                                                The conversion script automatically introduces the modifier
+                                                \"normalized=false\" for existing models.</td></tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> RealInput<br>
+                                                RealOutput</td>
+          <td valign=\"top\"> Removed \"SignalType\", since extending from a replaceable class
+                                                and this is not allowed in Modelica 3.<br>The conversion script
+                                                removes modifiers to SignalType.</td></tr>
+
+<tr><td valign=\"top\"> RealSignal<br>
+                                                IntegerSignal<br>
+                                                BooleanSignal</td>
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since these connectors
+                                                are no longer allowed in Modelica 3<br>
+                                                (prefixes input and/or output are required).</td></tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Interfaces.Adaptors.</b></td></tr>
+<tr><td valign=\"top\"> AdaptorReal<br>
+                                                AdaptorBoolean<br>
+                                                AdaptorInteger</td>
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since the models are not \"balanced\".
+                                                These are completely obsolete adaptors<br>between the Real, Boolean, Integer
+                                                signal connectors of version 1.6 and version &ge; 2.1 of the Modelica
+                                                Standard Library.</td></tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\"> ConvertAllUnits</td>
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since extending from a replaceable class
+                                                and this is not allowed in Modelica 3.<br> It would be possible to rewrite this
+                                                model to use a replaceable component. However, the information about the
+                                                conversion<br> cannot be visualized in the icon in this case.</td></tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Math.UnitConversions.</b></td></tr>
+<tr><td valign=\"top\"> TwoInputs<br>
+                                                TwoOutputs</td>
+          <td valign=\"top\"> Moved to library ObsoleteModelica3, since the models are not \"balanced\".
+                                                A new component<br>\"InverseBlockConstraints\"
+                                                is provided instead that has the same feature, but is \"balanced\".</td></tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Analog.Baisc.</b></td></tr>
+<tr><td valign=\"top\"> HeatingResistor</td>
+          <td valign=\"top\"> The heatPort has to be connected; otherwise the component Resistor (without heatPort) has to be used.<br>
+                                                cardinality() is only used to check whether the heatPort is connected.</td></tr>
+
+<tr><td colspan=\"2\"><b>Electrical.MultiPhase.Examples.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Moved package <code>Machines.Examples.Utilities</code> to <code>Machines.Utilities</code></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Removed all nonSIunits; especially in DCMachines<br>
+                                                parameter NonSIunits.AngularVelocity_rpm rpmNominal was replaced by<br>
+                                                parameter SIunits.AngularVelocity wNominal</td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the following component variable and parameter names to be more concise:<br>
+                                                Removed suffix \"DamperCage\" from all synchronous induction machines
+                                                since the user can choose whether the damper cage is present or not.<br><code>
+                                                RotorAngle ... RotorDisplacementAngle<br>
+                                                J_Rotor ... Jr<br>
+                                                Rr ........ Rrd (damper of synchronous induction machines)<br>
+                                                Lrsigma ... Lrsigmad (damper of synchronous induction machines)<br>
+                                                phi_mechanical ... phiMechanical<br>
+                                                w_mechanical ..... wMechanical<br>
+                                                rpm_mechanical ... rpmMechanical<br>
+                                                tau_electrical ... tauElectrical<br>
+                                                tau_shaft ........ tauShaft<br>
+                                                TurnsRatio ....... turnsRatio    (AIMS)<br>
+                                                VsNom ............ VsNominal     (AIMS)<br>
+                                                Vr_Lr ............ VrLockedRotor (AIMS)<br>
+                                                DamperCage ....... useDamperCage (synchronous induction machines)<br>
+                                                V0 ............... VsOpenCicuit  (SMPM)<br>
+                                                Ie0 .............. IeOpenCicuit  (SMEE)
+                                                </code></td></tr>
+<tr><td valign=\"top\">Interfaces.</td>
+          <td valign=\"top\"> Moved as much code as possible from specific machine models to partials to reduce redundant code.</td></tr>
+<tr><td valign=\"top\">Interfaces.Adapter</td>
+          <td valign=\"top\"> Removed to avoid cardinality; instead, the following solution has been implemented:</td></tr>
+<tr><td valign=\"top\">Sensors.RotorDisplacementAngle<br>Interfaces.PartialBasicMachine</td>
+          <td valign=\"top\"> Introduced <code>parameter Boolean useSupport=false \"enable / disable (=fixed stator) support\"</code><br>
+                                                The rotational support connector is only present with <code>useSupport = true;</code><br>
+                                                otherwise the stator is fixed internally.</td></tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.Examples.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the names of the examples to more meaningful names.<br>
+                                                Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
+<tr><td valign=\"top\">SMEE_Generator</td>
+          <td valign=\"top\"> Initialization of <code>smee.phiMechanical</code> with <code>fixed=true</code></td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.</b></td></tr>
+<tr><td valign=\"top\"> World</td>
+          <td valign=\"top\"> Changed default value of parameter driveTrainMechanics3D from false to true.<br>
+                                                3-dim. effects in Rotor1D, Mounting1D and BevelGear1D are therefore taken<br>
+                                                into account by default (previously this was only the case, if
+                                                world.driveTrainMechanics3D was explicitly set).</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Forces.</b></td></tr>
+<tr><td valign=\"top\"> FrameForce<br>
+                                                FrameTorque<br>
+                                                FrameForceAndTorque</td>
+          <td valign=\"top\"> Models removed, since functionality now available via Force, Torque, ForceAndTorque</td></tr>
+<tr><td valign=\"top\"> WorldForce<br>
+                                                WorldTorque<br>
+                                                WorldForceAndTorque<br>
+                                                Force<br>
+                                                Torque<br>
+                                                ForceAndTorque</td>
+          <td valign=\"top\"> Connector frame_resolve is optionally enabled via parameter resolveInFrame<br>.
+                                                Forces and torques and be resolved in all meaningful frames defined
+                                                by enumeration resolveInFrame.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Frames.</b></td></tr>
+<tr><td valign=\"top\"> length<br>
+                                                normalize</td>
+          <td valign=\"top\"> Removed functions, since available also in Modelica.Math.Vectors
+                                                <br>The conversion script changes the references correspondingly.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Joints.</b></td></tr>
+<tr><td valign=\"top\"> Prismatic<br>
+                                                ActuatedPrismatic<br>
+                                                Revolute<br>
+                                                ActuatedRevolute<br>
+                                                Cylindrical<br>
+                                                Universal<br>
+                                                Planar<br>
+                                                Spherical<br>
+                                                FreeMotion</td>
+          <td valign=\"top\"> Changed initialization, by replacing initial value parameters with
+                                                start/fixed attributes.<br>
+                                                When start/fixed attributes are properly supported
+                                                in the parameter menu by a Modelica tool,<br>
+                                                the initialization is considerably simplified for the
+                                                user and the implementation is much simpler.<br>
+                                                Replaced parameter \"enforceStates\" by the more general
+                                                built-in enumeration stateSelect=StateSelection.xxx.<br>
+                                                The conversion script automatically
+                                                transforms from the \"old\" to the \"new\" forms.</td></tr>
+<tr><td valign=\"top\"> Revolute<br>
+                                                ActuatedRevolute</td>
+          <td valign=\"top\"> Parameter \"planarCutJoint\" in the \"Advanced\" menu of \"Revolute\" and of
+                                                \"ActuatedRevolute\" removed.<br>
+                                                A new joint \"RevolutePlanarLoopConstraint\" introduced that defines the constraints
+                                                of a revolute joint<br> as cut-joint in a planar loop.
+                                                This change was needed in order that the revolute joint can be
+                                                properly used<br>in advanced model checking.<br>
+                                                ActuatedRevolute joint removed. Flange connectors of Revolute joint<br>
+                                                can be enabled with parameter useAxisFlange.</td></tr>
+<tr><td valign=\"top\"> Prismatic<br>
+                                                ActuatedPrismatic</td>
+          <td valign=\"top\"> ActuatedPrismatic joint removed. Flange connectors of Prismatic joint<br>
+                                                can be enabled with parameter useAxisFlange.</td></tr>
+<tr><td valign=\"top\"> Assemblies</td>
+          <td valign=\"top\"> Assembly joint implementation slightly changed, so that
+                                                annotation \"structurallyIncomplete\" <br>could be removed
+                                                (all Assembly joint models are now \"balanced\").</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Joints.Internal</b></td></tr>
+<tr><td valign=\"top\"> RevoluteWithLengthConstraint<br>
+                                                PrismaticWithLengthConstraint</td>
+          <td valign=\"top\"> These joints should not be used by a user of the MultiBody library.
+                                                They are only provided to built-up the
+                                                MultiBody.Joints.Assemblies.JointXYZ joints.
+                                                These two joints have been changed in a slightly not backward compatible
+                                                way, in order that the usage in the Assemblies.JointXYZ joints results in
+                                                balanced models (<b>no conversion is provided for this change since the
+                                                user should not have used these joints and the conversion would be too
+                                                complicated</b>):
+                                                In releases before version 3.0 of the Modelica Standard Library,
+                                                it was possible to activate the torque/force projection equation
+                                                (= cut-torque/-force projected to the rotation/translation
+                                                axis must be identical to
+                                                the drive torque/force of flange axis) via parameter <b>axisTorqueBalance</b>.
+                                                This is no longer possible, since otherwise this model would not be
+                                                \"balanced\" (= same number of unknowns as equations). Instead, when
+                                                using this model in version 3.0 and later versions, the torque/force
+                                                projection equation must be provided in the Advanced menu of joints
+                                                Joints.SphericalSpherical and Joints.UniversalSpherical
+                                                via the new parameter \"constraintResidue\".</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Parts.</b></td></tr>
+<tr><td valign=\"top\"> BodyBox<br>
+                                                BodyCylinder</td>
+          <td valign=\"top\"> Changed unit of parameter density from g/cm3 to the SI unit kg/m3
+                                                in order to allow stricter unit checking.<br>The conversion script multiplies
+                                                previous density values with 1000.</td></tr>
+<tr><td valign=\"top\"> Body<br>
+                                                BodyShape<br>
+                                                BodyBox<br>
+                                                BodyCylinder<br>
+                                                PointMass
+                                                Rotor1D</td>
+          <td valign=\"top\"> Changed initialization, by replacing initial value parameters with
+                                                start/fixed attributes.<br>
+                                                When start/fixed attributes are properly supported
+                                                in the parameter menu by a Modelica tool,<br>
+                                                the initialization is considerably simplified for the
+                                                user and the implementation is much simpler.<br>The conversion script automatically
+                                                transforms from the \"old\" to the \"new\" form of initialization.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Sensors.</b></td></tr>
+<tr><td valign=\"top\"> AbsoluteSensor<br>
+                                                RelativeSensor<br>
+                                                CutForceAndTorque</td>
+          <td valign=\"top\"> New design of sensor components: Via Boolean parameters<br>
+                                                signal connectors for the respective vectors are enabled/disabled.<br>
+                                                It is not possible to automatically convert models to this new design.<br>
+                                                Instead, references in existing models are changed to ObsoleteModelice3.<br>
+                                                This means that these models must be manually adapted.</td></tr>
+<tr><td valign=\"top\"> CutForce<br>
+                                                CutTorque</td>
+          <td valign=\"top\"> Slightly new design. The force and/or torque component can be
+                                                resolved in world, frame_a, or frame_resolved.<br>
+                                                Existing models are automatically converted.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Moved components to structured sub-packages (Sources, Components)</td></tr>
+<tr><td valign=\"top\"> Inertia<br>
+                                                SpringDamper<br>
+                                                RelativeStates</td>
+          <td valign=\"top\"> Changed initialization, by replacing initial value parameters with
+                                                start/fixed attributes.<br>
+                                                When start/fixed attributes are properly supported
+                                                in the parameter menu by a Modelica tool,<br>
+                                                the initialization is considerably simplified for the
+                                                user and the implementation is much simpler.<br>
+                                                Parameter \"stateSelection\" in \"Inertia\" and \"SpringDamper\" replaced
+                                                by the built-in enumeration<br>stateSelect=StateSelection.xxx.
+                                                Introduced the \"stateSelect\" enumeration in \"RelativeStates\".<br>
+                                                The conversion script automatically
+                                                transforms from the \"old\" to the \"new\" forms.</td></tr>
+<tr><td valign=\"top\"> LossyGear<br>
+                                                GearBox</td>
+          <td valign=\"top\"> Renamed gear ratio parameter \"i\" to \"ratio\", in order to have a
+                                                consistent naming convention.<br>
+                                                Existing models are automatically converted.</td></tr>
+<tr><td valign=\"top\"> SpringDamper<br>
+                                                ElastoBacklash<br>
+                                                Clutch<br>
+                                                OneWayClutch</td>
+          <td valign=\"top\"> Relative quantities (phi_rel, w_rel) are used as states, if possible
+                                                (due to StateSelect.prefer). <br>
+                                                In most cases, relative states in drive trains are better suited as
+                                                absolute states. <br> This change might give changes in the selected states
+                                                of existing models.<br>
+                                                This might give rise to problems if, e.g., the initialization was not
+                                                completely defined in a user model,<br> since the default
+                                                initialization heuristic may give different initial values.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Moved components to structured sub-packages (Sources, Components)</td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Adaptions corresponding to Rotational</td></tr>
+<tr><td valign=\"top\"> Stop</td>
+          <td valign=\"top\"> Renamed to Components.MassWithStopAndFriction to be more concise.<br>
+                                                MassWithStopAndFriction is not available with a support connector, <br>
+                                                since the reaction force can't be modeled in a meaningful way due to reinit of velocity v.<br>
+                                                Until a sound implementation of a hard stop is available, the old model may be used.</td></tr>
+<tr><td colspan=\"2\"><b>Media.</b></td></tr>
+<tr><td valign=\"top\"> constant nX <br>
+                                                constant nXi <br>
+                                                constant reference_X<br>
+                                                BaseProperties</td>
+          <td valign=\"top\"> The package constant nX = nS, now always, even for single species media. This also allows to define mixtures with only 1 element. The package constant nXi=if fixedX then 0 else if reducedX or nS==1 then nS - 1 else nS. This required that all BaseProperties for single species media get an additional equation to define the composition X as {1.0} (or reference_X, which is {1.0} for single species). This will also mean that all user defined single species media need to be updated by that equation.</td></tr>
+
+<tr><td colspan=\"2\"><b>SIunits.</b></td></tr>
+<tr><td valign=\"top\"> CelsiusTemperature </td>
+          <td valign=\"top\"> Removed, since no SI unit. The conversion script changes references to
+                                                SIunits.Conversions.NonSIunits.Temperature_degC </td></tr>
+<tr><td valign=\"top\"> ThermodynamicTemperature <br>
+                                                TemperatureDifference</td>
+          <td valign=\"top\"> Added annotation \"absoluteValue=true/false\"
+                                                in order that unit checking is possible<br>
+                                                (the unit checker needs to know for a unit that has an offset,
+                                                whether it is used as absolute or as a relative number)</td></tr>
+
+<tr><td colspan=\"2\"><b>SIunits.Conversions.NonSIunits.</b></td></tr>
+<tr><td valign=\"top\"> Temperature_degC<br>
+                                                Temperature_degF<br>
+                                                Temperature_degRk </td>
+          <td valign=\"top\"> Added annotation \"absoluteValue=true\"
+                                                in order that unit checking is possible<br>
+                                                (the unit checker needs to know for a unit that has an offset,
+                                                whether it is used as absolute or as a relative number)</td></tr>
+
+<tr><td colspan=\"2\"><b>StateGraph.Examples.</b></td></tr>
+<tr><td valign=\"top\"> ControlledTanks </td>
+          <td valign=\"top\"> The connectors of the ControlledTanks did not fulfill the new
+                                                restrictions of Modelica 3. This has been fixed.</td></tr>
+<tr><td valign=\"top\"> Utilities </td>
+          <td valign=\"top\"> Replacing inflow, outflow by connectors inflow1, inflow2,
+                                                outflow1, outflow2 with appropriate input/output prefixes in
+                                                order to fulfill the restrictions of Modelica 3 to arrive
+                                                at balanced models. No conversion is provided, since
+                                                too difficult and since the non-backward compatible change is in
+                                                an example.</td></tr>
+
+<tr><td colspan=\"2\"><b>Thermal.FluidHeatFlow.Sensors.</b></td></tr>
+<tr><td valign=\"top\"> <br>
+                                                pSensor<br>TSensor<br>dpSensor<br>dTSensor<br>m_flowSensor<br>V_flowSensor<br>H_flowSensor</td>
+          <td valign=\"top\"> renamed to:<br>
+                                                PressureSensor<br>TemperatureSensor<br>RelPressureSensor<br>RelTemperatureSensor<br>MassFlowSensor<br>VolumeFlowSensor<br>EnthalpyFlowSensor
+                                                </td></tr>
+
+<tr><td colspan=\"2\"><b>Thermal.FluidHeatFlow.Sources.</b></td></tr>
+<tr><td valign=\"top\"> Ambient<br>PrescribedAmbient</td>
+          <td valign=\"top\"> available as one combined component Ambient<br>
+                                                Boolean parameters usePressureInput and useTemperatureInput decide
+                                                whether pressure and/or temperature are constant or prescribed</td></tr>
+<tr><td valign=\"top\"> ConstantVolumeFlow<br>PrescribedVolumeFlow</td>
+          <td valign=\"top\"> available as one combined component VolumeFlow<br>
+                                                Boolean parameter useVolumeFlowInput decides
+                                                whether volume flow is constant or prescribed</td></tr>
+<tr><td valign=\"top\"> ConstantPressureIncrease<br>PrescribedPressureIncrease</td>
+          <td valign=\"top\"> available as one combined component PressureIncrease<br>
+                                                Boolean parameter usePressureIncreaseInput decides
+                                                whether pressure increase is constant or prescribed</td></tr>
+
+<tr><td colspan=\"2\"><b>Thermal.FluidHeatFlow.Examples.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
+
+<tr><td colspan=\"2\"><b>Thermal.HeatTransfer.(Components)</b></td></tr>
+<tr><td valign=\"top\"> HeatCapacitor</td>
+          <td valign=\"top\"> Initialization changed: SteadyStateStart removed. Instead
+                                                start/fixed values for T and der_T<br>(initial temperature and its derivative).</td></tr>
+
+<tr><td valign=\"top\"> <br><br>HeatCapacitor<br>ThermalConductor<br>ThermalConvection<br>BodyRadiation<br><br>
+                                                TemperatureSensor<br>RelTemperatureSensor<br>HeatFlowSensor<br><br>
+                                                FixedTemperature<br>PrescribedTemperature<br>FixedHeatFlow<br>PrescribedHeatFlow</td>
+          <td valign=\"top\"> Moved components to sub-packages:<br><br>
+                                                Components.HeatCapacitor<br>Components.ThermalConductor<br>Components.ThermalConvection<br>Components.BodyRadiation<br><br>
+                                                Sensors.TemperatureSensor<br>Sensors.RelTemperatureSensor<br>Sensors.HeatFlowSensor<br><br>
+                                                Sources.FixedTemperature<br>Sources.PrescribedTemperature<br>Sources.FixedHeatFlow<br>Sources.PrescribedHeatFlow
+                                                </td></tr>
+
+<tr><td colspan=\"2\"><b>Thermal.FluidHeatFlow.Examples.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Changed the instance names of components used in the examples to more up-to-date style.</td></tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">improved</b> in a
+<b style=\"color:blue\">backward compatible</b> way:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td valign=\"top\"> <b>Modelica.*</b> </td>
+          <td valign=\"top\"> Parameter declarations, input and output function arguments without description
+                                                strings improved<br> by providing meaningful description texts.
+                                                </td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Continuous.</b></td></tr>
+<tr><td valign=\"top\"> TransferFunction </td>
+          <td valign=\"top\"> Internal scaling of the controller canonical states introduced
+                                                in order to enlarge the range of transfer functions where the default
+                                                relative tolerance of the simulator is sufficient.</td>
+</tr>
+
+<tr><td valign=\"top\"> Butterworth<br>CriticalDamping </td>
+          <td valign=\"top\"> Documentation improved and plots of the filter characteristics added.</td></tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Analog.Basic.</b></td></tr>
+<tr><td valign=\"top\"> EMF </td>
+          <td valign=\"top\"> New parameter \"useSupport\" to optionally enable a support connector.</td></tr>
+
+<tr><td colspan=\"2\"><b>Icons.</b></td></tr>
+<tr><td valign=\"top\"> TranslationalSensor<br>
+                                                RotationalSensor</td>
+          <td valign=\"top\"> Removed drawing from the diagram layer (kept drawing only in
+                                                icon layer),<br> in order that this icon can be used in situations
+                                                where components are dragged in the diagram layer.</td></tr>
+
+<tr><td colspan=\"2\"><b>Math.Vectors.</b></td></tr>
+<tr><td valign=\"top\"> normalize</td>
+          <td valign=\"top\"> Implementation changed, so that the result is awalys continuous<br>
+                                                (previously, this was not the case for small vectors: normalize(eps,eps)).
+                                                </td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.</b></td></tr>
+<tr><td valign=\"top\"> </td>
+          <td valign=\"top\"> Renamed non-standard keywords defineBranch, defineRoot, definePotentialRoot,
+                                                isRooted to the standard names:<br>
+                                                Connections.branch/.root/.potentialRoot/.isRooted.</td></tr>
+<tr><td valign=\"top\"> Frames </td>
+          <td valign=\"top\"> Added annotation \"Inline=true\" to all one-line functions
+                                                (which should be all inlined).</td></tr>
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Parts.</b></td></tr>
+<tr><td valign=\"top\"> Mounting1D<br>
+                                                Rotor1D<br>
+                                                BevelGear1D</td>
+          <td valign=\"top\"> Changed implementation so that no longer modifiers for connector
+                                                variables are used,<br>because this violates the restrictions on
+                                                \"balanced models\" of Modelica 3.</td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> InitializeFlange</td>
+          <td valign=\"top\"> Changed implementation so that counting unknowns and
+                                                equations is possible without actual values of parameters.</td></tr>
+
+<tr><td colspan=\"2\"><b>Thermal.FluidHeatFlow.Interfaces.Partials.</b></td></tr>
+<tr><td valign=\"top\">TwoPort</td>
+          <td valign=\"top\"> Introduced <code>parameter Real tapT(final min=0, final max=1)=1</code> <br> that defines the temperature of the heatPort
+                                                between inlet and outlet.</td></tr>
+
+<tr><td colspan=\"2\"><b>StateGraph.</b></td></tr>
+<tr><td valign=\"top\"> InitialStep<br>
+                                                InitialStepWithSignal<br>
+                                                Step<br>
+                                                StepWithSignal</td>
+          <td valign=\"top\"> Changed implementation so that no longer modifiers for output
+                                                variables are used,<br>because this violates the restrictions on
+                                                \"balanced models\" of Modelica 3.</td></tr>
+
+</table>
+
+<p><br>
+The following <b style=\"color:red\">critical errors</b> have been fixed (i.e., errors
+that can lead to wrong simulation results):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Electrical.Analog.Examples.</b></td></tr>
+<tr><td valign=\"top\"> CauerLowPassSC </td>
+          <td valign=\"top\"> Wrong calculation of Capacitor1 both in Rn and Rp corrected
+                                                (C=clock/R instead of C=clock*R) </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Parts.</b></td></tr>
+<tr><td valign=\"top\"> Rotor1D </td>
+          <td valign=\"top\"> The 3D reaction torque was not completely correct and gave in
+                                                some situations a wrong result. This bug should not influence the
+                                                movement of a multi-body system, but only the constraint torques
+                                                are sometimes not correct.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> ElastoBacklash </td>
+          <td valign=\"top\"> If the damping torque was too large, the reaction torque
+                                                could \"pull\" which is unphysical. The component was
+                                                newly written by limiting the damping torque in such a case
+                                                so that \"pulling\" torques can no longer occur. Furthermore,
+                                                during initialization the characteristics is made continuous
+                                                to reduce numerical errors. The relative angle and relative
+                                                angular velocities are used as states, if possible
+                                                (StateSelect.prefer), since relative quantities lead usually
+                                                to better behavior.  </td>
+</tr>
+<tr><td valign=\"top\"> Position<br>Speed<br>Accelerate<br>Move</td>
+          <td valign=\"top\"> The movement of the flange was wrongly defined as absolute;
+                                                this is corrected as relative to connector support.<br>
+                                                For Accelerate, it was necessary to rename
+                                                RealInput a to a_ref, as well as the start values
+                                                phi_start to phi.start and w_start to w.start.
+                                                The conversion script performs the necessary conversion of
+                                                existing models automatically.</td>
+</tr>
+<tr><td colspan=\"2\"><b>Media.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialSimpleIdealGasMedium </td>
+          <td valign=\"top\"> Inconsistency in reference temperature corrected. This may give
+                                                different results for functions:<br>
+                                                specificEnthalpy, specificInternalEnergy, specificGibbsEnergy,
+                                                specificHelmholtzEnergy.</td>
+</tr>
+<tr><td colspan=\"2\"><b>Media.Air.</b></td></tr>
+<tr><td valign=\"top\"> specificEntropy </td>
+          <td valign=\"top\"> Small bug in entropy computation of ideal gas mixtures corrected.</td>
+</tr>
+<tr><td colspan=\"2\"><b>Media.IdealGases.Common.MixtureGasNasa</b></td></tr>
+<tr><td valign=\"top\"> specificEntropy </td>
+          <td valign=\"top\"> Small bug in entropy computation of ideal gas mixtures corrected.</td>
+</tr>
+</table>
+
+<p><br>
+The following <b style=\"color:red\">uncritical errors</b> have been fixed (i.e., errors
+that do <b style=\"color:red\">not</b> lead to wrong simulation results, but, e.g.,
+units are wrong or errors in documentation):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Blocks.Tables.</b></td></tr>
+<tr><td valign=\"top\"> CombiTable2D</td>
+          <td valign=\"top\"> Documentation improved.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrica.Digital.Gates</b></td></tr>
+<tr><td valign=\"top\"> AndGate<br>
+                                                NandGate<br>
+                                                OrGate<br>
+                                                NorGate<br>
+                                                XorGate<br>
+                                                XnorGate</td>
+          <td valign=\"top\"> The number of inputs was not correctly propagated
+                                                to the included base model.<br>
+                                                This gave a translation error, if the number
+                                                of inputs was changed (and not the default used).</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrica.Digital.Sources</b></td></tr>
+<tr><td valign=\"top\"> Pulse </td>
+          <td valign=\"top\"> Model differently implemented, so that
+                                                warning message about \"cannot properly initialize\" is gone.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> BearingFriction<br>
+                                                Clutch<br>
+                                                OneWayClutch<br>
+                                                Brake <br>
+                                                Gear </td>
+          <td valign=\"top\"> Declaration of table parameter changed from
+                                                table[:,:] to table[:,2].</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Examples.Loops.Utilities.</b></td></tr>
+<tr><td valign=\"top\"> GasForce </td>
+          <td valign=\"top\"> Unit of variable \"press\" corrected (from Pa to bar)</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>StateGraph.Examples.</b></td></tr>
+<tr><td valign=\"top\">SimpleFriction</td>
+          <td valign=\"top\"> The internal parameter k is defined and calculated with the appropriate unit.</td></tr>
+
+<tr><td colspan=\"2\"><b>Thermal.FluidHeatFlow.Interfaces.Partials.</b></td></tr>
+<tr><td valign=\"top\">SimpleFriction</td>
+          <td valign=\"top\"> The internal parameter k is defined and calculated with the appropriate unit.</td></tr>
+
+</table>
+
+</html>"));
+end Version_3_0;
+
+class Version_2_2_2 "Version 2.2.2 (Aug. 31, 2007)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+<p>
+Version 2.2.2 is backward compatible to version 2.2.1 and 2.2 with
+the following exceptions:
+</p>
+<ul>
+<li> Removal of package Modelica.Media.Interfaces.PartialTwoPhaseMediumWithCache
+         (this was not yet utilized).</li>
+<li> Removal of the media packages in
+         Modelica.Media.IdealGases.SingleGases that are not type compatible
+         to Modelica.Media.Interfaces.PartialMedium, because a FluidConstants
+         record definition is missing,
+         for details, see
+          <a href=\"modelica://Modelica.Media.IdealGases\">Modelica.Media.IdealGases</a>
+         (this is seen as a bug fix).</li>
+</ul>
+
+<p>
+An overview of the differences between version 2.2.2 and the previous
+version 2.2.1 is given below. The exact differences (but without
+differences in the documentation) are available in
+<a href=\"modelica://Modelica/Resources/Documentation/Differences-Modelica-221-222.html\">Differences-Modelica-221-222.html</a>.
+This comparison file was generated automatically with Dymola's
+ModelManagement.compare function.
+</p>
+
+<p>
+In this version, <b>no</b> new libraries have been added. The <b>documentation</b>
+of the whole library was improved.
+</p>
+
+<p><br>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Blocks.Logical.</b></td></tr>
+<tr><td valign=\"top\"> TerminateSimulation</td>
+          <td valign=\"top\"> Terminate a simulation by a given condition.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Routing.</b></td></tr>
+<tr><td valign=\"top\"> RealPassThrough<br>
+                   IntegerPassThrough<br>
+                   BooleanPassThrough</td>
+          <td valign=\"top\"> Pass a signal from input to output
+                   (useful in combination with a bus due to restrictions
+                   of expandable connectors).</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Sources.</b></td></tr>
+<tr><td valign=\"top\"> KinematicPTP2 </td>
+          <td valign=\"top\"> Directly gives q,qd,qdd as output (and not just qdd as KinematicPTP).
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.Examples.</b></td></tr>
+<tr><td valign=\"top\"> TransformerTestbench </td>
+          <td valign=\"top\"> Transformer Testbench
+          </td></tr>
+<tr><td valign=\"top\"> Rectifier6pulse </td>
+          <td valign=\"top\"> 6-pulse rectifier with 1 transformer
+          </td>
+</tr>
+<tr><td valign=\"top\"> Rectifier12pulse </td>
+          <td valign=\"top\"> 12-pulse rectifier with 2 transformers
+          </td>
+</tr>
+<tr><td valign=\"top\"> AIMC_Steinmetz </td>
+          <td valign=\"top\"> Asynchronous induction machine squirrel cage with Steinmetz connection
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.BasicMachines.Components.</b></td></tr>
+<tr><td valign=\"top\"> BasicAIM </td>
+          <td valign=\"top\"> Partial model for asynchronous induction machine
+          </td></tr>
+<tr><td valign=\"top\"> BasicSM </td>
+          <td valign=\"top\"> Partial model for synchronous induction machine
+          </td></tr>
+<tr><td valign=\"top\"> PartialAirGap </td>
+          <td valign=\"top\"> Partial airgap model
+          </td></tr>
+<tr><td valign=\"top\"> BasicDCMachine </td>
+          <td valign=\"top\"> Partial model for DC machine
+          </td></tr>
+<tr><td valign=\"top\"> PartialAirGapDC </td>
+          <td valign=\"top\"> Partial airgap model of a DC machine
+          </td></tr>
+<tr><td valign=\"top\"> BasicTransformer </td>
+          <td valign=\"top\"> Partial model of threephase transformer
+          </td></tr>
+<tr><td valign=\"top\"> PartialCore </td>
+          <td valign=\"top\"> Partial model of transformer core with 3 windings
+          </td></tr>
+<tr><td valign=\"top\"> IdealCore </td>
+          <td valign=\"top\"> Ideal transformer with 3 windings
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.BasicMachines.</b></td></tr>
+<tr><td valign=\"top\"> Transformers </td>
+          <td valign=\"top\"> Sub-Library for technical 3phase transformers
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> Adapter </td>
+          <td valign=\"top\"> Adapter to model housing of electrical machine
+          </td>
+</tr>
+<tr><td colspan=\"2\"><b>Math.</b></td></tr>
+<tr><td valign=\"top\"> Vectors </td>
+          <td valign=\"top\"> New library of functions operating on vectors
+          </td>
+</tr>
+<tr><td valign=\"top\"> atan3 </td>
+          <td valign=\"top\"> Four quadrant inverse tangent (select solution that is closest to given angle y0)
+          </td>
+</tr>
+<tr><td valign=\"top\"> asinh </td>
+          <td valign=\"top\"> Inverse of sinh (area hyperbolic sine)
+          </td>
+</tr>
+<tr><td valign=\"top\"> acosh </td>
+          <td valign=\"top\"> Inverse of cosh (area hyperbolic cosine)
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Math.Vectors</b></td></tr>
+<tr><td valign=\"top\"> isEqual </td>
+          <td valign=\"top\"> Determine if two Real vectors are numerically identical
+          </td>
+</tr>
+<tr><td valign=\"top\"> norm </td>
+          <td valign=\"top\"> Return the p-norm of a vector
+          </td></tr>
+<tr><td valign=\"top\"> length </td>
+          <td valign=\"top\"> Return length of a vector (better as norm(), if further symbolic processing is performed)
+          </td></tr>
+<tr><td valign=\"top\"> normalize </td>
+          <td valign=\"top\"> Return normalized vector such that length = 1 and prevent zero-division for zero vector
+          </td></tr>
+<tr><td valign=\"top\"> reverse </td>
+          <td valign=\"top\"> Reverse vector elements (e.g., v[1] becomes last element)
+          </td></tr>
+<tr><td valign=\"top\"> sort </td>
+          <td valign=\"top\"> Sort elements of vector in ascending or descending order
+          </td></tr>
+
+<tr><td colspan=\"2\"><b>Math.Matrices</b></td></tr>
+<tr><td valign=\"top\"> solve2 </td>
+          <td valign=\"top\"> Solve real system of linear equations A*X=B with a B matrix
+                   (Gaussian elimination with partial pivoting)
+          </td>
+</tr>
+<tr><td valign=\"top\"> LU_solve2 </td>
+          <td valign=\"top\"> Solve real system of linear equations P*L*U*X=B with a B matrix
+                   and an LU decomposition (from LU(..))
+          </td></tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> InitializeFlange </td>
+          <td valign=\"top\"> Initialize a flange according to given signals
+                   (useful if initialization signals are provided by a signal bus).
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialMedium.</b></td></tr>
+<tr><td valign=\"top\"> density_pTX </td>
+          <td valign=\"top\"> Return density from p, T, and X or Xi
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialTwoPhaseMedium.</b></td></tr>
+<tr><td valign=\"top\"> BaseProperties </td>
+          <td valign=\"top\"> Base properties (p, d, T, h, u, R, MM, x) of a two phase medium
+          </td>
+</tr>
+<tr><td valign=\"top\"> molarMass </td>
+          <td valign=\"top\"> Return the molar mass of the medium
+          </td>
+</tr>
+<tr><td valign=\"top\"> saturationPressure_sat </td>
+          <td valign=\"top\"> Return saturation pressure
+          </td>
+</tr>
+<tr><td valign=\"top\"> saturationTemperature_sat </td>
+          <td valign=\"top\"> Return saturation temperature
+          </td>
+</tr>
+<tr><td valign=\"top\"> saturationTemperature_derp_sat </td>
+          <td valign=\"top\"> Return derivative of saturation temperature w.r.t. pressure
+          </td>
+</tr>  <tr><td valign=\"top\"> setState_px </td>
+          <td valign=\"top\"> Return thermodynamic state from pressure and vapour quality
+          </td>
+</tr>  <tr><td valign=\"top\"> setState_Tx </td>
+          <td valign=\"top\"> Return thermodynamic state from temperature and vapour quality
+          </td>
+</tr>  <tr><td valign=\"top\"> vapourQuality </td>
+          <td valign=\"top\"> Return vapour quality
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialLinearFluid </td>
+          <td valign=\"top\"> Generic pure liquid model with constant cp,
+                   compressibility and thermal expansion coefficients
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Air.MoistAir.</b></td></tr>
+<tr><td valign=\"top\"> massFraction_pTphi </td>
+          <td valign=\"top\"> Return the steam mass fraction from relative humidity and T
+          </td>
+</tr>
+<tr><td valign=\"top\"> saturationTemperature </td>
+          <td valign=\"top\"> Return saturation temperature from (partial) pressure
+                   via numerical inversion of function saturationPressure
+          </td>
+</tr>
+<tr><td valign=\"top\"> enthalpyOfWater </td>
+          <td valign=\"top\"> Return specific enthalpy of water (solid/liquid) near
+                   atmospheric pressure from temperature
+          </td>
+</tr>
+<tr><td valign=\"top\"> enthalpyOfWater_der </td>
+          <td valign=\"top\"> Return derivative of enthalpyOfWater()\" function
+          </td>
+</tr>
+<tr><td valign=\"top\"> PsychrometricData </td>
+          <td valign=\"top\"> Model to generate plot data for psychrometric chart
+          </td>
+</tr>
+<tr><td colspan=\"2\"><b>Media.CompressibleLiquids.</b><br>
+          New sub-library for simple compressible liquid models</td></tr>
+<tr><td valign=\"top\"> LinearColdWater </td>
+          <td valign=\"top\"> Cold water model with linear compressibility
+          </td>
+</tr>
+<tr><td valign=\"top\"> LinearWater_pT_Ambient </td>
+          <td valign=\"top\"> Liquid, linear compressibility water model at 1.01325 bar
+                   and 25 degree Celsius
+          </td>
+</tr>
+<tr><td colspan=\"2\"><b>SIunits.</b></td></tr>
+<tr><td valign=\"top\"> TemperatureDifference </td>
+          <td valign=\"top\"> Type for temperature difference
+          </td>
+</tr>
+</table>
+
+<p><br>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">improved</b>:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Blocks.Examples.</b></td></tr>
+<tr><td valign=\"top\"> BusUsage</td>
+          <td valign=\"top\"> Example changed from the \"old\" to the \"new\" bus concept with
+                   expandable connectors.</td></tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Discrete.</b></td></tr>
+<tr><td valign=\"top\"> ZeroOrderHold</td>
+          <td valign=\"top\"> Sample output ySample moved from \"protected\" to \"public\"
+                   section with new attributes (start=0, fixed=true).
+          </td>
+</tr>
+<tr><td valign=\"top\"> TransferFunction</td>
+          <td valign=\"top\"> Discrete state x with new attributes (each start=0, each fixed=0).
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.</b></td></tr>
+<tr><td valign=\"top\"> Analog<br>MultiPhase</td>
+          <td valign=\"top\"> Improved some icons.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Digital.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> MISO</td>
+          <td valign=\"top\"> Removed \"algorithm\" from this partial block.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Digital.Delay.</b></td></tr>
+<tr><td valign=\"top\"> DelayParams</td>
+          <td valign=\"top\"> Removed \"algorithm\" from this partial block.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Digital.Delay.</b></td></tr>
+<tr><td valign=\"top\"> DelayParams</td>
+          <td valign=\"top\"> Removed \"algorithm\" from this partial block.
+          </td>
+</tr>
+<tr><td valign=\"top\"> TransportDelay</td>
+          <td valign=\"top\">  If delay time is zero, an infinitely small delay is
+                        introduced via pre(x) (previously \"x\" was used).
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Digital.Sources.</b></td></tr>
+<tr><td valign=\"top\"> Clock<br>Step</td>
+          <td valign=\"top\"> Changed if-conditions from \"xxx < time\" to \"time >= xxx\"
+                   (according to the Modelica specification, in the second case
+                   a time event should be triggered, i.e., this change leads
+                   potentially to a faster simulation).
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Digital.Converters.</b></td></tr>
+<tr><td valign=\"top\"> BooleanToLogic<br>
+                   LogicToBoolean<br>
+                   RealToLogic<br>
+                   LogicToReal</td>
+          <td valign=\"top\"> Changed from \"algorithm\" to \"equation\" section
+                   to allow better symbolic preprocessing
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.</b></td></tr>
+<tr><td valign=\"top\"> Machines</td>
+          <td valign=\"top\"> Slightly improved documentation, typos in
+                   documentation corrected
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.Examples.</b></td></tr>
+<tr><td valign=\"top\"> AIMS_start</td>
+          <td valign=\"top\"> Changed QuadraticLoadTorque1(TorqueDirection=true) to
+                   QuadraticLoadTorque1(TorqueDirection=false) since more realistic
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialBasicMachine</td>
+          <td valign=\"top\"> Introduced support flange to model the
+                   reaction torque to the housing
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Machines.Sensors.</b></td></tr>
+<tr><td valign=\"top\"> Rotorangle</td>
+          <td valign=\"top\"> Introduced support flange to model the
+                   reaction torque to the housing
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Examples.Elementary.</b></td></tr>
+<tr><td valign=\"top\"> PointMassesWithGravity</td>
+          <td valign=\"top\"> Added two point masses connected by a line force to demonstrate
+                   additionally how this works. Connections of point masses
+                   with 3D-elements are demonstrated in the new example
+                   PointMassesWithGravity (there is the difficulty that the orientation
+                   is not defined in a PointMass object and therefore some
+                   special handling is needed in case of a connection with
+                   3D-elements, where the orientation of the point mass is not
+                   determined by these elements.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Examples.Systems.</b></td></tr>
+<tr><td valign=\"top\"> RobotR3</td>
+          <td valign=\"top\"> Changed from the \"old\" to the \"new\" bus concept with expandable connectors.
+                   Replaced the non-standard Modelica function \"constrain()\" by
+                   standard Modelica components. As a result, the non-standard function
+                   constrain() is no longer used in the Modelica Standard Library.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Frames.Orientation.</b></td></tr>
+<tr><td valign=\"top\"> equalityConstraint</td>
+          <td valign=\"top\"> Use a better residual for the equalityConstraint function.
+                   As a result, the non-linear equation system of a kinematic
+                   loop is formulated in a better way (the range where the
+                   desired result is a unique solution of the non-linear
+                   system of equations becomes much larger).</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.</b></td></tr>
+<tr><td valign=\"top\"> Visualizers.</td>
+          <td valign=\"top\"> Removed (misleading) annotation \"structurallyIncomplete\"
+                   in the models of this sub-library
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> Examples</td>
+          <td valign=\"top\"> For all models in this sub-library:
+                   <ul>
+                   <li> Included a housing object in all examples to compute
+                                all support torques.</li>
+                   <li> Replaced initialization by modifiers via the
+                                initialization menu parameters of Inertia components.</li>
+                   <li> Removed \"encapsulated\" and unnecessary \"import\".</li>
+                   <li> Included \"StopTime\" in the annotations.</li>
+                   </ul>
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Introduced \"fixed=true\" for Boolean variables startForward,
+                   startBackward, mode.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Introduced \"fixed=true\" for Boolean variables startForward,
+                   startBackward, mode.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.UsersGuide.MediumUsage.</b></td></tr>
+<tr><td valign=\"top\"> TwoPhase</td>
+          <td valign=\"top\"> Improved documentation and demonstrating the newly introduced functions
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Examples.</b></td></tr>
+<tr><td valign=\"top\"> WaterIF97</td>
+          <td valign=\"top\"> Provided (missing) units for variables V, dV, H_flow_ext, m, U.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialMedium</td>
+          <td valign=\"top\"> Final modifiers are removed from nX and nXi, to allow
+                   customized medium models such as mixtures of refrigerants with oil, etc.
+          </td>
+</tr>
+<tr><td valign=\"top\"> PartialCondensingGases</td>
+          <td valign=\"top\"> Included attributes \"min=1, max=2\" for input argument FixedPhase
+                   for functions setDewState and setBubbleState (in order to guarantee
+                   that input arguments are correct).
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Interfaces.PartialMedium.</b></td></tr>
+<tr><td valign=\"top\"> BaseProperties</td>
+          <td valign=\"top\"> New Boolean parameter \"standardOrderComponents\".
+                   If true, last element vector X is computed from 1-sum(Xi) (= default)
+                   otherwise, no equation is provided for it in PartialMedium.
+          </td>
+</tr>
+<tr><td valign=\"top\"> IsentropicExponent</td>
+          <td valign=\"top\"> \"max\" value changed from 1.7 to 500000
+          </td>
+</tr>
+<tr><td valign=\"top\"> setState_pTX<br>
+                   setState_phX<br>
+                   setState_psX<br>
+                   setState_dTX<br>
+                   specificEnthalpy_pTX<br>
+                   temperature_phX<br>
+                   density_phX<br>
+                   temperature_psX<br>
+                   density_psX<br>
+                   specificEnthalpy_psX</td>
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Interfaces.PartialSimpleMedium.</b></td></tr>
+<tr><td valign=\"top\"> setState_pTX<br>
+                   setState_phX<br>
+                   setState_psX<br>
+                   setState_dTX</td>
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Interfaces.PartialSimpleIdealGasMedium.</b></td></tr>
+<tr><td valign=\"top\"> setState_pTX<br>
+                   setState_phX<br>
+                   setState_psX<br>
+                   setState_dTX</td>
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Air.MoistAir.</b></td></tr>
+<tr><td valign=\"top\"> setState_pTX<br>
+                   setState_phX<br>
+                   setState_dTX</td>
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.IdealGases.Common.SingleGasNasa.</b></td></tr>
+<tr><td valign=\"top\"> setState_pTX<br>
+                   setState_phX<br>
+                   setState_psX<br>
+                   setState_dTX</td>
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.IdealGases.Common.MixtureGasNasa.</b></td></tr>
+<tr><td valign=\"top\"> setState_pTX<br>
+                   setState_phX<br>
+                   setState_psX<br>
+                   setState_dTX<br>
+                   h_TX</td>
+          <td valign=\"top\"> Introduced default value \"reference_X\" for input argument \"X\".
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Common.</b></td></tr>
+<tr><td valign=\"top\"> IF97PhaseBoundaryProperties<br>
+                   gibbsToBridgmansTables </td>
+          <td valign=\"top\"> Introduced unit for variables vt, vp.
+          </td>
+</tr>
+<tr><td valign=\"top\"> SaturationProperties</td>
+          <td valign=\"top\"> Introduced unit for variable dpT.
+          </td>
+</tr>
+<tr><td valign=\"top\"> BridgmansTables</td>
+          <td valign=\"top\"> Introduced unit for dfs, dgs.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Common.ThermoFluidSpecial.</b></td></tr>
+<tr><td valign=\"top\"> gibbsToProps_ph<br>
+                   gibbsToProps_ph  <br>
+                   gibbsToBoundaryProps<br>
+                   gibbsToProps_dT<br>
+                   gibbsToProps_pT</td>
+          <td valign=\"top\"> Introduced unit for variables vt, vp.
+          </td></tr>
+<tr><td valign=\"top\"> TwoPhaseToProps_ph</td>
+          <td valign=\"top\"> Introduced unit for variables dht, dhd, detph.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.</b></td></tr>
+<tr><td valign=\"top\"> MoistAir</td>
+          <td valign=\"top\"> Documentation of moist air model significantly improved.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.MoistAir.</b></td></tr>
+<tr><td valign=\"top\"> enthalpyOfVaporization</td>
+          <td valign=\"top\"> Replaced by linear correlation since simpler and more
+                   accurate in the entire region.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Media.Water.IF97_Utilities.BaseIF97.Regions.</b></td></tr>
+<tr><td valign=\"top\"> drhovl_dp</td>
+          <td valign=\"top\"> Introduced unit for variable dd_dp.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b> Thermal.</b></td></tr>
+<tr><td valign=\"top\"> FluidHeatFlow</td>
+          <td valign=\"top\"> Introduced new parameter tapT (0..1) to define the
+                   temperature of the HeatPort as linear combination of the
+                   flowPort_a (tapT=0) and flowPort_b (tapT=1) temperatures.
+          </td>
+</tr>
+</table>
+
+<p><br>
+The following <b style=\"color:red\">critical errors</b> have been fixed (i.e., errors
+that can lead to wrong simulation results):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Electrical.Machines.BasicMachines.Components.</b></td></tr>
+<tr><td valign=\"top\"> ElectricalExcitation</td>
+          <td valign=\"top\"> Excitation voltage ve is calculated as
+                   \"spacePhasor_r.v_[1]*TurnsRatio*3/2\" instead of
+                   \"spacePhasor_r.v_[1]*TurnsRatio
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Parts.</b></td></tr>
+<tr><td valign=\"top\"> FixedRotation</td>
+          <td valign=\"top\"> Bug corrected that the torque balance was wrong in the
+                   following cases (since vector r was not transformed
+                   from frame_a to frame_b; note this special case occurs very seldom in practice):
+                   <ul><li> frame_b is in the spanning tree closer to the root
+                                        (usually this is frame_a).</li>
+                           <li> vector r from frame_a to frame_b is not zero.</li>
+                   </ul>
+           </td>
+</tr>
+
+<tr><td valign=\"top\"> PointMass</td>
+         <td valign=\"top\"> If a PointMass model is connected so that no equations are present
+                  to compute its orientation object, the orientation was arbitrarily
+                  set to a unit rotation. In some cases this can lead to a wrong overall
+                  model, depending on how the PointMass model is used. For this reason,
+                  such cases lead now to an error (via an assert(..)) with an explanation
+                  how to fix this.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialPureSubstance.</b></td></tr>
+<tr><td valign=\"top\"> pressure_dT<br>
+                   specificEnthalpy_dT
+          </td>
+          <td valign=\"top\"> Changed wrong call from \"setState_pTX\" to \"setState_dTX\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialTwoPhaseMedium.</b></td></tr>
+<tr><td valign=\"top\"> pressure_dT<br>
+                   specificEnthalpy_dT
+          </td>
+          <td valign=\"top\"> Changed wrong call from \"setState_pTX\" to \"setState_dTX\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Common.ThermoFluidSpecial.</b></td></tr>
+<tr><td valign=\"top\"> gibbsToProps_dT<br>
+                   helmholtzToProps_ph<br>
+                   helmholtzToProps_pT<br>
+                   helmholtzToProps_dT</td>
+          <td valign=\"top\"> Bugs in equations corrected </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Common.</b></td></tr>
+<tr><td valign=\"top\"> helmholtzToBridgmansTables<br>
+                   helmholtzToExtraDerivs</td>
+          <td valign=\"top\"> Bugs in equations corrected </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.IdealGases.Common.SingleGasNasa.</b></td></tr>
+<tr><td valign=\"top\"> density_derp_T</td>
+          <td valign=\"top\"> Bug in equation of partial derivative corrected </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Water.IF97_Utilities.</b></td></tr>
+<tr><td valign=\"top\"> BaseIF97.Inverses.dtofps3<br>
+                   isentropicExponent_props_ph<br>
+                   isentropicExponent_props_pT<br>
+                   isentropicExponent_props_dT</td>
+          <td valign=\"top\"> Bugs in equations corrected </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Air.MoistAir.</b></td></tr>
+<tr><td valign=\"top\"> h_pTX</td>
+          <td valign=\"top\"> Bug in setState_phX due to wrong vector size in h_pTX corrected.
+                   Furthermore, syntactical errors corrected:
+                   <ul><li> In function massFractionpTphi an equation
+                                        sign is used in an algorithm.</li>
+                           <li> Two consecutive semicolons removed</li>
+                   </ul>
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Water.</b></td></tr>
+<tr><td valign=\"top\"> waterConstants</td>
+          <td valign=\"top\"> Bug in equation of criticalMolarVolume corrected.
+          </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Water.IF97_Utilities.BaseIF97.Regions.</b></td></tr>
+<tr><td valign=\"top\"> region_ph<br>
+                   region_ps</td>
+          <td valign=\"top\"> Bug in region determination corrected.
+          </td>
+</tr>
+
+<tr><td valign=\"top\"> boilingcurve_p<br>
+                   dewcurve_p</td>
+          <td valign=\"top\"> Bug in equation of plim corrected.
+          </td>
+</tr>
+</table>
+
+<p><br>
+The following <b style=\"color:red\">uncritical errors</b> have been fixed (i.e., errors
+that do <b style=\"color:red\">not</b> lead to wrong simulation results, but, e.g.,
+units are wrong or errors in documentation):
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2 style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>Blocks.</b></td></tr>
+<tr><td valign=\"top\"> Examples</td>
+          <td valign=\"top\"> Corrected typos in description texts of bus example models.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Continuous.</b></td></tr>
+<tr><td valign=\"top\"> LimIntegrator</td>
+          <td valign=\"top\"> removed incorrect smooth(0,..) because expression might be discontinuous.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Blocks.Math.UnitConversions.</b></td></tr>
+<tr><td valign=\"top\"> block_To_kWh<br>block_From_kWh</td>
+          <td valign=\"top\"> Corrected unit from \"kWh\" to (syntactically correct) \"kW.h\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Analog.Examples.</b></td></tr>
+<tr><td valign=\"top\"> HeatingNPN_OrGate</td>
+          <td valign=\"top\"> Included start values, so that initialization is
+                                                successful </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Analog.Lines.</b></td></tr>
+<tr><td valign=\"top\"> OLine</td>
+          <td valign=\"top\"> Corrected unit from \"Siemens/m\" to \"S/m\".
+           </td></tr>
+<tr><td valign=\"top\"> TLine2</td>
+          <td valign=\"top\"> Changed wrong type of parameter NL (normalized length) from
+                   SIunits.Length to Real.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Digital.Delay.</b></td></tr>
+<tr><td valign=\"top\"> TransportDelay</td>
+          <td valign=\"top\"> Syntax error corrected
+                   (\":=\" in equation section is converted by Dymola silently to \"=\").
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.Digital</b></td></tr>
+<tr><td valign=\"top\"> Converters</td>
+          <td valign=\"top\"> Syntax error corrected
+                   (\":=\" in equation section is converted by Dymola silently to \"=\").
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.MultiPhase.Basic.</b></td></tr>
+<tr><td valign=\"top\"> Conductor</td>
+          <td valign=\"top\"> Changed wrong type of parameter G from SIunits.Resistance to
+                   SIunits.Conductance.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.MultiPhase.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> Plug<br></td>
+          <td valign=\"top\"> Made used \"pin\" connectors non-graphical (otherwise,
+                   there are difficulties to connect to Plug).
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Electrical.MultiPhase.Sources.</b></td></tr>
+<tr><td valign=\"top\"> SineCurrent</td>
+          <td valign=\"top\"> Changed wrong type of parameter offset from SIunits.Voltage to
+                   SIunits.Current.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Examples.Loops.</b></td></tr>
+<tr><td valign=\"top\"> EngineV6</td>
+          <td valign=\"top\"> Corrected wrong crankAngleOffset of some cylinders
+                   and improved the example.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Examples.Loops.Utilities.</b></td></tr>
+<tr><td valign=\"top\"> GasForce</td>
+          <td valign=\"top\"> Wrong units corrected:
+                   \"SIunitsPosition x,y\" to \"Real x,y\";
+           \"SIunits.Pressure press\" to \"SIunits.Conversions.NonSIunits.Pressure_bar\"
+           </td>
+</tr>
+<tr><td valign=\"top\"> GasForce2</td>
+          <td valign=\"top\"> Wrong unit corrected: \"SIunits.Position x\" to \"Real x\".
+           </td>
+</tr>
+<tr><td valign=\"top\"> EngineV6_analytic</td>
+          <td valign=\"top\"> Corrected wrong crankAngleOffset of some cylinders.
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> PartialLineForce</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Position eRod_a\" to \"Real eRod_a\";
+           </td>
+</tr>
+<tr><td valign=\"top\"> FlangeWithBearingAdaptor </td>
+          <td valign=\"top\"> If includeBearingConnector = false, connector \"fr\"
+                           + \"ame\" was not
+                   removed. As long as the connecting element to \"frame\" determines
+                   the non-flow variables, this is fine. In the corrected version, \"frame\"
+                   is conditionally removed in this case.</td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Forces.</b></td></tr>
+<tr><td valign=\"top\"> ForceAndTorque</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Force t_b_0\" to \"SIunits.Torque t_b_0\".
+           </td>
+</tr>
+<tr><td valign=\"top\"> LineForceWithTwoMasses</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Position e_rel_0\" to \"Real e_rel_0\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Frames.</b></td></tr>
+<tr><td valign=\"top\"> axisRotation</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Angle der_angle\" to
+                        \"SIunits.AngularVelocity der_angle\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Joints.Assemblies.</b></td></tr>
+<tr><td valign=\"top\"> JointUSP<br>JointSSP</td>
+          <td valign=\"top\"> Corrected wrong unit: \"SIunits.Position aux\"  to \"Real\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Sensors.</b></td></tr>
+<tr><td valign=\"top\"> AbsoluteSensor</td>
+          <td valign=\"top\"> Corrected wrong units: \"SIunits.Acceleration angles\" to
+                   \"SIunits.Angle angles\" and
+                   \"SIunits.Velocity w_abs_0\" to \"SIunits.AngularVelocity w_abs_0\"
+           </td>
+</tr>
+<tr><td valign=\"top\"> RelativeSensor</td>
+          <td valign=\"top\"> Corrected wrong units: \"SIunits.Acceleration angles\" to
+                   \"SIunits.Angle angles\"
+           </td>
+</tr>
+<tr><td valign=\"top\"> Distance</td>
+          <td valign=\"top\"> Corrected wrong units: \"SIunits.Length L2\" to \"SIunits.Area L2\" and
+                   SIunits.Length s_small2\" to \"SIunits.Area s_small2\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.MultiBody.Visualizers.Advanced.</b></td></tr>
+<tr><td valign=\"top\"> Shape</td>
+          <td valign=\"top\"> Changed \"MultiBody.Types.Color color\" to \"Real color[3]\", since
+                   \"Types.Color\" is \"Integer color[3]\" and there have been backward
+                   compatibility problems with models using \"color\" before it was changed
+                   to \"Types.Color\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Rewrote equations with new variables \"unitAngularAcceleration\" and
+                   \"unitTorque\" in order that the equations are correct with respect
+                   to units (previously, variable \"s\" can be both a torque and an
+                   angular acceleration and this lead to unit incompatibilities)
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> OneWayClutch<br>LossyGear</td>
+          <td valign=\"top\"> Rewrote equations with new variables \"unitAngularAcceleration\" and
+                   \"unitTorque\" in order that the equations are correct with respect
+                   to units (previously, variable \"s\" can be both a torque and an
+                   angular acceleration and this lead to unit incompatibilities)
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> FrictionBase</td>
+          <td valign=\"top\"> Rewrote equations with new variables \"unitAngularAcceleration\" and
+                   \"unitTorque\" in order that the equations are correct with respect
+                   to units (previously, variable \"s\" can be both a torque and an
+                   angular acceleration and this lead to unit incompatibilities)
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Mechanics.Translational.</b></td></tr>
+<tr><td valign=\"top\"> Speed</td>
+          <td valign=\"top\"> Corrected unit of v_ref from SIunits.Position to SIunits.Velocity
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Examples.Tests.Components.</b></td></tr>
+<tr><td valign=\"top\"> PartialTestModel<br>PartialTestModel2</td>
+          <td valign=\"top\"> Corrected unit of h_start from \"SIunits.Density\" to \"SIunits.SpecificEnthalpy\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Examples.SolveOneNonlinearEquation.</b></td></tr>
+<tr><td valign=\"top\"> Inverse_sh_T
+                   InverseIncompressible_sh_T<br>
+                   Inverse_sh_TX</td>
+          <td valign=\"top\"> Rewrote equations so that dimensional (unit) analysis is correct\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Incompressible.Examples.</b></td></tr>
+<tr><td valign=\"top\"> TestGlycol</td>
+          <td valign=\"top\"> Rewrote equations so that dimensional (unit) analysis is correct\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Interfaces.PartialTwoPhaseMedium.</b></td></tr>
+<tr><td valign=\"top\"> dBubbleDensity_dPressure<br>dDewDensity_dPressure</td>
+          <td valign=\"top\"> Changed wrong type of ddldp from \"DerDensityByEnthalpy\"
+                   to \"DerDensityByPressure\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Common.ThermoFluidSpecial.</b></td></tr>
+<tr><td valign=\"top\"> ThermoProperties</td>
+          <td valign=\"top\"> Changed wrong units:
+                   \"SIunits.DerEnergyByPressure dupT\" to \"Real dupT\" and
+                   \"SIunits.DerEnergyByDensity dudT\" to \"Real dudT\"
+           </td>
+</tr>
+<tr><td valign=\"top\"> ThermoProperties_ph</td>
+          <td valign=\"top\"> Changed wrong unit from \"SIunits.DerEnergyByPressure duph\" to \"Real duph\"
+           </td>
+</tr>
+<tr><td valign=\"top\"> ThermoProperties_pT</td>
+          <td valign=\"top\"> Changed wrong unit from \"SIunits.DerEnergyByPressure dupT\" to \"Real dupT\"
+           </td>
+</tr>
+<tr><td valign=\"top\"> ThermoProperties_dT</td>
+          <td valign=\"top\">  Changed wrong unit from \"SIunits.DerEnergyByDensity dudT\" to \"Real dudT\"
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.IdealGases.Common.SingleGasNasa.</b></td></tr>
+<tr><td valign=\"top\"> cp_Tlow_der</td>
+          <td valign=\"top\"> Changed wrong unit from \"SIunits.Temperature dT\" to \"Real dT\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Water.IF97_Utilities.BaseIF97.Basic.</b></td></tr>
+<tr><td valign=\"top\"> p1_hs<br>
+                   h2ab_s<br>
+                   p2a_hs<br>
+                   p2b_hs<br>
+                   p2c_hs<br>
+                   h3ab_p<br>
+                   T3a_ph<br>
+                   T3b_ph<br>
+                   v3a_ph<br>
+                   v3b_ph<br>
+                   T3a_ps<br>
+                   T3b_ps<br>
+                   v3a_ps<br>
+                   v3b_ps</td>
+          <td valign=\"top\"> Changed wrong unit of variables h/hstar, s, sstar from
+                   \"SIunits.Enthalpy\" to \"SIunits.SpecificEnthalpy\",
+                   \"SIunits.SpecificEntropy\", \"SIunits.SpecificEntropy
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Water.IF97_Utilities.BaseIF97.Transport.</b></td></tr>
+<tr><td valign=\"top\"> cond_dTp</td>
+          <td valign=\"top\"> Changed wrong unit of TREL, rhoREL, lambdaREL from
+                   \"SIunits.Temperature\", \"SIunit.Density\", \"SIunits.ThermalConductivity\"
+                   to \"Real\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Water.IF97_Utilities.BaseIF97.Inverses.</b></td></tr>
+<tr><td valign=\"top\"> tofps5<br>tofpst5</td>
+          <td valign=\"top\"> Changed wrong unit of pros from \"SIunits.SpecificEnthalpy\" to
+                   \"SIunits.SpecificEntropy\".
+           </td>
+</tr>
+
+<tr><td colspan=\"2\"><b>Media.Water.IF97_Utilities.</b></td></tr>
+<tr><td valign=\"top\"> waterBaseProp_ph</td>
+          <td valign=\"top\"> Improved calculation at the limits of the validity.
+           </td>
+</tr>
+
+        <tr><td colspan=\"2\"><b>Thermal.</b></td></tr>
+<tr><td valign=\"top\"> FluidHeatFlow<br>HeatTransfer</td>
+          <td valign=\"top\"> Corrected wrong unit \"SIunits.Temperature\" of difference temperature
+                        variables with \"SIunits.TemperatureDifference\".
+           </td>
+</tr>
+
+</table>
+
+</html>"));
+end Version_2_2_2;
+
+class Version_2_2_1 "Version 2.2.1 (March 24, 2006)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p>
+Version 2.2.1 is backward compatible to version 2.2.
+</p>
+
+<p>
+In this version, <b>no</b> new libraries have been added.
+The following major improvements have been made:
+</p>
+
+<ul>
+<li> The <b>Documentation</b> of the Modelica standard library was
+         considerably improved:<br>
+         In Dymola 6, the new feature was introduced to automatically add tables
+         for class content and component interface definitions (parameters and
+         connectors) to the info layer. For this reason, the corresponding (partial)
+         tables previously present in the Modelica Standard Library have been
+         removed. The new feature of Dymola 6 has the significant advantage that
+         all tables are now guaranteed to be up-to-date.<br>
+         Additionally, the documentation has been improved by adding appropriate
+         description texts to parameters, connector instances, function input
+         and output arguments etc., in order that the automatically generated
+         tables do not have empty entries. Also new User's Guides for sublibraries
+         Rotational and SIunits have been added and the User's Guide on top
+         level (Modelica.UsersGuide) has been improved.<br>&nbsp;</li>
+
+<li> Initialization options have been added to the Modelica.Blocks.<b>Continuous</b>
+         blocks (NoInit, SteadyState, InitialState, InitialOutput). If InitialOutput
+         is selected, the block output is provided as initial condition. The states
+         of the block are then initialized as close as possible to steady state.
+         Furthermore, the Continuous.LimPID block has been significantly
+         improved and much better documented.<br>&nbsp;</li>
+
+<li> The Modelica.<b>Media</b> library has been significantly improved:<br>
+         New functions setState_pTX, setState_phX, setState_psX, setState_dTX
+         have been added to PartialMedium to compute the independent medium variables
+         (= state of medium) from p,T,X, or from p,h,X or from p,s,X or from
+         d,T,X. Then functions are provided for all interesting medium variables
+         to compute them from its medium state. All these functions are
+         implemented in a robust way for all media (with a few exceptions, if the
+         generic function does not make sense for a particular medium).</li>
+</ul>
+
+<p>
+The following <b>new components</b> have been added to <b>existing</b> libraries:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Examples.</b></td></tr>
+<tr><td valign=\"top\"> PID_Controller</td>
+          <td valign=\"top\"> Example to demonstrate the usage of the
+                   Blocks.Continuous.LimPID block.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\"> UnitConversions.*</td>
+          <td valign=\"top\"> New package that provides blocks for unit conversions.
+                   UnitConversions.ConvertAllBlocks allows to select all
+                   available conversions from a menu.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines.</b></td></tr>
+<tr><td valign=\"top\"> SM_ElectricalExcitedDamperCage</td>
+          <td valign=\"top\"> Electrical excited synchronous induction machine with damper cage</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.BasicMachines.Components.</b></td></tr>
+<tr><td valign=\"top\"> ElectricalExcitation </td>
+          <td valign=\"top\"> Electrical excitation for electrical excited synchronous
+                   induction machines</td></tr>
+<tr><td valign=\"top\"> DamperCage</td>
+          <td valign=\"top\"> Unsymmetrical damper cage for electrical excited synchronous
+                   induction machines. At least the user has to specify the dampers
+                   resistance and stray inductance in d-axis; if he omits the
+                   parameters of the q-axis, the same values as for the d.axis
+                   are used, assuming a symmetrical damper.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.Examples.</b></td></tr>
+<tr><td valign=\"top\"> SMEE_Gen </td>
+          <td valign=\"top\"> Test example 7: ElectricalExcitedSynchronousInductionMachine
+                   as Generator</td></tr>
+<tr><td valign=\"top\"> Utilities.TerminalBox</td>
+          <td valign=\"top\"> Terminal box for three-phase induction machines to choose
+                   either star (wye) ? or delta ? connection</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices.</b></td></tr>
+<tr><td valign=\"top\"> equalityLeastSquares</td>
+          <td valign=\"top\"> Solve a linear equality constrained least squares problem:<br>
+                  min|A*x-a|^2 subject to B*x=b</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.</b></td></tr>
+<tr><td valign=\"top\"> Parts.PointMass</td>
+          <td valign=\"top\"> Point mass, i.e., body where inertia tensor is neglected.</td></tr>
+<tr><td valign=\"top\"> Interfaces.FlangeWithBearing</td>
+          <td valign=\"top\"> Connector consisting of 1-dim. rotational flange and its
+                   3-dim. bearing frame.</td></tr>
+<tr><td valign=\"top\"> Interfaces.FlangeWithBearingAdaptor</td>
+          <td valign=\"top\"> Adaptor to allow direct connections to the sub-connectors
+                   of FlangeWithBearing.</td></tr>
+<tr><td valign=\"top\"> Types.SpecularCoefficient</td>
+          <td valign=\"top\"> New type to define a specular coefficient.</td></tr>
+<tr><td valign=\"top\"> Types.ShapeExtra</td>
+          <td valign=\"top\"> New type to define the extra data for visual shape objects and to
+                   have a central place for the documentation of this data.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Examples.Elementary</b></td></tr>
+<tr><td valign=\"top\"> PointGravityWithPointMasses</td>
+          <td valign=\"top\"> Example of two point masses in a central gravity field.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\">UsersGuide</td>
+          <td valign=\"top\"> A User's Guide has been added by using the documentation previously
+                   present in the package documentation of Rotational.</td></tr>
+<tr><td valign=\"top\">Sensors.PowerSensor</td>
+          <td valign=\"top\"> New component to measure the energy flow between two connectors
+                   of the Rotational library.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Translational.</b></td></tr>
+<tr><td valign=\"top\">Speed</td>
+          <td valign=\"top\"> New component to move a translational flange
+                   according to a reference speed</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Media.Interfaces.PartialMedium.</b></td></tr>
+<tr><td valign=\"top\">specificEnthalpy_pTX</td>
+          <td valign=\"top\"> New function to compute specific enthalpy from pressure, temperature
+                   and mass fractions.</td></tr>
+<tr><td valign=\"top\">temperature_phX</td>
+          <td valign=\"top\"> New function to compute temperature from pressure, specific enthalpy,
+                   and mass fractions.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Icons.</b></td></tr>
+<tr><td valign=\"top\"> SignalBus</td>
+          <td valign=\"top\"> Icon for signal bus</td></tr>
+<tr><td valign=\"top\"> SignalSubBus</td>
+          <td valign=\"top\"> Icon for signal sub-bus</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.SIunits.</b></td></tr>
+<tr><td valign=\"top\">UsersGuide</td>
+          <td valign=\"top\"> A User's Guide has been added that describes unit handling.</td></tr>
+<tr><td valign=\"top\"> Resistance<br>
+                   Conductance</td>
+          <td valign=\"top\"> Attribute 'min=0' removed from these types.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Thermal.FluidHeatFlow.</b></td></tr>
+<tr><td valign=\"top\"> Components.Valve</td>
+          <td valign=\"top\"> Simple controlled valve with either linear or
+                   exponential characteristic.</td></tr>
+<tr><td valign=\"top\"> Sources. IdealPump </td>
+          <td valign=\"top\"> Simple ideal pump (resp. fan)  dependent on the shaft's speed;
+                   pressure increase versus volume flow is defined as a linear
+                   function. Torque * Speed = Pressure increase * Volume flow
+                   (without losses).</td></tr>
+<tr><td valign=\"top\"> Examples.PumpAndValve </td>
+          <td valign=\"top\"> Test example for valves.</td></tr>
+<tr><td valign=\"top\"> Examples.PumpDropOut </td>
+          <td valign=\"top\"> Drop out of 1 pump to test behavior of semiLinear.</td></tr>
+<tr><td valign=\"top\"> Examples.ParallelPumpDropOut </td>
+          <td valign=\"top\"> Drop out of 2 parallel pumps to test behavior of semiLinear.</td></tr>
+<tr><td valign=\"top\"> Examples.OneMass </td>
+          <td valign=\"top\"> Cooling of 1 hot mass to test behavior of semiLinear.</td></tr>
+<tr><td valign=\"top\"> Examples.TwoMass </td>
+          <td valign=\"top\"> Cooling of 2 hot masses to test behavior of semiLinear.</td></tr>
+</table>
+
+<p>
+The following <b>components</b> have been improved:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td colspan=\"2\"><b>Modelica.</b></td></tr>
+<tr><td valign=\"top\"> UsersGuide</td>
+          <td valign=\"top\"> User's Guide and package description of Modelica Standard Library improved.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Interfaces.</b></td></tr>
+<tr><td valign=\"top\"> RealInput<br>
+                   BooleanInput<br>
+                   IntegerInput</td>
+          <td valign=\"top\"> When dragging one of these connectors the width and height
+                   is a factor of 2 larger as a standard icon. Previously,
+                   these connectors have been dragged and then manually enlarged
+                   by a factor of 2 in the Modelica standard library.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.</b></td></tr>
+<tr><td valign=\"top\"> Continuous.*</td>
+          <td valign=\"top\"> Initialization options added to all blocks
+                   (NoInit, SteadyState, InitialState, InitialOutput).
+                   New parameter limitsAtInit to switch off the limits
+                   of LimIntegrator or LimPID during initialization</td></tr>
+<tr><td valign=\"top\"> Continuous.LimPID</td>
+          <td valign=\"top\"> Option to select P, PI, PD, PID controller.
+                   Documentation significantly improved.</td></tr>
+<tr><td valign=\"top\"> Nonlinear.Limiter<br>
+                   Nonlinear.VariableLimiter<br>
+                   Nonlinear.Deadzone</td>
+          <td valign=\"top\"> New parameter limitsAtInit/deadZoneAtInit to switch off the limits
+                   or the dead zone during initialization</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog. </b></td></tr>
+<tr><td valign=\"top\"> Sources</td>
+          <td valign=\"top\"> Icon improved (+/- added to voltage sources, arrow added to
+                   current sources).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Semiconductors. </b></td></tr>
+<tr><td valign=\"top\"> Diode</td>
+          <td valign=\"top\"> smooth() operator included to improve numerics.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.BasicMachines.SynchronousInductionMachines. </b></td></tr>
+<tr><td valign=\"top\"> SM_PermanentMagnetDamperCage<br>
+                   SM_ElectricalExcitedDamperCage<br>
+                   SM_ReluctanceRotorDamperCage</td>
+          <td valign=\"top\"> The user can choose \"DamperCage = false\" (default: true)
+                   to remove all equations for the damper cage from the model.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Machines.BasicMachines.AsynchronousInductionMachines. </b></td></tr>
+<tr><td valign=\"top\"> AIM_SlipRing</td>
+          <td valign=\"top\"> Easier parameterization: if the user selects \"useTurnsRatio = false\"
+                   (default: true, this is the same behavior as before),
+                        parameter TurnsRatio is calculated internally from
+                        Nominal stator voltage and Locked-rotor voltage.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Math.Matrices.</b></td></tr>
+<tr><td valign=\"top\">leastSquares</td>
+          <td valign=\"top\">The A matrix in the least squares problem might be rank deficient.
+                  Previously, it was required that A has full rank.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.</b></td></tr>
+<tr><td valign=\"top\">all models</td>
+          <td valign=\"top\"> <ul>
+                   <li> All components with animation information have a new variable
+                                <b>specularCoefficient</b> to define the reflection of ambient light.
+                                The default value is world.defaultSpecularCoefficient which has
+                                a default of 0.7. By changing world.defaultSpecularCoefficient, the
+                                specularCoefficient of all components is changed that are not
+                                explicitly set differently. Since specularCoefficient is a variable
+                                (and no parameter), it can be changed during simulation. Since
+                                annotation(Dialog) is set, this variable still appears in the
+                                parameter menus.<br>
+                                Previously, a constant specularCoefficient of 0.7 was used
+                                for all components.</li>
+                   <li> Variable <b>color</b> of all components is no longer a parameter
+                                but an input variable. Also all parameters in package <b>Visualizers</b>,
+                                with the exception of <b>shapeType</b> are no longer parameters but
+                                defined as input variables with annotation(Dialog). As a result,
+                                all these variables appear still in parameter menus, but they can
+                                be changed during simulation (e.g., color might be used to
+                                display the temperature of a part).</li>
+                   <li> All menus have been changed to follow the Modelica 2.2 annotations
+                                \"Dialog, group, tab, enable\" (previously, a non-standard Dymola
+                                definition for menus was used). Also, the \"enable\" annotation
+                                is used in all menus
+                                to disable input fields if the input would be ignored.</li>
+                   <li> All visual shapes are now defined with conditional declarations
+                                (to remove them, if animation is switched off). Previously,
+                                these (protected) objects have been defined by arrays with
+                                dimension 0 or 1.</li>
+                   </ul></td></tr>
+
+<tr><td valign=\"top\">Frames.resolveRelative</td>
+          <td valign=\"top\"> The derivative of this function added as function and defined via
+                   an annotation. In certain situations, tools had previously
+                   difficulties to differentiate the inlined function automatically.</td></tr>
+
+<tr><td valign=\"top\">Forces.*</td>
+          <td valign=\"top\"> The scaling factors N_to_m and Nm_to_m have no longer a default
+                   value of 1000 but a default value of world.defaultN_to_m (=1000)
+                   and world.defaultNm_to_m (=1000). This allows to change the
+                   scaling factors for all forces and torques in the world
+                   object.</td></tr>
+<tr><td valign=\"top\">Interfaces.Frame.a<br>
+                  Interfaces.Frame.b<br>
+                  Interfaces.Frame_resolve</td>
+          <td valign=\"top\"> The Frame connectors are now centered around the origin to ease
+                   the usage. The shape was changed, such that the icon is a factor
+                   of 1.6 larger as a standard icon (previously, the icon had a
+                   standard size when dragged and then the icon was manually enlarged
+                   by a factor of 1.5 in the y-direction in the MultiBody library;
+                   the height of 16 allows easy positioning on the standard grid size of 2).
+                   The double line width of the border in icon and diagram layer was changed
+                   to a single line width and when making a connection the connection
+                   line is dark grey and no longer black which looks better.</td></tr>
+<tr><td valign=\"top\">Joints.Assemblies.*</td>
+          <td valign=\"top\"> When dragging an assembly joint, the icon is a factor of 2
+                   larger as a standard icon. Icon texts and connectors have a
+                   standard size in this enlarged icon (and are not a factor of 2
+                   larger as previously).</td></tr>
+<tr><td valign=\"top\">Types.*</td>
+          <td valign=\"top\"> All types have a corresponding icon now to visualize the content
+                   in the package browser (previously, the types did not have an icon).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\"> Inertia</td>
+          <td valign=\"top\"> Initialization and state selection added.</td></tr>
+<tr><td valign=\"top\"> SpringDamper</td>
+          <td valign=\"top\"> Initialization and state selection added.</td></tr>
+<tr><td valign=\"top\"> Move</td>
+          <td valign=\"top\"> New implementation based solely on Modelica 2.2 language
+                   (previously, the Dymola specific constrain(..) function was used).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Translational.</b></td></tr>
+<tr><td valign=\"top\"> Move</td>
+          <td valign=\"top\"> New implementation based solely on Modelica 2.2 language
+                   (previously, the Dymola specific constrain(..) function was used).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Thermal.FluidHeatFlow.Interfaces.Partials.</b></td></tr>
+<tr><td valign=\"top\"> SimpleFriction</td>
+          <td valign=\"top\"> Calculates friction losses from pressure drop and volume flow.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Thermal.FluidHeatFlow.Components.</b></td></tr>
+<tr><td valign=\"top\"> IsolatedPipe <br>
+                   HeatedPipe</td>
+          <td valign=\"top\"> Added geodetic height as a source of pressure change;
+                   feeds friction losses as calculated by simple friction to
+                   the energy balance of the medium.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Media.Interfaces.PartialMedium.FluidConstants.</b></td></tr>
+<tr><td valign=\"top\">HCRIT0</td><td valign=\"top\">Critical specific enthalpy of the fundamental
+                  equation (base formulation of the fluid medium model).</td></tr>
+<tr><td valign=\"top\">SCRIT0</td><td valign=\"top\">Critical specific entropy of the fundamental
+                  equation (base formulation of the fluid medium model).</td></tr>
+<tr><td valign=\"top\">deltah</td><td valign=\"top\">Enthalpy offset (default: 0) between the
+                  specific enthalpy of the fluid model and the user-visible
+                  specific enthalpy in the model: deltah = h_model - h_fundamentalEquation.
+</td></tr>
+<tr><td valign=\"top\">deltas</td><td valign=\"top\">Entropy offset (default: 0) between the
+                  specific entropy of the fluid model and the user-visible
+                  specific entropy in the model: deltas = s_model - s_fundamentalEquation.</td></tr>
+<tr><td valign=\"top\">T_default</td><td valign=\"top\">Default value for temperature of medium (for initialization)</td></tr>
+<tr><td valign=\"top\">h_default</td><td valign=\"top\">Default value for specific enthalpy of medium (for initialization)</td></tr>
+<tr><td valign=\"top\">p_default</td><td valign=\"top\">Default value for pressure of medium (for initialization)</td></tr>
+<tr><td valign=\"top\">X_default</td><td valign=\"top\">Default value for mass fractions of medium (for initialization)</td></tr>
+</table>
+<p>
+The following <b>errors</b> have been fixed:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Tables.</b></td></tr>
+<tr><td valign=\"top\">CombiTable1D<br>
+                  CombiTable1Ds<br>
+                  CombiTable2D</td>
+          <td valign=\"top\"> Parameter \"tableOnFile\" determines now whether a table is read from
+                   file or used from parameter \"table\". Previously, if \"fileName\" was not
+                   \"NoName\", a table was always read from file \"fileName\", independently
+                   of the setting of \"tableOnFile\". This has been corrected.<br>
+                   Furthermore, the initialization of a table is now performed in a
+                   when-clause and no longer in a parameter declaration, because some
+                   tools evaluate the parameter declaration in some situation more than
+                   once and then the table is unnecessarily read several times
+                   (and occupies also more memory).</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Sources.</b></td></tr>
+<tr><td valign=\"top\">CombiTimeTable</td>
+          <td valign=\"top\"> Same bug fix/improvement as for the tables from Modelica.Blocks.Tables
+                   as outlined above.</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Semiconductors. </b></td></tr>
+<tr><td valign=\"top\"> PMOS<br>
+                   NMOS<br>
+                   HeatingPMOS<br>
+                   HeatingNMOS</td>
+          <td valign=\"top\"> The Drain-Source-Resistance RDS had actually a resistance of
+                   RDS/v, with v=Beta*(W+dW)/(L+dL). The correct formula is without
+                   the division by \"v\". This has now been corrected.<br>
+                   This bug fix should not have an essential effect in most applications.
+                   In the default case (Beta=1e-5), the Drain-Source-Resistance was
+                   a factor of 1e5 too large and had in the default case the
+                   wrong value 1e12, although it should have the value 1e7. The effect
+                   was that this resistance had practically no effect.</td></tr>
+
+<tr><td colspan=\"2\"> <b>Modelica.Media.IdealGases.Common.SingleGasNasa.</b></td></tr>
+<tr><td valign=\"top\"> dynamicViscosityLowPressure</td>
+          <td valign=\"top\"> Viscosity and thermal conductivity (which needs viscosity as input)
+                   were computed wrong for polar gases and gas mixtures
+                   (i.e., if dipole moment not 0.0). This has been fixed in version 2.2.1.</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Utilities.Streams.</b></td></tr>
+<tr><td valign=\"top\">readLine</td>
+          <td valign=\"top\"> Depending on the C-implementation, the stream was not correctly closed.
+                   This has been corrected by adding a \"Streams.close(..)\"
+                   after reading the file content.</td></tr>
+
+</table>
+</html>"));
+end Version_2_2_1;
+
+class Version_2_2 "Version 2.2 (April 6, 2005)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p>
+Version 2.2 is backward compatible to version 2.1.
+</p>
+
+<p>
+The following <b>new libraries</b> have been added:
+</p>
+
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Media\">Modelica.Media</a></td>
+          <td valign=\"top\"> Property models of liquids and gases, especially
+                   <ul>
+                   <li>1241 detailed gas models,</li>
+                   <li> moist air,</li>
+                   <li> high precision water model (according to IAPWS/IF97 standard), </li>
+                   <li> incompressible media defined by tables (cp(T), rho(t), eta(T), etc. are defined by tables).</li>
+                   </ul>
+                   The user can conveniently define mixtures of gases between the
+                   1241 gas models. The models are
+                   designed to work well in dynamic simulations. They
+                   are based on a new standard interface for media with
+                   single and multiple substances and one or multiple phases
+                   with the following features:
+                   <ul>
+                   <li> The independent variables of a medium model do not influence the
+                                definition of a fluid connector port or how the
+                                balance equations have to be implemented.<br>
+                                Used independent variables: \"p,T\", \"p,T,X\", \"p,h\", \"d,T\".</li>
+                   <li> Optional variables, e.g., dynamic viscosity, are only computed
+                                if needed.</li>
+                   <li> The medium models are implemented with regards to efficient
+                                dynamic simulation.</li>
+                   </ul>
+          </td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Thermal.FluidHeatFlow\">Modelica.Thermal.FluidHeatFlow</a></td>
+          <td valign=\"top\"> Simple components for 1-dim., incompressible thermo-fluid flow
+                   to model coolant flows, e.g., of electrical machines.
+                   Components can be connected arbitrarily together (= ideal mixing
+                   at connection points) and fluid may reverse direction of flow.
+</td></tr>
+</table>
+<p>
+The following <b>changes</b> have been performed in the
+<b>Modelica.Mechanics.MultiBody</b> library:
+</p>
+<ul>
+<li> Component MultiBody.World has a new parameter
+         <b>driveTrainMechanics3D</b>. If set to <b>true</b>, 3D mechanical effects
+         of MultiBody.Parts.Mounting1D/Rotor1D/BevelGear1D are taken into account. If set to
+         <b>false</b> (= default), 3D mechanical effects in these elements
+         are not taken into account and the
+         frame connectors to connect to 3D parts are disabled (all
+         connections to such a disabled connector are also disabled, due to the
+         new feature of conditional declarations in Modelica language 2.2)</li>
+<li> All references to \"MultiBody.xxx\" have
+         been changed to \"Modelica.Mechanics.MultiBodys.xxx\" in order that after
+         copying of a component outside of the Modelica library, the references
+         still remain valid.</li>
+</ul>
+</html>"));
+end Version_2_2;
+
+class Version_2_1 "Version 2.1 (Nov. 11, 2004)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p> This is a major change with respect to previous versions of the
+        Modelica Standard Library, because <b>many new libraries</b> and components
+        are included and because the input/output blocks (Modelica.Blocks)
+        have been considerably simplified:
+</p>
+<ul>
+<li> An input/output connector is defined <b>without</b> a hierarchy (this is possible
+         due to new features of the Modelica language). For example, the input
+         signal of a block \"FirstOrder\" was previously accessed as \"FirstOrder.inPort.signal[1]\".
+         Now it is accessed as \"FirstOrder.u\". This simplifies the understanding and usage
+         especially for beginners.</li>
+<li> De-vectorized the <b>Modelica.Blocks</b> library. All blocks in the
+         Modelica.Blocks library are now scalar blocks. As a result,
+         the parameters of the Blocks are scalars and no vectors any
+         more. For example, a parameter \"amplitude\" that might had
+         a value of \"{1}\" previously, has now a value of \"1\". This simplifies
+         the understanding and usage especially for beginners.<br>
+         If a vector of blocks is needed, this can be easily
+         accomplished by adding a dimension to the instance. For example
+         \"Constant const[3](k={1,2,3}\" defines three Constant blocks.
+         An additional advantage of the new approach is that
+         the implementation of Modelica.Blocks is much simpler and is easier to
+         understand.
+</li>
+</ul>
+
+<p>
+The discussed changes of Modelica.Blocks are not backward compatible.
+A script to <b>automatically</b> convert models to this new version is
+provided. There might be rare cases, where this script does not convert.
+In this case models have to be manually converted.
+In any case you should make a back-up copy of your model
+before automatic conversion is performed.
+</p>
+<p>
+The following <b>new libraries</b> have been added:
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Digital\">Modelica.Electrical.Digital</a></td>
+          <td valign=\"top\">Digital electrical components based on 2-,3-,4-, and 9-valued logic<br>
+                  according to the VHDL standard</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Machines\">Modelica.Electrical.Machines</a></td>
+          <td valign=\"top\">Asynchronous, synchronous and DC motor and generator models</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Math.Matrices\">Modelica.Math.Matrices</a></td>
+          <td valign=\"top\">Functions operating on matrices such as solve() (A*x=b), leastSquares(),<br>
+                  norm(), LU(), QR(),  eigenValues(), singularValues(), exp(), ...</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.StateGraph\">Modelica.StateGraph</a></td>
+          <td valign=\"top\"> Modeling of <b>discrete event</b> and <b>reactive</b> systems in a convenient way using<br>
+                   <b>hierarchical state machines</b> and <b>Modelica</b> as <b>action language</b>. <br>
+                   It is based on JGrafchart and Grafcet and  has a similar modeling power as <br>
+                   StateCharts. It avoids deficiencies of usually used action languages. <br>
+                   This library makes the ModelicaAdditions.PetriNets library obsolete.</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Files\">Modelica.Utilities.Files</a></td>
+          <td valign=\"top\">Functions to operate on files and directories (copy, move, remove files etc.)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Streams\">Modelica.Utilities.Streams</a></td>
+          <td valign=\"top\">Read from files and write to files (print, readLine, readFile, error, ...)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.Strings\">Modelica.Utilities.Strings</a></td>
+          <td valign=\"top\">Operations on strings (substring, find, replace, sort, scanToken, ...)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.System\">Modelica.Utilities.System</a></td>
+          <td valign=\"top\">Get/set current directory, get/set environment variable, execute shell command, etc.</td></tr>
+</table>
+<p>
+The following existing libraries outside of the Modelica standard library
+have been improved and added as <b>new libraries</b>
+(models using the previous libraries are automatically converted
+to the new sublibraries inside package Modelica):
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Discrete\">Modelica.Blocks.Discrete</a></td>
+          <td valign=\"top\"> Discrete input/output blocks with fixed sample period<br>
+                   (from ModelicaAdditions.Blocks.Discrete)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Logical\">Modelica.Blocks.Logical</a></td>
+          <td valign=\"top\"> Logical components with Boolean input and output signals<br>
+                   (from ModelicaAdditions.Blocks.Logical)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Nonlinear\">Modelica.Blocks.Nonlinear</a></td>
+          <td valign=\"top\"> Discontinuous or non-differentiable algebraic control blocks such as variable limiter,<br>
+                   fixed, variable and Pade delay etc. (from ModelicaAdditions.Blocks.Nonlinear)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Routing\">Modelica.Blocks.Routing</a></td>
+          <td valign=\"top\"> Blocks to combine and extract signals, such as multiplexer<br>
+                   (from ModelicaAdditions.Blocks.Multiplexer)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Blocks.Tables\">Modelica.Blocks.Tables</a></td>
+          <td valign=\"top\"> One and two-dimensional interpolation in tables. CombiTimeTable is available<br>
+                   in Modelica.Blocks.Sources (from ModelicaAdditions.Tables)</td></tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody\">Modelica.Mechanics.MultiBody</a></td>
+          <td valign=\"top\"> Components to model the movement of 3-dimensional mechanical systems. Contains <br>
+                   body, joint, force and sensor components, analytic handling of kinematic loops,<br>
+                   force elements with mass, series/parallel connection of 3D force elements etc.<br>
+                   (from MultiBody 1.0 where the new signal connectors are used;<br>
+                   makes the ModelicaAdditions.MultiBody library obsolete)</td></tr>
+</table>
+<p>
+As a result, the ModelicaAdditions library is obsolete, because all components
+are either included in the Modelica library or are replaced by much more
+powerful libraries (MultiBody, StateGraph).
+</p>
+<p>
+The following <b>new components</b> have been added to <b>existing</b> libraries.
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Logical.</b></td></tr>
+<tr><td valign=\"top\">Pre</td>
+          <td valign=\"top\">y = pre(u): Breaks algebraic loops by an infinitesimal small <br>
+                  time delay (event iteration continues until u = pre(u))</td></tr>
+<tr><td valign=\"top\">Edge</td>
+          <td valign=\"top\">y = edge(u): Output y is true, if the input u has a rising edge </td></tr>
+<tr><td valign=\"top\">FallingEdge</td>
+          <td valign=\"top\">y = edge(not u): Output y is true, if the input u has a falling edge </td></tr>
+<tr><td valign=\"top\">Change</td>
+          <td valign=\"top\">y = change(u): Output y is true, if the input u has a rising or falling edge </td></tr>
+<tr><td valign=\"top\">GreaterEqual</td>
+          <td valign=\"top\">Output y is true, if input u1 is greater or equal than input u2 </td></tr>
+<tr><td valign=\"top\">Less</td>
+          <td valign=\"top\">Output y is true, if input u1 is less than input u2 </td></tr>
+<tr><td valign=\"top\">LessEqual</td>
+          <td valign=\"top\">Output y is true, if input u1 is less or equal than input u2 </td></tr>
+<tr><td valign=\"top\">Timer</td>
+          <td valign=\"top\">Timer measuring the time from the time instant where the <br>
+                  Boolean input became true </td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\">BooleanToReal</td>
+          <td valign=\"top\">Convert Boolean to Real signal</td></tr>
+<tr><td valign=\"top\">BooleanToInteger</td>
+          <td valign=\"top\">Convert Boolean to Integer signal</td></tr>
+<tr><td valign=\"top\">RealToBoolean</td>
+          <td valign=\"top\">Convert Real to Boolean signal</td></tr>
+<tr><td valign=\"top\">IntegerToBoolean</td>
+          <td valign=\"top\">Convert Integer to Boolean signal</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Sources.</b></td></tr>
+<tr><td valign=\"top\">RealExpression</td>
+          <td valign=\"top\">Set output signal to a time varying Real expression</td></tr>
+<tr><td valign=\"top\">IntegerExpression</td>
+          <td valign=\"top\">Set output signal to a time varying Integer expression</td></tr>
+<tr><td valign=\"top\">BooleanExpression</td>
+          <td valign=\"top\">Set output signal to a time varying Boolean expression</td></tr>
+<tr><td valign=\"top\">BooleanTable</td>
+          <td valign=\"top\">Generate a Boolean output signal based on a vector of time instants</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.</b></td></tr>
+<tr><td valign=\"top\">Frames.from_T2</td>
+          <td valign=\"top\">Return orientation object R from transformation matrix T and its derivative der(T)</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\">LinearSpeedDependentTorque</td>
+          <td valign=\"top\">Linear dependency of torque versus speed (acts as load torque)</td></tr>
+<tr><td valign=\"top\">QuadraticSpeedDependentTorque</td>
+          <td valign=\"top\">Quadratic dependency of torque versus speed (acts as load torque)</td></tr>
+<tr><td valign=\"top\">ConstantTorque</td>
+          <td valign=\"top\">Constant torque, not dependent on speed (acts as load torque)</td></tr>
+<tr><td valign=\"top\">ConstantSpeed</td>
+          <td valign=\"top\">Constant speed, not dependent on torque (acts as load torque)</td></tr>
+<tr><td valign=\"top\">TorqueStep</td>
+          <td valign=\"top\">Constant torque, not dependent on speed (acts as load torque)</td></tr>
+</table>
+<p>
+The following <b>bugs</b> have been <b>corrected</b>:
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.MultiBody.Forces.</b></td></tr>
+<tr><td valign=\"top\">LineForceWithMass<br>
+                  Spring</td>
+          <td valign=\"top\">If mass of the line force or spring component is not zero, the<br>
+                  mass was (implicitly) treated as \"mass*mass\" instead of as \"mass\"</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\">Speed</td>
+          <td valign=\"top\">If parameter exact=<b>false</b>, the filter was wrong<br>
+                  (position was filtered and not the speed input signal)</td></tr>
+</table>
+<p>
+Other changes:
+</p>
+<ul>
+<li> All connectors are now smaller in the diagram layer. This gives
+         a nicer layout when connectors and components are used together
+         in a diagram</li>
+<li> Default instance names are defined for all connectors, according
+         to a new annotation introduced in Modelica 2.1. For example,
+         when dragging connector \"Flange_a\" from the Rotational library to
+         the diagram layer, the default connector instance name is
+         \"flange_a\" and not \"Flange_a1\".</li>
+<li> The Modelica.Mechanics.Rotational connectors are changed from
+         a square to a circle</li>
+<li> The Modelica.Mechanics.Translational connectors are changed from a
+         green to a dark green color in order that connection lines
+         can be better seen, especially when printed.</li>
+<li> The Modelica.Blocks connectors for Real signals are changed from
+         blue to dark blue in order to distinguish them from electrical signals.</li>
+</ul>
+</html>"));
+end Version_2_1;
+
+class Version_1_6 "Version 1.6 (June 21, 2004)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p> Added 1 new library (Electrical.MultiPhase), 17 new components,
+        improved 3 existing components
+        in the Modelica.Electrical library and improved 3 types
+        in the Modelica.SIunits library. Furthermore,
+        this User's Guide has been started. The improvements
+        in more detail:
+</p>
+<p>
+<b>New components</b>
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Basic.</b></td></tr>
+<tr><td valign=\"top\">SaturatingInductor</td>
+          <td valign=\"top\">Simple model of an inductor with saturation</td></tr>
+<tr><td valign=\"top\">VariableResistor</td>
+          <td valign=\"top\">Ideal linear electrical resistor with variable resistance</td></tr>
+<tr><td valign=\"top\">VariableConductor</td>
+          <td valign=\"top\">Ideal linear electrical conductor with variable conductance</td></tr>
+<tr><td valign=\"top\">VariableCapacitor</td>
+          <td valign=\"top\">Ideal linear electrical capacitor with variable capacitance</td></tr>
+<tr><td valign=\"top\">VariableInductor</td>
+          <td valign=\"top\">Ideal linear electrical inductor with variable inductance</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Semiconductors.</b></td></tr>
+<tr><td valign=\"top\">HeatingDiode</td>
+          <td valign=\"top\">Simple diode with heating port</td></tr>
+<tr><td valign=\"top\">HeatingNMOS</td>
+          <td valign=\"top\">Simple MOS Transistor with heating port</td></tr>
+<tr><td valign=\"top\">HeatingPMOS</td>
+          <td valign=\"top\">Simple PMOS Transistor with heating port</td></tr>
+<tr><td valign=\"top\">HeatingNPN</td>
+          <td valign=\"top\">Simple NPN BJT according to Ebers-Moll with heating port</td></tr>
+<tr><td valign=\"top\">HeatingPNP</td>
+          <td valign=\"top\">Simple PNP BJT according to Ebers-Moll with heating port</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.MultiPhase</b><br>
+          A new library for multi-phase electrical circuits</td></tr>
+</table>
+<p>
+<b>New examples</b>
+</p>
+<p>
+The following new examples have been added to
+Modelica.Electrical.Analog.Examples:
+</p>
+<p>
+CharacteristicThyristors,
+CharacteristicIdealDiodes,
+HeatingNPN_OrGate,
+HeatingMOSInverter,
+HeatingRectifier,
+Rectifier,
+ShowSaturatingInductor
+ShowVariableResistor
+</p>
+<p>
+<b>Improved existing components</b>
+</p>
+<p>In the library Modelica.Electrical.Analog.Ideal,
+a knee voltage has been introduced for the components
+IdealThyristor, IdealGTOThyristor, IdealDiode in order
+that the approximation of these ideal elements is improved
+with not much computational effort.</p>
+<p> In the Modelica.SIunits library, the following changes
+        have been made:</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\">Inductance</td>
+          <td valign=\"top\">min=0 removed</td></tr>
+<tr><td valign=\"top\">SelfInductance</td>
+          <td valign=\"top\">min=0 added</td></tr>
+<tr><td valign=\"top\">ThermodynamicTemperature</td>
+          <td valign=\"top\">min=0 added</td></tr>
+</table>
+</html>"));
+end Version_1_6;
+
+class Version_1_5 "Version 1.5 (Dec. 16, 2002)"
+  extends Modelica.Icons.ReleaseNotes;
+
+   annotation (Documentation(info="<html>
+
+<p> Added 55 new components. In particular, added new package
+        <b>Thermal.HeatTransfer</b> for modeling of lumped
+        heat transfer, added model <b>LossyGear</b> in Mechanics.Rotational
+        to model gear efficiency and bearing friction according to a new
+        theory in a robust way, added 10 new models in Electrical.Analog and
+        added several other new models and improved existing models.
+</p>
+<p>
+<b>New components</b>
+</p>
+<table border=\"1\" cellspacing=0 cellpadding=2>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.</b></td></tr>
+<tr><td valign=\"top\">Continuous.Der</td><td valign=\"top\">Derivative of input (= analytic differentiations)</td></tr>
+<tr><td valign=\"top\"><b><i>Examples</i></b></td><td valign=\"top\">Demonstration examples of the components of this package</td></tr>
+<tr><td valign=\"top\">Nonlinear.VariableLimiter</td><td valign=\"top\">Limit the range of a signal with variable limits</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Interfaces.</b></td></tr>
+<tr><td valign=\"top\">RealPort</td><td valign=\"top\">Real port (both input/output possible)</td></tr>
+<tr><td valign=\"top\">IntegerPort</td><td valign=\"top\">Integer port (both input/output possible)</td></tr>
+<tr><td valign=\"top\">BooleanPort</td><td valign=\"top\">Boolean port (both input/output possible)</td></tr>
+<tr><td valign=\"top\">SIMO</td><td valign=\"top\">Single Input Multiple Output continuous control block</td></tr>
+<tr><td valign=\"top\">IntegerBlockIcon</td><td valign=\"top\">Basic graphical layout of Integer block</td></tr>
+<tr><td valign=\"top\">IntegerMO</td><td valign=\"top\">Multiple Integer Output continuous control block</td></tr>
+<tr><td valign=\"top\">IntegerSignalSource</td><td valign=\"top\">Base class for continuous Integer signal source</td></tr>
+<tr><td valign=\"top\">IntegerMIBooleanMOs</td><td valign=\"top\">Multiple Integer Input Multiple Boolean Output continuous control block with same number of inputs and outputs</td></tr>
+<tr><td valign=\"top\">BooleanMIMOs</td><td valign=\"top\">Multiple Input Multiple Output continuous control block with same number of inputs and outputs of Boolean type</td></tr>
+<tr><td valign=\"top\"><b><i>BusAdaptors</i></b></td><td valign=\"top\">Components to send signals to the bus or receive signals from the bus</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Math.</b></td></tr>
+<tr><td valign=\"top\">RealToInteger</td><td valign=\"top\">Convert real to integer signals</td></tr>
+<tr><td valign=\"top\">IntegerToReal</td><td valign=\"top\">Convert integer to real signals</td></tr>
+<tr><td valign=\"top\">Max</td><td valign=\"top\">Pass through the largest signal</td></tr>
+<tr><td valign=\"top\">Min</td><td valign=\"top\">Pass through the smallest signal</td></tr>
+<tr><td valign=\"top\">Edge</td><td valign=\"top\">Indicates rising edge of Boolean signal</td></tr>
+<tr><td valign=\"top\">BooleanChange</td><td valign=\"top\">Indicates Boolean signal changing</td></tr>
+<tr><td valign=\"top\">IntegerChange</td><td valign=\"top\">Indicates integer signal changing</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Blocks.Sources.</b></td></tr>
+<tr><td valign=\"top\">IntegerConstant</td><td valign=\"top\">Generate constant signals of type Integer</td></tr>
+<tr><td valign=\"top\">IntegerStep</td><td valign=\"top\">Generate step signals of type Integer</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Basic.</b></td></tr>
+<tr><td valign=\"top\">HeatingResistor</td><td valign=\"top\">Temperature dependent electrical resistor</td></tr>
+<tr><td valign=\"top\">OpAmp</td><td valign=\"top\">Simple nonideal model of an OpAmp with limitation</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Ideal.</b></td></tr>
+<tr><td valign=\"top\">IdealCommutingSwitch</td><td valign=\"top\">Ideal commuting switch</td></tr>
+<tr><td valign=\"top\">IdealIntermediateSwitch</td><td valign=\"top\">Ideal intermediate switch</td></tr>
+<tr><td valign=\"top\">ControlledIdealCommutingSwitch</td><td valign=\"top\">Controlled ideal commuting switch</td></tr>
+<tr><td valign=\"top\">ControlledIdealIntermediateSwitch</td><td valign=\"top\">Controlled ideal intermediate switch</td></tr>
+<tr><td valign=\"top\">IdealOpAmpLimited</td><td valign=\"top\">Ideal operational amplifier with limitation</td></tr>
+<tr><td valign=\"top\">IdealOpeningSwitch</td><td valign=\"top\">Ideal opener</td></tr>
+<tr><td valign=\"top\">IdealClosingSwitch</td><td valign=\"top\">Ideal closer</td></tr>
+<tr><td valign=\"top\">ControlledIdealOpeningSwitch</td><td valign=\"top\">Controlled ideal opener</td></tr>
+<tr><td valign=\"top\">ControlledIdealClosingSwitch</td><td valign=\"top\">Controlled ideal closer</td></tr>
+
+<tr><td colspan=\"2\"><b>Modelica.Electrical.Analog.Lines.</b></td></tr>
+<tr><td valign=\"top\">TLine1</td><td valign=\"top\">Lossless transmission line (Z0, TD)</td></tr>
+<tr><td valign=\"top\">TLine2</td><td valign=\"top\">Lossless transmission line (Z0, F, NL)</td></tr>
+<tr><td valign=\"top\">TLine2</td><td valign=\"top\">Lossless transmission line (Z0, F)</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Icons.</b></td></tr>
+<tr><td valign=\"top\">Function</td><td valign=\"top\">Icon for a function</td></tr>
+<tr><td valign=\"top\">Record</td><td valign=\"top\">Icon for a record</td></tr>
+<tr><td valign=\"top\">Enumeration</td><td valign=\"top\">Icon for an enumeration</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Math.</b></td></tr>
+<tr><td valign=\"top\">tempInterpol2</td><td valign=\"top\">temporary routine for vectorized linear interpolation (will be removed)</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.Mechanics.Rotational.</b></td></tr>
+<tr><td valign=\"top\">Examples.LossyGearDemo1</td><td valign=\"top\">Example to show that gear efficiency may lead to stuck motion</td></tr>
+<tr><td valign=\"top\">Examples.LossyGearDemo2</td><td valign=\"top\">Example to show combination of LossyGear and BearingFriction</td></tr>
+<tr><td valign=\"top\">LossyGear</td><td valign=\"top\">Gear with mesh efficiency and bearing friction (stuck/rolling possible)</td></tr>
+<tr><td valign=\"top\">Gear2</td><td valign=\"top\">Realistic model of a gearbox (based on LossyGear)</td></tr>
+<tr><td colspan=\"2\"><b>Modelica.SIunits.</b></td></tr>
+<tr><td valign=\"top\"><b><i>Conversions</i></b></td><td valign=\"top\">Conversion functions to/from non SI units and type definitions of non SI units</td></tr>
+<tr><td valign=\"top\">EnergyFlowRate</td><td valign=\"top\">Same definition as <i>Power</i></td></tr>
+<tr><td valign=\"top\">EnthalpyFlowRate</td><td valign=\"top\"><code>Real (final quantity=\"EnthalpyFlowRate\", final unit=\"W\")</code></td></tr>
+<tr><td colspan=\"2\"><b>Modelica.</b></td></tr>
+<tr><td valign=\"top\"><b><i>Thermal.HeatTransfer</i></b></td><td valign=\"top\">1-dimensional heat transfer with lumped elements</td></tr>
+<tr><td colspan=\"2\"><b>ModelicaAdditions.Blocks.Discrete.</b></td></tr>
+<tr><td valign=\"top\">TriggeredSampler</td><td valign=\"top\">Triggered sampling of continuous signals</td></tr>
+<tr><td valign=\"top\">TriggeredMax</td><td valign=\"top\">Compute maximum, absolute value of continuous signal at trigger instants</td></tr>
+<tr><td colspan=\"2\"><b>ModelicaAdditions.Blocks.Logical.Interfaces.</b></td></tr>
+<tr><td valign=\"top\">BooleanMIRealMOs</td><td valign=\"top\">Multiple Boolean Input Multiple Real Output continuous control block with same number of inputs and outputs</td></tr>
+<tr><td valign=\"top\">RealMIBooleanMOs</td><td valign=\"top\">Multiple Real Input Multiple Boolean Output continuous control block with same number of inputs and outputs</td></tr>
+<tr><td colspan=\"2\"><b>ModelicaAdditions.Blocks.Logical.</b></td></tr>
+<tr><td valign=\"top\">TriggeredTrapezoid</td><td valign=\"top\">Triggered trapezoid generator</td></tr>
+<tr><td valign=\"top\">Hysteresis</td><td valign=\"top\">Transform Real to Boolean with Hysteresis</td></tr>
+<tr><td valign=\"top\">OnOffController</td><td valign=\"top\">On-off controller</td></tr>
+<tr><td valign=\"top\">Compare</td><td valign=\"top\">True, if signal of inPort1 is larger than signal of inPort2</td></tr>
+<tr><td valign=\"top\">ZeroCrossing</td><td valign=\"top\">Trigger zero crossing of input signal</td></tr>
+<tr><td colspan=\"2\"><b>ModelicaAdditions.</b></td></tr>
+<tr><td valign=\"top\">Blocks.Multiplexer.Extractor</td><td valign=\"top\">Extract scalar signal out of signal vector dependent on IntegerRealInput index</td></tr>
+<tr><td valign=\"top\">Tables.CombiTable1Ds</td><td valign=\"top\">Table look-up in one dimension (matrix/file) with only single input</td></tr>
+</table>
+<p>
+<b>Package-specific Changes</b>
+</p>
+<ul>
+<li>All example models made <b>encapsulated</b></li>
+<li>Upper case constants changed to lower case (cf. Modelica.Constants)</li>
+<li>Introduced Modelica.SIunits.Wavelength due to typo \"Wavelenght\"</li>
+<li>Introduced ModelicaAdditions.Blocks.Logical.Interfaces.Comparison due to typo \"Comparision\"</li>
+<li>Changed these components of *.Blocks to <code>block</code> class, which have not been already of block type</li>
+<li>Changed *.Interfaces.RelativeSensor to <code>partial</code> models</li>
+</ul>
+<p>
+<b>Class-specific Changes</b>
+</p>
+<p>
+<i>Modelica.SIunits</i>
+</p>
+<p>Removed <code>final</code> from quantity attribute for <i>Mass</i> and <i>MassFlowRate</i>.</p>
+<p>
+<i>Modelica.Blocks.Math.Sum</i>
+</p>
+<p>Implemented avoiding algorithm section, which would lead to expensive function calls.</p>
+<p><i>Modelica.Blocks.Sources.Step</i></p>
+<pre>
+block Step \"Generate step signals of type Real\"
+        parameter Real height[:]={1} \"Heights of steps\";
+<b> // parameter Real offset[:]={0} \"Offsets of output signals\";
+// parameter SIunits.Time startTime[:]={0} \"Output = offset for time < startTime\";
+// extends Interfaces.MO          (final nout=max([size(height, 1); size(offset, 1); size(startTime, 1)]));
+        extends Interfaces.SignalSource(final nout=max([size(height, 1); size(offset, 1); size(startTime, 1)]));</b>
+</pre>
+<p><i>Modelica.Blocks.Sources.Exponentials</i></p>
+<p>Replaced usage of built-in function <code>exp</code> by Modelica.Math.exp.</p>
+<p><i>Modelica.Blocks.Sources.TimeTable</i></p>
+<p>Interface definition changed from</p>
+<pre>    parameter Real table[:, :]=[0, 0; 1, 1; 2, 4] \"Table matrix (time = first column)\";
+</pre>
+<p>to</p>
+<pre>    parameter Real table[:, <b>2</b>]=[0, 0; 1, 1; 2, 4] \"Table matrix (time = first column)\";
+</pre>
+<p>Did the same for subfunction <i>getInterpolationCoefficients</i>.</p>
+<p>Bug in <i>getInterpolationCoefficients</i> for startTime <> 0 fixed:</p>
+<pre>        ...
+                end if;
+          end if;
+          <b>// Take into account startTime \"a*(time - startTime) + b\"
+          b := b - a*startTime;</b>
+        end getInterpolationCoefficients;
+</pre>
+<p><i>Modelica.Blocks.Sources.BooleanStep</i></p>
+<pre>
+block BooleanStep \"Generate step signals of type Boolean\"
+        parameter SIunits.Time startTime[:]={0} \"Time instants of steps\";
+        <b>parameter Boolean startValue[size(startTime, 1)]=fill(false, size(startTime, 1)) \"Output before startTime\";</b>
+        extends Interfaces.BooleanSignalSource(final nout=size(startTime, 1));
+equation
+        for i in 1:nout loop
+<b>//   outPort.signal[i] = time >= startTime[i];
+          outPort.signal[i] = if time >= startTime[i] then not startValue[i] else startValue[i];</b>
+        end for;
+end BooleanStep;
+</pre>
+<p>
+<i>Modelica.Electrical.Analog</i></p>
+<p>Corrected table of values and default for Beta by dividing them by 1000
+(consistent with the values used in the NAND-example model):
+</p>
+<ul>
+<li>Semiconductors.PMOS</li>
+<li>Semiconductors.NMOS</li>
+</ul>
+<p>Corrected parameter defaults, unit and description for TrapezoidCurrent.
+This makes the parameters consistent with their use in the model.
+Models specifying parameter values are not changed.
+Models not specifying parameter values did not generate trapezoids previously.
+</p>
+<p>Icon layer background changed from transparent to white:</p>
+<ul>
+<li>Basic.Gyrator</li>
+<li>Basic.EMF</li>
+<li>Ideal.Idle</li>
+<li>Ideal.Short</li>
+</ul>
+<p>Basic.Transformer: Replaced invalid escape characters '\\ ' and '\\[newline]' in documentation by '|'.</p>
+<p><i>Modelica.Mechanics.Rotational</i></p>
+<p>Removed arrows and names documentation from flanges in diagram layer</p>
+<p><i>Modelica.Mechanics.Rotational.Interfaces.FrictionBase</i></p>
+<p><i>Modelica.Mechanics.Rotational.Position</i></p>
+<p>Replaced <code>reinit</code> by <code>initial equation</code></p>
+<p><i>Modelica.Mechanics.Rotational.RelativeStates</i></p>
+<p>Bug corrected by using modifier <code>stateSelect = StateSelect.prefer</code> as implementation</p>
+<p><i>Modelica.Mechanics.Translational.Interfaces.flange_b</i></p>
+<p>Attribute <b>fillColor=7</b> added to Rectangle on Icon layer, i.e., it is now
+filled with white and not transparent any more.</p>
+<p><i>Modelica.Mechanics.Translational.Position</i></p>
+<p>Replaced <code>reinit</code> by <code>initial equation</code></p>
+<p><i>Modelica.Mechanics.Translational.RelativeStates</i></p>
+<p>Bug corrected by using modifier <code>stateSelect = StateSelect.prefer</code> as implementation</p>
+<p><i>Modelica.Mechanics.Translational.Stop</i></p>
+<p>Use <code>stateSelect = StateSelect.prefer</code>.</p>
+<p><i>Modelica.Mechanics.Translational.Examples.PreLoad</i></p>
+<p>Improved documentation and coordinate system used for example.</p>
+<p><i>ModelicaAdditions.Blocks.Nonlinear.PadeDelay</i></p>
+<p>Replaced <code>reinit</code> by <code>initial equation</code></p>
+<p><i>ModelicaAdditions.HeatFlow1D.Interfaces</i></p>
+<p>Definition of connectors <i>Surface_a</i> and <i>Surface_b</i>:<br>
+<code>flow SIunits.HeatFlux q;</code> changed to <code>flow SIunits.HeatFlowRate q;</code></p>
+<p><i>MultiBody.Parts.InertialSystem</i></p>
+<p>Icon corrected.</p>
+</html>"));
+end Version_1_5;
+
+class Version_1_4 "Version 1.4 (June 28, 2001)"
+  extends Modelica.Icons.ReleaseNotes;
+
+annotation (Documentation(info="<html>
+
+<ul>
+<li>Several minor bugs fixed.</li>
+<li>New models:<br>
+        Modelica.Blocks.Interfaces.IntegerRealInput/IntegerRealOutput,<br>
+        Modelica.Blocks.Math.TwoInputs/TwoOutputs<br>
+        Modelica.Electrical.Analog.Ideal.IdealOpAmp3Pin,<br>
+        Modelica.Mechanics.Rotational.Move,<br>
+        Modelica.Mechanics.Translational.Move.<br>
+        </li>
+</ul>
+<hr>
+<h4>Version 1.4.1beta1 (February 12, 2001)</h4>
+<p> Adapted to Modelica 1.4</p>
+<hr>
+<h4>Version 1.3.2beta2 (June 20, 2000)</h4>
+<ul>
+        <li>New subpackage Modelica.Mechanics.<b>Translational</b></li>
+        <li>Changes to Modelica.Mechanics.<b>Rotational</b>:<br>
+           New elements:
+<pre>
+IdealGearR2T    Ideal gear transforming rotational in translational motion.
+Position        Forced movement of a flange with a reference angle
+                                   given as input signal
+RelativeStates  Definition of relative state variables
+</pre>
+</li>
+        <li>Changes to Modelica.<b>SIunits</b>:<br>
+          Introduced new types:<br>
+          type Temperature = ThermodynamicTemperature;<br>
+          types DerDensityByEnthalpy, DerDensityByPressure,
+          DerDensityByTemperature, DerEnthalpyByPressure,
+          DerEnergyByDensity, DerEnergyByPressure<br>
+          Attribute \"final\" removed from min and max values
+          in order that these values can still be changed to narrow
+          the allowed range of values.<br>
+          Quantity=\"Stress\" removed from type \"Stress\", in order
+          that a type \"Stress\" can be connected to a type \"Pressure\".</li>
+        <li>Changes to Modelica.<b>Icons</b>:<br>
+           New icons for motors and gearboxes.</li>
+        <li>Changes to Modelica.<b>Blocks.Interfaces</b>:<br>
+           Introduced a replaceable signal type into
+           Blocks.Interfaces.RealInput/RealOutput:
+<pre>
+replaceable type SignalType = Real
+</pre>
+           in order that the type of the signal of an input/output block
+           can be changed to a physical type, for example:
+<pre>
+Sine sin1(outPort(redeclare type SignalType=Modelica.SIunits.Torque))
+</pre>
+</li>
+</ul>
+<hr>
+<h4>Version 1.3.1 (Dec. 13, 1999)</h4>
+<p>
+First official release of the library.
+</p>
+</html>"));
+end Version_1_4;
+ annotation (Documentation(info="<html>
+
+<p>
+This section summarizes the changes that have been performed
+on the Modelica standard library. Furthermore, it is explained in
+<a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.VersionManagement\">Modelica.UsersGuide.ReleaseNotes.VersionManagement</a>
+how the versions are managed with the subversion management systems.
+This is especially important for maintenance (bug-fix) releases where the
+main version number is not changed.
+</p>
+
+</html>"));
+end ReleaseNotes;
+
+class Contact "Contact"
+  extends Modelica.Icons.Contact;
+
+ annotation (Documentation(info="<html>
+<dl><dt>The Modelica Standard Library (this Modelica package) is developed by many people from different organizations (see list below). It is licensed under the <a href=\"modelica://Modelica.UsersGuide.ModelicaLicense2\">Modelica License 2</a> by:</dt>
+<dt>&nbsp;</dt>
+<dd>Modelica Association</dd>
+<dd>(Ideella F&ouml;reningar 822003-8858 in Link&ouml;ping)</dd>
+<dd>c/o PELAB, IDA, Link&ouml;pings Universitet</dd>
+<dd>S-58183 Link&ouml;ping</dd>
+<dd>Sweden</dd>
+<dd>email: <a href=\"mailto:Board@Modelica.org\">Board@Modelica.org</a></dd>
+<dd>web: <a href=\"https://www.Modelica.org\">https://www.Modelica.org</a></dd>
+<dd>&nbsp;&nbsp;</dd>
+
+<dt>The development of this Modelica package, starting with version 3.2.1, is organized by:</dt>
+<dd><a href=\"http://www.haumer.at/eindex.htm\">Anton Haumer</a></dd>
+<dd>Technical Consulting &amp; Electrical Engineering</dd>
+<dd>A-3423 St.Andrae-Woerdern, Hadersfelderweg 21</dd>
+<dd>Austria</dd>
+<dd>email: <a href=\"mailto:A.Haumer@Haumer.at\">A.Haumer@Haumer.at</a></dd>
+<dd>&nbsp;&nbsp;</dd>
+
+<dt>The development of this Modelica package up to and including version 3.2.1 was organized by:</dt>
+<dd><a href=\"http://www.robotic.dlr.de/Martin.Otter/\">Martin Otter</a></dd>
+<dd>German Aerospace Center (DLR)</dd>
+<dd>Robotics and Mechatronics Center (RMC)</dd>
+<dd>Institute of System Dynamics and Control (SR)</dd>
+<dd>Postfach 1116</dd>
+<dd>D-82230 Wessling</dd>
+<dd>Germany</dd>
+<dd>email: <a href=\"mailto:Martin.Otter@dlr.de\">Martin.Otter@dlr.de</a></dd>
+</dl>
+<p>Since end of 2007, the development of the sublibraries of package Modelica is organized by personal and/or organizational <b>library officers</b> assigned by the Modelica Association. They are responsible for the maintenance and for the further organization of the development. Other persons may also contribute, but the final decision for library improvements and/or changes is performed by the responsible library officer(s). In order that a new sublibrary or a new version of a sublibrary is ready to be released, the responsible library officers report the changes to the members of the Modelica Association and the library is made available for beta testing to interested parties before a final decision. A new release of a sublibrary is formally decided by voting of the Modelica Association members.</p>
+<p>The following library officers are currently assigned:</p>
+
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><b>Sublibraries</b> </td>
+   <td valign=\"top\"><b>Library officers</b></td>
+</tr>
+
+<tr><td valign=\"top\"> Complex </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+        (Martin Otter)<br>
+        Anton Haumer, Consultant, St.Andrae-Woerdern, Austria, <br>
+        Christian Kral, Vienna, Austria, <br>
+        AIT, Vienna, Austria
+</td>
+
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Blocks <br>
+                      Modelica.Constants </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+        (Martin Otter)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Electrical.Analog<br>
+                      Modelica.Electrical.Digital<br>
+                      Modelica.Electrical.Spice3 </td>
+   <td valign=\"top\"> Fraunhofer Institute for Integrated Circuits, Dresden, Germany<br>
+      (Christoph Clauss)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.ComplexBlocks<br>
+                      Modelica.Electrical.Machines<br>
+                      Modelica.Electrical.MultiPhase<br>
+                      Modelica.Electrical.QuasiStationary </td>
+   <td valign=\"top\"> Anton Haumer, Consultant, St.Andrae-Woerdern, Austria,<br>
+        Christian Kral, Vienna, Austria, <br>
+        AIT, Vienna, Austria</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Magnetic.FluxTubes </td>
+   <td valign=\"top\"> Thomas B&ouml;drich, Dresden, Germany<br>
+                               (Dresden University of Technology,<br>
+                               Institute of Electromechanical and Electronic Design)
+</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Magnetic.FundamentalWave </td>
+   <td valign=\"top\"> Christian Kral, Vienna, Austria, <br>
+                     AIT, Vienna, Austria<br>
+                     Anton Haumer, Consultant, St.Andrae-Woerdern, Austria
+</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Fluid </td>
+   <td valign=\"top\"> Politecnico di Milano (Francesco Casella), and<br>
+                            R&uuml;diger Franke (ABB)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Fluid.Dissipation </td>
+   <td valign=\"top\"> XRG Simulation, Hamburg, Germany (Stefan Wischhusen)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Icons </td>
+   <td valign=\"top\"> Modelon AB, Lund, Sweden (Johan Andreasson) </td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Math </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+      (Martin Otter)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.ComplexMath </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+      (Martin Otter)<br>
+      Anton Haumer, Consultant, St.Andrae-Woerdern, Austria,<br>
+      Christian Kral, Vienna, Austria, <br>
+      AIT, Vienna, Austria
+   </td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Mechanics.MultiBody </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+      (Martin Otter),<br>
+       Modelon AB, Lund, Sweden (Johan Andreasson) </td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Mechanics.Rotational </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+      (Martin Otter)<br>
+      Anton Haumer, Consultant, St.Andrae-Woerdern, Austria,<br>
+      Christian Kral, Vienna, Austria, <br>
+      AIT, Vienna, Austria, <br>
+      Modelon AB, Lund, Sweden (Johan Andreasson)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Mechanics.Translational </td>
+   <td valign=\"top\"> Anton Haumer, Consultant, St.Andrae-Woerdern, Austria,<br>
+      Christian Kral, Vienna, Austria, <br>
+      AIT, Vienna, Austria,<br>
+      DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+      (Martin Otter)<br>
+       Modelon AB, Lund, Sweden (Johan Andreasson)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Media </td>
+   <td valign=\"top\"> Modelon AB, Lund, Sweden (Hubertus Tummescheit) </td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.SIunits <br>
+      Modelica.StateGraph </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+      (Martin Otter)</td>
+</tr>
+
+<tr><td valign=\"top\"> Modelica.Thermal.FluidHeatFlow <br>
+      Modelica.Thermal.HeatTransfer </td>
+   <td valign=\"top\"> Anton Haumer, Consultant, St.Andrae-Woerdern, Austria, and<br>
+      Christian Kral, Vienna, Austria, <br>
+      AIT, Vienna, Austria</td></tr>
+
+<tr><td valign=\"top\"> Modelica.Utilities </td>
+   <td valign=\"top\"> DLR Institute of System Dynamics and Control, Oberpfaffenhofen, Germany<br>
+      (Martin Otter)<br>
+      Dassault Syst&egrave;mes AB, Lund, Sweden (Hans Olsson)</td>
+</tr>
+</table>
+
+<p>
+The following people have directly contributed to the implementation
+of the Modelica package (many more people have contributed to the design):
+</p>
+
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><b>Marcus Baur</b> </td>
+   <td valign=\"top\"> Institute of System Dynamics and Control<br>
+     DLR, German Aerospace Center, <br>
+     Oberpfaffenhofen, Germany</td>
+   <td valign=\"top\"> Complex<br>
+                     Modelica.Math.Vectors<br>
+                     Modelica.Math.Matrices</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Peter Beater</b> </td>
+   <td valign=\"top\"> University of Paderborn, Germany</td>
+   <td valign=\"top\"> Modelica.Mechanics.Translational </td>
+</tr>
+
+
+
+<tr><td valign=\"top\"><b>Thomas Beutlich</b> </td>
+   <td valign=\"top\"> ITI GmbH, Germany</td>
+   <td valign=\"top\"> Modelica.Blocks.Sources.CombiTimeTable<br>
+                       Modelica.Blocks.Tables </td>
+</tr>
+
+<tr><td valign=\"top\"><b>Thomas B&ouml;drich</b> </td>
+   <td valign=\"top\"> Dresden University of Technology, Germany</td>
+   <td valign=\"top\"> Modelica.Magnetic.FluxTubes </td>
+</tr>
+
+<tr><td valign=\"top\"><b>Dag Br&uuml;ck</b> </td>
+   <td valign=\"top\"> Dassault Syst&egrave;mes AB, Lund, Sweden</td>
+   <td valign=\"top\"> Modelica.Utilities</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Francesco Casella</b> </td>
+   <td valign=\"top\"> Politecnico di Milano, Milano, Italy</td>
+   <td valign=\"top\"> Modelica.Fluid<br>
+                            Modelica.Media</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Christoph Clauss</b> </td>
+   <td valign=\"top\"> Fraunhofer Institute for Integrated Circuits,<br> Dresden, Germany</td>
+   <td valign=\"top\"> Modelica.Electrical.Analog<br>
+     Modelica.Electrical.Digital<br>
+     Modelica.Electrical.Spice3</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Jonas Eborn</b> </td>
+   <td valign=\"top\"> Modelon AB, Lund, Sweden</td>
+   <td valign=\"top\"> Modelica.Media</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Hilding Elmqvist</b> </td>
+   <td valign=\"top\"> Dassault Syst&egrave;mes AB, Lund, Sweden</td>
+   <td valign=\"top\"> Modelica.Mechanics.MultiBody<br>
+                   Modelica.Fluid<br>
+     Modelica.Media<br>
+     Modelica.StateGraph<br>
+     Modelica.Utilities<br>
+     Conversion from 1.6 to 2.0</td>
+</tr>
+
+<tr><td valign=\"top\"><b>R&uuml;diger Franke</b> </td>
+   <td valign=\"top\"> ABB Corporate Research,<br>Ladenburg, German</td>
+   <td valign=\"top\"> Modelica.Fluid<br>
+                            Modelica.Media</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Manuel Gr&auml;ber</b> </td>
+   <td valign=\"top\"> Institut f&uuml;r Thermodynamik, <br>
+     Technische Universit&auml;t Braunschweig, <br>
+     Germany</td>
+   <td valign=\"top\"> Modelica.Fluid</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Anton Haumer</b> </td>
+   <td valign=\"top\"> Consultant, St.Andrae-Woerdern,<br>Austria</td>
+   <td valign=\"top\"> Modelica.ComplexBlocks<br>
+     Modelica.Electrical.Machines<br>
+     Modelica.Electrical.Multiphase<br>
+     Modelica.Electrical.QuasiStationary<br>
+     Modelica.Magnetics.FundamentalWave<br>
+     Modelica.Mechanics.Rotational<br>
+     Modelica.Mechanics.Translational<br>
+     Modelica.Thermal.FluidHeatFlow<br>
+     Modelica.Thermal.HeatTransfer<br>
+     Modelica.ComplexMath<br>
+     Conversion from 1.6 to 2.0<br>
+     Conversion from 2.2 to 3.0</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Hans-Dieter Joos</b> </td>
+   <td valign=\"top\"> Institute of System Dynamics and Control<br>
+     DLR, German Aerospace Center, <br>
+     Oberpfaffenhofen, Germany</td>
+   <td valign=\"top\"> Modelica.Math.Matrices</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Christian Kral</b> </td>
+   <td valign=\"top\"> Modeling and Simulation of Electric Machines, Drives and Mechatronic Systems, Vienna, Austria</td>
+   <td valign=\"top\"> Modelica.ComplexBlocks<br>
+     Modelica.Electrical.Machines<br>
+     Modelica.Electrical.MultiPhase<br>
+     Modelica.Electrical.QuasiStationary<br>
+     Modelica.Magnetics.FundamentalWave<br>
+     Modelica.Mechanics.Rotational<br>
+     Modelica.Mechanics.Translational<br>
+     Modelica.Thermal.FluidHeatFlow<br>
+     Modelica.Thermal.HeatTransfer<br>
+     Modelica.ComplexMath
+     </td>
+</tr>
+
+<tr><td valign=\"top\"><b>Sven Erik Mattsson</b> </td>
+   <td valign=\"top\"> Dassault Syst&egrave;mes AB, Lund, Sweden</td>
+   <td valign=\"top\"> Modelica.Mechanics.MultiBody</td>
+</tr>
+<tr><td valign=\"top\"><b>Hans Olsson</b> </td>
+   <td valign=\"top\"> Dassault Syst&egrave;mes AB, Lund, Sweden</td>
+   <td valign=\"top\"> Modelica.Blocks<br>
+     Modelica.Math.Matrices<br>
+     Modelica.Utilities<br>
+     Conversion from 1.6 to 2.0<br>
+     Conversion from 2.2 to 3.0</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Martin Otter</b> </td>
+   <td valign=\"top\"> Institute of System Dynamics and Control<br>
+     DLR, German Aerospace Center, <br>
+     Oberpfaffenhofen, Germany</td>
+   <td valign=\"top\"> Complex<br>
+     Modelica.Blocks<br>
+     Modelica.Fluid<br>
+     Modelica.Mechanics.MultiBody<br>
+     Modelica.Mechanics.Rotational<br>
+     Modelica.Mechanics.Translational<br>
+     Modelica.Math<br>
+     Modelica.ComplexMath<br>
+     Modelica.Media<br>
+     Modelica.SIunits<br>
+     Modelica.StateGraph<br>
+     Modelica.Thermal.HeatTransfer<br>
+     Modelica.Utilities<br>
+     ModelicaReference<br>
+     Conversion from 1.6 to 2.0<br>
+     Conversion from 2.2 to 3.0</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Katrin Pr&ouml;l&szlig;</b> </td>
+   <td valign=\"top\"> Modelon AB, Lund, Sweden<br>
+                            until 2008:<br>
+                            Department of Technical Thermodynamics,<br>
+     Technical University Hamburg-Harburg,<br>Germany</td>
+   <td valign=\"top\"> Modelica.Fluid<br>
+                            Modelica.Media</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Christoph C. Richter</b> </td>
+   <td valign=\"top\"> until 2009:<br>
+     Institut f&uuml;r Thermodynamik, <br>
+     Technische Universit&auml;t Braunschweig, <br>
+     Germany</td>
+   <td valign=\"top\"> Modelica.Fluid<br>
+                            Modelica.Media</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Andr&eacute; Schneider</b> </td>
+   <td valign=\"top\"> Fraunhofer Institute for Integrated Circuits,<br> Dresden, Germany</td>
+   <td valign=\"top\"> Modelica.Electrical.Analog<br>
+     Modelica.Electrical.Digital</td>
+</tr>
+<tr><td valign=\"top\"><b>Christian Schweiger</b> </td>
+   <td valign=\"top\"> Until 2006:<br>
+     Institute of System Dynamics and Control,<br>
+     DLR, German Aerospace Center,<br>
+     Oberpfaffenhofen, Germany</td>
+   <td valign=\"top\"> Modelica.Mechanics.Rotational<br>
+     ModelicaReference<br>
+     Conversion from 1.6 to 2.0</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Michael Sielemann</b> </td>
+   <td valign=\"top\"> Institute of System Dynamics and Control<br>
+     DLR, German Aerospace Center, <br>
+     Oberpfaffenhofen, Germany</td>
+   <td valign=\"top\"> Modelica.Fluid<br>
+                       Modelica.Media</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Michael Tiller</b> </td>
+   <td valign=\"top\"> Emmeskay, Inc., Dearborn, MI, U.S.A, <br>
+     (previously Ford Motor Company, Dearborn) </td>
+   <td valign=\"top\"> Modelica.Media<br>
+     Modelica.Thermal.HeatTransfer</td>
+</tr>
+<tr><td valign=\"top\"><b>Hubertus Tummescheit</b> </td>
+   <td valign=\"top\"> Modelon AB, Lund, Sweden </td>
+   <td valign=\"top\"> Modelica.Media<br>
+     Modelica.Thermal.HeatTransfer</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Thorsten Vahlenkamp</b> </td>
+   <td valign=\"top\"> until 2010:<br>
+                     XRG Simulation GmbH, Hamburg, Germany</td>
+   <td valign=\"top\"> Modelica.Fluid.Dissipation</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Nico Walter</b> </td>
+   <td valign=\"top\"> Master thesis at HTWK Leipzig<br>
+     (Prof. R. M&uuml;ller) and<br>
+     DLR Oberpfaffenhofen, Germany</td>
+   <td valign=\"top\"> Modelica.Math.Matrices</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Michael Wetter</b> </td>
+   <td valign=\"top\"> Lawrence Berkeley National Laboratory; U.S.A.</td>
+   <td valign=\"top\"> Modelica.Fluid</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Hans-J&uuml;rg Wiesmann</b> </td>
+   <td valign=\"top\"> Switzerland</td>
+   <td valign=\"top\"> Modelica.ComplexMath</td>
+</tr>
+
+<tr><td valign=\"top\"><b>Stefan Wischhusen</b> </td>
+   <td valign=\"top\"> XRG Simulation GmbH, Hamburg, Germany</td>
+   <td valign=\"top\"> Modelica.Fluid.Dissipation<br>
+                       Modelica.Media</td>
+</tr>
+</table>
+
+</html>"));
+
+end Contact;
+
+annotation (DocumentationClass=true, Documentation(info="<html>
+<p>
+Package <b>Modelica</b> is a <b>standardized</b> and <b>pre-defined</b> package
+that is developed together with the Modelica language from the
+Modelica Association, see
+<a href=\"https://www.Modelica.org\">https://www.Modelica.org</a>.
+It is also called <b>Modelica Standard Library</b>.
+It provides constants, types, connectors, partial models and model
+components in various disciplines.
+</p>
+<p>
+This is a short <b>User's Guide</b> for
+the overall library. Some of the main sublibraries have their own
+User's Guides that can be accessed by the following links:
+</p>
+
+<table border=1 cellspacing=0 cellpadding=2>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Electrical.Digital.UsersGuide\">Digital</a>
+   </td>
+   <td valign=\"top\">Library for digital electrical components based on the VHDL standard
+   (2-,3-,4-,9-valued logic)</td>
+</tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Magnetic.FluxTubes.UsersGuide\">FluxTubes</a>
+    </td>
+   <td valign=\"top\">Library for modelling of electromagnetic devices with lumped magnetic networks</td>
+</tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.MultiBody.UsersGuide\">MultiBody</a>
+    </td>
+   <td valign=\"top\">Library to model 3-dimensional mechanical systems</td>
+</tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Rotational.UsersGuide\">Rotational</a>
+    </td>
+   <td valign=\"top\">Library to model 1-dimensional, rotational mechanical systems</td>
+</tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Mechanics.Translational.UsersGuide\">Translational</a>
+    </td>
+   <td valign=\"top\">Library to model 1-dimensional, translational mechanical systems</td>
+</tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Fluid.UsersGuide\">Fluid</a></td>
+    <td valign=\"top\">Library of 1-dim. thermo-fluid flow models using the Modelica.Media media description</td>
+</tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Media.UsersGuide\">Media</a>
+    </td>
+   <td valign=\"top\">Library of media property models</td>
+</tr>
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.SIunits.UsersGuide\">SIunits</a> </td>
+   <td valign=\"top\">Library of type definitions based on SI units according to ISO 31-1992</td>
+</tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.StateGraph.UsersGuide\">StateGraph</a>
+    </td>
+   <td valign=\"top\">Library to model discrete event and reactive systems by hierarchical state machines</td>
+</tr>
+
+<tr><td valign=\"top\"><a href=\"modelica://Modelica.Utilities.UsersGuide\">Utilities</a>
+    </td>
+   <td valign=\"top\">Library of utility functions especially for scripting (Files, Streams, Strings, System)</td>
+</tr>
+</table>
+
+</html>"));
+end UsersGuide;
+
+
+annotation (
+preferredView="info",
+version="3.2.2",
+versionBuild=3,
+versionDate="2016-04-03",
+dateModified = "2016-04-03 08:44:41Z",
+revisionId="$Id::                                       $",
+uses(Complex(version="3.2.2"), ModelicaServices(version="3.2.2")),
+conversion(
+ noneFromVersion="3.2.1",
+ noneFromVersion="3.2",
+ noneFromVersion="3.1",
+ noneFromVersion="3.0.1",
+ noneFromVersion="3.0",
+ from(version="2.1", script="modelica://Modelica/Resources/Scripts/Dymola/ConvertModelica_from_2.2.2_to_3.0.mos"),
+ from(version="2.2", script="modelica://Modelica/Resources/Scripts/Dymola/ConvertModelica_from_2.2.2_to_3.0.mos"),
+ from(version="2.2.1", script="modelica://Modelica/Resources/Scripts/Dymola/ConvertModelica_from_2.2.2_to_3.0.mos"),
+ from(version="2.2.2", script="modelica://Modelica/Resources/Scripts/Dymola/ConvertModelica_from_2.2.2_to_3.0.mos")),
+Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}), graphics={
+  Polygon(
+    origin={-6.9888,20.048},
+    fillColor={0,0,0},
+    pattern=LinePattern.None,
+    fillPattern=FillPattern.Solid,
+    points={{-93.0112,10.3188},{-93.0112,10.3188},{-73.011,24.6},{-63.011,31.221},{-51.219,36.777},{-39.842,38.629},{-31.376,36.248},{-25.819,29.369},{-24.232,22.49},{-23.703,17.463},{-15.501,25.135},{-6.24,32.015},{3.02,36.777},{15.191,39.423},{27.097,37.306},{32.653,29.633},{35.035,20.108},{43.501,28.046},{54.085,35.19},{65.991,39.952},{77.897,39.688},{87.422,33.338},{91.126,21.696},{90.068,9.525},{86.099,-1.058},{79.749,-10.054},{71.283,-21.431},{62.816,-33.337},{60.964,-32.808},{70.489,-16.14},{77.368,-2.381},{81.072,10.054},{79.749,19.05},{72.605,24.342},{61.758,23.019},{49.587,14.817},{39.003,4.763},{29.214,-6.085},{21.012,-16.669},{13.339,-26.458},{5.401,-36.777},{-1.213,-46.037},{-6.24,-53.446},{-8.092,-52.387},{-0.684,-40.746},{5.401,-30.692},{12.81,-17.198},{19.424,-3.969},{23.658,7.938},{22.335,18.785},{16.514,23.283},{8.047,23.019},{-1.478,19.05},{-11.267,11.113},{-19.734,2.381},{-29.259,-8.202},{-38.519,-19.579},{-48.044,-31.221},{-56.511,-43.392},{-64.449,-55.298},{-72.386,-66.939},{-77.678,-74.612},{-79.53,-74.083},{-71.857,-61.383},{-62.861,-46.037},{-52.278,-28.046},{-44.869,-15.346},{-38.784,-2.117},{-35.344,8.731},{-36.403,19.844},{-42.488,23.813},{-52.013,22.49},{-60.744,16.933},{-68.947,10.054},{-76.884,2.646},{-93.0112,-12.1707},{-93.0112,-12.1707}},
+    smooth=Smooth.Bezier),
+  Ellipse(
+    origin={40.8208,-37.7602},
+    fillColor={161,0,4},
+    pattern=LinePattern.None,
+    fillPattern=FillPattern.Solid,
+    extent={{-17.8562,-17.8563},{17.8563,17.8562}})}),
+Documentation(info="<html>
+<p>
+Package <b>Modelica&reg;</b> is a <b>standardized</b> and <b>free</b> package
+that is developed together with the Modelica&reg; language from the
+Modelica Association, see
+<a href=\"https://www.Modelica.org\">https://www.Modelica.org</a>.
+It is also called <b>Modelica Standard Library</b>.
+It provides model components in many domains that are based on
+standardized interface definitions. Some typical examples are shown
+in the next figure:
+</p>
+
+<p>
+<img src=\"modelica://Modelica/Resources/Images/UsersGuide/ModelicaLibraries.png\">
+</p>
+
+<p>
+For an introduction, have especially a look at:
+</p>
+<ul>
+<li> <a href=\"modelica://Modelica.UsersGuide.Overview\">Overview</a>
+  provides an overview of the Modelica Standard Library
+  inside the <a href=\"modelica://Modelica.UsersGuide\">User's Guide</a>.</li>
+<li><a href=\"modelica://Modelica.UsersGuide.ReleaseNotes\">Release Notes</a>
+ summarizes the changes of new versions of this package.</li>
+<li> <a href=\"modelica://Modelica.UsersGuide.Contact\">Contact</a>
+  lists the contributors of the Modelica Standard Library.</li>
+<li> The <b>Examples</b> packages in the various libraries, demonstrate
+  how to use the components of the corresponding sublibrary.</li>
+</ul>
+
+<p>
+This version of the Modelica Standard Library consists of
+</p>
+<ul>
+<li><b>1600</b> models and blocks, and</li>
+<li><b>1350</b> functions</li>
+</ul>
+<p>
+that are directly usable (= number of public, non-partial classes). It is fully compliant
+to <a href=\"https://www.modelica.org/documents/ModelicaSpec32Revision2.pdf\">Modelica Specification Version 3.2 Revision 2</a>
+and it has been tested with Modelica tools from different vendors.
+</p>
+
+<p>
+<b>Licensed by the Modelica Association under the Modelica License 2</b><br>
+Copyright &copy; 1998-2016, ABB, AIT, T.&nbsp;B&ouml;drich, DLR, Dassault Syst&egrave;mes AB, Fraunhofer, A.&nbsp;Haumer, ITI, C.&nbsp;Kral, Modelon,
+TU Hamburg-Harburg, Politecnico di Milano, XRG Simulation.
+</p>
+
+<p>
+<i>This Modelica package is <u>free</u> software and the use is completely at <u>your own risk</u>; it can be redistributed and/or modified under the terms of the Modelica License 2. For license conditions (including the disclaimer of warranty) see <a href=\"modelica://Modelica.UsersGuide.ModelicaLicense2\">Modelica.UsersGuide.ModelicaLicense2</a> or visit <a href=\"https://www.modelica.org/licenses/ModelicaLicense2\"> https://www.modelica.org/licenses/ModelicaLicense2</a>.</i>
+</p>
+
+<p>
+<b>Modelica&reg;</b> is a registered trademark of the Modelica Association.
+</p>
+</html>"));
+end Modelica;

--- a/modelica/modelica.g4
+++ b/modelica/modelica.g4
@@ -93,7 +93,7 @@ element
    ;
 
 import_clause
-   : 'import' (IDENT '=' name | name ('.' ('*' | '{' import_list '}'))?) comment
+   : 'import' (IDENT '=' name | name '.*' | name '.{' import_list '}' | name ) comment
    ;
 
 import_list
@@ -200,11 +200,11 @@ statement
    ;
 
 if_equation
-   : 'if' expression 'then' (equation ';')* ('elseif' expression 'then')* (equation ';')* ('else' (equation ';')*)? 'end' 'if'
+   : 'if' expression 'then' (equation ';')* ('elseif' expression 'then' (equation ';')*)* ('else' (equation ';')*)? 'end' 'if'
    ;
 
 if_statement
-   : 'if' expression 'then' (statement ';')* ('elseif' expression 'then')* (statement ';')* ('else')? (statement ';')* 'end' 'if'
+   : 'if' expression 'then' (statement ';')* ('elseif' expression 'then' (statement ';')*)* ('else' (statement ';')*)? 'end' 'if'
    ;
 
 for_equation
@@ -351,7 +351,7 @@ expression_list
    ;
 
 array_subscripts
-   : '(' subscript (',' subscript)* ']'
+   : '[' subscript (',' subscript)* ']'
    ;
 
 subscript
@@ -393,7 +393,7 @@ fragment NONDIGIT
 
 
 STRING
-   : '"' S_CHAR* '"'
+   : '"' ( S_CHAR | S_ESCAPE )* '"'
    ;
 
 
@@ -403,7 +403,7 @@ fragment Q_CHAR
 
 
 fragment S_ESCAPE
-   : '’' | '\'' | '?' | '\\' | 'a' | 'b' | 'f' | 'v'
+   : '\\' ('’' | '\'' | '"' | '?' | '\\' | 'a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v')
    ;
 
 
@@ -425,3 +425,11 @@ UNSIGNED_NUMBER
 WS
    : [ \r\n\t] + -> channel (HIDDEN)
    ;
+
+COMMENT
+    :   '/*' .*? '*/' -> channel (HIDDEN)
+    ;
+
+LINE_COMMENT
+    :   '//' ~[\r\n]* -> channel (HIDDEN)
+    ;


### PR DESCRIPTION
Added definitions for comments. Corrected definition of strings (including escape sequences). Corrected if_equation and if_statement definitions (misplaced parentheses). Corrected import definition ("name" needs to come last else it seems to match too eagerly). Corrected definition of array indices ('[' vs '(').