### PR TITLE
Fixed contains DECIMAL termination in tsql predicate clause.

### DIFF
--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -756,7 +756,6 @@ predicate
     | expression NOT? LIKE expression (ESCAPE expression)?
     | expression IS null_notnull
     | '(' search_condition ')'
-	| DECIMAL
     ;
 
 query_expression


### PR DESCRIPTION
<predicate> clause not contains DECIMAL termination.

https://msdn.microsoft.com/en-us/library/ms173545.aspx
