### PR TITLE
 CPP14.g4 bugfix - relational ops in template arguments

### DIFF
--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -1239,8 +1239,8 @@ templateargumentlist
 
 templateargument
 :
-	constantexpression
-	| typeid
+	typeid
+	| constantexpression
 	| idexpression
 ;
 

--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -1320,12 +1320,12 @@ noexceptspecification
 
 MultiLineMacro
 :
-    '#' (.*? '\\' [\r\n]+)+ ~[\r\n]+ -> skip
+    '#' (~[\n]*? '\\' '\r'? '\n')+ ~[\n]+ -> channel(HIDDEN)
 ;
 
 Directive
 :
-	'#' ~[\r\n]* -> skip
+    '#' ~[\n]* -> channel(HIDDEN)
 ;
 
 /*Lexer*/

--- a/cpp/examples/template_args_test.cpp
+++ b/cpp/examples/template_args_test.cpp
@@ -1,0 +1,3 @@
+void TemplateArgsTest(vector<ClassA> args, vector <ClassB> args2)
+{
+}


### PR DESCRIPTION
Consider the signature
void TestFunc(vector< ClassA > args, vector < ClassB > args2)

Right now this is parsed as 
- a declaration of a variable args2 
- the type of args2 is vector <A, B> 
    where A = (ClassA > args) 
               B = (vector < B) 
   i.e. a a template instantiation that has two relational expressions that are the arguments

This stems from the priority order of the template argument list which is 
templateargument : constantexpression | typeid | idexpression;

Changing the order to : typeid | constantexpression| idexpression; fixes this.

Tested that this is the same behavior as observed in Microsoft c++ compiler, gcc, clang and icc.