### PR TITLE
removed unused element which breaks python target

### DIFF
--- a/java8/Java8.g4
+++ b/java8/Java8.g4
@@ -70,11 +70,6 @@ literal
  * Productions from §4 (Types, Values, and Variables)
  */
 
-type
-	:	primitiveType
-	|	referenceType
-	;
-
 primitiveType
 	:	annotation* numericType
 	|	annotation* 'boolean'


### PR DESCRIPTION
Java8 grammar is broken for python target as "type" is a python keyword. Moreover the element which breaks it is not used, so it was deleted