### PR TITLE
add dimensions support for YEAR data type

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -1876,7 +1876,7 @@ data_type
    | (DECIMAL | NUMERIC) 
      length_two_optional_dimension? UNSIGNED? ZEROFILL?        #dimensionDatatype
    | (DATE | YEAR | TINYBLOB | BLOB | MEDIUMBLOB | LONGBLOB)      #simpleDatatype
-   | (BIT | TIME | TIMESTAMP | DATETIME | BINARY | VARBINARY) 
+   | (BIT | TIME | TIMESTAMP | DATETIME | YEAR | BINARY | VARBINARY) 
      length_one_dimension?                               #dimensionDatatype
    | (ENUM | SET) 
      '(' STRING_LITERAL (',' STRING_LITERAL)* ')' BINARY? 

--- a/mysql/examples/ddl_create.sql
+++ b/mysql/examples/ddl_create.sql
@@ -5,7 +5,7 @@ create table log_table(row varchar(512));
 create table ships(name varchar(255), class_id int, id int);
 create table ships_guns(guns_id int, ship_id int);
 create table guns(id int, power decimal(7,2), callibr decimal(10,3));
-create table ship_class(id int, class_name varchar(100), tonange decimal(10,2), max_length decimal(10,2), start_build year, max_guns_size int);
+create table ship_class(id int, class_name varchar(100), tonange decimal(10,2), max_length decimal(10,2), start_build year, end_build year(4), max_guns_size int);
 create table `some table $$`(id int auto_increment key, class varchar(10), data binary) engine=MYISAM;
 create table `parent_table`(id int primary key, column1 varchar(30), index parent_table_i1(column1(20)), check(char_length(column1)>10)) engine InnoDB;
 create table child_table(id int unsigned auto_increment primary key, id_parent int references parent_table(id) match full on update cascade on delete set null) engine=InnoDB;


### PR DESCRIPTION
`YEAR` data type can also be specified as `YEAR(4)` (and `YEAR(2)` in older MySQL versions. See docs: https://dev.mysql.com/doc/refman/5.7/en/year.html