### PR TITLE
Add support to included columns when creating index and filtered index

### DIFF
--- a/tsql/examples/ddl_index.sql
+++ b/tsql/examples/ddl_index.sql
@@ -1,0 +1,20 @@
+-- Create a nonclustered index on a table or view  
+CREATE INDEX i1 ON t1 (col1);  
+
+--Create a clustered index on a table and use a 3-part name for the table  
+CREATE CLUSTERED INDEX i1 ON d1.s1.t1 (col1);  
+
+-- Create a nonclustered index with a unique constraint on 3 columns and specify the sort order for each column  
+CREATE UNIQUE INDEX i1 ON t1 (col1 DESC, col2 ASC, col3 DESC);  
+
+-- Create a nonclustered index with a unique constraint on 3 columns and specify the sort order for each column  
+CREATE UNIQUE INDEX i1 ON t1 (col1 DESC, col2 ASC, col3 DESC);  
+
+CREATE NONCLUSTERED INDEX IX_Address_PostalCode  
+    ON Person.Address (PostalCode)  
+    INCLUDE (AddressLine1, AddressLine2, City, StateProvinceID);  
+
+-- filtered index
+CREATE NONCLUSTERED INDEX IX_BillOfMaterials_ComponentID
+    ON Production.BillOfMaterials (ComponentID, StartDate)
+    WHERE EndDate IS NOT NULL ; 

--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -220,7 +220,7 @@ create_database
 
 // https://msdn.microsoft.com/en-us/library/ms188783.aspx
 create_index
-    : CREATE UNIQUE? clustered? INDEX id ON table_name_with_hint '(' column_name_list (ASC | DESC)? ')'
+    : CREATE UNIQUE? clustered? INDEX id ON table_name_with_hint '(' column_name_list_with_order ')'
     (INCLUDE '(' column_name_list ')' )?
     (WHERE where=search_condition)?
     (index_options)?
@@ -1208,6 +1208,10 @@ ddl_object
 
 full_column_name
     : (table_name '.')? id
+    ;
+
+column_name_list_with_order
+    : id (ASC | DESC)? (',' id (ASC | DESC)?)*
     ;
 
 column_name_list

--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -1547,6 +1547,7 @@ IDENTITYCOL:                           I D E N T I T Y C O L;
 IDENTITY_INSERT:                       I D E N T I T Y '_' I N S E R T;
 IF:                                    I F;
 IN:                                    I N;
+INCLUDE:                               I N C L U D E;
 INDEX:                                 I N D E X;
 INNER:                                 I N N E R;
 INSERT:                                I N S E R T;

--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -221,6 +221,8 @@ create_database
 // https://msdn.microsoft.com/en-us/library/ms188783.aspx
 create_index
     : CREATE UNIQUE? clustered? INDEX id ON table_name_with_hint '(' column_name_list (ASC | DESC)? ')'
+    (INCLUDE '(' column_name_list ')' )?
+    (WHERE where=search_condition)?
     (index_options)?
     (ON id)?
     ';'?


### PR DESCRIPTION
Following query will generate parsing error since grammar doesn't support INCLUDED columns.

`CREATE NONCLUSTERED  INDEX [ACTIVITIES__ACTIVITYSTATUS_ENDINGDATE]  ON [DBO].[ACTIVITIES] ([ACTIVITYSTATUS] ASC, [ENDINGDATE] ASC) INCLUDE ([BEGINNINGDATE], [SEASON_ID], [CHILD_SEASON_ID], [ACTIVITY_TYPE_ID], [ACTIVITY_DEPARTMENT_ID], [RG_CATEGORY_ID], [RG_SUB_CATEGORY_ID])`