### PR TITLE
Fix unnecessary +

### DIFF
--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -764,7 +764,7 @@ query_expression
     ;
 
 union
-    : (UNION ALL? | EXCEPT | INTERSECT) (query_specification | ('(' query_expression ')')+)
+    : (UNION ALL? | EXCEPT | INTERSECT) (query_specification | ('(' query_expression ')'))
     ;
 
 // https://msdn.microsoft.com/en-us/library/ms176104.aspx


### PR DESCRIPTION
[Original syntax](https://msdn.microsoft.com/en-us/library/ms189499.aspx) is:

```
<query_expression> ::=
    { <query_specification> | ( <query_expression> ) }
    [  { UNION [ ALL ] | EXCEPT | INTERSECT } 
        <query_specification> | ( <query_expression> ) [...n ] ]
```

The rule of `query_expression` that is defined by tsql.g4 allow multiple `union`.
So the rule of `union` is not necessary `+`.