### PR TITLE
Support for line comment only.

### DIFF
--- a/mysql/MySQLLexer.g4
+++ b/mysql/MySQLLexer.g4
@@ -32,7 +32,7 @@ channels { MYSQLCOMMENT, ERRORCHANNEL }
 SPACE:                               [ \t\r\n]+    -> channel(HIDDEN);
 SPEC_MYSQL_COMMENT:                  '/*!' .+? '*/' -> channel(MYSQLCOMMENT);
 COMMENT_INPUT:                       '/*' .*? '*/' -> channel(HIDDEN);
-LINE_COMMENT:                        ('-- ' | '#') ~[\r\n]* ('\r'? '\n' | EOF) -> channel(HIDDEN);
+LINE_COMMENT:                        (('-- ' | '#') ~[\r\n]* ('\r'? '\n' | EOF) | '--' ('\r'? '\n' | EOF)) -> channel(HIDDEN);
 
 
 // Keywords


### PR DESCRIPTION
There was not support for lines that only consist of a line comment with no trailing space.