### PR TITLE
Fix CSV generation error for python runtime

### DIFF
--- a/csv/CSV.g4
+++ b/csv/CSV.g4
@@ -28,7 +28,7 @@
 
 grammar CSV;
 
-file: hdr row+ ;
+csvFile: hdr row+ ;
 hdr : row ;
 
 row : field (',' field)* '\r'? '\n' ;

--- a/csv/pom.xml
+++ b/csv/pom.xml
@@ -37,7 +37,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>file</entryPoint>
+					<entryPoint>csvFile</entryPoint>
 					<grammarName>CSV</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>


### PR DESCRIPTION
When generating parser/lexer for python runtime, an error is raised:

`error(134): CSV.g4:31:0: symbol file conflicts with generated code in target language or runtime`.

Changing `file` to `csvFile` fixes it.