### PR TITLE
Tsql. Implements `throw_statement` via independent rules instead of inline class

### DIFF
--- a/tsql/tsql.g4
+++ b/tsql/tsql.g4
@@ -135,7 +135,19 @@ if_statement
 
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/throw-transact-sql
 throw_statement
-    : THROW (error_number=(DECIMAL | LOCAL_ID) ',' message=(STRING | LOCAL_ID) ',' state=(DECIMAL | LOCAL_ID))? ';'?
+    : THROW (throw_error_number ',' throw_message ',' throw_state)? ';'?
+    ;
+
+throw_error_number
+    : DECIMAL | LOCAL_ID
+    ;
+
+throw_message
+    : STRING | LOCAL_ID
+    ;
+
+throw_state
+    : DECIMAL | LOCAL_ID
     ;
 
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/try-catch-transact-sql


### PR DESCRIPTION
During the manual visiting of AST for `throw_statement` there is necessary to build little bit complex algorithm to recognize actual part of rule. At least need one counter for `LOCAL_ID` part for don't get `out of bound exception` during get values from `LOCAL_ID` collection.
For example:

```
int localIdCounter = 0;
...
if (DECIMAL(0) == null) {
    ...
    localIdCounter++;
}
if (STRING == null) {
    ...
    localIdCounter++;
}
if (DECIMAL(1) == null) {
    Identifier someVal = LOCAL_ID(2);
}

```
This logic hasn't applied sense and it's more more easy to get this kind information from AST.