### PR TITLE
Modified to allow Create table as select (CTAS) to only need to speci…

### DIFF
--- a/plsql/PlSqlParser.g4
+++ b/plsql/PlSqlParser.g4
@@ -663,7 +663,7 @@ container_clause
 
 create_table
     : CREATE (GLOBAL TEMPORARY)? TABLE tableview_name 
-        LEFT_PAREN (','? datatype_null_enable)+
+        ( '(' (','? datatype_null_enable)+
         (',' CONSTRAINT constraint_name
           ( primary_key_clause
           | foreign_key_clause
@@ -671,7 +671,7 @@ create_table
           | check_constraint
           )
         )*
-        RIGHT_PAREN
+        ')' )?
         (ON COMMIT (DELETE | PRESERVE) ROWS)?
         (SEGMENT CREATION (IMMEDIATE | DEFERRED))?
         (PCTFREE pctfree=UNSIGNED_INTEGER

--- a/plsql/examples/ctas.sql
+++ b/plsql/examples/ctas.sql
@@ -1,0 +1,3 @@
+create table junk as select sysdate from dual;
+
+create table junk1 INITRANS 10 as select sysdate from dual;


### PR DESCRIPTION
Modified to allow Create table as select (CTAS) to only need to specify table name and not need a column definition section.