### PR TITLE
antlr4: Fix LexerAdaptor's init.

### DIFF
--- a/antlr4/LexerAdaptor.py
+++ b/antlr4/LexerAdaptor.py
@@ -18,8 +18,8 @@ class LexerAdaptor(Lexer):
 
     _currentRuleType = Token.INVALID_TYPE
 
-    def __init__(self, inp):
-        Lexer.__init__(self, inp)
+    def __init__(self, inp, output):
+        Lexer.__init__(self, inp, output)
 
     def getCurrentRuleType(self):
         return self._currentRuleType


### PR DESCRIPTION
In #1651 the init of Python lexers and parsers got a second
parameter to customize the output stream. However, the LexerAdaptor
class - which is the ancestor of the generated ANTLRv4Lexer - was
not adapted to this change. The patch fixes this.