### PR TITLE
Disallow control characters in string fields

### DIFF
--- a/json/JSON.g4
+++ b/json/JSON.g4
@@ -34,7 +34,7 @@ value
 
 
 STRING
-   : '"' (ESC | ~ ["\\])* '"'
+   : '"' (ESC | SAFECODEPOINT)* '"'
    ;
 
 
@@ -50,6 +50,11 @@ fragment UNICODE
 
 fragment HEX
    : [0-9a-fA-F]
+   ;
+
+
+fragment SAFECODEPOINT
+   : ~ ["\\\u0000-\u001F]
    ;
 
 


### PR DESCRIPTION
According to the [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)  standard, strings cannot contain control characters U+0000 to U+001F in addition to the characters `"` and `\`.

> #### 9. String
> ... 
> All code points may be placed within the quotation marks except for the code points that must be escaped: quotation mark (U+0022), reverse solidus (U+005C), and the control characters U+0000 to U+001F.
> ... 

Therefore, some changes have been made to conform to the spec.