### PR TITLE
Tsql. Fix real

### DIFF
--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -2396,7 +2396,7 @@ ID:                  ( [a-zA-Z_#] | FullWidthLetter) ( [a-zA-Z_#$@0-9] | FullWid
 STRING:              N? '\'' (~'\'' | '\'\'')* '\'';
 BINARY:              '0' X HEX_DIGIT*;
 FLOAT:               DEC_DOT_DEC;
-REAL:                DEC_DOT_DEC (E [+-]? DEC_DIGIT+)?;
+REAL:                (DECIMAL | DEC_DOT_DEC) (E [+-]? DEC_DIGIT+);
 
 EQUAL:               '=';
 


### PR DESCRIPTION
According https://docs.microsoft.com/en-us/sql/t-sql/data-types/constants-transact-sql 
can be used without dot(Tested in SQL server 2016 Developer)