### PR TITLE
Java method single receiver parameter

### DIFF
--- a/java8/Java8.g4
+++ b/java8/Java8.g4
@@ -456,7 +456,8 @@ methodDeclarator
 	;
 
 formalParameterList
-	:	formalParameters ',' lastFormalParameter
+	:	receiverParameter
+	|	formalParameters ',' lastFormalParameter
 	|	lastFormalParameter
 	;
 

--- a/java8/examples/Receiver.java
+++ b/java8/examples/Receiver.java
@@ -1,0 +1,5 @@
+public class Currency {
+  public String getCode(Currency this) {
+  }
+}
+


### PR DESCRIPTION
Fixes issue #989 in the [java8](https://github.com/antlr/grammars-v4/blob/master/java8/) grammar (not the [java](https://github.com/antlr/grammars-v4/blob/master/java/) grammar) and adds a test to prevent regressions.