### PR TITLE
Make JSON grammar Python compatible.

### DIFF
--- a/json/JSON.g4
+++ b/json/JSON.g4
@@ -8,7 +8,7 @@ json
    : value
    ;
 
-object
+obj
    : '{' pair (',' pair)* '}'
    | '{' '}'
    ;
@@ -25,7 +25,7 @@ array
 value
    : STRING
    | NUMBER
-   | object
+   | obj
    | array
    | 'true'
    | 'false'


### PR DESCRIPTION
The 'object' parser rule was renamed to 'obj' to avoid symbol
conflict with Python's builtin object.