### PR TITLE
fix queue_setting

### DIFF
--- a/tsql/TSqlParser.g4
+++ b/tsql/TSqlParser.g4
@@ -1654,13 +1654,22 @@ queue_settings
        (RETENTION EQUAL (ON | OFF) COMMA?)?
        (ACTIVATION
          LR_BRACKET
-           (COMMA? STATUS EQUAL (ON | OFF))?
-           (COMMA? PROCEDURE_NAME EQUAL func_proc_name)?
-           (COMMA? MAX_QUEUE_READERS EQUAL max_readers=DECIMAL)?
-           (COMMA? EXECUTE AS (SELF | user_name=STRING | OWNER))?
-           (COMMA? POISON_MESSAGE_HANDLING STATUS EQUAL (ON | OFF))?
-           (COMMA? DROP)?
-         RR_BRACKET)?
+           (
+             (
+              (STATUS EQUAL (ON | OFF) COMMA? )?
+              (PROCEDURE_NAME EQUAL func_proc_name COMMA?)?
+              (MAX_QUEUE_READERS EQUAL max_readers=DECIMAL COMMA?)?
+              (EXECUTE AS (SELF | user_name=STRING | OWNER) COMMA?)?
+             )
+             | DROP
+           )
+         RR_BRACKET COMMA?
+       )?
+       (POISON_MESSAGE_HANDLING
+         LR_BRACKET
+           (STATUS EQUAL (ON | OFF))
+         RR_BRACKET
+       )?
     ;
 
 alter_queue


### PR DESCRIPTION
Fix ALTER QUEUE according https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-queue-transact-sql. I write simple tool(fuzzer) for check grammar. Fuzzer builds query's according grammar file(*.g4) and checks for correctness.  And next query: ALTER QUEUE WORK WITH STATUS = ON , RETENTION = ON , ACTIVATION( , STATUS = ON DROP ); exception  Incorrect syntax in Microsoft SQL Server 2017
https://github.com/PrVrSs/AntlrGrammarFuzzer - fuzzer