### PR TITLE
Implement golang semicolon insertion

### DIFF
--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -238,12 +238,12 @@ statement
 
 //SimpleStmt = EmptyStmt | ExpressionStmt | SendStmt | IncDecStmt | Assignment | ShortVarDecl .
 simpleStmt
-//    : emptyStmt
     : sendStmt
     | expressionStmt
     | incDecStmt
     | assignment
     | shortVarDecl
+    | emptyStmt
     ;
 
 //ExpressionStmt = Expression .
@@ -278,9 +278,9 @@ shortVarDecl
     : identifierList ':=' expressionList
     ;
 
-//emptyStmt
-//    :
-//    ;
+emptyStmt
+    : ';'
+    ;
 
 //LabeledStmt = Label ":" Statement .
 //Label       = identifier .

--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -32,9 +32,80 @@
  */
 grammar Golang;
 
+@parser::members {
+
+    /**
+     * Returns {@code true} iff on the current index of the parser's
+     * token stream a token exists on the {@code HIDDEN} channel which
+     * either is a line terminator, or is a multi line comment that
+     * contains a line terminator.
+     *
+     * @return {@code true} iff on the current index of the parser's
+     * token stream a token exists on the {@code HIDDEN} channel which
+     * either is a line terminator, or is a multi line comment that
+     * contains a line terminator.
+     */
+    private boolean lineTerminatorAhead() {
+        // Get the token ahead of the current index.
+        int possibleIndexEosToken = this.getCurrentToken().getTokenIndex() - 1;
+        Token ahead = _input.get(possibleIndexEosToken);
+        if (ahead.getChannel() != Lexer.HIDDEN) {
+            // We're only interested in tokens on the HIDDEN channel.
+            return false;
+        }
+
+        if (ahead.getType() == TERMINATOR) {
+            // There is definitely a line terminator ahead.
+            return true;
+        }
+
+        if (ahead.getType() == WS) {
+            // Get the token ahead of the current whitespaces.
+            possibleIndexEosToken = this.getCurrentToken().getTokenIndex() - 2;
+            ahead = _input.get(possibleIndexEosToken);
+        }
+
+        // Get the token's text and type.
+        String text = ahead.getText();
+        int type = ahead.getType();
+
+        // Check if the token is, or contains a line terminator.
+        return (type == COMMENT && (text.contains("\r") || text.contains("\n"))) ||
+                (type == TERMINATOR);
+    }
+}
+
+@lexer::members {
+
+    // The most recently produced token.
+    private Token lastToken = null;
+
+    /**
+     * Return the next token from the character stream and records this last
+     * token in case it resides on the default channel. This recorded token
+     * is used to determine when the lexer could possibly match a regex
+     * literal.
+     *
+     * @return the next token from the character stream.
+     */
+    @Override
+    public Token nextToken() {
+
+        // Get the next token.
+        Token next = super.nextToken();
+
+        if (next.getChannel() == Token.DEFAULT_CHANNEL) {
+            // Keep track of the last token on the default channel.
+            this.lastToken = next;
+        }
+
+        return next;
+    }
+}
+
 //SourceFile       = PackageClause ";" { ImportDecl ";" } { TopLevelDecl ";" } .
 sourceFile
-    : packageClause ';'? ( importDecl ';'? )* ( topLevelDecl ';'?)*
+    : packageClause eos ( importDecl eos )* ( topLevelDecl eos)*
     ;
 
 //PackageClause  = "package" PackageName .
@@ -44,7 +115,7 @@ packageClause
     ;
 
 importDecl
-    : 'import' ( importSpec | '(' ( importSpec ';'? )* ')' )
+    : 'import' ( importSpec | '(' ( importSpec eos )* ')' )
     ;
 
 importSpec
@@ -72,7 +143,7 @@ declaration
 
 //ConstDecl      = "const" ( ConstSpec | "(" { ConstSpec ";" } ")" ) .
 constDecl
-    : 'const' ( constSpec | '(' ( constSpec ';'? )* ')' )   // TODO EOS optional?
+    : 'const' ( constSpec | '(' ( constSpec eos )* ')' )
     ;
 
 //ConstSpec      = IdentifierList [ [ Type ] "=" ExpressionList ] .
@@ -128,9 +199,8 @@ receiver
 
 //VarDecl     = "var" ( VarSpec | "(" { VarSpec ";" } ")" ) .
 //VarSpec     = IdentifierList ( Type [ "=" ExpressionList ] | "=" ExpressionList ) .
-// TODO EOS optional?
 varDecl
-    : 'var' ( varSpec | '(' ( varSpec ';'? )* ')' )
+    : 'var' ( varSpec | '(' ( varSpec eos )* ')' )
     ;
 
 varSpec
@@ -145,7 +215,7 @@ block
 
 //StatementList = { Statement ";" } .
 statementList
-    : ( statement eos? )*  // TODO EOS optional?
+    : ( statement eos )*
     ;
 
 statement
@@ -169,8 +239,8 @@ statement
 //SimpleStmt = EmptyStmt | ExpressionStmt | SendStmt | IncDecStmt | Assignment | ShortVarDecl .
 simpleStmt
 //    : emptyStmt
-    : expressionStmt
-    | sendStmt
+    : sendStmt
+    | expressionStmt
     | incDecStmt
     | assignment
     | shortVarDecl
@@ -387,7 +457,7 @@ pointerType
 //MethodName         = identifier .
 //InterfaceTypeName  = TypeName .
 interfaceType
-    : 'interface' '{' ( methodSpec ';'? )* '}'
+    : 'interface' '{' ( methodSpec eos )* '}'
     ;
 
 //SliceType = "[" "]" ElementType .
@@ -533,7 +603,7 @@ element
 //AnonymousField = [ "*" ] TypeName .
 //Tag            = string_lit .
 structType
-    : 'struct' '{' ( fieldDecl ';'? )* '}'   // TODO EOS optional?
+    : 'struct' '{' ( fieldDecl eos )* '}'
     ;
 
 fieldDecl
@@ -630,6 +700,8 @@ conversion
 eos
     : ';'
     | EOF
+    | {lineTerminatorAhead()}?
+    | {_input.LT(1).getText().equals("}") }?
     ;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1167,12 +1239,17 @@ fragment UNICODE_LETTER
 // Whitespace and comments
 //
 
-WS  :  [ \t\r\n\u000C]+ -> skip
+WS  :  [ \t]+ -> channel(HIDDEN)
     ;
 
 COMMENT
-    :   '/*' .*? '*/' -> skip
+    :   '/*' .*? '*/' -> channel(HIDDEN)
     ;
+
+TERMINATOR
+	: [\r\n]+ -> channel(HIDDEN)
+	;
+
 
 LINE_COMMENT
     :   '//' ~[\r\n]* -> skip

--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -1,6 +1,6 @@
 /*
  [The "BSD licence"]
- Copyright (c) 2016 Sasa Coh
+ Copyright (c) 2017 Sasa Coh, Michał Błotniak
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -638,107 +638,13 @@ eos
 // LEXER
 
 
-// Operators
-//
-//binary_op  = "||" | "&&" | rel_op | add_op | mul_op .
-//rel_op     = "==" | "!=" | "<" | "<=" | ">" | ">=" .
-//add_op     = "+" | "-" | "|" | "^" .
-//mul_op     = "*" | "/" | "%" | "<<" | ">>" | "&" | "&^" .
-//
-//unary_op   = "+" | "-" | "!" | "^" | "*" | "&" | "<-" .
-fragment
-BINARY_OP
-//    : '||' | '&&' | REL_OP | ADD_OP | MUL_OP
-    : '||' | '&&' | '==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '|' | '^' | '*' | '/' | '%' | '<<' | '>>' | '&' | '&^'
+// Identifiers
+//identifier = letter { letter | unicode_digit } .
+IDENTIFIER
+    : LETTER ( LETTER | UNICODE_DIGIT )*
     ;
 
-fragment
-REL_OP
-    : '=='
-    | '!='
-    | '<'
-    | '<='
-    | '>'
-    | '>='
-    ;
-
-fragment
-ADD_OP
-    : '+'
-    | '-'
-    | '|'
-    | '^'
-    ;
-
-fragment
-MUL_OP
-    : '*'
-    | '/'
-    | '%'
-    | '<<'
-    | '>>'
-    | '&'
-    | '&^'
-    ;
-
-fragment
-UNARY_OP
-    : ('+'|'-'|'!'|'^'|'*'|'&'|'<-')
-    ;
-
-// Literals
-
-//int_lit     = decimal_lit | octal_lit | hex_lit .
-//decimal_lit = ( "1" … "9" ) { decimal_digit } .
-//octal_lit   = "0" { octal_digit } .
-//hex_lit     = "0" ( "x" | "X" ) hex_digit { hex_digit } .
-
-INT_LIT
-    : DECIMAL_LIT
-    | OCTAL_LIT
-    | HEX_LIT
-    ;
-
-fragment DECIMAL_LIT
-    : [1-9] DECIMAL_DIGIT*
-    ;
-
-fragment OCTAL_LIT
-    : '0' OCTAL_DIGIT*
-    ;
-
-fragment HEX_LIT
-    : '0' ( 'x' | 'X' ) HEX_DIGIT+
-    ;
-
-
-//float_lit = decimals "." [ decimals ] [ exponent ] |
-//            decimals exponent |
-//            "." decimals [ exponent ] .
-//decimals  = decimal_digit { decimal_digit } .
-//exponent  = ( "e" | "E" ) [ "+" | "-" ] decimals .
-FLOAT_LIT
-    : DECIMALS '.' DECIMALS? EXPONENT?
-    | DECIMALS EXPONENT
-    | '.' DECIMALS EXPONENT?
-    ;
-
-fragment
-DECIMALS
-    : DECIMAL_DIGIT+
-    ;
-
-fragment
-EXPONENT
-    : ( 'e' | 'E' ) ( '+' | '-' )? DECIMALS
-    ;
-
-//imaginary_lit = (decimals | float_lit) "i" .
-IMAGINARY_LIT
-    : (DECIMALS | FLOAT_LIT) 'i'
-    ;
-
-
+// Keywords
 KEYWORD
     : 'break'
     | 'default'
@@ -767,47 +673,113 @@ KEYWORD
     | 'var'
     ;
 
-IDENTIFIER
-    : LETTER ( LETTER | UNICODE_DIGIT )*
+
+// Operators
+
+//binary_op  = "||" | "&&" | rel_op | add_op | mul_op .
+BINARY_OP
+    : '||' | '&&' | REL_OP | ADD_OP | MUL_OP
     ;
 
+//rel_op     = "==" | "!=" | "<" | "<=" | ">" | ">=" .
+fragment REL_OP
+    : '=='
+    | '!='
+    | '<'
+    | '<='
+    | '>'
+    | '>='
+    ;
+
+//add_op     = "+" | "-" | "|" | "^" .
+fragment ADD_OP
+    : '+'
+    | '-'
+    | '|'
+    | '^'
+    ;
+
+//mul_op     = "*" | "/" | "%" | "<<" | ">>" | "&" | "&^" .
+fragment MUL_OP
+    : '*'
+    | '/'
+    | '%'
+    | '<<'
+    | '>>'
+    | '&'
+    | '&^'
+    ;
+
+//unary_op   = "+" | "-" | "!" | "^" | "*" | "&" | "<-" .
+fragment UNARY_OP
+    : '+'
+    | '-'
+    | '!'
+    | '^'
+    | '*'
+    | '&'
+    | '<-'
+    ;
+
+
+// Integer literals
+
+//int_lit     = decimal_lit | octal_lit | hex_lit .
+INT_LIT
+    : DECIMAL_LIT
+    | OCTAL_LIT
+    | HEX_LIT
+    ;
+
+//decimal_lit = ( "1" … "9" ) { decimal_digit } .
+fragment DECIMAL_LIT
+    : [1-9] DECIMAL_DIGIT*
+    ;
+
+//octal_lit   = "0" { octal_digit } .
+fragment OCTAL_LIT
+    : '0' OCTAL_DIGIT*
+    ;
+
+//hex_lit     = "0" ( "x" | "X" ) hex_digit { hex_digit } .
+fragment HEX_LIT
+    : '0' ( 'x' | 'X' ) HEX_DIGIT+
+    ;
+
+
+// Floating-point literals
+
+//float_lit = decimals "." [ decimals ] [ exponent ] |
+//            decimals exponent |
+//            "." decimals [ exponent ] .
+FLOAT_LIT
+    : DECIMALS '.' DECIMALS? EXPONENT?
+    | DECIMALS EXPONENT
+    | '.' DECIMALS EXPONENT?
+    ;
+
+//decimals  = decimal_digit { decimal_digit } .
+fragment DECIMALS
+    : DECIMAL_DIGIT+
+    ;
+
+//exponent  = ( "e" | "E" ) [ "+" | "-" ] decimals .
+fragment EXPONENT
+    : ( 'e' | 'E' ) ( '+' | '-' )? DECIMALS
+    ;
+
+// Imaginary literals
+//imaginary_lit = (decimals | float_lit) "i" .
+IMAGINARY_LIT
+    : (DECIMALS | FLOAT_LIT) 'i'
+    ;
+
+
+// Rune literals
 
 //rune_lit         = "'" ( unicode_value | byte_value ) "'" .
 RUNE_LIT
     : '\'' ( UNICODE_VALUE | BYTE_VALUE ) '\''
-    ;
-
-
-//string_lit             = raw_string_lit | interpreted_string_lit .
-//raw_string_lit         = "`" { unicode_char | newline } "`" .
-//interpreted_string_lit = `"` { unicode_value | byte_value } `"` .
-STRING_LIT
-    : RAW_STRING_LIT
-    | INTERPRETED_STRING_LIT
-    ;
-
-fragment RAW_STRING_LIT
-//    : '`' ( UNICODE_CHAR | NEWLINE )* '`'
-    : '`' ( RAW_STRING_CHAR | NEWLINE )* '`'
-    ;
-
-fragment INTERPRETED_STRING_LIT
-//    : '"' ( UNICODE_VALUE | BYTE_VALUE )* '"'
-    : '"' ( STRING_CHAR | BYTE_VALUE )* '"'
-    ;
-
-fragment STRING_CHAR
-    : ~["\\]
-    | LITTLE_U_VALUE
-    | BIG_U_VALUE
-    | ESCAPED_CHAR
-    ;
-
-fragment RAW_STRING_CHAR
-    : ~[`]
-    | LITTLE_U_VALUE
-    | BIG_U_VALUE
-    | ESCAPED_CHAR
     ;
 
 //unicode_value    = unicode_char | little_u_value | big_u_value | escaped_char .
@@ -816,17 +788,6 @@ fragment UNICODE_VALUE
     | LITTLE_U_VALUE
     | BIG_U_VALUE
     | ESCAPED_CHAR
-    ;
-
-//
-//little_u_value   = `\` "u" hex_digit hex_digit hex_digit hex_digit .
-//big_u_value      = `\` "U" hex_digit hex_digit hex_digit hex_digit
-//                           hex_digit hex_digit hex_digit hex_digit .
-LITTLE_U_VALUE
-    : '\\u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
-    ;
-BIG_U_VALUE
-    : '\\U' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
     ;
 
 //byte_value       = octal_byte_value | hex_byte_value .
@@ -844,29 +805,76 @@ fragment HEX_BYTE_VALUE
     : '\\' 'x' HEX_DIGIT HEX_DIGIT
     ;
 
+//little_u_value   = `\` "u" hex_digit hex_digit hex_digit hex_digit .
+//                           hex_digit hex_digit hex_digit hex_digit .
+LITTLE_U_VALUE
+    : '\\u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+    ;
+
+//big_u_value      = `\` "U" hex_digit hex_digit hex_digit hex_digit
+BIG_U_VALUE
+    : '\\U' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+    ;
+
 //escaped_char     = `\` ( "a" | "b" | "f" | "n" | "r" | "t" | "v" | `\` | "'" | `"` ) .
 fragment ESCAPED_CHAR
     : '\\' ( 'a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' | '\\' | '\'' | '"' )
     ;
 
 
-fragment LETTER : UNICODE_LETTER | '_'
+// String literals
+
+//string_lit             = raw_string_lit | interpreted_string_lit .
+STRING_LIT
+    : RAW_STRING_LIT
+    | INTERPRETED_STRING_LIT
     ;
 
-fragment DECIMAL_DIGIT : [0-9]
+//raw_string_lit         = "`" { unicode_char | newline } "`" .
+fragment RAW_STRING_LIT
+    : '`' ( UNICODE_CHAR | NEWLINE )* '`'
     ;
 
-fragment OCTAL_DIGIT   : [0-7]
+//interpreted_string_lit = `"` { unicode_value | byte_value } `"` .
+fragment INTERPRETED_STRING_LIT
+    : '"' ( UNICODE_VALUE | BYTE_VALUE )* '"'
     ;
 
-fragment HEX_DIGIT     : [0-9a-fA-F]
+
+//
+// Source code representation
+//
+
+//letter        = unicode_letter | "_" .
+fragment LETTER
+    : UNICODE_LETTER
+    | '_'
     ;
 
-fragment NEWLINE        : [\u000A] ; /* the Unicode code point U+000A */
-fragment UNICODE_CHAR   : ~[\u000A] ; /* an arbitrary Unicode code point except newline */
-//UNICODE_LETTER : ; /* a Unicode code point classified as "Letter" */ .
-//UNICODE_DIGIT  : ; /* a Unicode code point classified as "Number, decimal digit" */ .
+//decimal_digit = "0" … "9" .
+fragment DECIMAL_DIGIT
+    : [0-9]
+    ;
 
+//octal_digit   = "0" … "7" .
+fragment OCTAL_DIGIT
+    : [0-7]
+    ;
+
+//hex_digit     = "0" … "9" | "A" … "F" | "a" … "f" .
+fragment HEX_DIGIT
+    : [0-9a-fA-F]
+    ;
+
+//newline = /* the Unicode code point U+000A */ .
+fragment NEWLINE
+    : [\u000A]
+    ;
+
+//unicode_char = /* an arbitrary Unicode code point except newline */ .
+fragment UNICODE_CHAR   : ~[\u000A] ;
+
+//unicode_digit = /* a Unicode code point classified as "Number, decimal digit" */ .
 fragment UNICODE_DIGIT
  : [\u0030-\u0039]
  | [\u0660-\u0669]
@@ -890,6 +898,7 @@ fragment UNICODE_DIGIT
  | [\uFF10-\uFF19]
  ;
 
+//unicode_letter = /* a Unicode code point classified as "Letter" */ .
 fragment UNICODE_LETTER
  : [\u0041-\u005A]
  | [\u0061-\u007A]

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,2 @@
+# Golang Grammar
+An ANTRL4 grammar for Golang based on [The Go Programming Language Specification](https://golang.org/ref/spec).

--- a/golang/examples/ill_but_correct.go
+++ b/golang/examples/ill_but_correct.go
@@ -1,0 +1,6 @@
+package main;
+
+import "fmt"
+
+func main() { ;
+	ch <- 1 }


### PR DESCRIPTION
Based on ASI from [ECMAScript grammar](https://github.com/antlr/grammars-v4/blob/master/ecmascript/ECMAScript.g4).

Closes #584 