### PR TITLE
antlr4: do not refer parser rules from lexer.

### DIFF
--- a/antlr4/ANTLRv4Parser.g4
+++ b/antlr4/ANTLRv4Parser.g4
@@ -239,7 +239,7 @@ lexerElement
 
 // but preds can be anywhere
 labeledLexerElement
-   : identifier (ASSIGN | PLUS_ASSIGN) (lexerAtom | block)
+   : identifier (ASSIGN | PLUS_ASSIGN) (lexerAtom | lexerBlock)
    ;
 
 lexerBlock


### PR DESCRIPTION
Until now, the labeledLexerElement rule of the antlr4 parser grammar
enabled having a block element on its right hand side, which meant
enabling parser rule references in lexer rules. The patch fixes this.