### PR TITLE
Fix GML grammar for Go

### DIFF
--- a/gml/gml.g4
+++ b/gml/gml.g4
@@ -46,7 +46,7 @@ kv
 
 value
    : integer
-   | real
+   | realnum
    | stringliteral
    | str
    | list
@@ -60,7 +60,7 @@ integer
    : SIGN? DIGIT +
    ;
 
-real
+realnum
    : REAL
    ;
 
@@ -99,7 +99,7 @@ MANTISSA
 
 
 VALUE
-   : [a-zA-z0-9] +
+   : [a-zA-Z0-9] +
    ;
 
 


### PR DESCRIPTION
Also clean up a warning

```
warning(180): gml.g4:102:5: chars "A-z" used multiple times in set [a-zA-z0-9]
error(134): gml.g4:63:0: symbol real conflicts with generated code in target language or runtime
error(134): gml.g4:49:5: symbol real conflicts with generated code in target language or runtime
```