### PR TITLE
newline isn't a valid char,  ~['\\] -> ~['\\\r\n]

### DIFF
--- a/java/Java.g4
+++ b/java/Java.g4
@@ -867,7 +867,7 @@ CharacterLiteral
 
 fragment
 SingleCharacter
-    :   ~['\\]
+    :   ~['\\\r\n]
     ;
 
 // §3.10.5 String Literals


### PR DESCRIPTION
char invalidChar = '
';