### PR TITLE
Newline cannot be in char or string literals in Java

### DIFF
--- a/java8-pt/JavaLexer.g4
+++ b/java8-pt/JavaLexer.g4
@@ -97,9 +97,9 @@ HEX_FLOAT_LITERAL:  '0' [xX] (HexDigits '.'? | HexDigits? '.' HexDigits) [pP] [+
 
 BOOL_LITERAL:       'true' | 'false';
 
-CHAR_LITERAL:       '\'' (~['\\] | EscapeSequence) '\'';
+CHAR_LITERAL:       '\'' (~['\\\r\n] | EscapeSequence) '\'';
 
-STRING_LITERAL:     '"' (~["\\] | EscapeSequence)* '"';
+STRING_LITERAL:     '"' (~["\\\r\n] | EscapeSequence)* '"';
 
 NULL_LITERAL:       'null';
 

--- a/java8/Java8.g4
+++ b/java8/Java8.g4
@@ -1639,7 +1639,7 @@ StringCharacters
 
 fragment
 StringCharacter
-	:	~["\\]
+	:	~["\\\r\n]
 	|	EscapeSequence
 	;
 

--- a/java8/Java8.g4
+++ b/java8/Java8.g4
@@ -1623,7 +1623,7 @@ CharacterLiteral
 
 fragment
 SingleCharacter
-	:	~['\\]
+	:	~['\\\r\n]
 	;
 
 // §3.10.5 String Literals


### PR DESCRIPTION
The follow code will be compiled fail.

char newline_char = '
';

String newline_string = "abc
";
