### PR TITLE
ecmascript: objectLiteral must not contain a single comma only

### DIFF
--- a/ecmascript/ECMAScript.CSharpTarget.g4
+++ b/ecmascript/ECMAScript.CSharpTarget.g4
@@ -430,7 +430,8 @@ elision
 ///     { PropertyNameAndValueList }
 ///     { PropertyNameAndValueList , }
 objectLiteral
- : '{' propertyNameAndValueList? ','? '}'
+ : '{' '}'
+ | '{' propertyNameAndValueList ','? '}'
  ;
 
 /// PropertyNameAndValueList :

--- a/ecmascript/ECMAScript.JavaScriptTarget.g4
+++ b/ecmascript/ECMAScript.JavaScriptTarget.g4
@@ -410,7 +410,8 @@ elision
 ///     { PropertyNameAndValueList }
 ///     { PropertyNameAndValueList , }
 objectLiteral
- : '{' propertyNameAndValueList? ','? '}'
+ : '{' '}'
+ | '{' propertyNameAndValueList ','? '}'
  ;
 
 /// PropertyNameAndValueList :

--- a/ecmascript/ECMAScript.PythonTarget.g4
+++ b/ecmascript/ECMAScript.PythonTarget.g4
@@ -436,7 +436,8 @@ elision
 ///     { PropertyNameAndValueList }
 ///     { PropertyNameAndValueList , }
 objectLiteral
- : '{' propertyNameAndValueList? ','? '}'
+ : '{' '}'
+ | '{' propertyNameAndValueList ','? '}'
  ;
 
 /// PropertyNameAndValueList :

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -452,7 +452,8 @@ elision
 ///     { PropertyNameAndValueList }
 ///     { PropertyNameAndValueList , }
 objectLiteral
- : '{' propertyNameAndValueList? ','? '}'
+ : '{' '}'
+ | '{' propertyNameAndValueList ','? '}'
  ;
 
 /// PropertyNameAndValueList :


### PR DESCRIPTION
The objectLiteral rule must match on zero or more elements,
separated by commas and if it contained at least one element,
then it may end with an optional trailing comma. However,
the current grammar enables a single comma, without any other
elements. The patch fixes this in every ecmascript targets.