### PR TITLE
Fix: Issues 1065, 1066.

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -238,6 +238,7 @@ typeSpecifier
     |   enumSpecifier
     |   typedefName
     |   '__typeof__' '(' constantExpression ')' // GCC extension
+    |   typeSpecifier pointer
     ;
 
 structOrUnionSpecifier
@@ -334,6 +335,7 @@ directDeclarator
     |   directDeclarator '(' parameterTypeList ')'
     |   directDeclarator '(' identifierList? ')'
     |   Identifier ':' DigitSequence  // bit field
+    |   '(' typeSpecifier? pointer directDeclarator ')' // function pointer like: (__cdecl *f)
     ;
 
 gccDeclaratorExtension

--- a/c/examples/FunctionPointer.c
+++ b/c/examples/FunctionPointer.c
@@ -1,0 +1,29 @@
+//function pointer
+typedef
+void *
+(*f1)(
+          const MyType        *param1,
+          long             param2,
+    void              *param3,
+          short             param4
+  );
+
+
+typedef
+int
+(*f2)(
+          const MyType        *param1,
+          long             param2,
+    char              *param3,
+          int             param4
+  );
+
+
+typedef
+MyStruct
+( *f3 ) (
+          const MyType        *param1,
+          double             param2,
+    float              *param3,
+          long             param4
+  );

--- a/c/examples/FunctionReturningPointer.c
+++ b/c/examples/FunctionReturningPointer.c
@@ -1,0 +1,20 @@
+//function returns pointer
+void *
+__cdecl
+f1(
+   UINTN             param1
+  );
+
+
+int *
+__cdecl
+f2 (
+   int             param1
+  );
+
+
+int MyStruct *
+f3 (
+   int             param1,
+   char            param2
+  );

--- a/c/examples/ParameterOfPointerType.c
+++ b/c/examples/ParameterOfPointerType.c
@@ -1,0 +1,22 @@
+//parameter contains pointer
+int
+__cdecl
+f1 (
+   const MyType        *param1,
+   int                  param2
+  );
+
+
+MyType1
+__cdecl
+f1 (
+   MyType        *param1,
+   int       *     param2
+  );
+
+
+void
+__cdecl
+f1 (
+   void        *param1
+  );


### PR DESCRIPTION
- parser rule for: function returns pointer type
- parser rule for: function pointer.

Related issues:
https://github.com/antlr/grammars-v4/issues/1065
https://github.com/antlr/grammars-v4/issues/1066