### PR TITLE
Same thing 'type' element is not used throw it breaks python target a…

### DIFF
--- a/java9/Java9.g4
+++ b/java9/Java9.g4
@@ -81,11 +81,6 @@ literal
  * Productions from §4 (Types, Values, and Variables)
  */
 
-type
-	:	primitiveType
-	|	referenceType
-	;
-
 primitiveType
 	:	annotation* numericType
 	|	annotation* 'boolean'


### PR DESCRIPTION
Same thing 'type' element is not used throw it breaks python target as it is a keyword in python