### PR TITLE
PL/SQL CREATE TABLE update with test example

### DIFF
--- a/plsql/PlSqlParser.g4
+++ b/plsql/PlSqlParser.g4
@@ -526,7 +526,7 @@ drop_index
 
 create_table
     : CREATE (GLOBAL TEMPORARY)? TABLE tableview_name 
-        LEFT_PAREN column_name datatype (NOT NULL)? (ENABLE | DISABLE)? (',' column_name datatype (NOT NULL)? (ENABLE | DISABLE)?)*
+        LEFT_PAREN datatype_null_enable? (',' datatype_null_enable?)*
         (',' CONSTRAINT constraint_name
           ( primary_key_clause
           | foreign_key_clause
@@ -570,6 +570,10 @@ create_table
 // Many more varations to capture
       SEMICOLON
     ;
+
+datatype_null_enable
+   :  column_name datatype (NOT NULL)? (ENABLE | DISABLE)?
+   ;
 
 size_clause
     : UNSIGNED_INTEGER REGULAR_ID

--- a/plsql/PlSqlParser.g4
+++ b/plsql/PlSqlParser.g4
@@ -526,7 +526,14 @@ drop_index
 
 create_table
     : CREATE (GLOBAL TEMPORARY)? TABLE tableview_name 
-        LEFT_PAREN column_name datatype (',' column_name datatype)*
+        LEFT_PAREN column_name datatype (NOT NULL)? (ENABLE | DISABLE)? (',' column_name datatype (NOT NULL)? (ENABLE | DISABLE)?)*
+        (',' CONSTRAINT constraint_name
+          ( primary_key_clause
+          | foreign_key_clause
+          | unique_key_clause
+          | check_constraint
+          )
+        )*
         RIGHT_PAREN
         (ON COMMIT (DELETE | PRESERVE) ROWS)?
         (SEGMENT CREATION (IMMEDIATE | DEFERRED))?
@@ -548,7 +555,7 @@ create_table
           )+
          RIGHT_PAREN
         )?
-        (TABLESPACE tablespace_name=REGULAR_ID)?
+        (TABLESPACE tablespace_name=(REGULAR_ID | DELIMITED_ID))?
         (LOGGING | NOLOGGING | FILESYSTEM_LIKE_LOGGING)?
         ( COMPRESS
            (BASIC

--- a/plsql/examples-sql-script/green_table.sql
+++ b/plsql/examples-sql-script/green_table.sql
@@ -2,9 +2,11 @@ drop table green_table;
 
 create table green_table
 (
-  green_col_one number(10)
+  green_col_one number(10) not null disable
 , green_col_two varchar2(64)
-);
+)
+tablespace "greenspace"
+;
 
 insert into green_table (green_col_one, green_col_two)
 values (100021, 'green-varchar-21');


### PR DESCRIPTION
PL/SQL: Support NOT NULL, ENABLE/DISABLE inline column constraints in CREATE TABLE along with quoted identifiers for TABLESPACE.