### PR TITLE
Fixing exception in the ECAMScript JavaScript grammar

### DIFF
--- a/ecmascript/ECMAScript.JavaScriptTarget.g4
+++ b/ecmascript/ECMAScript.JavaScriptTarget.g4
@@ -269,21 +269,21 @@ iterationStatement
 ///     continue ;
 ///     continue [no LineTerminator here] Identifier ;
 continueStatement
- : Continue ({!this.here(LineTerminator)}? Identifier)? eos
+ : Continue ({!this.here(ECMAScriptParser.LineTerminator)}? Identifier)? eos
  ;
 
 /// BreakStatement :
 ///     break ;
 ///     break [no LineTerminator here] Identifier ;
 breakStatement
- : Break ({!this.here(LineTerminator)}? Identifier)? eos
+ : Break ({!this.here(ECMAScriptParser.LineTerminator)}? Identifier)? eos
  ;
 
 /// ReturnStatement :
 ///     return ;
 ///     return [no LineTerminator here] Expression ;
 returnStatement
- : Return ({!this.here(LineTerminator)}? expressionSequence)? eos
+ : Return ({!this.here(ECMAScriptParser.LineTerminator)}? expressionSequence)? eos
  ;
 
 /// WithStatement :
@@ -333,7 +333,7 @@ labelledStatement
 /// ThrowStatement :
 ///     throw [no LineTerminator here] Expression ;
 throwStatement
- : Throw {!this.here(LineTerminator)}? expressionSequence eos
+ : Throw {!this.here(ECMAScriptParser.LineTerminator)}? expressionSequence eos
  ;
 
 /// TryStatement :
@@ -585,8 +585,8 @@ singleExpression
  | singleExpression '.' identifierName                                    # MemberDotExpression
  | singleExpression arguments                                             # ArgumentsExpression
  | New singleExpression arguments?                                        # NewExpression
- | singleExpression {!this.here(LineTerminator)}? '++'                         # PostIncrementExpression
- | singleExpression {!this.here(LineTerminator)}? '--'                         # PostDecreaseExpression
+ | singleExpression {!this.here(ECMAScriptParser.LineTerminator)}? '++'                         # PostIncrementExpression
+ | singleExpression {!this.here(ECMAScriptParser.LineTerminator)}? '--'                         # PostDecreaseExpression
  | Delete singleExpression                                                # DeleteExpression
  | Void singleExpression                                                  # VoidExpression
  | Typeof singleExpression                                                # TypeofExpression


### PR DESCRIPTION
Fix for:
Parser generated from ECMAScript grammar throws exception.
see issue https://github.com/antlr/grammars-v4/issues/594
