### PR TITLE
antlr4: Parser rules must not contain character ranges.

### DIFF
--- a/antlr4/ANTLRv4Parser.g4
+++ b/antlr4/ANTLRv4Parser.g4
@@ -314,8 +314,7 @@ lexerAtom
    ;
 
 atom
-   : characterRange
-   | terminal
+   : terminal
    | ruleref
    | notSet
    | DOT elementOptions?


### PR DESCRIPTION
From antlr v3.3 character ranges are not allowed in parser rules,
however the official grammar still enables them. The patch fixes
this.