### PR TITLE
Update TSqlParser.g4

### DIFF
--- a/tsql/TSqlParser.g4
+++ b/tsql/TSqlParser.g4
@@ -1836,6 +1836,7 @@ id
 simple_id
     : ID
     | ABSOLUTE
+    | ACTIVE
     | APPLY
     | AUTO
     | AVG
@@ -1879,6 +1880,7 @@ simple_id
     | ISOLATION
     | KEEP
     | KEEPFIXED
+    | KEY
     | FORCED
     | KEYSET
     | IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX


### PR DESCRIPTION
added KEY and ACTIVE to simple_id since they can be keywords and identifiers

Solving #745
Closing #745
