### PR TITLE
Fixed TOP clause for optional bracket rules on tsql.g4.

### DIFF
--- a/tsql/examples/dml_select.sql
+++ b/tsql/examples/dml_select.sql
@@ -480,3 +480,68 @@ SELECT LastName, FirstName, JobTitle
 FROM dbo.EmployeeThree
 );
 GO
+
+--+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Using SELECT with TOP clause
+
+USE AdventureWorks2012;
+GO
+SELECT TOP 10 *
+FROM Production.Product
+ORDER BY Name ASC;
+-- Alternate way.
+USE AdventureWorks2012;
+GO
+SELECT TOP (10) *
+FROM Production.Product
+ORDER BY Name ASC;
+-- Alternate way.
+USE AdventureWorks2012;
+GO
+SELECT TOP (@localvar) *
+FROM Production.Product
+ORDER BY Name ASC;
+
+-- TOP with percentage.
+USE AdventureWorks2012;
+GO
+SELECT TOP 10.5 PERCENT *
+FROM Production.Product
+ORDER BY Name ASC;
+-- Alternate way.
+USE AdventureWorks2012;
+GO
+SELECT TOP (10.5) PERCENT *
+FROM Production.Product
+ORDER BY Name ASC;
+-- Alternate way.
+USE AdventureWorks2012;
+GO
+SELECT TOP (@localvar) PERCENT *
+FROM Production.Product
+ORDER BY Name ASC;
+
+-- TOP with ties.
+USE AdventureWorks2012;
+GO
+SELECT TOP 10 WITH TIES *
+FROM Production.Product
+ORDER BY Name ASC;
+-- Alternate way.
+USE AdventureWorks2012;
+GO
+SELECT TOP 10.5 PERCENT WITH TIES *
+FROM Production.Product
+ORDER BY Name ASC;
+-- Alternate way.
+USE AdventureWorks2012;
+GO
+SELECT TOP (@localvar) WITH TIES *
+FROM Production.Product
+ORDER BY Name ASC;
+-- Alternate way.
+USE AdventureWorks2012;
+GO
+SELECT TOP (@localvar) PERCENT WITH TIES *
+FROM Production.Product
+ORDER BY Name ASC;

--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -769,7 +769,7 @@ union
 
 // https://msdn.microsoft.com/en-us/library/ms176104.aspx
 query_specification
-    : SELECT (ALL | DISTINCT)? (TOP expression PERCENT? (WITH TIES)?)?
+    : SELECT (ALL | DISTINCT)? top_clause?
       select_list
       // https://msdn.microsoft.com/en-us/library/ms188029.aspx
       (INTO table_name)?
@@ -778,6 +778,21 @@ query_specification
       // https://msdn.microsoft.com/en-us/library/ms177673.aspx
       (GROUP BY group_by_item (',' group_by_item)*)?
       (HAVING having=search_condition)?
+    ;
+
+// https://msdn.microsoft.com/en-us/library/ms189463.aspx
+top_clause
+    : TOP (top_percent | top_count) (WITH TIES)?
+    ;
+
+top_percent
+    : (REAL | FLOAT) PERCENT
+    | '(' (REAL | FLOAT | LOCAL_ID) ')' PERCENT?
+    ;
+
+top_count
+    : DECIMAL
+    | '(' (DECIMAL | LOCAL_ID) ')'
     ;
 
 // https://msdn.microsoft.com/en-us/library/ms188385.aspx


### PR DESCRIPTION
On tsql, the TOP clause require must not parentheses,
but require parentheses for local variable reference.