### PR TITLE
fix: OBJECT can be variable name, i.e. is ambiguous keyword

### DIFF
--- a/vb6/VisualBasic6.g4
+++ b/vb6/VisualBasic6.g4
@@ -9,7 +9,7 @@
 /*
 * Visual Basic 6.0 Grammar for ANTLR4
 *
-* This is an approximate grammar for Visual Basic 6.0 and the parser at
+* This is a grammar for Visual Basic 6.0 and the parser at
 * https://github.com/uwol/vb6parser. The grammar is derived from the 
 * Visual Basic 6.0 language reference 
 * http://msdn.microsoft.com/en-us/library/aa338033%28v=vs.60%29.aspx 
@@ -908,6 +908,7 @@ ambiguousKeyword
    | NOT
    | NOTHING
    | NULL
+   | OBJECT
    | ON
    | OPEN
    | OPTIONAL
@@ -1010,18 +1011,18 @@ AS
    ;
 
 
+BEEP
+   : B E E P
+   ;
+
+
 BEGIN
    : B E G I N
    ;
 
 
 BEGINPROPERTY
-	: B E G I N P R O P E R T Y
-	;
-
-
-BEEP
-   : B E E P
+   : B E G I N P R O P E R T Y
    ;
 
 
@@ -1241,8 +1242,8 @@ END
 
 
 ENDPROPERTY
-	: E N D P R O P E R T Y
-	;
+   : E N D P R O P E R T Y
+   ;
 
 
 ENUM
@@ -1515,8 +1516,8 @@ NULL
    ;
 
 OBJECT 
-	: O B J E C T
-	;
+   : O B J E C T
+   ;
 
 ON
    : O N


### PR DESCRIPTION
All additions made by @lee-m also passed the test suite at [vb6parser](https://github.com/uwol/vb6parser) with exception of one unit test.

OBJECT can be variable name, i.e. is ambiguous keyword. I have modified the VB6 grammar accordingly. Optimized code style, too.