### PR TITLE
A grammar for Java 9

### DIFF
--- a/java9/Java9.g4
+++ b/java9/Java9.g4
@@ -1,0 +1,1855 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2014 Terence Parr
+ *  Copyright (c) 2014 Sam Harwell
+ *  Copyright (c) 2017 Chan Chung Kwong
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * A Java 8 grammar for ANTLR 4 derived from the Java Language Specification
+ * chapter 19.
+ *
+ * NOTE: This grammar results in a generated parser that is much slower
+ *       than the Java 7 grammar in the grammars-v4/java directory. This
+ *     one is, however, extremely close to the spec.
+ *
+ * You can test with
+ *
+ *  $ antlr4 Java9.g4
+ *  $ javac *.java
+ *  $ grun Java9 compilationUnit *.java
+ *
+ * Or,
+~/antlr/code/grammars-v4/java9 $ java Test .
+/Users/parrt/antlr/code/grammars-v4/java9/./Java9BaseListener.java
+/Users/parrt/antlr/code/grammars-v4/java9/./Java9Lexer.java
+/Users/parrt/antlr/code/grammars-v4/java9/./Java9Listener.java
+/Users/parrt/antlr/code/grammars-v4/java9/./Java9Parser.java
+/Users/parrt/antlr/code/grammars-v4/java9/./Test.java
+Total lexer+parser time 30844ms.
+ */
+grammar Java9;
+
+/*
+ * Productions from §3 (Lexical Structure)
+ */
+
+literal
+	:	IntegerLiteral
+	|	FloatingPointLiteral
+	|	BooleanLiteral
+	|	CharacterLiteral
+	|	StringLiteral
+	|	NullLiteral
+	;
+
+/*
+ * Productions from §4 (Types, Values, and Variables)
+ */
+
+type
+	:	primitiveType
+	|	referenceType
+	;
+
+primitiveType
+	:	annotation* numericType
+	|	annotation* 'boolean'
+	;
+
+numericType
+	:	integralType
+	|	floatingPointType
+	;
+
+integralType
+	:	'byte'
+	|	'short'
+	|	'int'
+	|	'long'
+	|	'char'
+	;
+
+floatingPointType
+	:	'float'
+	|	'double'
+	;
+
+referenceType
+	:	classOrInterfaceType
+	|	typeVariable
+	|	arrayType
+	;
+
+/*classOrInterfaceType
+	:	classType
+	|	interfaceType
+	;
+*/
+classOrInterfaceType
+	:	(	classType_lfno_classOrInterfaceType
+		|	interfaceType_lfno_classOrInterfaceType
+		)
+		(	classType_lf_classOrInterfaceType
+		|	interfaceType_lf_classOrInterfaceType
+		)*
+	;
+
+classType
+	:	annotation* Identifier typeArguments?
+	|	classOrInterfaceType '.' annotation* Identifier typeArguments?
+	;
+
+classType_lf_classOrInterfaceType
+	:	'.' annotation* Identifier typeArguments?
+	;
+
+classType_lfno_classOrInterfaceType
+	:	annotation* Identifier typeArguments?
+	;
+
+interfaceType
+	:	classType
+	;
+
+interfaceType_lf_classOrInterfaceType
+	:	classType_lf_classOrInterfaceType
+	;
+
+interfaceType_lfno_classOrInterfaceType
+	:	classType_lfno_classOrInterfaceType
+	;
+
+typeVariable
+	:	annotation* Identifier
+	;
+
+arrayType
+	:	primitiveType dims
+	|	classOrInterfaceType dims
+	|	typeVariable dims
+	;
+
+dims
+	:	annotation* '[' ']' (annotation* '[' ']')*
+	;
+
+typeParameter
+	:	typeParameterModifier* Identifier typeBound?
+	;
+
+typeParameterModifier
+	:	annotation
+	;
+
+typeBound
+	:	'extends' typeVariable
+	|	'extends' classOrInterfaceType additionalBound*
+	;
+
+additionalBound
+	:	'&' interfaceType
+	;
+
+typeArguments
+	:	'<' typeArgumentList '>'
+	;
+
+typeArgumentList
+	:	typeArgument (',' typeArgument)*
+	;
+
+typeArgument
+	:	referenceType
+	|	wildcard
+	;
+
+wildcard
+	:	annotation* '?' wildcardBounds?
+	;
+
+wildcardBounds
+	:	'extends' referenceType
+	|	'super' referenceType
+	;
+
+/*
+ * Productions from §6 (Names)
+ */
+
+moduleName
+	:	Identifier
+	|	moduleName '.' Identifier
+	;
+
+packageName
+	:	Identifier
+	|	packageName '.' Identifier
+	;
+
+typeName
+	:	Identifier
+	|	packageOrTypeName '.' Identifier
+	;
+
+packageOrTypeName
+	:	Identifier
+	|	packageOrTypeName '.' Identifier
+	;
+
+expressionName
+	:	Identifier
+	|	ambiguousName '.' Identifier
+	;
+
+methodName
+	:	Identifier
+	;
+
+ambiguousName
+	:	Identifier
+	|	ambiguousName '.' Identifier
+	;
+
+/*
+ * Productions from §7 (Packages)
+ */
+
+compilationUnit
+	:	ordinaryCompilation
+	|	modularCompilation
+	;
+
+ordinaryCompilation
+	:	packageDeclaration? importDeclaration* typeDeclaration* EOF
+	;
+
+modularCompilation
+	:	importDeclaration* moduleDeclaration
+	;
+
+packageDeclaration
+	:	packageModifier* 'package' packageName ';'
+	;
+
+packageModifier
+	:	annotation
+	;
+
+importDeclaration
+	:	singleTypeImportDeclaration
+	|	typeImportOnDemandDeclaration
+	|	singleStaticImportDeclaration
+	|	staticImportOnDemandDeclaration
+	;
+
+singleTypeImportDeclaration
+	:	'import' typeName ';'
+	;
+
+typeImportOnDemandDeclaration
+	:	'import' packageOrTypeName '.' '*' ';'
+	;
+
+singleStaticImportDeclaration
+	:	'import' 'static' typeName '.' Identifier ';'
+	;
+
+staticImportOnDemandDeclaration
+	:	'import' 'static' typeName '.' '*' ';'
+	;
+
+typeDeclaration
+	:	classDeclaration
+	|	interfaceDeclaration
+	|	';'
+	;
+
+moduleDeclaration
+	:	annotation* 'open'? 'module' moduleName '{' moduleDirective '}'
+	;
+
+moduleDirective
+	:	'requires' requiresModifier* moduleName ';'
+	|	'exports' packageName ('to' moduleName (',' moduleName)*)? ';'
+	|	'opens' packageName ('to' moduleName (',' moduleName)*)? ';'
+	|	'uses' typeName ';'
+	|	'provides' typeName 'with' typeName (',' typeName)* ';'
+	;
+
+requiresModifier
+	:	'transitive'
+	|	'static'
+	;
+
+/*
+ * Productions from §8 (Classes)
+ */
+
+classDeclaration
+	:	normalClassDeclaration
+	|	enumDeclaration
+	;
+
+normalClassDeclaration
+	:	classModifier* 'class' Identifier typeParameters? superclass? superinterfaces? classBody
+	;
+
+classModifier
+	:	annotation
+	|	'public'
+	|	'protected'
+	|	'private'
+	|	'abstract'
+	|	'static'
+	|	'final'
+	|	'strictfp'
+	;
+
+typeParameters
+	:	'<' typeParameterList '>'
+	;
+
+typeParameterList
+	:	typeParameter (',' typeParameter)*
+	;
+
+superclass
+	:	'extends' classType
+	;
+
+superinterfaces
+	:	'implements' interfaceTypeList
+	;
+
+interfaceTypeList
+	:	interfaceType (',' interfaceType)*
+	;
+
+classBody
+	:	'{' classBodyDeclaration* '}'
+	;
+
+classBodyDeclaration
+	:	classMemberDeclaration
+	|	instanceInitializer
+	|	staticInitializer
+	|	constructorDeclaration
+	;
+
+classMemberDeclaration
+	:	fieldDeclaration
+	|	methodDeclaration
+	|	classDeclaration
+	|	interfaceDeclaration
+	|	';'
+	;
+
+fieldDeclaration
+	:	fieldModifier* unannType variableDeclaratorList ';'
+	;
+
+fieldModifier
+	:	annotation
+	|	'public'
+	|	'protected'
+	|	'private'
+	|	'static'
+	|	'final'
+	|	'transient'
+	|	'volatile'
+	;
+
+variableDeclaratorList
+	:	variableDeclarator (',' variableDeclarator)*
+	;
+
+variableDeclarator
+	:	variableDeclaratorId ('=' variableInitializer)?
+	;
+
+variableDeclaratorId
+	:	Identifier dims?
+	;
+
+variableInitializer
+	:	expression
+	|	arrayInitializer
+	;
+
+unannType
+	:	unannPrimitiveType
+	|	unannReferenceType
+	;
+
+unannPrimitiveType
+	:	numericType
+	|	'boolean'
+	;
+
+unannReferenceType
+	:	unannClassOrInterfaceType
+	|	unannTypeVariable
+	|	unannArrayType
+	;
+
+/*unannClassOrInterfaceType
+	:	unannClassType
+	|	unannInterfaceType
+	;
+*/
+
+unannClassOrInterfaceType
+	:	(	unannClassType_lfno_unannClassOrInterfaceType
+		|	unannInterfaceType_lfno_unannClassOrInterfaceType
+		)
+		(	unannClassType_lf_unannClassOrInterfaceType
+		|	unannInterfaceType_lf_unannClassOrInterfaceType
+		)*
+	;
+
+unannClassType
+	:	Identifier typeArguments?
+	|	unannClassOrInterfaceType '.' annotation* Identifier typeArguments?
+	;
+
+unannClassType_lf_unannClassOrInterfaceType
+	:	'.' annotation* Identifier typeArguments?
+	;
+
+unannClassType_lfno_unannClassOrInterfaceType
+	:	Identifier typeArguments?
+	;
+
+unannInterfaceType
+	:	unannClassType
+	;
+
+unannInterfaceType_lf_unannClassOrInterfaceType
+	:	unannClassType_lf_unannClassOrInterfaceType
+	;
+
+unannInterfaceType_lfno_unannClassOrInterfaceType
+	:	unannClassType_lfno_unannClassOrInterfaceType
+	;
+
+unannTypeVariable
+	:	Identifier
+	;
+
+unannArrayType
+	:	unannPrimitiveType dims
+	|	unannClassOrInterfaceType dims
+	|	unannTypeVariable dims
+	;
+
+methodDeclaration
+	:	methodModifier* methodHeader methodBody
+	;
+
+methodModifier
+	:	annotation
+	|	'public'
+	|	'protected'
+	|	'private'
+	|	'abstract'
+	|	'static'
+	|	'final'
+	|	'synchronized'
+	|	'native'
+	|	'strictfp'
+	;
+
+methodHeader
+	:	result methodDeclarator throws_?
+	|	typeParameters annotation* result methodDeclarator throws_?
+	;
+
+result
+	:	unannType
+	|	'void'
+	;
+
+methodDeclarator
+	:	Identifier '(' formalParameterList? ')' dims?
+	;
+
+formalParameterList
+	:	formalParameters ',' lastFormalParameter
+	|	lastFormalParameter
+	|	receiverParameter
+	;
+
+formalParameters
+	:	formalParameter (',' formalParameter)*
+	|	receiverParameter (',' formalParameter)*
+	;
+
+formalParameter
+	:	variableModifier* unannType variableDeclaratorId
+	;
+
+variableModifier
+	:	annotation
+	|	'final'
+	;
+
+lastFormalParameter
+	:	variableModifier* unannType annotation* '...' variableDeclaratorId
+	|	formalParameter
+	;
+
+receiverParameter
+	:	annotation* unannType (Identifier '.')? 'this'
+	;
+
+throws_
+	:	'throws' exceptionTypeList
+	;
+
+exceptionTypeList
+	:	exceptionType (',' exceptionType)*
+	;
+
+exceptionType
+	:	classType
+	|	typeVariable
+	;
+
+methodBody
+	:	block
+	|	';'
+	;
+
+instanceInitializer
+	:	block
+	;
+
+staticInitializer
+	:	'static' block
+	;
+
+constructorDeclaration
+	:	constructorModifier* constructorDeclarator throws_? constructorBody
+	;
+
+constructorModifier
+	:	annotation
+	|	'public'
+	|	'protected'
+	|	'private'
+	;
+
+constructorDeclarator
+	:	typeParameters? simpleTypeName '(' formalParameterList? ')'
+	;
+
+simpleTypeName
+	:	Identifier
+	;
+
+constructorBody
+	:	'{' explicitConstructorInvocation? blockStatements? '}'
+	;
+
+explicitConstructorInvocation
+	:	typeArguments? 'this' '(' argumentList? ')' ';'
+	|	typeArguments? 'super' '(' argumentList? ')' ';'
+	|	expressionName '.' typeArguments? 'super' '(' argumentList? ')' ';'
+	|	primary '.' typeArguments? 'super' '(' argumentList? ')' ';'
+	;
+
+enumDeclaration
+	:	classModifier* 'enum' Identifier superinterfaces? enumBody
+	;
+
+enumBody
+	:	'{' enumConstantList? ','? enumBodyDeclarations? '}'
+	;
+
+enumConstantList
+	:	enumConstant (',' enumConstant)*
+	;
+
+enumConstant
+	:	enumConstantModifier* Identifier ('(' argumentList? ')')? classBody?
+	;
+
+enumConstantModifier
+	:	annotation
+	;
+
+enumBodyDeclarations
+	:	';' classBodyDeclaration*
+	;
+
+/*
+ * Productions from §9 (Interfaces)
+ */
+
+interfaceDeclaration
+	:	normalInterfaceDeclaration
+	|	annotationTypeDeclaration
+	;
+
+normalInterfaceDeclaration
+	:	interfaceModifier* 'interface' Identifier typeParameters? extendsInterfaces? interfaceBody
+	;
+
+interfaceModifier
+	:	annotation
+	|	'public'
+	|	'protected'
+	|	'private'
+	|	'abstract'
+	|	'static'
+	|	'strictfp'
+	;
+
+extendsInterfaces
+	:	'extends' interfaceTypeList
+	;
+
+interfaceBody
+	:	'{' interfaceMemberDeclaration* '}'
+	;
+
+interfaceMemberDeclaration
+	:	constantDeclaration
+	|	interfaceMethodDeclaration
+	|	classDeclaration
+	|	interfaceDeclaration
+	|	';'
+	;
+
+constantDeclaration
+	:	constantModifier* unannType variableDeclaratorList ';'
+	;
+
+constantModifier
+	:	annotation
+	|	'public'
+	|	'static'
+	|	'final'
+	;
+
+interfaceMethodDeclaration
+	:	interfaceMethodModifier* methodHeader methodBody
+	;
+
+interfaceMethodModifier
+	:	annotation
+	|	'public'
+	|	'private'//Introduced in Java 9
+	|	'abstract'
+	|	'default'
+	|	'static'
+	|	'strictfp'
+	;
+
+annotationTypeDeclaration
+	:	interfaceModifier* '@' 'interface' Identifier annotationTypeBody
+	;
+
+annotationTypeBody
+	:	'{' annotationTypeMemberDeclaration* '}'
+	;
+
+annotationTypeMemberDeclaration
+	:	annotationTypeElementDeclaration
+	|	constantDeclaration
+	|	classDeclaration
+	|	interfaceDeclaration
+	|	';'
+	;
+
+annotationTypeElementDeclaration
+	:	annotationTypeElementModifier* unannType Identifier '(' ')' dims? defaultValue? ';'
+	;
+
+annotationTypeElementModifier
+	:	annotation
+	|	'public'
+	|	'abstract'
+	;
+
+defaultValue
+	:	'default' elementValue
+	;
+
+annotation
+	:	normalAnnotation
+	|	markerAnnotation
+	|	singleElementAnnotation
+	;
+
+normalAnnotation
+	:	'@' typeName '(' elementValuePairList? ')'
+	;
+
+elementValuePairList
+	:	elementValuePair (',' elementValuePair)*
+	;
+
+elementValuePair
+	:	Identifier '=' elementValue
+	;
+
+elementValue
+	:	conditionalExpression
+	|	elementValueArrayInitializer
+	|	annotation
+	;
+
+elementValueArrayInitializer
+	:	'{' elementValueList? ','? '}'
+	;
+
+elementValueList
+	:	elementValue (',' elementValue)*
+	;
+
+markerAnnotation
+	:	'@' typeName
+	;
+
+singleElementAnnotation
+	:	'@' typeName '(' elementValue ')'
+	;
+
+/*
+ * Productions from §10 (Arrays)
+ */
+
+arrayInitializer
+	:	'{' variableInitializerList? ','? '}'
+	;
+
+variableInitializerList
+	:	variableInitializer (',' variableInitializer)*
+	;
+
+/*
+ * Productions from §14 (Blocks and Statements)
+ */
+
+block
+	:	'{' blockStatements? '}'
+	;
+
+blockStatements
+	:	blockStatement+
+	;
+
+blockStatement
+	:	localVariableDeclarationStatement
+	|	classDeclaration
+	|	statement
+	;
+
+localVariableDeclarationStatement
+	:	localVariableDeclaration ';'
+	;
+
+localVariableDeclaration
+	:	variableModifier* unannType variableDeclaratorList
+	;
+
+statement
+	:	statementWithoutTrailingSubstatement
+	|	labeledStatement
+	|	ifThenStatement
+	|	ifThenElseStatement
+	|	whileStatement
+	|	forStatement
+	;
+
+statementNoShortIf
+	:	statementWithoutTrailingSubstatement
+	|	labeledStatementNoShortIf
+	|	ifThenElseStatementNoShortIf
+	|	whileStatementNoShortIf
+	|	forStatementNoShortIf
+	;
+
+statementWithoutTrailingSubstatement
+	:	block
+	|	emptyStatement
+	|	expressionStatement
+	|	assertStatement
+	|	switchStatement
+	|	doStatement
+	|	breakStatement
+	|	continueStatement
+	|	returnStatement
+	|	synchronizedStatement
+	|	throwStatement
+	|	tryStatement
+	;
+
+emptyStatement
+	:	';'
+	;
+
+labeledStatement
+	:	Identifier ':' statement
+	;
+
+labeledStatementNoShortIf
+	:	Identifier ':' statementNoShortIf
+	;
+
+expressionStatement
+	:	statementExpression ';'
+	;
+
+statementExpression
+	:	assignment
+	|	preIncrementExpression
+	|	preDecrementExpression
+	|	postIncrementExpression
+	|	postDecrementExpression
+	|	methodInvocation
+	|	classInstanceCreationExpression
+	;
+
+ifThenStatement
+	:	'if' '(' expression ')' statement
+	;
+
+ifThenElseStatement
+	:	'if' '(' expression ')' statementNoShortIf 'else' statement
+	;
+
+ifThenElseStatementNoShortIf
+	:	'if' '(' expression ')' statementNoShortIf 'else' statementNoShortIf
+	;
+
+assertStatement
+	:	'assert' expression ';'
+	|	'assert' expression ':' expression ';'
+	;
+
+switchStatement
+	:	'switch' '(' expression ')' switchBlock
+	;
+
+switchBlock
+	:	'{' switchBlockStatementGroup* switchLabel* '}'
+	;
+
+switchBlockStatementGroup
+	:	switchLabels blockStatements
+	;
+
+switchLabels
+	:	switchLabel+
+	;
+
+switchLabel
+	:	'case' constantExpression ':'
+	|	'case' enumConstantName ':'
+	|	'default' ':'
+	;
+
+enumConstantName
+	:	Identifier
+	;
+
+whileStatement
+	:	'while' '(' expression ')' statement
+	;
+
+whileStatementNoShortIf
+	:	'while' '(' expression ')' statementNoShortIf
+	;
+
+doStatement
+	:	'do' statement 'while' '(' expression ')' ';'
+	;
+
+forStatement
+	:	basicForStatement
+	|	enhancedForStatement
+	;
+
+forStatementNoShortIf
+	:	basicForStatementNoShortIf
+	|	enhancedForStatementNoShortIf
+	;
+
+basicForStatement
+	:	'for' '(' forInit? ';' expression? ';' forUpdate? ')' statement
+	;
+
+basicForStatementNoShortIf
+	:	'for' '(' forInit? ';' expression? ';' forUpdate? ')' statementNoShortIf
+	;
+
+forInit
+	:	statementExpressionList
+	|	localVariableDeclaration
+	;
+
+forUpdate
+	:	statementExpressionList
+	;
+
+statementExpressionList
+	:	statementExpression (',' statementExpression)*
+	;
+
+enhancedForStatement
+	:	'for' '(' variableModifier* unannType variableDeclaratorId ':' expression ')' statement
+	;
+
+enhancedForStatementNoShortIf
+	:	'for' '(' variableModifier* unannType variableDeclaratorId ':' expression ')' statementNoShortIf
+	;
+
+breakStatement
+	:	'break' Identifier? ';'
+	;
+
+continueStatement
+	:	'continue' Identifier? ';'
+	;
+
+returnStatement
+	:	'return' expression? ';'
+	;
+
+throwStatement
+	:	'throw' expression ';'
+	;
+
+synchronizedStatement
+	:	'synchronized' '(' expression ')' block
+	;
+
+tryStatement
+	:	'try' block catches
+	|	'try' block catches? finally_
+	|	tryWithResourcesStatement
+	;
+
+catches
+	:	catchClause+
+	;
+
+catchClause
+	:	'catch' '(' catchFormalParameter ')' block
+	;
+
+catchFormalParameter
+	:	variableModifier* catchType variableDeclaratorId
+	;
+
+catchType
+	:	unannClassType ('|' classType)*
+	;
+
+finally_
+	:	'finally' block
+	;
+
+tryWithResourcesStatement
+	:	'try' resourceSpecification block catches? finally_?
+	;
+
+resourceSpecification
+	:	'(' resourceList ';'? ')'
+	;
+
+resourceList
+	:	resource (';' resource)*
+	;
+
+resource
+	:	variableModifier* unannType variableDeclaratorId '=' expression
+	|	variableAccess//Introduced in Java 9
+	;
+
+variableAccess
+	:	expressionName
+	|	fieldAccess
+	;
+
+/*
+ * Productions from §15 (Expressions)
+ */
+
+/*primary
+	:	primaryNoNewArray
+	|	arrayCreationExpression
+	;
+*/
+
+primary
+	:	(	primaryNoNewArray_lfno_primary
+		|	arrayCreationExpression
+		)
+		(	primaryNoNewArray_lf_primary
+		)*
+	;
+
+primaryNoNewArray
+	:	literal
+	|	classLiteral
+	|	'this'
+	|	typeName '.' 'this'
+	|	'(' expression ')'
+	|	classInstanceCreationExpression
+	|	fieldAccess
+	|	arrayAccess
+	|	methodInvocation
+	|	methodReference
+	;
+
+primaryNoNewArray_lf_arrayAccess
+	:
+	;
+
+primaryNoNewArray_lfno_arrayAccess
+	:	literal
+	|	typeName ('[' ']')* '.' 'class'
+	|	'void' '.' 'class'
+	|	'this'
+	|	typeName '.' 'this'
+	|	'(' expression ')'
+	|	classInstanceCreationExpression
+	|	fieldAccess
+	|	methodInvocation
+	|	methodReference
+	;
+
+primaryNoNewArray_lf_primary
+	:	classInstanceCreationExpression_lf_primary
+	|	fieldAccess_lf_primary
+	|	arrayAccess_lf_primary
+	|	methodInvocation_lf_primary
+	|	methodReference_lf_primary
+	;
+
+primaryNoNewArray_lf_primary_lf_arrayAccess_lf_primary
+	:
+	;
+
+primaryNoNewArray_lf_primary_lfno_arrayAccess_lf_primary
+	:	classInstanceCreationExpression_lf_primary
+	|	fieldAccess_lf_primary
+	|	methodInvocation_lf_primary
+	|	methodReference_lf_primary
+	;
+
+primaryNoNewArray_lfno_primary
+	:	literal
+	|	typeName ('[' ']')* '.' 'class'
+	|	unannPrimitiveType ('[' ']')* '.' 'class'
+	|	'void' '.' 'class'
+	|	'this'
+	|	typeName '.' 'this'
+	|	'(' expression ')'
+	|	classInstanceCreationExpression_lfno_primary
+	|	fieldAccess_lfno_primary
+	|	arrayAccess_lfno_primary
+	|	methodInvocation_lfno_primary
+	|	methodReference_lfno_primary
+	;
+
+primaryNoNewArray_lfno_primary_lf_arrayAccess_lfno_primary
+	:
+	;
+
+primaryNoNewArray_lfno_primary_lfno_arrayAccess_lfno_primary
+	:	literal
+	|	typeName ('[' ']')* '.' 'class'
+	|	unannPrimitiveType ('[' ']')* '.' 'class'
+	|	'void' '.' 'class'
+	|	'this'
+	|	typeName '.' 'this'
+	|	'(' expression ')'
+	|	classInstanceCreationExpression_lfno_primary
+	|	fieldAccess_lfno_primary
+	|	methodInvocation_lfno_primary
+	|	methodReference_lfno_primary
+	;
+
+classLiteral
+	:	(typeName|numericType|'boolean') ('[' ']')* '.' 'class'
+	|	'void' '.' 'class'	
+	;
+
+classInstanceCreationExpression
+	:	'new' typeArguments? annotation* Identifier ('.' annotation* Identifier)* typeArgumentsOrDiamond? '(' argumentList? ')' classBody?
+	|	expressionName '.' 'new' typeArguments? annotation* Identifier typeArgumentsOrDiamond? '(' argumentList? ')' classBody?
+	|	primary '.' 'new' typeArguments? annotation* Identifier typeArgumentsOrDiamond? '(' argumentList? ')' classBody?
+	;
+
+classInstanceCreationExpression_lf_primary
+	:	'.' 'new' typeArguments? annotation* Identifier typeArgumentsOrDiamond? '(' argumentList? ')' classBody?
+	;
+
+classInstanceCreationExpression_lfno_primary
+	:	'new' typeArguments? annotation* Identifier ('.' annotation* Identifier)* typeArgumentsOrDiamond? '(' argumentList? ')' classBody?
+	|	expressionName '.' 'new' typeArguments? annotation* Identifier typeArgumentsOrDiamond? '(' argumentList? ')' classBody?
+	;
+
+typeArgumentsOrDiamond
+	:	typeArguments
+	|	'<' '>'
+	;
+
+fieldAccess
+	:	primary '.' Identifier
+	|	'super' '.' Identifier
+	|	typeName '.' 'super' '.' Identifier
+	;
+
+fieldAccess_lf_primary
+	:	'.' Identifier
+	;
+
+fieldAccess_lfno_primary
+	:	'super' '.' Identifier
+	|	typeName '.' 'super' '.' Identifier
+	;
+
+/*arrayAccess
+	:	expressionName '[' expression ']'
+	|	primaryNoNewArray '[' expression ']'
+	;
+*/
+
+arrayAccess
+	:	(	expressionName '[' expression ']'
+		|	primaryNoNewArray_lfno_arrayAccess '[' expression ']'
+		)
+		(	primaryNoNewArray_lf_arrayAccess '[' expression ']'
+		)*
+	;
+
+arrayAccess_lf_primary
+	:	(	primaryNoNewArray_lf_primary_lfno_arrayAccess_lf_primary '[' expression ']'
+		)
+		(	primaryNoNewArray_lf_primary_lf_arrayAccess_lf_primary '[' expression ']'
+		)*
+	;
+
+arrayAccess_lfno_primary
+	:	(	expressionName '[' expression ']'
+		|	primaryNoNewArray_lfno_primary_lfno_arrayAccess_lfno_primary '[' expression ']'
+		)
+		(	primaryNoNewArray_lfno_primary_lf_arrayAccess_lfno_primary '[' expression ']'
+		)*
+	;
+
+
+methodInvocation
+	:	methodName '(' argumentList? ')'
+	|	typeName '.' typeArguments? Identifier '(' argumentList? ')'
+	|	expressionName '.' typeArguments? Identifier '(' argumentList? ')'
+	|	primary '.' typeArguments? Identifier '(' argumentList? ')'
+	|	'super' '.' typeArguments? Identifier '(' argumentList? ')'
+	|	typeName '.' 'super' '.' typeArguments? Identifier '(' argumentList? ')'
+	;
+
+methodInvocation_lf_primary
+	:	'.' typeArguments? Identifier '(' argumentList? ')'
+	;
+
+methodInvocation_lfno_primary
+	:	methodName '(' argumentList? ')'
+	|	typeName '.' typeArguments? Identifier '(' argumentList? ')'
+	|	expressionName '.' typeArguments? Identifier '(' argumentList? ')'
+	|	'super' '.' typeArguments? Identifier '(' argumentList? ')'
+	|	typeName '.' 'super' '.' typeArguments? Identifier '(' argumentList? ')'
+	;
+
+argumentList
+	:	expression (',' expression)*
+	;
+
+methodReference
+	:	expressionName '::' typeArguments? Identifier
+	|	referenceType '::' typeArguments? Identifier
+	|	primary '::' typeArguments? Identifier
+	|	'super' '::' typeArguments? Identifier
+	|	typeName '.' 'super' '::' typeArguments? Identifier
+	|	classType '::' typeArguments? 'new'
+	|	arrayType '::' 'new'
+	;
+
+methodReference_lf_primary
+	:	'::' typeArguments? Identifier
+	;
+
+methodReference_lfno_primary
+	:	expressionName '::' typeArguments? Identifier
+	|	referenceType '::' typeArguments? Identifier
+	|	'super' '::' typeArguments? Identifier
+	|	typeName '.' 'super' '::' typeArguments? Identifier
+	|	classType '::' typeArguments? 'new'
+	|	arrayType '::' 'new'
+	;
+
+arrayCreationExpression
+	:	'new' primitiveType dimExprs dims?
+	|	'new' classOrInterfaceType dimExprs dims?
+	|	'new' primitiveType dims arrayInitializer
+	|	'new' classOrInterfaceType dims arrayInitializer
+	;
+
+dimExprs
+	:	dimExpr+
+	;
+
+dimExpr
+	:	annotation* '[' expression ']'
+	;
+
+constantExpression
+	:	expression
+	;
+
+expression
+	:	lambdaExpression
+	|	assignmentExpression
+	;
+
+lambdaExpression
+	:	lambdaParameters '->' lambdaBody
+	;
+
+lambdaParameters
+	:	Identifier
+	|	'(' formalParameterList? ')'
+	|	'(' inferredFormalParameterList ')'
+	;
+
+inferredFormalParameterList
+	:	Identifier (',' Identifier)*
+	;
+
+lambdaBody
+	:	expression
+	|	block
+	;
+
+assignmentExpression
+	:	conditionalExpression
+	|	assignment
+	;
+
+assignment
+	:	leftHandSide assignmentOperator expression
+	;
+
+leftHandSide
+	:	expressionName
+	|	fieldAccess
+	|	arrayAccess
+	;
+
+assignmentOperator
+	:	'='
+	|	'*='
+	|	'/='
+	|	'%='
+	|	'+='
+	|	'-='
+	|	'<<='
+	|	'>>='
+	|	'>>>='
+	|	'&='
+	|	'^='
+	|	'|='
+	;
+
+conditionalExpression
+	:	conditionalOrExpression
+	|	conditionalOrExpression '?' expression ':' (conditionalExpression|lambdaExpression)
+	;
+
+conditionalOrExpression
+	:	conditionalAndExpression
+	|	conditionalOrExpression '||' conditionalAndExpression
+	;
+
+conditionalAndExpression
+	:	inclusiveOrExpression
+	|	conditionalAndExpression '&&' inclusiveOrExpression
+	;
+
+inclusiveOrExpression
+	:	exclusiveOrExpression
+	|	inclusiveOrExpression '|' exclusiveOrExpression
+	;
+
+exclusiveOrExpression
+	:	andExpression
+	|	exclusiveOrExpression '^' andExpression
+	;
+
+andExpression
+	:	equalityExpression
+	|	andExpression '&' equalityExpression
+	;
+
+equalityExpression
+	:	relationalExpression
+	|	equalityExpression '==' relationalExpression
+	|	equalityExpression '!=' relationalExpression
+	;
+
+relationalExpression
+	:	shiftExpression
+	|	relationalExpression '<' shiftExpression
+	|	relationalExpression '>' shiftExpression
+	|	relationalExpression '<=' shiftExpression
+	|	relationalExpression '>=' shiftExpression
+	|	relationalExpression 'instanceof' referenceType
+	;
+
+shiftExpression
+	:	additiveExpression
+	|	shiftExpression '<' '<' additiveExpression
+	|	shiftExpression '>' '>' additiveExpression
+	|	shiftExpression '>' '>' '>' additiveExpression
+	;
+
+additiveExpression
+	:	multiplicativeExpression
+	|	additiveExpression '+' multiplicativeExpression
+	|	additiveExpression '-' multiplicativeExpression
+	;
+
+multiplicativeExpression
+	:	unaryExpression
+	|	multiplicativeExpression '*' unaryExpression
+	|	multiplicativeExpression '/' unaryExpression
+	|	multiplicativeExpression '%' unaryExpression
+	;
+
+unaryExpression
+	:	preIncrementExpression
+	|	preDecrementExpression
+	|	'+' unaryExpression
+	|	'-' unaryExpression
+	|	unaryExpressionNotPlusMinus
+	;
+
+preIncrementExpression
+	:	'++' unaryExpression
+	;
+
+preDecrementExpression
+	:	'--' unaryExpression
+	;
+
+unaryExpressionNotPlusMinus
+	:	postfixExpression
+	|	'~' unaryExpression
+	|	'!' unaryExpression
+	|	castExpression
+	;
+
+/*postfixExpression
+	:	primary
+	|	expressionName
+	|	postIncrementExpression
+	|	postDecrementExpression
+	;
+*/
+
+postfixExpression
+	:	(	primary
+		|	expressionName
+		)
+		(	postIncrementExpression_lf_postfixExpression
+		|	postDecrementExpression_lf_postfixExpression
+		)*
+	;
+
+postIncrementExpression
+	:	postfixExpression '++'
+	;
+
+postIncrementExpression_lf_postfixExpression
+	:	'++'
+	;
+
+postDecrementExpression
+	:	postfixExpression '--'
+	;
+
+postDecrementExpression_lf_postfixExpression
+	:	'--'
+	;
+
+castExpression
+	:	'(' primitiveType ')' unaryExpression
+	|	'(' referenceType additionalBound* ')' unaryExpressionNotPlusMinus
+	|	'(' referenceType additionalBound* ')' lambdaExpression
+	;
+
+// LEXER
+
+// §3.9 Keywords
+
+ABSTRACT : 'abstract';
+ASSERT : 'assert';
+BOOLEAN : 'boolean';
+BREAK : 'break';
+BYTE : 'byte';
+CASE : 'case';
+CATCH : 'catch';
+CHAR : 'char';
+CLASS : 'class';
+CONST : 'const';
+CONTINUE : 'continue';
+DEFAULT : 'default';
+DO : 'do';
+DOUBLE : 'double';
+ELSE : 'else';
+ENUM : 'enum';
+EXTENDS : 'extends';
+FINAL : 'final';
+FINALLY : 'finally';
+FLOAT : 'float';
+FOR : 'for';
+IF : 'if';
+GOTO : 'goto';
+IMPLEMENTS : 'implements';
+IMPORT : 'import';
+INSTANCEOF : 'instanceof';
+INT : 'int';
+INTERFACE : 'interface';
+LONG : 'long';
+NATIVE : 'native';
+NEW : 'new';
+PACKAGE : 'package';
+PRIVATE : 'private';
+PROTECTED : 'protected';
+PUBLIC : 'public';
+RETURN : 'return';
+SHORT : 'short';
+STATIC : 'static';
+STRICTFP : 'strictfp';
+SUPER : 'super';
+SWITCH : 'switch';
+SYNCHRONIZED : 'synchronized';
+THIS : 'this';
+THROW : 'throw';
+THROWS : 'throws';
+TRANSIENT : 'transient';
+TRY : 'try';
+VOID : 'void';
+VOLATILE : 'volatile';
+WHILE : 'while';
+UNDER_SCORE : '_';//Introduced in Java 9
+
+// §3.10.1 Integer Literals
+
+IntegerLiteral
+	:	DecimalIntegerLiteral
+	|	HexIntegerLiteral
+	|	OctalIntegerLiteral
+	|	BinaryIntegerLiteral
+	;
+
+fragment
+DecimalIntegerLiteral
+	:	DecimalNumeral IntegerTypeSuffix?
+	;
+
+fragment
+HexIntegerLiteral
+	:	HexNumeral IntegerTypeSuffix?
+	;
+
+fragment
+OctalIntegerLiteral
+	:	OctalNumeral IntegerTypeSuffix?
+	;
+
+fragment
+BinaryIntegerLiteral
+	:	BinaryNumeral IntegerTypeSuffix?
+	;
+
+fragment
+IntegerTypeSuffix
+	:	[lL]
+	;
+
+fragment
+DecimalNumeral
+	:	'0'
+	|	NonZeroDigit (Digits? | Underscores Digits)
+	;
+
+fragment
+Digits
+	:	Digit (DigitsAndUnderscores? Digit)?
+	;
+
+fragment
+Digit
+	:	'0'
+	|	NonZeroDigit
+	;
+
+fragment
+NonZeroDigit
+	:	[1-9]
+	;
+
+fragment
+DigitsAndUnderscores
+	:	DigitOrUnderscore+
+	;
+
+fragment
+DigitOrUnderscore
+	:	Digit
+	|	'_'
+	;
+
+fragment
+Underscores
+	:	'_'+
+	;
+
+fragment
+HexNumeral
+	:	'0' [xX] HexDigits
+	;
+
+fragment
+HexDigits
+	:	HexDigit (HexDigitsAndUnderscores? HexDigit)?
+	;
+
+fragment
+HexDigit
+	:	[0-9a-fA-F]
+	;
+
+fragment
+HexDigitsAndUnderscores
+	:	HexDigitOrUnderscore+
+	;
+
+fragment
+HexDigitOrUnderscore
+	:	HexDigit
+	|	'_'
+	;
+
+fragment
+OctalNumeral
+	:	'0' Underscores? OctalDigits
+	;
+
+fragment
+OctalDigits
+	:	OctalDigit (OctalDigitsAndUnderscores? OctalDigit)?
+	;
+
+fragment
+OctalDigit
+	:	[0-7]
+	;
+
+fragment
+OctalDigitsAndUnderscores
+	:	OctalDigitOrUnderscore+
+	;
+
+fragment
+OctalDigitOrUnderscore
+	:	OctalDigit
+	|	'_'
+	;
+
+fragment
+BinaryNumeral
+	:	'0' [bB] BinaryDigits
+	;
+
+fragment
+BinaryDigits
+	:	BinaryDigit (BinaryDigitsAndUnderscores? BinaryDigit)?
+	;
+
+fragment
+BinaryDigit
+	:	[01]
+	;
+
+fragment
+BinaryDigitsAndUnderscores
+	:	BinaryDigitOrUnderscore+
+	;
+
+fragment
+BinaryDigitOrUnderscore
+	:	BinaryDigit
+	|	'_'
+	;
+
+// §3.10.2 Floating-Point Literals
+
+FloatingPointLiteral
+	:	DecimalFloatingPointLiteral
+	|	HexadecimalFloatingPointLiteral
+	;
+
+fragment
+DecimalFloatingPointLiteral
+	:	Digits '.' Digits? ExponentPart? FloatTypeSuffix?
+	|	'.' Digits ExponentPart? FloatTypeSuffix?
+	|	Digits ExponentPart FloatTypeSuffix?
+	|	Digits FloatTypeSuffix
+	;
+
+fragment
+ExponentPart
+	:	ExponentIndicator SignedInteger
+	;
+
+fragment
+ExponentIndicator
+	:	[eE]
+	;
+
+fragment
+SignedInteger
+	:	Sign? Digits
+	;
+
+fragment
+Sign
+	:	[+-]
+	;
+
+fragment
+FloatTypeSuffix
+	:	[fFdD]
+	;
+
+fragment
+HexadecimalFloatingPointLiteral
+	:	HexSignificand BinaryExponent FloatTypeSuffix?
+	;
+
+fragment
+HexSignificand
+	:	HexNumeral '.'?
+	|	'0' [xX] HexDigits? '.' HexDigits
+	;
+
+fragment
+BinaryExponent
+	:	BinaryExponentIndicator SignedInteger
+	;
+
+fragment
+BinaryExponentIndicator
+	:	[pP]
+	;
+
+// §3.10.3 Boolean Literals
+
+BooleanLiteral
+	:	'true'
+	|	'false'
+	;
+
+// §3.10.4 Character Literals
+
+CharacterLiteral
+	:	'\'' SingleCharacter '\''
+	|	'\'' EscapeSequence '\''
+	;
+
+fragment
+SingleCharacter
+	:	~['\\\r\n]
+	;
+
+// §3.10.5 String Literals
+
+StringLiteral
+	:	'"' StringCharacters? '"'
+	;
+
+fragment
+StringCharacters
+	:	StringCharacter+
+	;
+
+fragment
+StringCharacter
+	:	~["\\\r\n]
+	|	EscapeSequence
+	;
+
+// §3.10.6 Escape Sequences for Character and String Literals
+
+fragment
+EscapeSequence
+	:	'\\' [btnfr"'\\]
+	|	OctalEscape
+    |   UnicodeEscape // This is not in the spec but prevents having to preprocess the input
+	;
+
+fragment
+OctalEscape
+	:	'\\' OctalDigit
+	|	'\\' OctalDigit OctalDigit
+	|	'\\' ZeroToThree OctalDigit OctalDigit
+	;
+
+fragment
+ZeroToThree
+	:	[0-3]
+	;
+
+// This is not in the spec but prevents having to preprocess the input
+fragment
+UnicodeEscape
+    :   '\\' 'u'+ HexDigit HexDigit HexDigit HexDigit
+    ;
+
+// §3.10.7 The Null Literal
+
+NullLiteral
+	:	'null'
+	;
+
+// §3.11 Separators
+
+LPAREN : '(';
+RPAREN : ')';
+LBRACE : '{';
+RBRACE : '}';
+LBRACK : '[';
+RBRACK : ']';
+SEMI : ';';
+COMMA : ',';
+DOT : '.';
+ELLIPSIS : '...';
+AT : '@';
+COLONCOLON : '::';
+
+
+// §3.12 Operators
+
+ASSIGN : '=';
+GT : '>';
+LT : '<';
+BANG : '!';
+TILDE : '~';
+QUESTION : '?';
+COLON : ':';
+ARROW : '->';
+EQUAL : '==';
+LE : '<=';
+GE : '>=';
+NOTEQUAL : '!=';
+AND : '&&';
+OR : '||';
+INC : '++';
+DEC : '--';
+ADD : '+';
+SUB : '-';
+MUL : '*';
+DIV : '/';
+BITAND : '&';
+BITOR : '|';
+CARET : '^';
+MOD : '%';
+//LSHIFT : '<<';
+//RSHIFT : '>>';
+//URSHIFT : '>>>';
+
+ADD_ASSIGN : '+=';
+SUB_ASSIGN : '-=';
+MUL_ASSIGN : '*=';
+DIV_ASSIGN : '/=';
+AND_ASSIGN : '&=';
+OR_ASSIGN : '|=';
+XOR_ASSIGN : '^=';
+MOD_ASSIGN : '%=';
+LSHIFT_ASSIGN : '<<=';
+RSHIFT_ASSIGN : '>>=';
+URSHIFT_ASSIGN : '>>>=';
+
+// §3.8 Identifiers (must appear after all keywords in the grammar)
+
+Identifier
+	:	JavaLetter JavaLetterOrDigit*
+	;
+
+fragment
+JavaLetter
+	:	[a-zA-Z$_] // these are the "java letters" below 0x7F
+	|	// covers all characters above 0x7F which are not a surrogate
+		~[\u0000-\u007F\uD800-\uDBFF]
+		{Character.isJavaIdentifierStart(_input.LA(-1))}?
+	|	// covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
+		[\uD800-\uDBFF] [\uDC00-\uDFFF]
+		{Character.isJavaIdentifierStart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
+	;
+
+fragment
+JavaLetterOrDigit
+	:	[a-zA-Z0-9$_] // these are the "java letters or digits" below 0x7F
+	|	// covers all characters above 0x7F which are not a surrogate
+		~[\u0000-\u007F\uD800-\uDBFF]
+		{Character.isJavaIdentifierPart(_input.LA(-1))}?
+	|	// covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
+		[\uD800-\uDBFF] [\uDC00-\uDFFF]
+		{Character.isJavaIdentifierPart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
+	;
+
+//
+// Whitespace and comments
+//
+
+WS  :  [ \t\r\n\u000C]+ -> skip
+    ;
+
+COMMENT
+    :   '/*' .*? '*/' -> channel(HIDDEN)
+    ;
+
+LINE_COMMENT
+    :   '//' ~[\r\n]* -> channel(HIDDEN)
+    ;

--- a/java9/Java9.g4
+++ b/java9/Java9.g4
@@ -51,6 +51,16 @@
 /Users/parrt/antlr/code/grammars-v4/java9/./Java9Parser.java
 /Users/parrt/antlr/code/grammars-v4/java9/./Test.java
 Total lexer+parser time 30844ms.
+~/antlr/code/grammars-v4/java9 $ java Test examples/module-info.java
+/home/kwong/projects/grammars-v4/java9/examples/module-info.java
+Total lexer+parser time 914ms.
+~/antlr/code/grammars-v4/java9 $ java Test examples/TryWithResourceDemo.java
+/home/kwong/projects/grammars-v4/java9/examples/TryWithResourceDemo.java
+Total lexer+parser time 3634ms.
+~/antlr/code/grammars-v4/java9 $ java Test examples/helloworld.java 
+/home/kwong/projects/grammars-v4/java9/examples/helloworld.java
+Total lexer+parser time 2497ms.
+
  */
 grammar Java9;
 
@@ -290,7 +300,7 @@ typeDeclaration
 	;
 
 moduleDeclaration
-	:	annotation* 'open'? 'module' moduleName '{' moduleDirective '}'
+	:	annotation* 'open'? 'module' moduleName '{' moduleDirective* '}'
 	;
 
 moduleDirective

--- a/java9/Test.java
+++ b/java9/Test.java
@@ -1,0 +1,287 @@
+/*
+ [The "BSD license"]
+  Copyright (c) 2013 Terence Parr
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.antlr.v4.runtime.ANTLRFileStream;
+import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.DiagnosticErrorListener;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.atn.LexerATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionMode;
+
+import java.io.File;
+import java.lang.System;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+/* This more or less duplicates the functionality of grun (TestRig) but it
+ * has a few specific options for benchmarking like -x2 and -threaded.
+ * It also allows directory names as commandline arguments. The simplest test is
+ * for the current directory:
+
+~/antlr/code/grammars-v4/java $ java Test .
+/Users/parrt/antlr/code/grammars-v4/java9/JavaBaseListener.java
+/Users/parrt/antlr/code/grammars-v4/java9/Java9Lexer.java
+/Users/parrt/antlr/code/grammars-v4/java9/JavaListener.java
+/Users/parrt/antlr/code/grammars-v4/java9/JavaParser.java
+/Users/parrt/antlr/code/grammars-v4/java9/Test.java
+Total lexer+parser time 1867ms.
+ */
+class Test {
+//	public static long lexerTime = 0;
+	public static boolean profile = false;
+	public static boolean notree = false;
+	public static boolean gui = false;
+	public static boolean printTree = false;
+	public static boolean SLL = false;
+	public static boolean diag = false;
+	public static boolean bail = false;
+	public static boolean x2 = false;
+	public static boolean threaded = false;
+	public static boolean quiet = false;
+//	public static long parserStart;
+//	public static long parserStop;
+	public static Worker[] workers = new Worker[3];
+	static int windex = 0;
+
+	public static CyclicBarrier barrier;
+
+	public static volatile boolean firstPassDone = false;
+
+	public static class Worker implements Runnable {
+		public long parserStart;
+		public long parserStop;
+		List<String> files;
+		public Worker(List<String> files) {
+			this.files = files;
+		}
+		@Override
+		public void run() {
+			parserStart = System.currentTimeMillis();
+			for (String f : files) {
+				parseFile(f);
+			}
+			parserStop = System.currentTimeMillis();
+			try {
+				barrier.await();
+			}
+			catch (InterruptedException ex) {
+				return;
+			}
+			catch (BrokenBarrierException ex) {
+				return;
+			}
+		}
+	}
+
+	public static void main(String[] args) {
+		doAll(args);
+	}
+
+	public static void doAll(String[] args) {
+		List<String> inputFiles = new ArrayList<String>();
+		long start = System.currentTimeMillis();
+		try {
+			if (args.length > 0 ) {
+				// for each directory/file specified on the command line
+				for(int i=0; i< args.length;i++) {
+					if ( args[i].equals("-notree") ) notree = true;
+					else if ( args[i].equals("-gui") ) gui = true;
+					else if ( args[i].equals("-ptree") ) printTree = true;
+					else if ( args[i].equals("-SLL") ) SLL = true;
+					else if ( args[i].equals("-bail") ) bail = true;
+					else if ( args[i].equals("-diag") ) diag = true;
+					else if ( args[i].equals("-2x") ) x2 = true;
+					else if ( args[i].equals("-threaded") ) threaded = true;
+					else if ( args[i].equals("-quiet") ) quiet = true;
+					if ( args[i].charAt(0)!='-' ) { // input file name
+						inputFiles.add(args[i]);
+					}
+				}
+				List<String> javaFiles = new ArrayList<String>();
+				for (String fileName : inputFiles) {
+					List<String> files = getFilenames(new File(fileName));
+					javaFiles.addAll(files);
+				}
+				doFiles(javaFiles);
+
+//				DOTGenerator gen = new DOTGenerator(null);
+//				String dot = gen.getDOT(Java9Parser._decisionToDFA[112], false);
+//				System.out.println(dot);
+//				dot = gen.getDOT(Java9Parser._decisionToDFA[81], false);
+//				System.out.println(dot);
+
+				if ( x2 ) {
+					System.gc();
+					System.out.println("waiting for 1st pass");
+					if ( threaded ) while ( !firstPassDone ) { } // spin
+					System.out.println("2nd pass");
+					doFiles(javaFiles);
+				}
+			}
+			else {
+				System.err.println("Usage: java Main <directory or file name>");
+			}
+		}
+		catch(Exception e) {
+			System.err.println("exception: "+e);
+			e.printStackTrace(System.err);   // so we can get stack trace
+		}
+		long stop = System.currentTimeMillis();
+//		System.out.println("Overall time " + (stop - start) + "ms.");
+		System.gc();
+	}
+
+	public static void doFiles(List<String> files) throws Exception {
+		long parserStart = System.currentTimeMillis();
+//		lexerTime = 0;
+		if ( threaded ) {
+			barrier = new CyclicBarrier(3,new Runnable() {
+				public void run() {
+					report(); firstPassDone = true;
+				}
+			});
+			int chunkSize = files.size() / 3;  // 10/3 = 3
+			int p1 = chunkSize; // 0..3
+			int p2 = 2 * chunkSize; // 4..6, then 7..10
+			workers[0] = new Worker(files.subList(0,p1+1));
+			workers[1] = new Worker(files.subList(p1+1,p2+1));
+			workers[2] = new Worker(files.subList(p2+1,files.size()));
+			new Thread(workers[0], "worker-"+windex++).start();
+			new Thread(workers[1], "worker-"+windex++).start();
+			new Thread(workers[2], "worker-"+windex++).start();
+		}
+		else {
+			for (String f : files) {
+				parseFile(f);
+			}
+			long parserStop = System.currentTimeMillis();
+			System.out.println("Total lexer+parser time " + (parserStop - parserStart) + "ms.");
+		}
+	}
+
+	private static void report() {
+//		parserStop = System.currentTimeMillis();
+//		System.out.println("Lexer total time " + lexerTime + "ms.");
+		long time = 0;
+		if ( workers!=null ) {
+			// compute max as it's overlapped time
+			for (Worker w : workers) {
+				long wtime = w.parserStop - w.parserStart;
+				time = Math.max(time,wtime);
+				System.out.println("worker time " + wtime + "ms.");
+			}
+		}
+		System.out.println("Total lexer+parser time " + time + "ms.");
+
+		System.out.println("finished parsing OK");
+		System.out.println(LexerATNSimulator.match_calls+" lexer match calls");
+//		System.out.println(ParserATNSimulator.predict_calls +" parser predict calls");
+//		System.out.println(ParserATNSimulator.retry_with_context +" retry_with_context after SLL conflict");
+//		System.out.println(ParserATNSimulator.retry_with_context_indicates_no_conflict +" retry sees no conflict");
+//		System.out.println(ParserATNSimulator.retry_with_context_predicts_same_alt +" retry predicts same alt as resolving conflict");
+	}
+
+	public static List<String> getFilenames(File f) throws Exception {
+		List<String> files = new ArrayList<String>();
+		getFilenames_(f, files);
+		return files;
+	}
+
+	public static void getFilenames_(File f, List<String> files) throws Exception {
+		// If this is a directory, walk each file/dir in that directory
+		if (f.isDirectory()) {
+			String flist[] = f.list();
+			for(int i=0; i < flist.length; i++) {
+				getFilenames_(new File(f, flist[i]), files);
+			}
+		}
+
+		// otherwise, if this is a java file, parse it!
+		else if ( ((f.getName().length()>5) &&
+			f.getName().substring(f.getName().length()-5).equals(".java")) )
+		{
+			files.add(f.getAbsolutePath());
+		}
+	}
+
+	// This method decides what action to take based on the type of
+	//   file we are looking at
+//	public static void doFile_(File f) throws Exception {
+//		// If this is a directory, walk each file/dir in that directory
+//		if (f.isDirectory()) {
+//			String files[] = f.list();
+//			for(int i=0; i < files.length; i++) {
+//				doFile_(new File(f, files[i]));
+//			}
+//		}
+//
+//		// otherwise, if this is a java file, parse it!
+//		else if ( ((f.getName().length()>5) &&
+//			f.getName().substring(f.getName().length()-5).equals(".java")) )
+//		{
+//			System.err.println(f.getAbsolutePath());
+//			parseFile(f.getAbsolutePath());
+//		}
+//	}
+
+	public static void parseFile(String f) {
+		try {
+			if ( !quiet ) System.err.println(f);
+			// Create a scanner that reads from the input stream passed to us
+			Lexer lexer = new Java9Lexer(new ANTLRFileStream(f));
+
+			CommonTokenStream tokens = new CommonTokenStream(lexer);
+//			long start = System.currentTimeMillis();
+//			tokens.fill(); // load all and check time
+//			long stop = System.currentTimeMillis();
+//			lexerTime += stop-start;
+
+			// Create a parser that reads from the scanner
+			Java9Parser parser = new Java9Parser(tokens);
+			if ( diag ) parser.addErrorListener(new DiagnosticErrorListener());
+			if ( bail ) parser.setErrorHandler(new BailErrorStrategy());
+			if ( SLL ) parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+
+			// start parsing at the compilationUnit rule
+			ParserRuleContext t = parser.compilationUnit();
+			if ( notree ) parser.setBuildParseTree(false);
+//			if ( gui ) t.inspect(parser);
+			if ( printTree ) System.out.println(t.toStringTree(parser));
+		}
+		catch (Exception e) {
+			System.err.println("parser exception: "+e);
+			e.printStackTrace();   // so we can get stack trace
+		}
+	}
+}
+

--- a/java9/examples/TryWithResourceDemo.java
+++ b/java9/examples/TryWithResourceDemo.java
@@ -1,0 +1,16 @@
+public class TryWithResourceDemo implements AutoCloseable{
+	public static void main(String[] args){
+		TryWithResourceDemo demo=new TryWithResourceDemo();
+		try(demo){demo.doSomething();}
+		/* Prior to Java 9, you should write something like
+			try(TryWithResourceDemo demo=new TryWithResourceDemo()){demo.doSomething();}
+		*/
+	}
+	public void doSomething(){
+		System.out.println("Hello world!");
+	}
+	@Override
+	public void close(){
+		System.out.println("I am going to be closed");
+	}
+}

--- a/java9/examples/helloworld.java
+++ b/java9/examples/helloworld.java
@@ -1,0 +1,6 @@
+public class HelloWorld { 
+   public static void main(String[] args) { 
+      System.out.println("Hello, World");
+   }
+}
+

--- a/java9/examples/module-info.java
+++ b/java9/examples/module-info.java
@@ -1,0 +1,12 @@
+module com.example.foo {
+	requires com.example.foo.http;
+	requires java.logging;
+	requires transitive com.example.foo.network;
+	exports com.example.foo.bar;
+	exports com.example.foo.internal to com.example.foo.probe;
+	opens com.example.foo.quux;
+	opens com.example.foo.internal to com.example.foo.network,
+	com.example.foo.probe;
+	uses com.example.foo.spi.Intf;
+	provides com.example.foo.spi.Intf with com.example.foo.Impl;
+}

--- a/java9/pom.xml
+++ b/java9/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>java9</artifactId>
+	<packaging>jar</packaging>
+	<name>Java9 grammar</name>
+	<parent>
+		<groupId>com.antlr.grammarsv4</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<grammars>Java9.g4</grammars>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>compilationUnit</entryPoint>
+					<grammarName>Java9</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
A grammar for Java 9 is generated by updating the Java 8 grammar to caught up with the latest Java Language Specification, including support for module declaration and modifed try-with-resources-statement.