### PR TITLE
Set tab_width and other properties in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root=true
+
+[*]
+tab_width = 4
+
+[*.g4]
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root=true
 tab_width = 4
 
 [*.g4]
+end_of_line = lf
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
tab-width to show tabs correctly, trim_trailing_whitespace, indent_style, indent_size, root.
See <http://editorconfig.org> doc.