### PR TITLE
Tsql. Remove erroneous `expression?` sub-statemet in DECLARE statement.

### DIFF
--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -906,7 +906,7 @@ execute_clause
     ;
 
 declare_local
-    : LOCAL_ID AS? data_type ('=' expression)? expression?
+    : LOCAL_ID AS? data_type ('=' expression)?
     ;
 
 table_type_definition


### PR DESCRIPTION
According the
[https://github.com/antlr/grammars-v4/commit/363b5fa63be3c1d48b76c05653450534402ea399#commitcomment-22347468](url)
 , i suppose all the same that there is a mistake in double `expression?` statement.
It's possible to hold several variables in one DECLARE statement, for example:

`DECLARE @v1 varchar(500) = 'some value', @v2 int = '5';`

But it doesn't possible to do something like this:

`DECLARE @v1 varchar(500) = 'some expression' 'another expression';`
