### PR TITLE
Added ++ and -- to regex delimiter check

### DIFF
--- a/ecmascript/CSharp/ECMAScript.g4
+++ b/ecmascript/CSharp/ECMAScript.g4
@@ -148,6 +148,8 @@ grammar ECMAScript;
             case DecimalLiteral:
             case HexIntegerLiteral:
             case StringLiteral:
+            case PlusPlus:
+            case MinusMinus:
                 // After any of the tokens above, no regex literal can follow.
                 return false;
             default:

--- a/ecmascript/CSharpSharwell/ECMAScript.g4
+++ b/ecmascript/CSharpSharwell/ECMAScript.g4
@@ -148,6 +148,8 @@ grammar ECMAScript;
             case DecimalLiteral:
             case HexIntegerLiteral:
             case StringLiteral:
+            case PlusPlus:
+            case MinusMinus:
                 // After any of the tokens above, no regex literal can follow.
                 return false;
             default:

--- a/ecmascript/ECMAScript.GoTarget.g4
+++ b/ecmascript/ECMAScript.GoTarget.g4
@@ -140,7 +140,9 @@ func (l *ECMAScriptLexer) isRegexPossible() bool {
             tokenType == ECMAScriptLexerOctalIntegerLiteral ||
             tokenType == ECMAScriptLexerDecimalLiteral ||
             tokenType == ECMAScriptLexerHexIntegerLiteral ||
-            tokenType == ECMAScriptLexerStringLiteral {
+            tokenType == ECMAScriptLexerStringLiteral ||
+            tokenType == ECMAScriptLexerPlusPlus ||
+            tokenType == ECMAScriptLexerMinusMinus {
         // After any of the tokens above, no regex literal can follow.
         return false
     }

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -170,6 +170,8 @@ grammar ECMAScript;
             case DecimalLiteral:
             case HexIntegerLiteral:
             case StringLiteral:
+            case PlusPlus:
+            case MinusMinus:
                 // After any of the tokens above, no regex literal can follow.
                 return false;
             default:

--- a/ecmascript/JavaScript/ECMAScript.g4
+++ b/ecmascript/JavaScript/ECMAScript.g4
@@ -131,6 +131,10 @@ ECMAScriptLexer.prototype.isRegexPossible = function() {
             return false;
         case ECMAScriptLexer.StringLiteral:
             return false;
+        case ECMAScriptLexer.PlusPlus:
+            return false;
+        case ECMAScriptLexer.MinusMinus:
+            return false;
         default:
             return true;
     }

--- a/ecmascript/Python/ECMAScript.g4
+++ b/ecmascript/Python/ECMAScript.g4
@@ -155,7 +155,9 @@ def isRegexPossible(self):
             self._lastToken.type == ECMAScriptLexer.OctalIntegerLiteral or \
             self._lastToken.type == ECMAScriptLexer.DecimalLiteral or \
             self._lastToken.type == ECMAScriptLexer.HexIntegerLiteral or \
-            self._lastToken.type == ECMAScriptLexer.StringLiteral:
+            self._lastToken.type == ECMAScriptLexer.StringLiteral or \
+            self._lastToken.type == ECMAScriptLexer.PlusPlus or \
+            self._lastToken.type == ECMAScriptLexer.MinusMinus:
         # After any of the tokens above, no regex literal can follow.
         return False
     else:


### PR DESCRIPTION
From an expression like `foo++/bar`, the `/` was interpreted as the regex delimiter instead of the division operator. Fixed it by adding the tokens `++` and `--` to the `isRegexPossible()` method/function.