### PR TITLE
support CURRENT_TIMESTAMP default value

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -337,7 +337,13 @@ column_def_table_constraint
    ;
 
 column_definition
-    : data_type separate_column_constraint*
+    : (TIMESTAMP | DATETIME) (timestamp_datetime_column_constraint)*    #timestampColDef
+   | data_type separate_column_constraint*                              #datatypeColDef
+   ;
+
+timestamp_column_constraint
+    : separate_column_constraint
+   | DEFAULT CURRENT_TIMESTAMP
    ;
 
 separate_column_constraint

--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -337,7 +337,7 @@ column_def_table_constraint
    ;
 
 column_definition
-    : (TIMESTAMP | DATETIME) (timestamp_datetime_column_constraint)*    #timestampColDef
+    : (TIMESTAMP | DATETIME) (timestamp_column_constraint)*    #timestampColDef
    | data_type separate_column_constraint*                              #datatypeColDef
    ;
 

--- a/mysql/examples/ddl_create.sql
+++ b/mysql/examples/ddl_create.sql
@@ -10,6 +10,7 @@ create table `some table $$`(id int auto_increment key, class varchar(10), data 
 create table `parent_table`(id int primary key, column1 varchar(30), index parent_table_i1(column1(20)), check(char_length(column1)>10)) engine InnoDB;
 create table child_table(id int unsigned auto_increment primary key, id_parent int references parent_table(id) match full on update cascade on delete set null) engine=InnoDB;
 create table `another some table $$` like `some table $$`;
+create table `actor` (`last_update` timestamp default CURRENT_TIMESTAMP, `birthday` datetime default CURRENT_TIMESTAMP);
 #end
 #begin
 -- Rename table


### PR DESCRIPTION
As described in #962, current grammar does not allow for CURRENT_TIMESTAMP keyword as a default value for TIMESTAMP and DATETIME columns. This pull request aims to add such capability. Probably the new rules need to be labeled so comments and additions are welcome. The changes still look a bit like a workaround for a specific case, but it *is* a specific case in MySQL syntax as they clearly state in their docs.