### PR TITLE
Java language identifier fragments per spec

### DIFF
--- a/java/Java.g4
+++ b/java/Java.g4
@@ -975,22 +975,22 @@ Identifier
     :   JavaLetter JavaLetterOrDigit*
     ;
 
+
+// The "Java letters" include uppercase and lowercase ASCII Latin letters A-Z (\u0041-\u005a), 
+// and a-z (\u0061-\u007a), and, for historical reasons, the ASCII underscore (_, or \u005f) 
+// and dollar sign ($, or \u0024). The $ sign should be used only in mechanically generated source
+// code or, rarely, to access pre-existing names on legacy systems. 
+
 fragment
 JavaLetter
-    :   [a-zA-Z$_] // these are the "java letters" below 0x7F
-    |   // covers all characters above 0x7F which are not a surrogate
-        ~[\u0000-\u007F\uD800-\uDBFF]
-    |   // covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
-        [\uD800-\uDBFF] [\uDC00-\uDFFF]
+    :   [a-zA-Z$_] // these are the "java letters" 
     ;
+
+// The "Java digits" include the ASCII digits 0-9 (\u0030-\u0039). 
 
 fragment
 JavaLetterOrDigit
-    :   [a-zA-Z0-9$_] // these are the "java letters or digits" below 0x7F
-    |   // covers all characters above 0x7F which are not a surrogate
-        ~[\u0000-\u007F\uD800-\uDBFF]
-    |   // covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
-        [\uD800-\uDBFF] [\uDC00-\uDFFF]
+    :   [a-zA-Z0-9$_] // these are the "java letters or digits" 
     ;
 
 //

--- a/java8/Java8.g4
+++ b/java8/Java8.g4
@@ -1734,26 +1734,24 @@ Identifier
 	:	JavaLetter JavaLetterOrDigit*
 	;
 
+
+// The "Java letters" include uppercase and lowercase ASCII Latin letters A-Z (\u0041-\u005a), 
+// and a-z (\u0061-\u007a), and, for historical reasons, the ASCII underscore (_, or \u005f) 
+// and dollar sign ($, or \u0024). The $ sign should be used only in mechanically generated source
+// code or, rarely, to access pre-existing names on legacy systems. 
+
+The "Java digits" include the ASCII digits 0-9 (\u0030-\u0039). 
+
 fragment
 JavaLetter
 	:	[a-zA-Z$_] // these are the "java letters" below 0x7F
-	|	// covers all characters above 0x7F which are not a surrogate
-		~[\u0000-\u007F\uD800-\uDBFF]
-		{Character.isJavaIdentifierStart(_input.LA(-1))}?
-	|	// covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
-		[\uD800-\uDBFF] [\uDC00-\uDFFF]
-		{Character.isJavaIdentifierStart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
-	;
+		;
+
+// The "Java digits" include the ASCII digits 0-9 (\u0030-\u0039). 
 
 fragment
 JavaLetterOrDigit
 	:	[a-zA-Z0-9$_] // these are the "java letters or digits" below 0x7F
-	|	// covers all characters above 0x7F which are not a surrogate
-		~[\u0000-\u007F\uD800-\uDBFF]
-		{Character.isJavaIdentifierPart(_input.LA(-1))}?
-	|	// covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
-		[\uD800-\uDBFF] [\uDC00-\uDFFF]
-		{Character.isJavaIdentifierPart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
 	;
 
 //

--- a/java8/Java8.g4
+++ b/java8/Java8.g4
@@ -1740,18 +1740,16 @@ Identifier
 // and dollar sign ($, or \u0024). The $ sign should be used only in mechanically generated source
 // code or, rarely, to access pre-existing names on legacy systems. 
 
-The "Java digits" include the ASCII digits 0-9 (\u0030-\u0039). 
-
 fragment
 JavaLetter
-	:	[a-zA-Z$_] // these are the "java letters" below 0x7F
-		;
+	:	[a-zA-Z$_] // these are the "java letters" 
+	;
 
 // The "Java digits" include the ASCII digits 0-9 (\u0030-\u0039). 
 
 fragment
 JavaLetterOrDigit
-	:	[a-zA-Z0-9$_] // these are the "java letters or digits" below 0x7F
+	:	[a-zA-Z0-9$_] // these are the "java letters or digits" 
 	;
 
 //


### PR DESCRIPTION
This is intended to make the Java and Java8 grammars both more compliant with the official specs, and cross-target (by removing unnecessary predicates.)  It appears these were mistakenly extended to include non-ASCII characters.    Intended to fix antlr/antlr4#1885

Based on http://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-Identifier as "official" definitions.   I am **not** a Java developer, so I can only go by what I read.

Note: There are tests failing, but I *think* not due to this change.    Master seems to be failing as well.   First failure message on my machine.  If it breaks on travis-ci, I may need a Java guy to help me understand why.

```
[INFO] Unicode TR29 Grapheme Cluster Boundary Parsing ..... FAILURE [  0.251 s]
````