### PR TITLE
Fix type setting in antlr4's LexerAdaptor.

### DIFF
--- a/antlr4/LexerAdaptor.py
+++ b/antlr4/LexerAdaptor.py
@@ -37,12 +37,12 @@ class LexerAdaptor(Lexer):
     def handleEndArgument(self):
         self.popMode()
         if len(self._modeStack) > 0:
-            self.setType(self.ARGUMENT_CONTENT)
+            self._type = self.ARGUMENT_CONTENT
 
     def handleEndAction(self):
         self.popMode()
         if len(self._modeStack) > 0:
-            self.setType(self.ACTION_CONTENT)
+            self._type = self.ACTION_CONTENT
 
     def emit(self):
         if self._type == self.ID:


### PR DESCRIPTION
The type of LexerAdaptor can be set via its `_type` field
instead of the nonexistent setType method.