### PR TITLE
emailaddress: fix the lwsp-char rule.

### DIFF
--- a/emailaddress/emailaddress.g4
+++ b/emailaddress/emailaddress.g4
@@ -71,7 +71,7 @@ word
     :  atom | quotedstring;
 
 lwspchar
-    : SPACE | TAB;
+    : SPACE | HTAB;
 
 lwsp
     : (CRLF? lwspchar)+;


### PR DESCRIPTION
According to the RFC 822 standard, a linear whitespace character
should either be a space or a horizontal tab. However, the current
grammar tries to match on the TAB lexer rule (which is not even
defined). The patch fixes this.