### PR TITLE
Add Apache Thrift, Cap'n Proto, Google FlatBuffers grammars

### DIFF
--- a/capnproto/CapnProto.g4
+++ b/capnproto/CapnProto.g4
@@ -1,0 +1,147 @@
+
+grammar CapnProto;
+
+// parser rules
+
+document :
+	file_identifier using_import* namespace? document_content* EOF	;
+
+file_identifier :
+	FILE_ID ';' ;
+	
+using_import :
+	'using' ( NAME '=' )? 'import' TEXT ( '.' NAME )? ';' ;
+	
+namespace :
+	'$' NAME '.namespace' '(' TEXT ')' ';' ;
+
+document_content :
+	struct_def | interface_def | function_def | annotation_def | const_def | enum_def ;
+
+struct_def :
+	'struct' type annotation_reference? '{' struct_content* '}' ;
+
+struct_content : 
+	field_def | enum_def | named_union_def 
+	| unnamed_union_def | interface_def | annotation_def
+	| struct_def | group_def | const_def | inner_using ;
+
+interface_def :
+	'interface' type ( 'extends' '(' type ')' )? '{' interface_content* '}' ;
+
+interface_content : 
+	field_def | enum_def | named_union_def 
+	| unnamed_union_def | interface_def 
+	| struct_def | function_def ;
+
+field_def :	
+	NAME LOCATOR ':' type ( '=' const_value )? ';' ;
+
+type :
+	NAME 
+	inner_type?
+	( '.' type )? ;
+
+inner_type :
+	'(' type inner_type? ( ',' type inner_type? )* ')' ;
+	
+enum_def :
+	'enum' NAME annotation_reference? '{' enum_content* '}' ;
+
+annotation_reference :
+	'$' type '.ann'? '(' TEXT ')' ;
+	
+enum_content :
+	NAME LOCATOR annotation_reference? ';' ;
+
+named_union_def :
+	NAME LOCATOR? ':union' '{' union_content* '}' ;
+
+unnamed_union_def :
+	'union' '{' union_content* '}' ;
+
+union_content :
+	field_def | group_def | unnamed_union_def | named_union_def ;
+	
+group_def :
+	NAME ':group' '{' group_content* '}' ;
+
+group_content :
+	field_def | unnamed_union_def | named_union_def ;
+	
+function_def :
+	NAME LOCATOR? generic_type_parameters? ( function_parameters | type )
+	( '->' ( function_parameters | type ) )?
+	';' ;
+
+generic_type_parameters :
+	'[' 
+		NAME ( ',' NAME )*
+	']' ;
+	
+function_parameters :
+	'(' 
+		( NAME ':' type ( '=' const_value )?
+			( ',' NAME ':' type ( '=' const_value )? )*
+		)?
+	')' ;
+	
+annotation_def :
+	'annotation' type annotation_parameters? ':' type ';' ;
+
+annotation_parameters :
+	'(' 'struct' ')' ;
+	
+const_def :
+	'const' NAME ':' type '=' const_value ';' ;
+	
+const_value :
+	'-'? '.'? NAME ( '.' NAME )? | INTEGER | FLOAT 
+	| TEXT | BOOLEAN | HEXADECIMAL | VOID 
+	| literal_list | literal_union | literal_bytes ;
+	
+literal_union :
+	'(' NAME '=' union_mapping ( ',' NAME '=' union_mapping )* ')' ;
+
+literal_list :
+	'[' const_value ( ',' const_value )* ']' ;
+
+literal_bytes :
+	'0x' TEXT ;
+	
+union_mapping :
+	'(' NAME '=' const_value ')' | const_value ;
+
+inner_using :
+	'using' NAME ( '.' NAME )*
+	( '=' type )?
+	';' ;
+	
+	
+// lexer rules
+
+fragment DIGIT : [0-9] ;
+
+fragment HEX_DIGIT : DIGIT | 'A'..'F' | 'a'..'f' ;
+
+LOCATOR : '@' DIGIT+ '!'? ;
+
+TEXT : '"' ~["]*? '"' ;
+
+INTEGER : '-'? DIGIT+ ;
+
+FLOAT : '-'? DIGIT+ ( '.' DIGIT+ )? ( 'e' '-'? DIGIT+ )? ;
+
+HEXADECIMAL : '-'? '0x' HEX_DIGIT+ ;
+
+FILE_ID : '@' HEXADECIMAL ;
+
+BOOLEAN : 'true' | 'false' ;
+
+VOID : 'void' ;
+
+NAME : [a-zA-Z] [a-zA-Z0-9]* ;
+
+COMMENT : '#' ~[\n]* -> channel(HIDDEN) ;
+
+WHITESPACE : [ \t\r\n] -> skip ;

--- a/capnproto/README.md
+++ b/capnproto/README.md
@@ -1,0 +1,1 @@
+ANTLR v4 grammar for the Cap'n Proto schema language: https://capnproto.org/language.html

--- a/capnproto/examples/addressbook.capnp
+++ b/capnproto/examples/addressbook.capnp
@@ -1,0 +1,55 @@
+# Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@0x9eb32e19f86ee174;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("addressbook");
+
+struct Person {
+  id @0 :UInt32;
+  name @1 :Text;
+  email @2 :Text;
+  phones @3 :List(PhoneNumber);
+
+  struct PhoneNumber {
+    number @0 :Text;
+    type @1 :Type;
+
+    enum Type {
+      mobile @0;
+      home @1;
+      work @2;
+    }
+  }
+
+  employment :union {
+    unemployed @4 :Void;
+    employer @5 :Text;
+    school @6 :Text;
+    selfEmployed @7 :Void;
+    # We assume that a person is only one of these.
+  }
+}
+
+struct AddressBook {
+  people @0 :List(Person);
+}

--- a/capnproto/examples/calculator.capnp
+++ b/capnproto/examples/calculator.capnp
@@ -1,0 +1,118 @@
+# Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@0x85150b117366d14b;
+
+interface Calculator {
+  # A "simple" mathematical calculator, callable via RPC.
+  #
+  # But, to show off Cap'n Proto, we add some twists:
+  #
+  # - You can use the result from one call as the input to the next
+  #   without a network round trip.  To accomplish this, evaluate()
+  #   returns a `Value` object wrapping the actual numeric value.
+  #   This object may be used in a subsequent expression.  With
+  #   promise pipelining, the Value can actually be used before
+  #   the evaluate() call that creates it returns!
+  #
+  # - You can define new functions, and then call them.  This again
+  #   shows off pipelining, but it also gives the client the
+  #   opportunity to define a function on the client side and have
+  #   the server call back to it.
+  #
+  # - The basic arithmetic operators are exposed as Functions, and
+  #   you have to call getOperator() to obtain them from the server.
+  #   This again demonstrates pipelining -- using getOperator() to
+  #   get each operator and then using them in evaluate() still
+  #   only takes one network round trip.
+
+  evaluate @0 (expression :Expression) -> (value :Value);
+  # Evaluate the given expression and return the result.  The
+  # result is returned wrapped in a Value interface so that you
+  # may pass it back to the server in a pipelined request.  To
+  # actually get the numeric value, you must call read() on the
+  # Value -- but again, this can be pipelined so that it incurs
+  # no additional latency.
+
+  struct Expression {
+    # A numeric expression.
+
+    union {
+      literal @0 :Float64;
+      # A literal numeric value.
+
+      previousResult @1 :Value;
+      # A value that was (or, will be) returned by a previous
+      # evaluate().
+
+      parameter @2 :UInt32;
+      # A parameter to the function (only valid in function bodies;
+      # see defFunction).
+
+      call :group {
+        # Call a function on a list of parameters.
+        function @3 :Function;
+        params @4 :List(Expression);
+      }
+    }
+  }
+
+  interface Value {
+    # Wraps a numeric value in an RPC object.  This allows the value
+    # to be used in subsequent evaluate() requests without the client
+    # waiting for the evaluate() that returns the Value to finish.
+
+    read @0 () -> (value :Float64);
+    # Read back the raw numeric value.
+  }
+
+  defFunction @1 (paramCount :Int32, body :Expression)
+              -> (func :Function);
+  # Define a function that takes `paramCount` parameters and returns the
+  # evaluation of `body` after substituting these parameters.
+
+  interface Function {
+    # An algebraic function.  Can be called directly, or can be used inside
+    # an Expression.
+    #
+    # A client can create a Function that runs on the server side using
+    # `defFunction()` or `getOperator()`.  Alternatively, a client can
+    # implement a Function on the client side and the server will call back
+    # to it.  However, a function defined on the client side will require a
+    # network round trip whenever the server needs to call it, whereas
+    # functions defined on the server and then passed back to it are called
+    # locally.
+
+    call @0 (params :List(Float64)) -> (value :Float64);
+    # Call the function on the given parameters.
+  }
+
+  getOperator @2 (op :Operator) -> (func :Function);
+  # Get a Function representing an arithmetic operator, which can then be
+  # used in Expressions.
+
+  enum Operator {
+    add @0;
+    subtract @1;
+    multiply @2;
+    divide @3;
+  }
+}

--- a/capnproto/examples/capnp-rust/test.capnp
+++ b/capnproto/examples/capnp-rust/test.capnp
@@ -1,0 +1,633 @@
+# example taken from https://github.com/capnproto/capnpc-rust/blob/master/test/test.capnp
+
+# Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+@0x99d187209d25cee7;
+
+struct TestPrimList {
+    uint8List  @0 : List(UInt8);
+    int8List   @1 : List(Int8);
+    uint16List @2 : List(UInt16);
+    int16List  @3 : List(Int16);
+    uint32List @4 : List(UInt32);
+    int32List  @5 : List(Int32);
+    uint64List @6 : List(UInt64);
+    int64List @7 : List(Int64);
+    float32List @8 : List(Float32);
+    boolList @9 : List(Bool);
+    voidList @10 : List(Void);
+}
+
+struct TestStructList {
+   structList @0 : List(TestPrimList);
+}
+
+struct TestBlob {
+   textField @0 : Text;
+   dataField @1 : Data;
+}
+
+struct TestBigStruct {
+  voidField      @0  : Void;
+  boolField      @1  : Bool;
+  int8Field      @2  : Int8;
+  int16Field     @3  : Int16;
+  int32Field     @4  : Int32;
+  int64Field     @5  : Int64;
+  uint8Field     @6  : UInt8;
+  uint16Field    @7  : UInt16;
+  uint32Field    @8  : UInt32;
+  uint64Field    @9  : UInt64;
+  float32Field   @10 : Float32;
+  float64Field   @11 : Float64;
+
+  structField @12 : Inner;
+  anotherStructField @13 : Inner;
+
+  struct Inner {
+    uint32Field    @0  : UInt32;
+    uint64Field    @1  : UInt64;
+    float32Field   @2 : Float32;
+    float64Field   @3 : Float64;
+    boolFieldA     @4  : Bool;
+    boolFieldB     @5  : Bool;
+    boolFieldC     @6  : Bool;
+    boolFieldD     @7  : Bool;
+  }
+}
+
+enum AnEnum {
+     foo @0;
+     bar @1;
+     baz @2;
+     qux @3;
+}
+
+struct TestComplexList {
+   enumList @0 : List(AnEnum);
+   textList @1 : List(Text);
+   dataList @2 : List(Data);
+   primListList @3 : List(List(Int32));
+   primListListList @4 : List(List(List(Int16)));
+   enumListList @5 : List(List(AnEnum));
+   textListList @6 : List(List(Text));
+   dataListList @7 : List(List(Data));
+   structListList @8 : List(List(TestBigStruct));
+}
+
+enum TestEnum {
+  foo @0;
+  bar @1;
+  baz @2;
+  qux @3;
+  quux @4;
+  corge @5;
+  grault @6;
+  garply @7;
+}
+
+struct TestAllTypes {
+  voidField      @0  : Void;
+  boolField      @1  : Bool;
+  int8Field      @2  : Int8;
+  int16Field     @3  : Int16;
+  int32Field     @4  : Int32;
+  int64Field     @5  : Int64;
+  uInt8Field     @6  : UInt8;
+  uInt16Field    @7  : UInt16;
+  uInt32Field    @8  : UInt32;
+  uInt64Field    @9  : UInt64;
+  float32Field   @10 : Float32;
+  float64Field   @11 : Float64;
+  textField      @12 : Text;
+  dataField      @13 : Data;
+  structField    @14 : TestAllTypes;
+  enumField      @15 : TestEnum;
+  interfaceField @16 : Void;  # TODO
+
+  voidList      @17 : List(Void);
+  boolList      @18 : List(Bool);
+  int8List      @19 : List(Int8);
+  int16List     @20 : List(Int16);
+  int32List     @21 : List(Int32);
+  int64List     @22 : List(Int64);
+  uInt8List     @23 : List(UInt8);
+  uInt16List    @24 : List(UInt16);
+  uInt32List    @25 : List(UInt32);
+  uInt64List    @26 : List(UInt64);
+  float32List   @27 : List(Float32);
+  float64List   @28 : List(Float64);
+  textList      @29 : List(Text);
+  dataList      @30 : List(Data);
+  structList    @31 : List(TestAllTypes);
+  enumList      @32 : List(TestEnum);
+  interfaceList @33 : List(Void);  # TODO
+}
+
+struct TestDefaults {
+   voidField     @0  :Void      = void;
+   boolField     @1  :Bool      = true;
+   int8Field     @2  :Int8      = -123;
+   int16Field    @3  :Int16     = -12345;
+   int32Field    @4  :Int32     = -12345678;
+   int64Field    @5  :Int64     = -123456789012345;
+   uint8Field    @6  :UInt8     = 234;
+   uint16Field   @7  :UInt16    = 45678;
+   uint32Field   @8  :UInt32    = 3456789012;
+   uint64Field   @9  :UInt64    = 12345678901234567890;
+   float32Field  @10 :Float32   = 1234.5;
+   float64Field  @11 :Float64   = -123e45;
+   textField     @12 :Text      = "foo";
+   dataField     @13 :Data      = 0x"62 61 72"; # "bar"
+   structField   @14 : TestAllTypes = (
+      voidField      = void,
+      boolField      = true,
+      int8Field      = -12,
+      int16Field     = 3456,
+      int32Field     = -78901234,
+      int64Field     = 56789012345678,
+      uInt8Field     = 90,
+      uInt16Field    = 1234,
+      uInt32Field    = 56789012,
+      uInt64Field    = 345678901234567890,
+      float32Field   = -1.25e-10,
+      float64Field   = 345,
+      textField      = "baz",
+      dataField      = "qux",
+      structField    = (
+          textField = "nested",
+          structField = (textField = "really nested")),
+      enumField      = baz,
+      # interfaceField can't have a default
+
+      voidList      = [void, void, void],
+      boolList      = [false, true, false, true, true],
+      int8List      = [12, -34, -0x80, 0x7f],
+      int16List     = [1234, -5678, -0x8000, 0x7fff],
+      int32List     = [12345678, -90123456, -0x80000000, 0x7fffffff],
+      int64List     = [123456789012345, -678901234567890, -0x8000000000000000, 0x7fffffffffffffff],
+      uInt8List     = [12, 34, 0, 0xff],
+      uInt16List    = [1234, 5678, 0, 0xffff],
+      uInt32List    = [12345678, 90123456, 0, 0xffffffff],
+      uInt64List    = [123456789012345, 678901234567890, 0, 0xffffffffffffffff],
+      float32List   = [0, 1234567, 1e37, -1e37, 1e-37, -1e-37],
+      float64List   = [0, 123456789012345, 1e306, -1e306, 1e-306, -1e-306],
+      textList      = ["quux", "corge", "grault"],
+      dataList      = ["garply", "waldo", "fred"],
+      structList    = [
+          (textField = "x structlist 1"),
+          (textField = "x structlist 2"),
+          (textField = "x structlist 3")],
+      enumList      = [qux, bar, grault]
+      # interfaceList can't have a default
+      );
+
+   enumField      @15 : TestEnum = corge;
+   interfaceField @16 : Void;  # TODO
+
+   voidList      @17 : List(Void)    = [void, void, void, void, void, void];
+   boolList      @18 : List(Bool)    = [true, false, false, true];
+   int8List      @19 : List(Int8)    = [111, -111];
+   int16List     @20 : List(Int16)   = [11111, -11111];
+   int32List     @21 : List(Int32)   = [111111111, -111111111];
+   int64List     @22 : List(Int64)   = [1111111111111111111, -1111111111111111111];
+   uInt8List     @23 : List(UInt8)   = [111, 222] ;
+   uInt16List    @24 : List(UInt16)  = [33333, 44444];
+   uInt32List    @25 : List(UInt32)  = [3333333333];
+   uInt64List    @26 : List(UInt64)  = [11111111111111111111];
+   float32List   @27 : List(Float32) = [5555.5, inf, -inf, nan];
+   float64List   @28 : List(Float64) = [7777.75, inf, -inf, nan];
+   textList      @29 : List(Text)    = ["plugh", "xyzzy", "thud"];
+   dataList      @30 : List(Data)    = ["oops", "exhausted", "rfc3092"];
+   structList    @31 : List(TestAllTypes) = [
+       (textField = "structlist 1"),
+       (textField = "structlist 2"),
+       (textField = "structlist 3")];
+   enumList      @32 : List(TestEnum) = [foo, garply];
+   interfaceList @33 : List(Void);  # TODO
+}
+
+struct TestAnyPointer {
+   anyPointerField @0 :AnyPointer;
+}
+
+struct TestUnion {
+   union0 :union {
+     u0f0s0  @0 :Void;
+     u0f0s1  @1 :Bool;
+     u0f0s8  @2 :Int8;
+     u0f0s16 @3 :Int16;
+     u0f0s32 @4 :Int32;
+     u0f0s64 @5 :Int64;
+     u0f0sp  @6 :Text;
+   }
+}
+
+struct TestGroups {
+  groups :union {
+    foo :group {
+      corge @0 :Int32;
+      grault @2 :Int64;
+      garply @8 :Text;
+    }
+    bar :group {
+      corge @3 :Int32;
+      grault @4 :Text;
+      garply @5 :Int64;
+    }
+    baz :group {
+      corge @1 :Int32;
+      grault @6 :Text;
+      garply @7 :Text;
+      quz @9 :Float64;
+      anEnum @10 :TestEnum;
+    }
+  }
+}
+
+struct TestLists {
+  struct Struct0  { f @0 :Void; }
+  struct Struct1  { f @0 :Bool; }
+  struct Struct8  { f @0 :UInt8; }
+  struct Struct16 { f @0 :UInt16; }
+  struct Struct32 { f @0 :UInt32; }
+  struct Struct64 { f @0 :UInt64; }
+  struct StructP  { f @0 :Text; }
+
+  struct Struct0c  { f @0 :Void; pad @1 :Text; }
+  struct Struct1c  { f @0 :Bool; pad @1 :Text; }
+  struct Struct8c  { f @0 :UInt8; pad @1 :Text; }
+  struct Struct16c { f @0 :UInt16; pad @1 :Text; }
+  struct Struct32c { f @0 :UInt32; pad @1 :Text; }
+  struct Struct64c { f @0 :UInt64; pad @1 :Text; }
+  struct StructPc  { f @0 :Text; pad @1 :UInt64; }
+
+  list0  @0 :List(Struct0);
+  list1  @1 :List(Struct1);
+  list8  @2 :List(Struct8);
+  list16 @3 :List(Struct16);
+  list32 @4 :List(Struct32);
+  list64 @5 :List(Struct64);
+  listP  @6 :List(StructP);
+
+  int32ListList @7 :List(List(Int32));
+  textListList @8 :List(List(Text));
+  structListList @9 :List(List(TestAllTypes));
+}
+
+struct TestOldVersion {
+  # A subset of TestNewVersion.
+  old1 @0 :Int64;
+  old2 @1 :Text;
+  old3 @2 :TestOldVersion;
+}
+
+struct TestNewVersion {
+  # A superset of TestOldVersion.
+  old1 @0 :Int64;
+  old2 @1 :Text;
+  old3 @2 :TestNewVersion;
+  new1 @3 :Int64 = 987;
+  new2 @4 :Text = "baz";
+  new3 @5 :TestDefaults;
+}
+
+struct TestOldUnionVersion {
+  union {
+    a @0 :Void;
+    b @1 :UInt64;
+  }
+}
+
+struct TestNewUnionVersion {
+  union {
+    a :union {
+      a0 @0 :Void;
+      a1 @2 :UInt64;
+    }
+    b @1 :UInt64;
+  }
+}
+
+struct TestGenerics(Foo, Bar) {
+  foo @0 :Foo;
+  bar @1 :Bar;
+  rev @2 :TestGenerics(Bar, Foo);
+  dub @3 :TestGenerics(Text, List(UInt8));
+
+  struct Inner {
+    foo @0 :Foo;
+    bar @1 :Bar;
+  }
+
+  struct Inner2(Baz) {
+    bar @0 :Bar;
+    baz @1 :Baz;
+    innerBound @2 :Inner;
+    innerUnbound @3 :TestGenerics.Inner;
+
+    struct DeepNest(Qux) {
+      foo @0 :Foo;
+      bar @1 :Bar;
+      baz @2 :Baz;
+      qux @3 :Qux;
+    }
+  }
+
+  interface Inter2face(Qux) {
+    call @0 Inner2(Text) -> (qux :Qux, gen :TestGenerics(TestAllTypes, TestAnyPointer));
+    otherCall @1 Inner2(List(Text)) -> Inner2(List(Int16));
+  }
+
+  annotation ann(struct) :Foo;
+
+  using AliasFoo = Foo;
+  using AliasInner = Inner;
+  using AliasInner2 = Inner2;
+  using AliasInner2Text = Inner2(Text);
+  using AliasRev = TestGenerics(Bar, Foo);
+
+  struct UseAliases {
+    foo @0 :AliasFoo;
+    inner @1 :AliasInner;
+    inner2 @2 :AliasInner2;
+    inner2Bind @3 :AliasInner2(Text);
+    inner2Text @4 :AliasInner2Text;
+    revFoo @5 :AliasRev.AliasFoo;
+  }
+}
+
+struct TestGenericsWrapper(Foo, Bar) {
+  value @0 :TestGenerics(Foo, Bar);
+}
+
+struct TestGenericsWrapper2 {
+  value @0 :TestGenericsWrapper(Text, TestAllTypes);
+}
+
+interface TestImplicitMethodParams {
+  call @0 [T, U] (foo :T, bar :U) -> TestGenerics(T, U);
+}
+
+interface TestImplicitMethodParamsInGeneric(V) {
+  call @0 [T, U] (foo :T, bar :U) -> TestGenerics(T, U);
+  call1 @1 [T, U] TestGenerics(T, U) -> (foo :T, bar: U);
+  call2 @2 [T, U] TestGenerics(T, U) -> TestAllTypes;
+  call3 @3 [T, U] TestAllTypes -> TestAllTypes;
+  call4 @4 [T, U] TestGenerics(V, V) -> TestGenerics(V, AnyPointer);
+}
+
+struct TestGenericsUnion(Foo, Bar) {
+  union {
+    foo1 @0 :Foo;
+    bar1 @1 :Bar;
+    foo2 @2 :Foo;
+  }
+}
+
+struct TestUseGenerics $TestGenerics(Text, Data).ann("foo") {
+  basic @0 :TestGenerics(TestAllTypes, TestAnyPointer);
+  inner @1 :TestGenerics(TestAllTypes, TestAnyPointer).Inner;
+  inner2 @2 :TestGenerics(TestAllTypes, TestAnyPointer).Inner2(Text);
+  unspecified @3 :TestGenerics;
+  unspecifiedInner @4 :TestGenerics.Inner2(Text);
+  wrapper @8 :TestGenericsWrapper(TestAllTypes, TestAnyPointer);
+  cap @18 :TestGenerics(TestInterface, Text);
+
+  genericCap @19 :TestGenerics(TestAllTypes, List(UInt32)).Interface(Data);
+
+  default @5 :TestGenerics(TestAllTypes, Text) =
+      (foo = (int16Field = 123), rev = (foo = "text", rev = (foo = (int16Field = 321))));
+  defaultInner @6 :TestGenerics(TestAllTypes, Text).Inner =
+      (foo = (int16Field = 123), bar = "text");
+  defaultUser @7 :TestUseGenerics = (basic = (foo = (int16Field = 123)));
+  defaultWrapper @9 :TestGenericsWrapper(Text, TestAllTypes) =
+      (value = (foo = "text", rev = (foo = (int16Field = 321))));
+  defaultWrapper2 @10 :TestGenericsWrapper2 =
+      (value = (value = (foo = "text", rev = (foo = (int16Field = 321)))));
+
+  aliasFoo @11 :TestGenerics(TestAllTypes, TestAnyPointer).AliasFoo = (int16Field = 123);
+  aliasInner @12 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner
+      = (foo = (int16Field = 123));
+  aliasInner2 @13 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner2
+      = (innerBound = (foo = (int16Field = 123)));
+  aliasInner2Bind @14 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner2(List(UInt32))
+      = (baz = [12, 34], innerBound = (foo = (int16Field = 123)));
+  aliasInner2Text @15 :TestGenerics(TestAllTypes, TestAnyPointer).AliasInner2Text
+      = (baz = "text", innerBound = (foo = (int16Field = 123)));
+  aliasRev @16 :TestGenerics(TestAnyPointer, Text).AliasRev.AliasFoo = "text";
+
+  useAliases @17 :TestGenerics(TestAllTypes, List(UInt32)).UseAliases = (
+      foo = (int16Field = 123),
+      inner = (foo = (int16Field = 123)),
+      inner2 = (innerBound = (foo = (int16Field = 123))),
+      inner2Bind = (baz = "text", innerBound = (foo = (int16Field = 123))),
+      inner2Text = (baz = "text", innerBound = (foo = (int16Field = 123))));
+}
+
+struct TestEmptyStruct {}
+
+struct TestConstants {
+   const voidConst     :Void = void;
+   const boolConst     :Bool = true;
+   const int8Const     :Int8 = -123;
+   const int16Const    :Int16 = -12345;
+   const int32Const    :Int32 = -12345678;
+   const int64Const    :Int64 = -123456789012345;
+   const uint8Const    :UInt8 = 234;
+   const uint16Const   :UInt16 = 45678;
+   const uint32Const   :UInt32 = 3456789012;
+   const uint64Const   :UInt64 = 12345678901234567890;
+   const float32Const  :Float32 = 1234.5;
+   const float64Const  :Float64 = -123e45;
+   const textConst     :Text    = "foo";
+#   const complexTextConst :Text    = "foo\"☺\'$$$";
+   const dataConst      :Data    = "bar";
+   const structConst    :TestAllTypes = (
+      voidField      = void,
+      boolField      = true,
+      int8Field      = -12,
+      int16Field     = 3456,
+      int32Field     = -78901234,
+      int64Field     = 56789012345678,
+      uInt8Field     = 90,
+      uInt16Field    = 1234,
+      uInt32Field    = 56789012,
+      uInt64Field    = 345678901234567890,
+      float32Field   = -1.25e-10,
+      float64Field   = 345,
+      textField      = "baz",
+      dataField      = "qux",
+      structField    = (
+          textField = "nested",
+          structField = (textField = "really nested")),
+      enumField      = baz,
+      voidList      = [void, void, void],
+      boolList      = [false, true, false, true, true],
+      int8List      = [12, -34, -0x80, 0x7f],
+      int16List     = [1234, -5678, -0x8000, 0x7fff],
+      int32List     = [12345678, -90123456, -0x80000000, 0x7fffffff],
+      int64List     = [123456789012345, -678901234567890, -0x8000000000000000, 0x7fffffffffffffff],
+      uInt8List     = [12, 34, 0, 0xff],
+      uInt16List    = [1234, 5678, 0, 0xffff],
+      uInt32List    = [12345678, 90123456, 0, 0xffffffff],
+      uInt64List    = [123456789012345, 678901234567890, 0, 0xffffffffffffffff],
+      float32List   = [0, 1234567, 1e37, -1e37, 1e-37, -1e-37],
+      float64List   = [0, 123456789012345, 1e306, -1e306, 1e-306, -1e-306],
+      textList      = ["quux", "corge", "grault"],
+      dataList      = ["garply", "waldo", "fred"],
+      structList    = [
+          (textField = "x structlist 1"),
+          (textField = "x structlist 2"),
+          (textField = "x structlist 3")],
+      enumList      = [qux, bar, grault]
+      );
+   const enumConst      :TestEnum = corge;
+   const voidListConst      :List(Void)    = [void, void, void, void, void, void];
+   const boolListConst      :List(Bool)    = [true, false, false, true];
+   const int8ListConst      :List(Int8)    = [111, -111];
+   const int16ListConst     :List(Int16)   = [11111, -11111];
+   const int32ListConst     :List(Int32)   = [111111111, -111111111];
+   const int64ListConst     :List(Int64)   = [1111111111111111111, -1111111111111111111];
+   const uint8ListConst     :List(UInt8)   = [111, 222] ;
+   const uint16ListConst    :List(UInt16)  = [33333, 44444];
+   const uint32ListConst    :List(UInt32)  = [3333333333];
+   const uint64ListConst    :List(UInt64)  = [11111111111111111111];
+   const float32ListConst   :List(Float32) = [5555.5, inf, -inf, nan];
+   const float64ListConst   :List(Float64) = [7777.75, inf, -inf, nan];
+   const textListConst      :List(Text)    = ["plugh", "xyzzy", "thud"];
+   const dataListConst      :List(Data)    = ["oops", "exhausted", "rfc3092"];
+   const structListConst    :List(TestAllTypes) = [
+       (textField = "structlist 1"),
+       (textField = "structlist 2"),
+       (textField = "structlist 3")];
+   const enumListConst      :List(TestEnum) = [foo, garply];
+}
+
+const globalInt :UInt32 = 12345;
+interface TestInterface {
+   foo @0 (i :UInt32, j :Bool) -> (x : Text);
+   bar @1 () -> ();
+   baz @2 (s : TestBigStruct);
+   bazz @3 (s : TestBigStruct) -> (r : TestBigStruct);
+}
+
+interface TestExtends extends(TestInterface) {
+   qux @0 ();
+   corge @1 TestBigStruct -> ();
+   grault @2 () -> TestBigStruct;
+}
+
+struct TestCapabilityList {
+   foo @0 :List(TestInterface);
+}
+
+interface EmptyInterface {}
+
+struct TestKeywords {
+  struct As {}
+  struct Box {}
+  struct Break {}
+  struct Continue {}
+  struct Crate {}
+  struct Else {}
+  struct Enum {}
+  struct Extern {}
+  # ...
+  struct Struct{}
+  struct Super{}
+  struct True{}
+  struct Trait{}
+  struct Type{}
+  struct Unsafe{}
+  struct Use{}
+  struct While{}
+}
+
+struct Issue77 {
+  data :union {
+     a @0 :UInt16;
+     b @1 :UInt8;
+  }
+  text :union {
+    c @2 :Bool;
+    d @3 :Int32;
+  }
+  layout :union {
+    e @4 :Void;
+    f @5 :Void;
+  }
+  structList :union {
+    g @6 :Void;
+    h @7 :Void;
+  }
+  enumList :union {
+    i @8 :Void;
+    j @9 :Void;
+  }
+  primitiveList :union {
+    k @10 :Void;
+    l @11 :Void;
+  }
+  dataList :union {
+    m @12 :Void;
+    n @13 :Void;
+  }
+  textList :union {
+    o @14 :Void;
+    p @15 :Void;
+  }
+  listList :union {
+    q @16 :Void;
+    r @17 :Void;
+  }
+}
+
+struct GenericOnce(Foo) {
+    genericField @0 : Foo;
+}
+
+struct BrandOnce {
+    brandedField @0 : GenericOnce(TestAllTypes);
+}
+
+struct GenericTwice(Foo,Bar) {
+    fooField @0 : Foo;
+    barField @1 : Bar;
+}
+
+struct BrandTwice {
+    bazField @0 : GenericTwice(Text, TestBlob);
+}
+
+struct Map(Key, Value) {
+  entries @0 :List(Entry);
+  struct Entry {
+    key @0 :Key;
+    value @1 :Value;
+  }
+}
+
+interface GenericBase(T) {}
+
+interface GenericExtend extends(GenericBase(Data)) {}

--- a/capnproto/examples/lua-capnproto/enums.capnp
+++ b/capnproto/examples/lua-capnproto/enums.capnp
@@ -1,0 +1,16 @@
+# example taken from https://github.com/cloudflare/lua-capnproto/blob/master/proto/enums.capnp
+
+@0xa7e0ba9e3ca0988d;
+
+using Lua = import "lua.capnp";
+
+enum EnumType2 $Lua.naming("lower_underscore") {
+    none @0;
+    enum5 @1;
+    enum6 @2;
+    enum7 @3;
+    upperDash @4 $Lua.naming("upper_dash");
+    lowerUnderScore @5 $Lua.naming("lower_underscore");
+    upperUnderScore @6 $Lua.naming("upper_underscore");
+    lowerSpace @7 $Lua.naming("lower_space");
+}

--- a/capnproto/examples/lua-capnproto/example.capnp
+++ b/capnproto/examples/lua-capnproto/example.capnp
@@ -1,0 +1,93 @@
+# example taken from https://github.com/cloudflare/lua-capnproto/blob/master/proto/example.capnp
+
+@0xa0d78d3689d48a0b;
+
+using import "enums.capnp".EnumType2;
+using import "struct.capnp".S1;
+using Lua = import "lua.capnp";
+
+const pi :Float32 = 3.14159;
+
+struct T1 {
+    struct T2 {
+        f0 @0 :Float32;
+        f1 @1 :Float64;
+        sd0 @2 :Data;
+    }
+
+    i0 @0 :UInt32;
+    i1 @1 :UInt16;
+    i2 @3 :Int8;
+    b0 @2 :Bool;
+    b1 @4 :Bool;
+    i3 @5 :Int32;
+    s0 @6 :T2;
+    e0 @7 :EnumType1;
+    l0 @8 :List(Int8);
+    t0 @9 :Text;
+    d0 @11 :Data;
+    e1 @10 :EnumType2;
+
+    enum EnumType1 $Lua.naming("lower_underscore") {
+        enum1 @0;
+        enum2 @1;
+        enum3 @2;
+        enum4 @3 $Lua.literal("wEirdENum4");
+        upperDash @4 $Lua.naming("upper_dash");
+    }
+
+    # unnamed union
+    union {
+        ui0 @12 :Int32;
+        ui1 @13 :Int32;
+        uv0 @14 :Void;
+    }
+
+    # group
+    g0 :group {
+        ui2 @15 :UInt32;
+    }
+
+    # named union = unamed union in a group
+    u0 :union {
+        ui3 @16 :UInt16;
+        uv1 @17 :Void;
+        ug0 :group {
+            ugv0 @18 :Void;
+            ugu0 @19 :UInt32;
+        }
+        ut0 @26 :Text;
+    }
+
+    ls0 @20 :List(T2);
+
+    du0 @21 :UInt32 = 65535;
+    db0 @22 :Bool = true;
+    end @23 :Bool; # "end" is lua's reserved word
+    o0  @24 :AnyPointer;
+    lt0 @25 :List(Text);
+    u1 :union {
+        g1 :group {
+            v1 @17 :Void;
+            ui4 @18 :UInt32;
+        }
+        g2 :group {
+            b2 @19 :Bool;
+        }
+    }
+    const welcomeText :Text = "Hello";
+    const constT2 :T2 = (f0 = 12345.67, f1 = 9876.54, sd0 = "\0\1\2\3");
+    u64 @27 :UInt64;
+}
+
+struct T3 {
+    lsU16 @0 :List(UInt16);
+    lsU32 @1 :List(UInt32);
+    lsU64 @2 :List(UInt64);
+    lsI16 @3 :List(Int16);
+    lsI32 @4 :List(Int32);
+    lsI64 @5 :List(Int64);
+}
+
+struct T4 {
+}

--- a/capnproto/examples/lua-capnproto/lua.capnp
+++ b/capnproto/examples/lua-capnproto/lua.capnp
@@ -1,0 +1,9 @@
+# example taken from https://github.com/cloudflare/lua-capnproto/blob/master/proto/lua.capnp
+
+@0xb1ce27b8f28b5e4d;
+
+#naming style
+annotation naming(en2um, enumerant) : Text;
+
+#literal enumerant value
+annotation literal(enumerant) : Text;

--- a/capnproto/examples/lua-capnproto/struct.capnp
+++ b/capnproto/examples/lua-capnproto/struct.capnp
@@ -1,0 +1,11 @@
+# example taken from https://github.com/cloudflare/lua-capnproto/blob/master/proto/struct.capnp
+
+@0x9d3083cc2fcde74b;
+
+struct S1 {
+    const flag1 :UInt32 = 0x1;
+    const flag2 :UInt32 = 0x2;
+    const flag3 :Text = "Hello";
+
+    name @0 :Text;
+}

--- a/capnproto/examples/node-capnp/test.capnp
+++ b/capnproto/examples/node-capnp/test.capnp
@@ -1,0 +1,690 @@
+# example taken from https://github.com/capnproto/node-capnp/blob/node8/src/node-capnp/test.capnp
+
+# Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@0xd508eebdc2dc42b8;
+
+using Cxx = import "/capnp/c++.capnp";
+
+# Use a namespace likely to cause trouble if the generated code doesn't use fully-qualified
+# names for stuff in the capnproto namespace.
+$Cxx.namespace("capnproto_test::capnp::test");
+
+enum TestEnum {
+  foo @0;
+  bar @1;
+  baz @2;
+  qux @3;
+  quux @4;
+  corge @5;
+  grault @6;
+  garply @7;
+}
+
+struct TestAllTypes {
+  voidField      @0  : Void;
+  boolField      @1  : Bool;
+  int8Field      @2  : Int8;
+  int16Field     @3  : Int16;
+  int32Field     @4  : Int32;
+  int64Field     @5  : Int64;
+  uInt8Field     @6  : UInt8;
+  uInt16Field    @7  : UInt16;
+  uInt32Field    @8  : UInt32;
+  uInt64Field    @9  : UInt64;
+  float32Field   @10 : Float32;
+  float64Field   @11 : Float64;
+  textField      @12 : Text;
+  dataField      @13 : Data;
+  structField    @14 : TestAllTypes;
+  enumField      @15 : TestEnum;
+  interfaceField @16 : Void;  # TODO
+
+  voidList      @17 : List(Void);
+  boolList      @18 : List(Bool);
+  int8List      @19 : List(Int8);
+  int16List     @20 : List(Int16);
+  int32List     @21 : List(Int32);
+  int64List     @22 : List(Int64);
+  uInt8List     @23 : List(UInt8);
+  uInt16List    @24 : List(UInt16);
+  uInt32List    @25 : List(UInt32);
+  uInt64List    @26 : List(UInt64);
+  float32List   @27 : List(Float32);
+  float64List   @28 : List(Float64);
+  textList      @29 : List(Text);
+  dataList      @30 : List(Data);
+  structList    @31 : List(TestAllTypes);
+  enumList      @32 : List(TestEnum);
+  interfaceList @33 : List(Void);  # TODO
+}
+
+struct TestDefaults {
+  voidField      @0  : Void    = void;
+  boolField      @1  : Bool    = true;
+  int8Field      @2  : Int8    = -123;
+  int16Field     @3  : Int16   = -12345;
+  int32Field     @4  : Int32   = -12345678;
+  int64Field     @5  : Int64   = -123456789012345;
+  uInt8Field     @6  : UInt8   = 234;
+  uInt16Field    @7  : UInt16  = 45678;
+  uInt32Field    @8  : UInt32  = 3456789012;
+  uInt64Field    @9  : UInt64  = 12345678901234567890;
+  float32Field   @10 : Float32 = 1234.5;
+  float64Field   @11 : Float64 = -123e45;
+  textField      @12 : Text    = "foo";
+  dataField      @13 : Data    = "bar";
+  structField    @14 : TestAllTypes = (
+      voidField      = void,
+      boolField      = true,
+      int8Field      = -12,
+      int16Field     = 3456,
+      int32Field     = -78901234,
+      int64Field     = 56789012345678,
+      uInt8Field     = 90,
+      uInt16Field    = 1234,
+      uInt32Field    = 56789012,
+      uInt64Field    = 345678901234567890,
+      float32Field   = -1.25e-10,
+      float64Field   = 345,
+      textField      = "baz",
+      dataField      = "qux",
+      structField    = (
+          textField = "nested",
+          structField = (textField = "really nested")),
+      enumField      = baz,
+      # interfaceField can't have a default
+
+      voidList      = [void, void, void],
+      boolList      = [false, true, false, true, true],
+      int8List      = [12, -34, -0x80, 0x7f],
+      int16List     = [1234, -5678, -0x8000, 0x7fff],
+      int32List     = [12345678, -90123456, -0x80000000, 0x7fffffff],
+      int64List     = [123456789012345, -678901234567890, -0x8000000000000000, 0x7fffffffffffffff],
+      uInt8List     = [12, 34, 0, 0xff],
+      uInt16List    = [1234, 5678, 0, 0xffff],
+      uInt32List    = [12345678, 90123456, 0, 0xffffffff],
+      uInt64List    = [123456789012345, 678901234567890, 0, 0xffffffffffffffff],
+      float32List   = [0, 1234567, 1e37, -1e37, 1e-37, -1e-37],
+      float64List   = [0, 123456789012345, 1e306, -1e306, 1e-306, -1e-306],
+      textList      = ["quux", "corge", "grault"],
+      dataList      = ["garply", "waldo", "fred"],
+      structList    = [
+          (textField = "x structlist 1"),
+          (textField = "x structlist 2"),
+          (textField = "x structlist 3")],
+      enumList      = [qux, bar, grault]
+      # interfaceList can't have a default
+      );
+  enumField      @15 : TestEnum = corge;
+  interfaceField @16 : Void;  # TODO
+
+  voidList      @17 : List(Void)    = [void, void, void, void, void, void];
+  boolList      @18 : List(Bool)    = [true, false, false, true];
+  int8List      @19 : List(Int8)    = [111, -111];
+  int16List     @20 : List(Int16)   = [11111, -11111];
+  int32List     @21 : List(Int32)   = [111111111, -111111111];
+  int64List     @22 : List(Int64)   = [1111111111111111111, -1111111111111111111];
+  uInt8List     @23 : List(UInt8)   = [111, 222] ;
+  uInt16List    @24 : List(UInt16)  = [33333, 44444];
+  uInt32List    @25 : List(UInt32)  = [3333333333];
+  uInt64List    @26 : List(UInt64)  = [11111111111111111111];
+  float32List   @27 : List(Float32) = [5555.5, inf, -inf, nan];
+  float64List   @28 : List(Float64) = [7777.75, inf, -inf, nan];
+  textList      @29 : List(Text)    = ["plugh", "xyzzy", "thud"];
+  dataList      @30 : List(Data)    = ["oops", "exhausted", "rfc3092"];
+  structList    @31 : List(TestAllTypes) = [
+      (textField = "structlist 1"),
+      (textField = "structlist 2"),
+      (textField = "structlist 3")];
+  enumList      @32 : List(TestEnum) = [foo, garply];
+  interfaceList @33 : List(Void);  # TODO
+}
+
+struct TestAnyPointer {
+  anyPointerField @0 :AnyPointer;
+
+  # Do not add any other fields here!  Some tests rely on anyPointerField being the last pointer
+  # in the struct.
+}
+
+struct TestOutOfOrder {
+  foo @3 :Text;
+  bar @2 :Text;
+  baz @8 :Text;
+  qux @0 :Text;
+  quux @6 :Text;
+  corge @4 :Text;
+  grault @1 :Text;
+  garply @7 :Text;
+  waldo @5 :Text;
+}
+
+struct TestUnion {
+  union0 @0! :union {
+    # Pack union 0 under ideal conditions: there is no unused padding space prior to it.
+    u0f0s0  @4: Void;
+    u0f0s1  @5: Bool;
+    u0f0s8  @6: Int8;
+    u0f0s16 @7: Int16;
+    u0f0s32 @8: Int32;
+    u0f0s64 @9: Int64;
+    u0f0sp  @10: Text;
+
+    # Pack more stuff into union0 -- should go in same space.
+    u0f1s0  @11: Void;
+    u0f1s1  @12: Bool;
+    u0f1s8  @13: Int8;
+    u0f1s16 @14: Int16;
+    u0f1s32 @15: Int32;
+    u0f1s64 @16: Int64;
+    u0f1sp  @17: Text;
+  }
+
+  # Pack one bit in order to make pathological situation for union1.
+  bit0 @18: Bool;
+
+  union1 @1! :union {
+    # Pack pathologically bad case.  Each field takes up new space.
+    u1f0s0  @19: Void;
+    u1f0s1  @20: Bool;
+    u1f1s1  @21: Bool;
+    u1f0s8  @22: Int8;
+    u1f1s8  @23: Int8;
+    u1f0s16 @24: Int16;
+    u1f1s16 @25: Int16;
+    u1f0s32 @26: Int32;
+    u1f1s32 @27: Int32;
+    u1f0s64 @28: Int64;
+    u1f1s64 @29: Int64;
+    u1f0sp  @30: Text;
+    u1f1sp  @31: Text;
+
+    # Pack more stuff into union1 -- each should go into the same space as corresponding u1f0s*.
+    u1f2s0  @32: Void;
+    u1f2s1  @33: Bool;
+    u1f2s8  @34: Int8;
+    u1f2s16 @35: Int16;
+    u1f2s32 @36: Int32;
+    u1f2s64 @37: Int64;
+    u1f2sp  @38: Text;
+  }
+
+  # Fill in the rest of that bitfield from earlier.
+  bit2 @39: Bool;
+  bit3 @40: Bool;
+  bit4 @41: Bool;
+  bit5 @42: Bool;
+  bit6 @43: Bool;
+  bit7 @44: Bool;
+
+  # Interleave two unions to be really annoying.
+  # Also declare in reverse order to make sure union discriminant values are sorted by field number
+  # and not by declaration order.
+  union2 @2! :union {
+    u2f0s64 @54: Int64;
+    u2f0s32 @52: Int32;
+    u2f0s16 @50: Int16;
+    u2f0s8 @47: Int8;
+    u2f0s1 @45: Bool;
+  }
+
+  union3 @3! :union {
+    u3f0s64 @55: Int64;
+    u3f0s32 @53: Int32;
+    u3f0s16 @51: Int16;
+    u3f0s8 @48: Int8;
+    u3f0s1 @46: Bool;
+  }
+
+  byte0 @49: UInt8;
+}
+
+struct TestUnnamedUnion {
+  before @0 :Text;
+
+  union {
+    foo @1 :UInt16;
+    bar @3 :UInt32;
+  }
+
+  middle @2 :UInt16;
+
+  after @4 :Text;
+}
+
+struct TestUnionInUnion {
+  # There is no reason to ever do this.
+  outer :union {
+    inner :union {
+      foo @0 :Int32;
+      bar @1 :Int32;
+    }
+    baz @2 :Int32;
+  }
+}
+
+struct TestGroups {
+  groups :union {
+    foo :group {
+      corge @0 :Int32;
+      grault @2 :Int64;
+      garply @8 :Text;
+    }
+    bar :group {
+      corge @3 :Int32;
+      grault @4 :Text;
+      garply @5 :Int64;
+    }
+    baz :group {
+      corge @1 :Int32;
+      grault @6 :Text;
+      garply @7 :Text;
+    }
+  }
+}
+
+struct TestInterleavedGroups {
+  group1 :group {
+    foo @0 :UInt32;
+    bar @2 :UInt64;
+    union {
+      qux @4 :UInt16;
+      corge :group {
+        grault @6 :UInt64;
+        garply @8 :UInt16;
+        plugh @14 :Text;
+        xyzzy @16 :Text;
+      }
+
+      fred @12 :Text;
+    }
+
+    waldo @10 :Text;
+  }
+
+  group2 :group {
+    foo @1 :UInt32;
+    bar @3 :UInt64;
+    union {
+      qux @5 :UInt16;
+      corge :group {
+        grault @7 :UInt64;
+        garply @9 :UInt16;
+        plugh @15 :Text;
+        xyzzy @17 :Text;
+      }
+
+      fred @13 :Text;
+    }
+
+    waldo @11 :Text;
+  }
+}
+
+struct TestUnionDefaults {
+  s16s8s64s8Set @0 :TestUnion =
+      (union0 = (u0f0s16 = 321), union1 = (u1f0s8 = 123), union2 = (u2f0s64 = 12345678901234567),
+       union3 = (u3f0s8 = 55));
+  s0sps1s32Set @1 :TestUnion =
+      (union0 = (u0f1s0 = void), union1 = (u1f0sp = "foo"), union2 = (u2f0s1 = true),
+       union3 = (u3f0s32 = 12345678));
+
+  unnamed1 @2 :TestUnnamedUnion = (foo = 123);
+  unnamed2 @3 :TestUnnamedUnion = (bar = 321, before = "foo", after = "bar");
+}
+
+struct TestNestedTypes {
+  enum NestedEnum {
+    foo @0;
+    bar @1;
+  }
+
+  struct NestedStruct {
+    enum NestedEnum {
+      baz @0;
+      qux @1;
+      quux @2;
+    }
+
+    outerNestedEnum @0 :TestNestedTypes.NestedEnum = bar;
+    innerNestedEnum @1 :NestedEnum = quux;
+  }
+
+  nestedStruct @0 :NestedStruct;
+
+  outerNestedEnum @1 :NestedEnum = bar;
+  innerNestedEnum @2 :NestedStruct.NestedEnum = quux;
+}
+
+struct TestUsing {
+  using OuterNestedEnum = TestNestedTypes.NestedEnum;
+  using TestNestedTypes.NestedStruct.NestedEnum;
+
+  outerNestedEnum @1 :OuterNestedEnum = bar;
+  innerNestedEnum @0 :NestedEnum = quux;
+}
+
+struct TestLists {
+  # Small structs, when encoded as list, will be encoded as primitive lists rather than struct
+  # lists, to save space.
+  struct Struct0  { f @0 :Void; }
+  struct Struct1  { f @0 :Bool; }
+  struct Struct8  { f @0 :UInt8; }
+  struct Struct16 { f @0 :UInt16; }
+  struct Struct32 { f @0 :UInt32; }
+  struct Struct64 { f @0 :UInt64; }
+  struct StructP  { f @0 :Text; }
+
+  # Versions of the above which cannot be encoded as primitive lists.
+  struct Struct0c  { f @0 :Void; pad @1 :Text; }
+  struct Struct1c  { f @0 :Bool; pad @1 :Text; }
+  struct Struct8c  { f @0 :UInt8; pad @1 :Text; }
+  struct Struct16c { f @0 :UInt16; pad @1 :Text; }
+  struct Struct32c { f @0 :UInt32; pad @1 :Text; }
+  struct Struct64c { f @0 :UInt64; pad @1 :Text; }
+  struct StructPc  { f @0 :Text; pad @1 :UInt64; }
+
+  list0  @0 :List(Struct0);
+  list1  @1 :List(Struct1);
+  list8  @2 :List(Struct8);
+  list16 @3 :List(Struct16);
+  list32 @4 :List(Struct32);
+  list64 @5 :List(Struct64);
+  listP  @6 :List(StructP);
+
+  int32ListList @7 :List(List(Int32));
+  textListList @8 :List(List(Text));
+  structListList @9 :List(List(TestAllTypes));
+}
+
+struct TestFieldZeroIsBit {
+  bit @0 :Bool;
+  secondBit @1 :Bool = true;
+  thirdField @2 :UInt8 = 123;
+}
+
+struct TestListDefaults {
+  lists @0 :TestLists = (
+      list0  = [(f = void), (f = void)],
+      list1  = [(f = true), (f = false), (f = true), (f = true)],
+      list8  = [(f = 123), (f = 45)],
+      list16 = [(f = 12345), (f = 6789)],
+      list32 = [(f = 123456789), (f = 234567890)],
+      list64 = [(f = 1234567890123456), (f = 2345678901234567)],
+      listP  = [(f = "foo"), (f = "bar")],
+      int32ListList = [[1, 2, 3], [4, 5], [12341234]],
+      textListList = [["foo", "bar"], ["baz"], ["qux", "corge"]],
+      structListList = [[(int32Field = 123), (int32Field = 456)], [(int32Field = 789)]]);
+}
+
+struct TestLateUnion {
+  # Test what happens if the unions are not the first ordinals in the struct.  At one point this
+  # was broken for the dynamic API.
+
+  foo @0 :Int32;
+  bar @1 :Text;
+  baz @2 :Int16;
+
+  theUnion @3! :union {
+    qux @4 :Text;
+    corge @5 :List(Int32);
+    grault @6 :Float32;
+  }
+
+  anotherUnion @7! :union {
+    qux @8 :Text;
+    corge @9 :List(Int32);
+    grault @10 :Float32;
+  }
+}
+
+struct TestOldVersion {
+  # A subset of TestNewVersion.
+  old1 @0 :Int64;
+  old2 @1 :Text;
+  old3 @2 :TestOldVersion;
+}
+
+struct TestNewVersion {
+  # A superset of TestOldVersion.
+  old1 @0 :Int64;
+  old2 @1 :Text;
+  old3 @2 :TestNewVersion;
+  new1 @3 :Int64 = 987;
+  new2 @4 :Text = "baz";
+}
+
+struct TestStructUnion {
+  un @0! :union {
+    str2uct @1 :SomeStruct;
+    object  @2 :TestAnyPointer;
+  }
+
+  struct SomeStruct {
+    someText @0 :Text;
+    moreText @1 :Text;
+  }
+}
+
+struct TestPrintInlineStructs {
+  someText @0 :Text;
+
+  structList @1 :List(InlineStruct);
+  struct InlineStruct {
+    int32Field @0 :Int32;
+    textField @1 :Text;
+  }
+}
+
+struct TestEmptyStruct {}
+
+struct TestConstants {
+  const voidConst      :Void    = void;
+  const boolConst      :Bool    = true;
+  const int8Const      :Int8    = -123;
+  const int16Const     :Int16   = -12345;
+  const int32Const     :Int32   = -12345678;
+  const int64Const     :Int64   = -123456789012345;
+  const uint8Const     :UInt8   = 234;
+  const uint16Const    :UInt16  = 45678;
+  const uint32Const    :UInt32  = 3456789012;
+  const uint64Const    :UInt64  = 12345678901234567890;
+  const float32Const   :Float32 = 1234.5;
+  const float64Const   :Float64 = -123e45;
+  const textConst      :Text    = "foo";
+  const dataConst      :Data    = "bar";
+  const structConst    :TestAllTypes = (
+      voidField      = void,
+      boolField      = true,
+      int8Field      = -12,
+      int16Field     = 3456,
+      int32Field     = -78901234,
+      int64Field     = 56789012345678,
+      uInt8Field     = 90,
+      uInt16Field    = 1234,
+      uInt32Field    = 56789012,
+      uInt64Field    = 345678901234567890,
+      float32Field   = -1.25e-10,
+      float64Field   = 345,
+      textField      = "baz",
+      dataField      = "qux",
+      structField    = (
+          textField = "nested",
+          structField = (textField = "really nested")),
+      enumField      = baz,
+      # interfaceField can't have a default
+ 
+      voidList      = [void, void, void],
+      boolList      = [false, true, false, true, true],
+      int8List      = [12, -34, -0x80, 0x7f],
+      int16List     = [1234, -5678, -0x8000, 0x7fff],
+      int32List     = [12345678, -90123456, -0x80000000, 0x7fffffff],
+      int64List     = [123456789012345, -678901234567890, -0x8000000000000000, 0x7fffffffffffffff],
+      uInt8List     = [12, 34, 0, 0xff],
+      uInt16List    = [1234, 5678, 0, 0xffff],
+      uInt32List    = [12345678, 90123456, 0, 0xffffffff],
+      uInt64List    = [123456789012345, 678901234567890, 0, 0xffffffffffffffff],
+      float32List   = [0, 1234567, 1e37, -1e37, 1e-37, -1e-37],
+      float64List   = [0, 123456789012345, 1e306, -1e306, 1e-306, -1e-306],
+      textList      = ["quux", "corge", "grault"],
+      dataList      = ["garply", "waldo", "fred"],
+      structList    = [
+          (textField = "x structlist 1"),
+          (textField = "x structlist 2"),
+          (textField = "x structlist 3")],
+      enumList      = [qux, bar, grault]
+      # interfaceList can't have a default
+      );
+  const enumConst      :TestEnum = corge;
+
+  const voidListConst      :List(Void)    = [void, void, void, void, void, void];
+  const boolListConst      :List(Bool)    = [true, false, false, true];
+  const int8ListConst      :List(Int8)    = [111, -111];
+  const int16ListConst     :List(Int16)   = [11111, -11111];
+  const int32ListConst     :List(Int32)   = [111111111, -111111111];
+  const int64ListConst     :List(Int64)   = [1111111111111111111, -1111111111111111111];
+  const uint8ListConst     :List(UInt8)   = [111, 222] ;
+  const uint16ListConst    :List(UInt16)  = [33333, 44444];
+  const uint32ListConst    :List(UInt32)  = [3333333333];
+  const uint64ListConst    :List(UInt64)  = [11111111111111111111];
+  const float32ListConst   :List(Float32) = [5555.5, inf, -inf, nan];
+  const float64ListConst   :List(Float64) = [7777.75, inf, -inf, nan];
+  const textListConst      :List(Text)    = ["plugh", "xyzzy", "thud"];
+  const dataListConst      :List(Data)    = ["oops", "exhausted", "rfc3092"];
+  const structListConst    :List(TestAllTypes) = [
+      (textField = "structlist 1"),
+      (textField = "structlist 2"),
+      (textField = "structlist 3")];
+  const enumListConst      :List(TestEnum) = [foo, garply];
+}
+
+const globalInt :UInt32 = 12345;
+const globalText :Text = "foobar";
+const globalStruct :TestAllTypes = (int32Field = 54321);
+const globalPrintableStruct :TestPrintInlineStructs = (someText = "foo");
+const derivedConstant :TestAllTypes = (
+    uInt32Field = .globalInt,
+    textField = TestConstants.textConst,
+    structField = TestConstants.structConst,
+    int16List = TestConstants.int16ListConst,
+    structList = TestConstants.structListConst);
+
+interface TestInterface {
+  foo @0 (i :UInt32, j :Bool) -> (x :Text);
+  bar @1 () -> ();
+  baz @2 (s: TestAllTypes);
+}
+
+interface TestExtends extends(TestInterface) {
+  qux @0 ();
+  corge @1 TestAllTypes -> ();
+  grault @2 () -> TestAllTypes;
+}
+
+interface TestPipeline {
+  getCap @0 (n: UInt32, inCap :TestInterface) -> (s: Text, outBox :Box);
+  testPointers @1 (cap :TestInterface, obj :AnyPointer, list :List(TestInterface)) -> ();
+
+  struct Box {
+    cap @0 :TestInterface;
+  }
+}
+
+interface TestCallOrder {
+  getCallSequence @0 (expected: UInt32) -> (n: UInt32);
+  # First call returns 0, next returns 1, ...
+  #
+  # The input `expected` is ignored but useful for disambiguating debug logs.
+}
+
+interface TestTailCallee {
+  struct TailResult {
+    i @0 :UInt32;
+    t @1 :Text;
+    c @2 :TestCallOrder;
+  }
+
+  foo @0 (i :Int32, t :Text) -> TailResult;
+}
+
+interface TestTailCaller {
+  foo @0 (i :Int32, callee :TestTailCallee) -> TestTailCallee.TailResult;
+}
+
+interface TestMoreStuff extends(TestCallOrder) {
+  # Catch-all type that contains lots of testing methods.
+
+  callFoo @0 (cap :TestInterface) -> (s: Text);
+  # Call `cap.foo()`, check the result, and return "bar".
+
+  callFooWhenResolved @1 (cap :TestInterface) -> (s: Text);
+  # Like callFoo but waits for `cap` to resolve first.
+
+  neverReturn @2 (cap :TestInterface) -> (capCopy :TestInterface);
+  # Doesn't return.  You should cancel it.
+
+  hold @3 (cap :TestInterface) -> ();
+  # Returns immediately but holds on to the capability.
+
+  callHeld @4 () -> (s: Text);
+  # Calls the capability previously held using `hold` (and keeps holding it).
+
+  getHeld @5 () -> (cap :TestInterface);
+  # Returns the capability previously held using `hold` (and keeps holding it).
+
+  echo @6 (cap :TestCallOrder) -> (cap :TestCallOrder);
+  # Just returns the input cap.
+
+  expectCancel @7 (cap :TestInterface) -> ();
+  # evalLater()-loops forever, holding `cap`.  Must be canceled.
+
+  methodWithDefaults @8 (a :Text, b :UInt32 = 123, c :Text = "foo") -> (d :Text, e :Text = "bar");
+}
+
+interface TestKeywordMethods {
+  delete @0 ();
+  class @1 ();
+  vo2id @2 ();
+  return @3 ();
+}
+
+struct TestSturdyRefHostId {
+  host @0 :Text;
+}
+
+struct TestSturdyRefObjectId {
+  tag @0 :Tag;
+  enum Tag {
+    testInterface @0;
+    testExtends @1;
+    testPipeline @2;
+    testTailCallee @3;
+    testTailCaller @4;
+    testMoreStuff @5;
+  }
+}
+
+struct TestProvisionId {}
+struct TestRecipientId {}
+struct TestThirdPartyCapId {}
+struct TestJoinResult {}

--- a/capnproto/pom.xml
+++ b/capnproto/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>capnproto</artifactId>
+	<packaging>jar</packaging>
+	<name>Cap'n Proto schema language grammar</name>
+	<parent>
+		<groupId>com.antlr.grammarsv4</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<grammars>CapnProto.g4</grammars>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>true</verbose>
+					<showTree>true</showTree>
+					<entryPoint>document</entryPoint>
+					<grammarName>CapnProto</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flatbuffers/FlatBuffers.g4
+++ b/flatbuffers/FlatBuffers.g4
@@ -1,0 +1,75 @@
+
+grammar FlatBuffers ;
+
+// Parser rules
+
+schema : include* ( namespace_decl | type_decl | enum_decl | root_decl | file_extension_decl | file_identifier_decl | attribute_decl | rpc_decl | object )* ;
+
+include : 'include' STRING_CONSTANT ';' ;
+
+namespace_decl : 'namespace' IDENT ( '.' IDENT )* ';' ;
+
+attribute_decl : 'attribute' STRING_CONSTANT ';' ;
+
+type_decl : ( 'table' | 'struct' ) IDENT metadata '{' ( field_decl )* '}' ;
+
+enum_decl : ( 'enum' IDENT ( ':' type )? | 'union' IDENT ) metadata '{' commasep_enumval_decl '}' ;
+
+root_decl : 'root_type' IDENT ';' ;
+
+field_decl : IDENT ':' type ( '=' scalar )? metadata ';' ;
+
+rpc_decl : 'rpc_service' IDENT '{' rpc_method+ '}' ;
+
+rpc_method : IDENT '(' IDENT ')' ':' IDENT metadata ';' ;
+
+// fixed original grammar: allow namespaces for IDENTs
+type : '[' type ']' | BASE_TYPE_NAME | ns_ident ;
+
+enumval_decl : ns_ident ( '=' INTEGER_CONSTANT )? ;
+
+commasep_enumval_decl : enumval_decl ( ',' enumval_decl )* ','? ;
+
+ident_with_opt_single_value : IDENT ( ':' single_value )? ;
+
+commasep_ident_with_opt_single_value : ident_with_opt_single_value ( ',' ident_with_opt_single_value )* ;
+
+metadata : ( '(' commasep_ident_with_opt_single_value ')' )? ;
+
+// fix original grammar: enum values (IDENT) are allowed as well
+scalar : INTEGER_CONSTANT | FLOAT_CONSTANT | IDENT ;
+
+object : '{' commasep_ident_with_value '}' ;
+
+ident_with_value : IDENT ':' value ;
+
+commasep_ident_with_value : ident_with_value ( ',' ident_with_value )* ','? ;
+
+single_value : scalar | STRING_CONSTANT ;
+
+value : single_value | object | '[' commasep_value ']' ;
+
+commasep_value : value( ',' value )* ','? ;
+
+file_extension_decl : 'file_extension' STRING_CONSTANT ;
+
+file_identifier_decl : 'file_identifier' STRING_CONSTANT ;
+
+ns_ident : IDENT ( '.' IDENT )* ;
+
+// Lexer rules
+
+STRING_CONSTANT : '"' ~["\r\n]* '"' ;
+
+BASE_TYPE_NAME : 'bool' | 'byte' | 'ubyte' | 'short' | 'ushort' | 'int' | 'uint' | 'float' | 'long' | 'ulong' | 'double' | 'int8' | 'uint8' | 'int16' | 'uint16' | 'int32' | 'uint32' | 'int64' | 'uint64' | 'float32' | 'float64' | 'string' ;
+
+IDENT : [a-zA-Z_] [a-zA-Z0-9_]* ;
+
+INTEGER_CONSTANT : '-'? [0-9]+ | 'true' | 'false' ;
+
+FLOAT_CONSTANT : '-'? [0-9]+ '.' [0-9]+ (('e'|'E') ('+'|'-')? [0-9]+ )? ;
+
+// fixed original grammar: allow line comments
+COMMENT : '//' ~[\r\n]* -> channel(HIDDEN);
+
+WHITESPACE : [ \t\r\n] -> skip ;

--- a/flatbuffers/README.md
+++ b/flatbuffers/README.md
@@ -1,0 +1,1 @@
+ANTLR v4 grammar for the FlatBuffers schema language: https://google.github.io/flatbuffers/flatbuffers_grammar.html

--- a/flatbuffers/examples/flatbench.fbs
+++ b/flatbuffers/examples/flatbench.fbs
@@ -1,0 +1,37 @@
+// trying to represent a typical mix of datatypes:
+// 1 array of 3 elements, each element: 1 string, 3 nested objects, 9 scalars
+// root element has the array, additional string and an enum
+
+namespace benchfb;
+
+enum Enum : short { Apples, Pears, Bananas }
+
+struct Foo {
+  id:ulong;
+  count:short;
+  prefix:byte;
+  length:uint;
+}
+
+struct Bar {
+  parent:Foo;
+  time:int;
+  ratio:float;
+  size:ushort;
+}
+
+table FooBar {
+  sibling:Bar;
+  name:string;
+  rating:double;
+  postfix:ubyte;
+}
+
+table FooBarContainer {
+  list:[FooBar];  // 3 copies of the above
+  initialized:bool;
+  fruit:Enum;
+  location:string;
+}
+
+root_type FooBarContainer;

--- a/flatbuffers/examples/greeter.fbs
+++ b/flatbuffers/examples/greeter.fbs
@@ -1,0 +1,17 @@
+table HelloReply {
+  message:string;
+}
+
+table HelloRequest {
+  name:string;
+}
+
+table ManyHellosRequest {
+  name:string;
+  num_greetings:int;
+}
+
+rpc_service Greeter {
+  SayHello(HelloRequest):HelloReply;
+  SayManyHellos(ManyHellosRequest):HelloReply (streaming: "server");
+}

--- a/flatbuffers/examples/monster.fbs
+++ b/flatbuffers/examples/monster.fbs
@@ -1,0 +1,32 @@
+// Example IDL file for our monster's schema.
+
+namespace MyGame.Sample;
+
+enum Color:byte { Red = 0, Green, Blue = 2 }
+
+union Equipment { Weapon } // Optionally add more tables.
+
+struct Vec3 {
+  x:float;
+  y:float;
+  z:float;
+}
+
+table Monster {
+  pos:Vec3;
+  mana:short = 150;
+  hp:short = 100;
+  name:string;
+  friendly:bool = false (deprecated);
+  inventory:[ubyte];
+  color:Color = Blue;
+  weapons:[Weapon];
+  equipped:Equipment;
+}
+
+table Weapon {
+  name:string;
+  damage:short;
+}
+
+root_type Monster;

--- a/flatbuffers/examples/monster2.fbs
+++ b/flatbuffers/examples/monster2.fbs
@@ -1,0 +1,80 @@
+// test schema file
+
+include "include_test1.fbs";
+
+namespace MyGame.Example2;
+
+table Monster {}  // Test having same name as below, but in different namespace.
+
+namespace MyGame.Example;
+
+attribute "priority";
+
+enum Color:byte (bit_flags) { Red = 0, Green, Blue = 3 }
+
+union Any { Monster, TestSimpleTableWithEnum, MyGame.Example2.Monster }
+
+struct Test { a:short; b:byte; }
+
+table TestSimpleTableWithEnum (csharp_partial) {
+  color: Color = Green;
+}
+
+struct Vec3 (force_align: 16) {
+  x:float;
+  y:float;
+  z:float;
+  test1:double;
+  test2:Color;
+  test3:Test;
+}
+
+table Stat {
+  id:string;
+  val:long;
+  count:ushort;
+}
+
+/// an example documentation comment: monster object
+table Monster {
+  pos:Vec3 (id: 0);
+  hp:short = 100 (id: 2);
+  mana:short = 150 (id: 1);
+  name:string (id: 3, required, key);
+  color:Color = Blue (id: 6);
+  inventory:[ubyte] (id: 5);
+  friendly:bool = false (deprecated, priority: 1, id: 4);
+  /// an example documentation comment: this will end up in the generated code
+  /// multiline too
+  testarrayoftables:[Monster] (id: 11);
+  testarrayofstring:[string] (id: 10);
+  testarrayofstring2:[string] (id: 28);
+  testarrayofbools:[bool] (id: 24);
+  enemy:MyGame.Example.Monster (id:12);  // Test referring by full namespace.
+  test:Any (id: 8);
+  test4:[Test] (id: 9);
+  testnestedflatbuffer:[ubyte] (id:13, nested_flatbuffer: "Monster");
+  testempty:Stat (id:14);
+  testbool:bool (id:15);
+  testhashs32_fnv1:int (id:16, hash:"fnv1_32");
+  testhashu32_fnv1:uint (id:17, hash:"fnv1_32");
+  testhashs64_fnv1:long (id:18, hash:"fnv1_64");
+  testhashu64_fnv1:ulong (id:19, hash:"fnv1_64");
+  testhashs32_fnv1a:int (id:20, hash:"fnv1a_32");
+  testhashu32_fnv1a:uint (id:21, hash:"fnv1a_32", cpp_type:"Stat");
+  testhashs64_fnv1a:long (id:22, hash:"fnv1a_64");
+  testhashu64_fnv1a:ulong (id:23, hash:"fnv1a_64");
+  testf:float = 3.14159 (id:25);
+  testf2:float = 3 (id:26);
+  testf3:float (id:27);
+}
+
+rpc_service MonsterStorage {
+  Store(Monster):Stat (streaming: "none");
+  Retrieve(Stat):Monster (streaming: "server", idempotent);
+}
+
+root_type Monster;
+
+file_identifier "MONS";
+file_extension "mon";

--- a/flatbuffers/examples/namespace_test1.fbs
+++ b/flatbuffers/examples/namespace_test1.fbs
@@ -1,0 +1,17 @@
+namespace NamespaceA.NamespaceB;
+
+table TableInNestedNS
+{
+    foo:int;
+}
+
+enum EnumInNestedNS:byte
+{
+	A, B, C
+}
+
+struct StructInNestedNS
+{
+    a:int;
+	b:int;
+}

--- a/flatbuffers/examples/namespace_test2.fbs
+++ b/flatbuffers/examples/namespace_test2.fbs
@@ -1,0 +1,24 @@
+include "namespace_test1.fbs";
+
+namespace NamespaceA;
+
+table TableInFirstNS
+{
+    foo_table:NamespaceB.TableInNestedNS;
+	foo_enum:NamespaceB.EnumInNestedNS;
+	foo_struct:NamespaceB.StructInNestedNS;
+}
+
+// Test switching namespaces inside a file.
+namespace NamespaceC;
+
+table TableInC {
+    refer_to_a1:NamespaceA.TableInFirstNS;
+    refer_to_a2:NamespaceA.SecondTableInA;
+}
+
+namespace NamespaceA;
+
+table SecondTableInA {
+    refer_to_c:NamespaceC.TableInC;
+}

--- a/flatbuffers/examples/resultinfo.fbs
+++ b/flatbuffers/examples/resultinfo.fbs
@@ -1,0 +1,21 @@
+namespace flatbuffer;
+
+table FResultInfo{
+    code : int;
+    data : FDebrisInfo;
+}
+
+table FDebrisInfo{
+    debrisList:[FDebris];
+    debrisHelp:string;
+
+}
+table FDebris{
+    image:string;
+    changeNum:int;
+    id:long;
+    name:string;
+    highlight:bool;
+}
+
+root_type FResultInfo;

--- a/flatbuffers/examples/saveschema.fbs
+++ b/flatbuffers/examples/saveschema.fbs
@@ -1,0 +1,36 @@
+// example save file
+
+namespace CompanyNamespaceWhatever;
+
+enum Color : byte { Red = 1, Green, Blue }
+
+union WeaponClassesOrWhatever { Sword, Gun }
+
+struct Vec3 {
+  x:float;
+  y:float;
+  z:float;
+}
+
+table GameDataWhatever {
+  pos:Vec3;
+  mana:short = 150;
+  hp:short = 100;
+  name:string;
+  inventory:[ubyte];
+  color:Color = Blue;
+  weapon:WeaponClassesOrWhatever;
+}
+
+table Sword {
+  damage:int = 10;
+  distance:short = 5;
+}
+
+table Gun {
+  damage:int = 500;
+  reloadspeed:short = 2;
+}
+
+root_type GameDataWhatever;
+file_identifier "WHAT";

--- a/flatbuffers/examples/zooshi/assets.fbs
+++ b/flatbuffers/examples/zooshi/assets.fbs
@@ -1,0 +1,42 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "anim_table.fbs";
+
+namespace fpl.zooshi;
+
+table ShaderDef {
+  alias:string;
+  source:string;
+  defines:[string];
+}
+
+// List of paths to all the assets we care about:
+table AssetManifest {
+  loading_material:string;
+  fader_material:string;
+  mesh_list:[string];
+  material_list:[string];
+  shader_list:[ShaderDef];
+  anims:motive.AnimTableFb;
+  font_list:[string];
+  license_file:string;
+  about_file:string;
+  sound_bank:string;
+}
+
+root_type AssetManifest;
+file_identifier "ASSE";
+file_extension "zooassets";
+

--- a/flatbuffers/examples/zooshi/attributes.fbs
+++ b/flatbuffers/examples/zooshi/attributes.fbs
@@ -1,0 +1,28 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace fpl.zooshi;
+
+enum AttributeDef : byte {
+  ProjectilesFired,
+  PatronsFed,
+  PatronsHit,
+  TargetScore,
+  TargetScoreIncrease,
+  LastLapScore,
+  LastLapNumber,
+  Size,
+  Unspecified
+}
+

--- a/flatbuffers/examples/zooshi/components.fbs
+++ b/flatbuffers/examples/zooshi/components.fbs
@@ -1,0 +1,343 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "attributes.fbs";
+include "bullet_def.fbs";
+include "common.fbs";
+include "library_components.fbs";
+include "editor_components.fbs";
+include "motive.fbs";
+include "unlockables.fbs";
+
+namespace fpl;
+
+table TimeLimitDef {
+  timelimit:float;
+}
+
+table RailDenizenDef {
+  start_time:float;
+  initial_playback_rate:float;
+  rail_name:string;
+  rail_offset:fplbase.Vec3; // Additional offset from the rail position
+  rail_orientation:fplbase.Vec3; // Rotation to apply to the rail
+  rail_scale:fplbase.Vec3; // Scale to apply to the rail
+  // Rate of convergence towards the target orientation.
+  // 0 = no convergence otherwise the time to converge in seconds is roughly
+  // 1 / log(0.5 + convergence_rate) (i.e 1 = 4s, 2 = 2s, 3 = 1.2s, ...)
+  orientation_convergence_rate:float = 0;
+  update_orientation:bool = true;
+  inherit_transform_data:bool = false;
+  enabled:bool = true;
+  // Percentage of when a lap ends. Values outside of (0,1] are treated as 1.
+  lap_end:float = 1.0;
+}
+
+table MotivatorObjectDef {
+  data:motive.OvershootParameters;
+}
+
+table SoundDef {
+  sound:string;
+}
+
+enum AnimObject : byte {
+  HungryHippo,
+  DapperCroc,
+  LadyMandrill,
+  LovelyGiraffette,
+  BankerBird,
+  FernShort,
+  FernMid,
+  FernTall,
+  Heart,
+  Scenery,
+  Gate,
+}
+
+enum PatronAction : byte {
+  GetUp,
+  Idle,
+  Eat,
+  Satisfied,
+  Fall,
+}
+
+enum ShaderIndex : ubyte {
+  Lit,
+  Depth,
+  Count
+}
+
+table SimpleMovementDef {
+  velocity:fplbase.Vec3;
+}
+
+table PatronEvent {
+  // Animation to play.
+  action:PatronAction;
+
+  // Time to start event.
+  // -1 means start as soon as previous event completes.
+  time:int = -1;
+}
+
+// Precondition: start_time < end_time.
+// When time <= start_time, return start_value.
+// When time >= end_time, return end_value.
+// else return Lerp(start_value, end_value,
+//                  (time - start_time) / (end_time - start_time))
+table InterpolantsDef {
+  start_time:float;
+  end_time:float;
+  start_value:float;
+  end_value:float;
+}
+
+table PatronDef {
+  // The type of patron being animated.
+  anim_object:AnimObject;
+
+  // Each time the raft makes a lap around the river, it's lap counter is
+  // incremented.  Patrons will only stand up when the lap counter is in the
+  // range [min_lap, max_lap].
+  min_lap:float = -1.0;
+  max_lap:float = -1.0;
+
+  // Time the patron is willing to wait while being ignored (i.e. not passed
+  // a sushi that comes close enough to chase after).
+  // In InterpolantsDef, x is lap. y is time, in seconds.
+  patience:InterpolantsDef;
+
+  // Sequence of animations to play when StartEvent() is called.
+  events:[PatronEvent];
+
+  // If the raft is within the pop in radius, this patron will stand up.
+  // In InterpolantsDef, x is lap. y is distance, in game units.
+  pop_in_radius:InterpolantsDef;
+
+  // If the raft is outside the pop out radius, this patron will fall down.
+  pop_out_radius:float;
+
+  // The tag of the physics body that needs to be hit to trigger a fall.
+  // An empty name uses all bodies.
+  target_tag:string;
+
+  // The maximum distance the patron will move when trying to catch sushi.
+  max_catch_distance:float = 5.0;
+
+  // The maximum distance the patron will move when trying to catch sushi.
+  max_catch_distance_for_search:float = 12.0;
+
+  // The maximum angle off of the vector to the raft that the patron with turn
+  // to face when trying to catch sushi. Note that 180 fully encompasses it.
+  max_catch_angle:float = 90.0;
+
+  // When looking at sushi to catch, consider the sushi's trajectory over
+  // this time range. In seconds.
+  min_catch_time_for_search:float = 0.01;
+  max_catch_time_for_search:float = 2.5;
+
+  // When actually moving to catch a sushi, make sure you get to the target
+  // position within this time. Ensures we don't react too quickly or slowly.
+  // Better to smoothly move to a close position in 200ms than to jerk to it
+  // in 10ms (we'll probably catch the sushi either way since our hit region
+  // is large). Likewise, better to move to the target position in 2.5s and
+  // wait, than to take 5s to move there and look like we're not responding.
+  // In seconds.
+  min_catch_time:float = 0.2;
+  max_catch_time:float = 2.5;
+
+  // Average speed at which to travel towards the sushi catch position.
+  min_catch_speed:float = 1.0;
+  max_catch_speed:float = 5.0;
+
+  // When moving towards a sushi, wait this amount of time before adjusting
+  // the search for another sushi.
+  time_between_catch_searches:float = 0.3;
+
+  // Time to return to the last idle position, after we're done trying to
+  // catch sushi.
+  return_time:float = 1.0;
+
+  // Time to accelerate onto the rails, if the patron is traveling along rails.
+  rail_accelerate_time:float = 0.5;
+
+  // The height above the patron at which to spawn the happy-indicator.
+  point_display_height:float = 10.0;
+
+  // The angle beyond which the patron should turn to face the raft, in degrees.
+  // This is the maximum we allow the patron to face away from the raft.
+  max_face_angle_away_from_raft:float = 90.0;
+
+  // The time to take turning to face the raft, in seconds.
+  time_to_face_raft:float = 0.2;
+
+  // After being ignored for a while, the patron will get exasperated and idle
+  // at a faster playback rate. If still no sushi is thrown at the patron,
+  // the patron will disappear. This is the amount of time before disappearing
+  // that the patron will be exasperated. Time in seconds.
+  time_exasperated_before_disappearing:float = 1.0;
+
+  // When exasperated, we play the idle animation faster. Therefore, this
+  // number should be > 1.
+  exasperated_playback_rate:float = 2.0;
+
+  // If true: when fed play eat, satisfied, disappear animations.
+  // If false: when fed play satisfied, disappear animations.
+  play_eating_animation:bool;
+}
+
+table PlayerDef {}
+
+table PlayerProjectileDef {}
+
+// A spline node for a rail.
+table RailNodeDef {
+  // The nodes are put in ascending order to define the rail spline.
+  // If you don't specify an ordering, the node entities will be given a
+  // default ordering matching the order they were defined in the entity file.
+  // This ordering will be preserved when you save out the entity list, even
+  // if the order has changed on export.
+  ordering:float;
+
+  // The name of the rail we're part of. You'll query RailNodeComponent by
+  // rail_name to get a list of rail points in the correct order.
+  rail_name:string;
+
+  // Total time for this rail. Only the first rail spline node (lowest ordering) for
+  // each rail should have this set.
+  total_time:float;
+
+  // Reliable distance for this rail. Only the first rail spline node (lowest
+  // ordering) for each rail should have this set.
+  reliable_distance:float;
+
+  // Does the rail wrap and restart at the end, or does it stop.
+  wraps:bool = true;
+}
+
+table RiverDef {
+  // Which rail to base the river on?
+  rail_name:string;
+
+  // Generating the banks of the river involves some random elements.
+  // Explicitly set the seed so that the banks are generated the same
+  // every time.
+  random_seed:uint;
+}
+
+// Component to hide and show the entity, based on the lap number of the raft
+// as it goes around the course.
+table LapDependentDef {
+  // The minimum lap amount to be visible for.
+  min_lap:float;
+  // The maximum lap amount to be visible for.
+  max_lap:float;
+}
+
+table SceneryDef {
+  // The type of scenery being animated.
+  anim_object:AnimObject;
+
+  // Whether scenery should rotate to face raft.
+  faces_raft:bool=false;
+}
+
+table LightDef {
+  // Intensity of shadows. 1.0 = solid black, 0.0 = invisible shadows.
+  shadow_intensity:float;
+
+  // Variables used in the Phong lighting model.
+  diffuse_color:fplbase.ColorRGBA;
+  ambient_color:fplbase.ColorRGBA;
+  specular_color:fplbase.ColorRGBA;
+  specular_exponent:float;
+
+  // Intensity for different lighting variables. Essentially a multiplier which
+  // will make the colors whiter.
+  diffuse_intensity:float;
+  ambient_intensity:float;
+  specular_intensity:float;
+}
+
+// No data, (never loaded from raw data) but we need it to be a thing so that it
+// ends up in the enum.
+table ListenerDef {}
+table AttributesDef {}
+table ServicesDef {}
+table ShadowControllerDef {}
+
+table Render3dTextDef {
+  animation_bone:int;
+  canvas_size:int;
+  font:string;
+  label_size:float;
+  translation:fplbase.Vec3;
+  rotation:fplbase.Vec3; // Degrees
+  scale:fplbase.Vec3;
+  text:string;
+}
+
+//-----------------------------------
+// Data for defining the entities themselves:
+// Union containing every component data type.
+union ComponentDataUnion {
+  corgi.CommonServicesDef,
+  SimpleMovementDef,
+  corgi.GraphDef,
+  ServicesDef,
+  corgi.MetaDef,
+  RailDenizenDef,
+  ShadowControllerDef,
+  LapDependentDef,
+  PlayerDef,
+  PatronDef,
+  PlayerProjectileDef,
+  corgi.PhysicsDef,
+  TimeLimitDef,
+  corgi.RenderMeshDef,
+  ListenerDef,
+  Render3dTextDef,
+  RiverDef,
+  SoundDef,
+  AttributesDef,
+  RailNodeDef,
+  SceneryDef,
+  LightDef,
+  corgi.TransformDef,
+  scene_lab.EditOptionsDef,
+  corgi.AnimationDef,
+}
+
+// Actual definition for each component.  Wrapped in a table because
+// you can't make arrays of raw unions.
+table ComponentDefInstance {
+  data:ComponentDataUnion;
+}
+
+// An entity is just a list of what components it has, and what their
+// starting values should be.
+table EntityDef {
+  component_list:[ComponentDefInstance];
+}
+
+// A list of entities.
+table EntityListDef {
+  entity_list:[EntityDef];
+}
+
+root_type EntityListDef;
+file_identifier "ENTI";
+file_extension "zooentity";

--- a/flatbuffers/examples/zooshi/config.fbs
+++ b/flatbuffers/examples/zooshi/config.fbs
@@ -1,0 +1,279 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "audio_config.fbs";
+include "bullet_def.fbs";
+include "common.fbs";
+include "components.fbs";
+include "scene_lab_config.fbs";
+include "gpg.fbs";
+include "unlockables.fbs";
+
+namespace fpl.zooshi;
+
+// One point in the river cross-section.
+//
+// 0      1     2    3     4     5          6    7
+// *---___                             _____*----*
+//        *-----*____       _____*-----
+//                   *_____*
+//
+//                   ^
+//                   |
+//                river_index
+//
+// Here the river cross-section has 8 points. Each point has a horizontal (x)
+// and vertical (z) offset. There's some randomness allowed for these offsets.
+// Therefore, we specify min/max pairs.
+//
+// The `river_index` indicates the left side of the river.
+// `river_index` + 1 is the right bank. Therefore, the river width is at least
+//      banks[river_index + 1].x_min - banks[river_index].x_min
+// and at most,
+//      banks[river_index + 1].x_max - banks[river_index].x_max
+//
+// So in the example above, to make the river wider, you'd decrease
+// banks[3].x_min/max and increase banks[3].x_min/max. Be sure to keep the
+// x-values monotonically increasing. You will get strange geometry otherwise.
+//
+// Riverbanks are zero-based, (with zero representing the width of the river
+// at that point), so 3 and 4 are likely to be at or near zero.
+// This means that in most cases, you probably want to have everything <=
+// river_index to have negative x values, and everything > river_index to have
+// positive x values.
+//
+table RiverBankContour {
+  x_min:float;  // Min absolute distance from the center of the river.
+  x_max:float;  // Max absolute distance from the center of the river.
+  z_min:float;  // Min absolute height of the bank.
+  z_max:float;  // Max absolute height of the bank.
+}
+
+// How far along the river to start each zone. The entire river ranges from
+// 0 to 1.
+table RiverZone {
+  zone_start:float;
+  material:string;
+  width:float = 0;
+  banks:[RiverBankContour];  // Override the default riverbanks - must be the
+                             // same size as RiverConfig's default_banks().
+}
+
+table RiverConfig {
+  // How much faster the river flows than the raft.  At 0.0, river and raft
+  // move at exactly the same speed.  Should be nonzero though, or it looks
+  // weird at the start of the game when the raft is stopped.
+  speed_boost:float = 0.5;
+  texture_repeats:float = 16;
+  spline_stepsize: float = 700.0;
+  track_height:float = -1.89;
+  texture_tile_size:float = 25.0;
+  material:string;
+  shader:string;
+
+  // Detail the cross section of the procedurally-generated banks.
+  // See the diagram in RiverBankContour for more information.
+  default_banks:[RiverBankContour];
+  default_width: float = 5.0;
+
+  // Zones for the riverbank. Each zone specifies a material to use.
+  zones:[RiverZone];
+
+  // Index into `banks` of the left side of the river. The right side is
+  // river_index + 1.
+  river_index:int;
+
+  // The collision type of the river banks.
+  collision_type:corgi.BulletCollisionType;
+
+  // What the river banks can collide with.
+  collides_with:[corgi.BulletCollisionType];
+
+  // The mass of the river banks.
+  mass:float = 1000;
+
+  // The restitution of the river banks.
+  restitution:float = 0.5;
+
+  // An arbitrary tag that is passed to the functions that handle collisions
+  // with the river.
+  user_tag:string;
+}
+
+table RenderConfig {
+  // Should we render shadows?
+  render_shadows_by_default:bool;
+
+  // Resolution (in pixels) of the shadowmap.
+  // Needs to be a power of 2, or GLES breaks
+  // Larger = shadows are visible further away, but takes more memory.
+  shadow_map_resolution:int;
+
+  // Scalar affecting the resolution/scale of the shadowmap.
+  // Smaller values mean low resolution - you can see them from
+  // far away, but shadows are blocky.
+  shadow_map_zoom:float;
+
+  // Distance (in world units) that the shadow-map should focus in front of
+  // the camera.  0 means the shadow map is perfectly centered on the camera.
+  shadow_map_offset:float;
+
+  // Minimum distance at which the fog does anything.
+  fog_roll_in_dist:float;
+
+  // Distance after which the fog no longer affects the color of the object.
+  fog_max_dist:float;
+
+  // The color of the fog.
+  fog_color:fplbase.ColorRGBA;
+
+  // The saturation of the color - 1.0 means that at max distance, objects
+  // will be entirely fog_color-colored.  0.0 means that the fog has no effect.
+  fog_max_saturation:float;
+
+  // Max distance at which an object renders - past this it just gets culled.
+  cull_distance:float;
+
+  // When distance exceeds this amount, cullable objects should try to get
+  // themselves out-of-view in a visually pleasing way. Suddenly being culled
+  // is jarring.
+  pop_out_distance:float;
+
+  // When distance is less than this amount, cullable objects should try to
+  // bring themselves into-view in a visually pleasing way. Suddenly appearing
+  // is jarring.
+  pop_in_distance:float;
+
+  // Depth bias for the shadow map.
+  shadow_map_bias:float;
+
+  // Viewport angle for the shadow map, in degrees.
+  shadow_map_viewport_angle:float;
+
+  // Apply Phong shading?
+  apply_phong_by_default:bool;
+
+  // Apply specular effect?
+  apply_specular_by_default:bool;
+
+  // Use normal maps?
+  apply_normal_maps_by_default:bool;
+
+  // Render shadows for Cardboard?
+  render_shadows_by_default_cardboard:bool;
+
+  // Apply Phong shading for Cardboard?
+  apply_phong_by_default_cardboard:bool;
+
+  // Apply specular effect for Cardboard?
+  apply_specular_by_default_cardboard:bool;
+
+  // Use normal maps for Cardboard?
+  apply_normal_maps_by_default_cardboard:bool;
+}
+
+// Table that describes elements specific to a single level.
+table LevelDef {
+  // The name of the level that will appear for UI.
+  name:string;
+  // Entity files that are loaded for this level.
+  entity_files:[string];
+  // Various settings for rendering the river.
+  river_config:RiverConfig;
+}
+
+table WorldDef {
+  // Entity files that are loaded for every level.
+  entity_files:[string];
+  // Different playable level definitions.
+  levels:[LevelDef];
+}
+
+enum UniqueBonusId : byte {
+  NonUnique = 0,
+  AdMobRewardedVideo = 1,
+}
+
+table Config {
+  // The name of the game, as displayed on the window title.
+  window_title:string;
+
+  // The relative path to the font file used for fine print menu text.
+  license_font:string;
+
+  // The relative path to the font file used to display menu items.
+  menu_font:string;
+
+  // Audio engine configuration file.
+  audio_config:string;
+
+  // Input configuration file.
+  input_config:string;
+
+  // The manifest of assets to load.
+  assets_filename:string;
+
+  // The initial offset from the player the projectile starts at, heightwise.
+  projectile_height_offset: float;
+
+  // The initial offset for the projectile in the direction it fires.
+  // It's nice to spawn projectile slightly in front of the player so that
+  // it doesn't get culled by the near plane.
+  projectile_forward_offset: float;
+
+  // Minimum anglular velocity, in degrees per second, of the launched
+  // projectiles, per axis.
+  projectile_min_angular_velocity: fplbase.Vec3;
+
+  // Maximum anglular velocity, in degrees per second, of the launched
+  // projectiles, per axis.
+  projectile_max_angular_velocity: fplbase.Vec3;
+
+  // The height above the patron to display the heart.
+  point_display_height: float;
+
+  // The strength of gravity
+  gravity: float;
+
+  // The maximum number of steps to advance bullet each frame
+  bullet_max_steps: int;
+
+  // The viewport angle to use when in Cardboard.
+  cardboard_viewport_angle:float;
+
+  // Configuration for the in-game editor, Scene Lab.
+  scene_lab_config: scene_lab.SceneLabConfig;
+
+  // Entity files to load.
+  world_def:WorldDef;
+
+  // Various settings for rendering:
+  rendering_config:RenderConfig;
+
+  // GPG configuration.
+  gpg_config:GPGConfig;
+
+  // Overshoot parameters for rotating scenery.
+  scenery_face_angle_def:motive.OvershootParameters;
+
+  // The different sushi types that will be used.
+  sushi_config:[UnlockableConfig];
+
+  // The amount of XP needed to get a reward.
+  xp_for_reward:int;
+}
+
+root_type Config;
+file_identifier "ZCON";
+file_extension "zooconfig";

--- a/flatbuffers/examples/zooshi/gpg.fbs
+++ b/flatbuffers/examples/zooshi/gpg.fbs
@@ -1,0 +1,34 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Definitions for meshes.
+
+include "common.fbs";
+
+namespace fpl.zooshi;
+table GPGLeaderboard {
+  name:string(key);
+  id:string;
+}
+
+table GPGAchievement {
+  name:string(key);
+  id:string;
+}
+
+table GPGConfig {
+  leaderboards:[GPGLeaderboard];
+  achievements:[GPGAchievement];
+}
+

--- a/flatbuffers/examples/zooshi/graph.fbs
+++ b/flatbuffers/examples/zooshi/graph.fbs
@@ -1,0 +1,54 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "attributes.fbs";
+include "common_modules.fbs";
+include "pindrop_module.fbs";
+include "mathfu_module.fbs";
+include "corgi_module.fbs";
+
+namespace fpl.zooshi;
+
+union InputType {
+  breadboard.module_library.OutputEdgeTarget,
+  breadboard.module_library.Pulse,
+  breadboard.module_library.Bool,
+  breadboard.module_library.Int,
+  breadboard.module_library.Float,
+  breadboard.module_library.String,
+  breadboard.module_library.Entity,
+  breadboard.module_library.Vec3,
+  breadboard.module_library.Vec4,
+  breadboard.module_library.SoundHandle,
+  breadboard.module_library.AudioChannel,
+}
+
+table InputEdgeDef {
+  edge:InputType;
+}
+
+table NodeDef {
+  module:string;
+  name:string;
+  input_edge_list:[InputEdgeDef];
+}
+
+table GraphDef {
+  node_list:[NodeDef];
+}
+
+file_identifier "GRPH";
+file_extension "bbgraph";
+
+root_type GraphDef;

--- a/flatbuffers/examples/zooshi/input_config.fbs
+++ b/flatbuffers/examples/zooshi/input_config.fbs
@@ -1,0 +1,27 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace fpl.zooshi;
+
+table InputConfig {
+  mouse_sensitivity:float;
+  invert_x:bool;
+  invert_y:bool;
+  gamepad_sensitivity:float;
+}
+
+root_type InputConfig;
+file_identifier "INCO";
+file_extension "zooinconfig";
+

--- a/flatbuffers/examples/zooshi/rail_def.fbs
+++ b/flatbuffers/examples/zooshi/rail_def.fbs
@@ -1,0 +1,28 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "common.fbs";
+
+namespace fpl.zooshi;
+
+table RailDef {
+  positions:[fplbase.Vec3];
+  total_time:float;
+  reliable_distance:float;
+  wraps:bool = true;
+}
+
+root_type RailDef;
+file_identifier "RAIL";
+file_extension "rail";

--- a/flatbuffers/examples/zooshi/save_data.fbs
+++ b/flatbuffers/examples/zooshi/save_data.fbs
@@ -1,0 +1,38 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Definitions for meshes.
+
+include "common.fbs";
+
+namespace fpl;
+
+table SaveData {
+  effect_volume:float;
+  music_volume:float;
+  render_shadows:bool;
+  apply_phong:bool;
+  apply_specular:bool;
+  render_shadows_cardboard:bool;
+  apply_phong_cardboard:bool;
+  apply_specular_cardboard:bool;
+  // Only used on touch devices that support head mounted displays
+  // (Android at the moment).
+  gyroscopic_controls_enabled:byte = 1;
+}
+
+root_type SaveData;
+file_identifier "ZSAV";
+file_extension "zoosave";
+

--- a/flatbuffers/examples/zooshi/unlockables.fbs
+++ b/flatbuffers/examples/zooshi/unlockables.fbs
@@ -1,0 +1,50 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace fpl.zooshi;
+
+enum UnlockableType : byte {
+  Sushi = 0,
+  Size
+}
+
+table SushiConfig {
+  // The description of the sushi that appears in the menu.
+  description:string;
+
+  // The name of the prototype to use with the sushi.
+  prototype:string;
+
+  // The initial speed of the projectiles on the forward vector.
+  speed:float = 40;
+
+  // The initial speed of the projectiles on the up vector.
+  upkick:float = 7.5;
+}
+
+union UnlockablesUnion {
+  SushiConfig
+}
+
+table UnlockableConfig {
+  // The name of the unlockable, used as part of the key.
+  name:string;
+
+  // Does the unlockable start unlocked initially.
+  starts_unlocked:bool = false;
+
+  // The specific data about the unlockable.
+  data:UnlockablesUnion;
+}
+

--- a/flatbuffers/pom.xml
+++ b/flatbuffers/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>flatbuffers</artifactId>
+	<packaging>jar</packaging>
+	<name>FlatBuffers schema language grammar</name>
+	<parent>
+		<groupId>com.antlr.grammarsv4</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<grammars>FlatBuffers.g4</grammars>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>true</verbose>
+					<showTree>true</showTree>
+					<entryPoint>schema</entryPoint>
+					<grammarName>FlatBuffers</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/thrift/README.md
+++ b/thrift/README.md
@@ -1,0 +1,1 @@
+ANTLR v4 grammar for Apache Thrift interface description language (IDL): http://thrift.apache.org/docs/idl

--- a/thrift/Thrift.g4
+++ b/thrift/Thrift.g4
@@ -1,0 +1,222 @@
+grammar Thrift;
+
+document
+    : header* definition* EOF
+    ;
+
+header
+    : include | namespace | cpp_include
+    ;
+
+include
+    : 'include' LITERAL
+    ;
+
+namespace
+    : 'namespace' '*' (IDENTIFIER | LITERAL)
+    | 'namespace' IDENTIFIER (IDENTIFIER | LITERAL)
+    | 'cpp_namespace' IDENTIFIER
+    | 'php_namespace' IDENTIFIER
+    ;
+
+cpp_include
+    : 'cpp_include' LITERAL
+    ;
+
+
+definition
+    : const_rule | typedef | enum_rule | senum | struct | union | exception | service
+    ;
+
+const_rule
+    : 'const' field_type IDENTIFIER ( '=' const_value )? list_separator?
+    ;
+
+typedef
+    : 'typedef' field_type IDENTIFIER type_annotations?
+    ;
+
+enum_rule
+    : 'enum' IDENTIFIER '{' enum_field* '}' type_annotations?
+    ;
+
+enum_field
+    : IDENTIFIER ('=' integer)? type_annotations? list_separator?
+    ;
+
+senum
+    : 'senum' IDENTIFIER '{' (LITERAL list_separator?)* '}' type_annotations?
+    ;
+
+struct
+    : 'struct' IDENTIFIER '{' field* '}' type_annotations?
+    ;
+
+union
+    : 'union' IDENTIFIER '{' field* '}' type_annotations?
+    ;
+
+exception
+    : 'exception' IDENTIFIER '{' field* '}' type_annotations?
+    ;
+
+service
+    : 'service' IDENTIFIER ('extends' IDENTIFIER)? '{' function* '}' type_annotations?
+    ;
+
+field
+    : field_id? field_req? field_type IDENTIFIER ('=' const_value)? type_annotations? list_separator?
+    ;
+
+field_id
+    : integer ':'
+    ;
+
+field_req
+    : 'required'
+    | 'optional'
+    ;
+
+function
+    : oneway? function_type IDENTIFIER '(' field* ')' throws_list? type_annotations? list_separator?
+    ;
+
+oneway
+    : ('oneway' | 'async')
+    ;
+
+function_type
+    : field_type
+    | 'void'
+    ;
+
+throws_list
+    : 'throws' '(' field* ')'
+    ;
+
+
+type_annotations
+    : '(' type_annotation* ')'
+    ;
+
+type_annotation
+    : IDENTIFIER ('=' annotation_value)? list_separator?
+    ;
+
+annotation_value
+    : integer | LITERAL
+    ;
+
+
+field_type
+    : base_type | IDENTIFIER | container_type
+    ;
+
+base_type
+    : real_base_type type_annotations?
+    ;
+
+container_type
+    : (map_type | set_type | list_type) type_annotations?
+    ;
+
+map_type
+    : 'map' cpp_type? '<' field_type COMMA field_type '>'
+    ;
+
+set_type
+    : 'set' cpp_type? '<' field_type '>'
+    ;
+
+list_type
+    : 'list' '<' field_type '>' cpp_type?
+    ;
+
+cpp_type
+    : 'cpp_type' LITERAL
+    ;
+
+const_value
+    : integer | DOUBLE | LITERAL | IDENTIFIER | const_list | const_map
+    ;
+
+integer
+    : INTEGER | HEX_INTEGER
+    ;
+
+INTEGER
+    : ('+' | '-')? DIGIT+
+    ;
+
+HEX_INTEGER
+    : '-'? '0x' HEX_DIGIT+
+    ;
+
+DOUBLE
+    : ('+' | '-')? ( DIGIT+ ('.' DIGIT+)? | '.' DIGIT+ ) (('E' | 'e') INTEGER)?
+    ;
+
+const_list
+    : '[' (const_value list_separator?)* ']'
+    ;
+
+const_map_entry
+    : const_value ':' const_value list_separator?
+    ;
+
+const_map
+    : '{' const_map_entry* '}'
+    ;
+
+list_separator
+    : COMMA | ';'
+    ;
+
+real_base_type
+    :  TYPE_BOOL | TYPE_BYTE | TYPE_I16 | TYPE_I32 | TYPE_I64 | TYPE_DOUBLE | TYPE_STRING | TYPE_BINARY
+    ;
+
+TYPE_BOOL: 'bool';
+TYPE_BYTE: 'byte';
+TYPE_I16: 'i16';
+TYPE_I32: 'i32';
+TYPE_I64: 'i64';
+TYPE_DOUBLE: 'double';
+TYPE_STRING: 'string';
+TYPE_BINARY: 'binary';
+
+LITERAL
+    : (('"' ~'"'* '"') | ('\'' ~'\''* '\''))
+    ;
+
+IDENTIFIER
+    : (LETTER | '_') (LETTER | DIGIT | '.' | '_')*
+    ;
+
+COMMA
+    : ','
+    ;
+
+fragment LETTER
+    : 'A'..'Z' | 'a'..'z'
+    ;
+
+fragment DIGIT
+    : '0'..'9'
+    ;
+
+fragment HEX_DIGIT
+    : DIGIT | 'A'..'F' | 'a'..'f'
+    ;
+
+WS
+    : (' ' | '\t' | '\r' '\n' | '\n')+ -> channel(HIDDEN)
+    ;
+
+SL_COMMENT
+    : ('//' | '#') (~'\n')* ('\r')? '\n' -> channel(HIDDEN)
+    ;
+
+ML_COMMENT
+    : '/*' .*? '*/' -> channel(HIDDEN)
+    ;

--- a/thrift/examples/cassandra.thrift
+++ b/thrift/examples/cassandra.thrift
@@ -1,0 +1,764 @@
+#!/usr/local/bin/thrift --java --php --py
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# *** PLEASE REMEMBER TO EDIT THE VERSION CONSTANT WHEN MAKING CHANGES ***
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#
+# Interface definition for Cassandra Service
+#
+
+namespace java org.apache.cassandra.thrift
+namespace cpp org.apache.cassandra
+namespace csharp Apache.Cassandra
+namespace py cassandra
+namespace php cassandra
+namespace perl Cassandra
+
+# Thrift.rb has a bug where top-level modules that include modules 
+# with the same name are not properly referenced, so we can't do
+# Cassandra::Cassandra::Client.
+namespace rb CassandraThrift
+
+# The API version (NOT the product version), composed as a dot delimited
+# string with major, minor, and patch level components.
+#
+#  - Major: Incremented for backward incompatible changes. An example would
+#           be changes to the number or disposition of method arguments.
+#  - Minor: Incremented for backward compatible changes. An example would
+#           be the addition of a new (optional) method.
+#  - Patch: Incremented for bug fixes. The patch level should be increased
+#           for every edit that doesn't result in a change to major/minor.
+#
+# See the Semantic Versioning Specification (SemVer) http://semver.org.
+#
+# Note that this backwards compatibility is from the perspective of the server,
+# not the client. Cassandra should always be able to talk to older client
+# software, but client software may not be able to talk to older Cassandra
+# instances.
+#
+# An effort should be made not to break forward-client-compatibility either
+# (e.g. one should avoid removing obsolete fields from the IDL), but no
+# guarantees in this respect are made by the Cassandra project.
+const string VERSION = "19.33.0"
+
+
+#
+# data structures
+#
+
+/** Basic unit of data within a ColumnFamily.
+ * @param name, the name by which this column is set and retrieved.  Maximum 64KB long.
+ * @param value. The data associated with the name.  Maximum 2GB long, but in practice you should limit it to small numbers of MB (since Thrift must read the full value into memory to operate on it).
+ * @param timestamp. The timestamp is used for conflict detection/resolution when two columns with same name need to be compared.
+ * @param ttl. An optional, positive delay (in seconds) after which the column will be automatically deleted. 
+ */
+struct Column {
+   1: required binary name,
+   2: optional binary value,
+   3: optional i64 timestamp,
+   4: optional i32 ttl,
+}
+
+/** A named list of columns.
+ * @param name. see Column.name.
+ * @param columns. A collection of standard Columns.  The columns within a super column are defined in an adhoc manner.
+ *                 Columns within a super column do not have to have matching structures (similarly named child columns).
+ */
+struct SuperColumn {
+   1: required binary name,
+   2: required list<Column> columns,
+}
+
+struct CounterColumn {
+    1: required binary name,
+    2: required i64 value
+}
+
+struct CounterSuperColumn {
+    1: required binary name,
+    2: required list<CounterColumn> columns
+}
+
+/**
+    Methods for fetching rows/records from Cassandra will return either a single instance of ColumnOrSuperColumn or a list
+    of ColumnOrSuperColumns (get_slice()). If you're looking up a SuperColumn (or list of SuperColumns) then the resulting
+    instances of ColumnOrSuperColumn will have the requested SuperColumn in the attribute super_column. For queries resulting
+    in Columns, those values will be in the attribute column. This change was made between 0.3 and 0.4 to standardize on
+    single query methods that may return either a SuperColumn or Column.
+    If the query was on a counter column family, you will either get a counter_column (instead of a column) or a 
+    counter_super_column (instead of a super_column)
+    @param column. The Column returned by get() or get_slice().
+    @param super_column. The SuperColumn returned by get() or get_slice().
+    @param counter_column. The Counterolumn returned by get() or get_slice().
+    @param counter_super_column. The CounterSuperColumn returned by get() or get_slice().
+ */
+struct ColumnOrSuperColumn {
+    1: optional Column column,
+    2: optional SuperColumn super_column,
+    3: optional CounterColumn counter_column,
+    4: optional CounterSuperColumn counter_super_column
+}
+
+
+#
+# Exceptions
+# (note that internal server errors will raise a TApplicationException, courtesy of Thrift)
+#
+
+/** A specific column was requested that does not exist. */
+exception NotFoundException {
+}
+
+/** Invalid request could mean keyspace or column family does not exist, required parameters are missing, or a parameter is malformed. 
+    why contains an associated error message.
+*/
+exception InvalidRequestException {
+    1: required string why
+}
+
+/** Not all the replicas required could be created and/or read. */
+exception UnavailableException {
+}
+
+/** RPC timeout was exceeded.  either a node failed mid-operation, or load was too high, or the requested op was too large. */
+exception TimedOutException {
+    /** 
+     * if a write operation was acknowledged some replicas but not enough to 
+     * satisfy the required ConsistencyLevel, the number of successful 
+     * replies will be given here
+     */
+    1: optional i32 acknowledged_by
+}
+
+/** invalid authentication request (invalid keyspace, user does not exist, or credentials invalid) */
+exception AuthenticationException {
+    1: required string why
+}
+
+/** invalid authorization request (user does not have access to keyspace) */
+exception AuthorizationException {
+    1: required string why
+}
+
+/** schemas are not in agreement across all nodes */
+exception SchemaDisagreementException {
+}
+
+
+#
+# service api
+#
+/** 
+ * The ConsistencyLevel is an enum that controls both read and write
+ * behavior based on the ReplicationFactor of the keyspace.  The
+ * different consistency levels have different meanings, depending on
+ * if you're doing a write or read operation. 
+ *
+ * If W + R > ReplicationFactor, where W is the number of nodes to
+ * block for on write, and R the number to block for on reads, you
+ * will have strongly consistent behavior; that is, readers will
+ * always see the most recent write. Of these, the most interesting is
+ * to do QUORUM reads and writes, which gives you consistency while
+ * still allowing availability in the face of node failures up to half
+ * of <ReplicationFactor>. Of course if latency is more important than
+ * consistency then you can use lower values for either or both.
+ * 
+ * Some ConsistencyLevels (ONE, TWO, THREE) refer to a specific number
+ * of replicas rather than a logical concept that adjusts
+ * automatically with the replication factor.  Of these, only ONE is
+ * commonly used; TWO and (even more rarely) THREE are only useful
+ * when you care more about guaranteeing a certain level of
+ * durability, than consistency.
+ * 
+ * Write consistency levels make the following guarantees before reporting success to the client:
+ *   ANY          Ensure that the write has been written once somewhere, including possibly being hinted in a non-target node.
+ *   ONE          Ensure that the write has been written to at least 1 node's commit log and memory table
+ *   TWO          Ensure that the write has been written to at least 2 node's commit log and memory table
+ *   THREE        Ensure that the write has been written to at least 3 node's commit log and memory table
+ *   QUORUM       Ensure that the write has been written to <ReplicationFactor> / 2 + 1 nodes
+ *   LOCAL_QUORUM Ensure that the write has been written to <ReplicationFactor> / 2 + 1 nodes, within the local datacenter (requires NetworkTopologyStrategy)
+ *   EACH_QUORUM  Ensure that the write has been written to <ReplicationFactor> / 2 + 1 nodes in each datacenter (requires NetworkTopologyStrategy)
+ *   ALL          Ensure that the write is written to <code>&lt;ReplicationFactor&gt;</code> nodes before responding to the client.
+ * 
+ * Read consistency levels make the following guarantees before returning successful results to the client:
+ *   ANY          Not supported. You probably want ONE instead.
+ *   ONE          Returns the record obtained from a single replica.
+ *   TWO          Returns the record with the most recent timestamp once two replicas have replied.
+ *   THREE        Returns the record with the most recent timestamp once three replicas have replied.
+ *   QUORUM       Returns the record with the most recent timestamp once a majority of replicas have replied.
+ *   LOCAL_QUORUM Returns the record with the most recent timestamp once a majority of replicas within the local datacenter have replied.
+ *   EACH_QUORUM  Returns the record with the most recent timestamp once a majority of replicas within each datacenter have replied.
+ *   ALL          Returns the record with the most recent timestamp once all replicas have replied (implies no replica may be down)..
+*/
+enum ConsistencyLevel {
+    ONE = 1,
+    QUORUM = 2,
+    LOCAL_QUORUM = 3,
+    EACH_QUORUM = 4,
+    ALL = 5,
+    ANY = 6,
+    TWO = 7,
+    THREE = 8,
+}
+
+/**
+    ColumnParent is used when selecting groups of columns from the same ColumnFamily. In directory structure terms, imagine
+    ColumnParent as ColumnPath + '/../'.
+    See also <a href="cassandra.html#Struct_ColumnPath">ColumnPath</a>
+ */
+struct ColumnParent {
+    3: required string column_family,
+    4: optional binary super_column,
+}
+
+/** The ColumnPath is the path to a single column in Cassandra. It might make sense to think of ColumnPath and
+ * ColumnParent in terms of a directory structure.
+ *
+ * ColumnPath is used to looking up a single column.
+ *
+ * @param column_family. The name of the CF of the column being looked up.
+ * @param super_column. The super column name.
+ * @param column. The column name.
+ */
+struct ColumnPath {
+    3: required string column_family,
+    4: optional binary super_column,
+    5: optional binary column,
+}
+
+/**
+    A slice range is a structure that stores basic range, ordering and limit information for a query that will return
+    multiple columns. It could be thought of as Cassandra's version of LIMIT and ORDER BY
+    @param start. The column name to start the slice with. This attribute is not required, though there is no default value,
+                  and can be safely set to '', i.e., an empty byte array, to start with the first column name. Otherwise, it
+                  must a valid value under the rules of the Comparator defined for the given ColumnFamily.
+    @param finish. The column name to stop the slice at. This attribute is not required, though there is no default value,
+                   and can be safely set to an empty byte array to not stop until 'count' results are seen. Otherwise, it
+                   must also be a valid value to the ColumnFamily Comparator.
+    @param reversed. Whether the results should be ordered in reversed order. Similar to ORDER BY blah DESC in SQL.
+    @param count. How many columns to return. Similar to LIMIT in SQL. May be arbitrarily large, but Thrift will
+                  materialize the whole result into memory before returning it to the client, so be aware that you may
+                  be better served by iterating through slices by passing the last value of one call in as the 'start'
+                  of the next instead of increasing 'count' arbitrarily large.
+ */
+struct SliceRange {
+    1: required binary start,
+    2: required binary finish,
+    3: required bool reversed=0,
+    4: required i32 count=100,
+}
+
+/**
+    A SlicePredicate is similar to a mathematic predicate (see http://en.wikipedia.org/wiki/Predicate_(mathematical_logic)),
+    which is described as "a property that the elements of a set have in common."
+    SlicePredicate's in Cassandra are described with either a list of column_names or a SliceRange.  If column_names is
+    specified, slice_range is ignored.
+    @param column_name. A list of column names to retrieve. This can be used similar to Memcached's "multi-get" feature
+                        to fetch N known column names. For instance, if you know you wish to fetch columns 'Joe', 'Jack',
+                        and 'Jim' you can pass those column names as a list to fetch all three at once.
+    @param slice_range. A SliceRange describing how to range, order, and/or limit the slice.
+ */
+struct SlicePredicate {
+    1: optional list<binary> column_names,
+    2: optional SliceRange   slice_range,
+}
+
+enum IndexOperator {
+    EQ,
+    GTE,
+    GT,
+    LTE,
+    LT
+}
+
+struct IndexExpression {
+    1: required binary column_name,
+    2: required IndexOperator op,
+    3: required binary value,
+}
+
+/**
+ * @Deprecated: use a KeyRange with row_filter in get_range_slices instead
+ */
+struct IndexClause {
+    1: required list<IndexExpression> expressions,
+    2: required binary start_key,
+    3: required i32 count=100,
+}
+
+
+/**
+The semantics of start keys and tokens are slightly different.
+Keys are start-inclusive; tokens are start-exclusive.  Token
+ranges may also wrap -- that is, the end token may be less
+than the start one.  Thus, a range from keyX to keyX is a
+one-element range, but a range from tokenY to tokenY is the
+full ring.
+*/
+struct KeyRange {
+    1: optional binary start_key,
+    2: optional binary end_key,
+    3: optional string start_token,
+    4: optional string end_token,
+    6: optional list<IndexExpression> row_filter,
+    5: required i32 count=100
+}
+
+/**
+    A KeySlice is key followed by the data it maps to. A collection of KeySlice is returned by the get_range_slice operation.
+    @param key. a row key
+    @param columns. List of data represented by the key. Typically, the list is pared down to only the columns specified by
+                    a SlicePredicate.
+ */
+struct KeySlice {
+    1: required binary key,
+    2: required list<ColumnOrSuperColumn> columns,
+}
+
+struct KeyCount {
+    1: required binary key,
+    2: required i32 count
+}
+
+/**
+ * Note that the timestamp is only optional in case of counter deletion.
+ */
+struct Deletion {
+    1: optional i64 timestamp,
+    2: optional binary super_column,
+    3: optional SlicePredicate predicate,
+}
+
+/**
+    A Mutation is either an insert (represented by filling column_or_supercolumn) or a deletion (represented by filling the deletion attribute).
+    @param column_or_supercolumn. An insert to a column or supercolumn (possibly counter column or supercolumn)
+    @param deletion. A deletion of a column or supercolumn
+*/
+struct Mutation {
+    1: optional ColumnOrSuperColumn column_or_supercolumn,
+    2: optional Deletion deletion,
+}
+
+struct EndpointDetails {
+    1: string host,
+    2: string datacenter,
+    3: optional string rack
+}
+
+/**
+    A TokenRange describes part of the Cassandra ring, it is a mapping from a range to
+    endpoints responsible for that range.
+    @param start_token The first token in the range
+    @param end_token The last token in the range
+    @param endpoints The endpoints responsible for the range (listed by their configured listen_address)
+    @param rpc_endpoints The endpoints responsible for the range (listed by their configured rpc_address)
+*/
+struct TokenRange {
+    1: required string start_token,
+    2: required string end_token,
+    3: required list<string> endpoints,
+    4: optional list<string> rpc_endpoints
+    5: optional list<EndpointDetails> endpoint_details,
+}
+
+/**
+    Authentication requests can contain any data, dependent on the IAuthenticator used
+*/
+struct AuthenticationRequest {
+    1: required map<string, string> credentials
+}
+
+enum IndexType {
+    KEYS,
+    CUSTOM
+}
+
+/* describes a column in a column family. */
+struct ColumnDef {
+    1: required binary name,
+    2: required string validation_class,
+    3: optional IndexType index_type,
+    4: optional string index_name,
+    5: optional map<string,string> index_options
+}
+
+
+/* describes a column family. */
+struct CfDef {
+    1: required string keyspace,
+    2: required string name,
+    3: optional string column_type="Standard",
+    5: optional string comparator_type="BytesType",
+    6: optional string subcomparator_type,
+    8: optional string comment,
+    12: optional double read_repair_chance,
+    13: optional list<ColumnDef> column_metadata,
+    14: optional i32 gc_grace_seconds,
+    15: optional string default_validation_class,
+    16: optional i32 id,
+    17: optional i32 min_compaction_threshold,
+    18: optional i32 max_compaction_threshold,
+    24: optional bool replicate_on_write,
+    26: optional string key_validation_class,
+    28: optional binary key_alias,
+    29: optional string compaction_strategy,
+    30: optional map<string,string> compaction_strategy_options,
+    32: optional map<string,string> compression_options,
+    33: optional double bloom_filter_fp_chance,
+    34: optional string caching="keys_only",
+    37: optional double dclocal_read_repair_chance = 0.0,
+
+    /* All of the following are now ignored and unsupplied. */
+
+    /** @deprecated */
+    9: optional double row_cache_size,
+    /** @deprecated */
+    11: optional double key_cache_size,
+    /** @deprecated */
+    19: optional i32 row_cache_save_period_in_seconds,
+    /** @deprecated */
+    20: optional i32 key_cache_save_period_in_seconds,
+    /** @deprecated */
+    21: optional i32 memtable_flush_after_mins,
+    /** @deprecated */
+    22: optional i32 memtable_throughput_in_mb,
+    /** @deprecated */
+    23: optional double memtable_operations_in_millions,
+    /** @deprecated */
+    25: optional double merge_shards_chance,
+    /** @deprecated */
+    27: optional string row_cache_provider,
+    /** @deprecated */
+    31: optional i32 row_cache_keys_to_save,
+}
+
+/* describes a keyspace. */
+struct KsDef {
+    1: required string name,
+    2: required string strategy_class,
+    3: optional map<string,string> strategy_options,
+
+    /** @deprecated, ignored */
+    4: optional i32 replication_factor,
+
+    5: required list<CfDef> cf_defs,
+    6: optional bool durable_writes=1,
+}
+
+/** CQL query compression */
+enum Compression {
+    GZIP = 1,
+    NONE = 2
+}
+
+enum CqlResultType {
+    ROWS = 1,
+    VOID = 2,
+    INT = 3
+}
+
+/** Row returned from a CQL query */
+struct CqlRow {
+    1: required binary key,
+    2: required list<Column> columns
+}
+
+struct CqlMetadata {
+    1: required map<binary,string> name_types,
+    2: required map<binary,string> value_types,
+    3: required string default_name_type,
+    4: required string default_value_type
+}
+
+struct CqlResult {
+    1: required CqlResultType type,
+    2: optional list<CqlRow> rows,
+    3: optional i32 num,
+    4: optional CqlMetadata schema
+}
+
+struct CqlPreparedResult {
+    1: required i32 itemId,
+    2: required i32 count,
+    3: optional list<string> variable_types,
+    4: optional list<string> variable_names
+}
+
+
+service Cassandra {
+  # auth methods
+  void login(1: required AuthenticationRequest auth_request) throws (1:AuthenticationException authnx, 2:AuthorizationException authzx),
+ 
+  # set keyspace
+  void set_keyspace(1: required string keyspace) throws (1:InvalidRequestException ire),
+  
+  # retrieval methods
+
+  /**
+    Get the Column or SuperColumn at the given column_path. If no value is present, NotFoundException is thrown. (This is
+    the only method that can throw an exception under non-failure conditions.)
+   */
+  ColumnOrSuperColumn get(1:required binary key,
+                          2:required ColumnPath column_path,
+                          3:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+                      throws (1:InvalidRequestException ire, 2:NotFoundException nfe, 3:UnavailableException ue, 4:TimedOutException te),
+
+  /**
+    Get the group of columns contained by column_parent (either a ColumnFamily name or a ColumnFamily/SuperColumn name
+    pair) specified by the given SlicePredicate. If no matching values are found, an empty list is returned.
+   */
+  list<ColumnOrSuperColumn> get_slice(1:required binary key, 
+                                      2:required ColumnParent column_parent, 
+                                      3:required SlicePredicate predicate, 
+                                      4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+                            throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+    returns the number of columns matching <code>predicate</code> for a particular <code>key</code>, 
+    <code>ColumnFamily</code> and optionally <code>SuperColumn</code>.
+  */
+  i32 get_count(1:required binary key, 
+                2:required ColumnParent column_parent, 
+                3:required SlicePredicate predicate,
+                4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+      throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+    Performs a get_slice for column_parent and predicate for the given keys in parallel.
+  */
+  map<binary,list<ColumnOrSuperColumn>> multiget_slice(1:required list<binary> keys, 
+                                                       2:required ColumnParent column_parent, 
+                                                       3:required SlicePredicate predicate, 
+                                                       4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+                                        throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+    Perform a get_count in parallel on the given list<binary> keys. The return value maps keys to the count found.
+  */
+  map<binary, i32> multiget_count(1:required list<binary> keys,
+                2:required ColumnParent column_parent,
+                3:required SlicePredicate predicate,
+                4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+      throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+   returns a subset of columns for a contiguous range of keys.
+  */
+  list<KeySlice> get_range_slices(1:required ColumnParent column_parent, 
+                                  2:required SlicePredicate predicate,
+                                  3:required KeyRange range,
+                                  4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+                 throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+   returns a range of columns, wrapping to the next rows if necessary to collect max_results.
+  */
+  list<KeySlice> get_paged_slice(1:required string column_family,
+                                 2:required KeyRange range,
+                                 3:required binary start_column,
+                                 4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+                 throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+    Returns the subset of columns specified in SlicePredicate for the rows matching the IndexClause
+    @Deprecated; use get_range_slices instead with range.row_filter specified
+    */
+  list<KeySlice> get_indexed_slices(1:required ColumnParent column_parent,
+                                    2:required IndexClause index_clause,
+                                    3:required SlicePredicate column_predicate,
+                                    4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+                 throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  # modification methods
+
+  /**
+   * Insert a Column at the given column_parent.column_family and optional column_parent.super_column.
+   */
+  void insert(1:required binary key, 
+              2:required ColumnParent column_parent,
+              3:required Column column,
+              4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+       throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+   * Increment or decrement a counter.
+   */
+  void add(1:required binary key,
+           2:required ColumnParent column_parent,
+           3:required CounterColumn column,
+           4:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+       throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+    Remove data from the row specified by key at the granularity specified by column_path, and the given timestamp. Note
+    that all the values in column_path besides column_path.column_family are truly optional: you can remove the entire
+    row by just specifying the ColumnFamily, or you can remove a SuperColumn or a single Column by specifying those levels too.
+   */
+  void remove(1:required binary key,
+              2:required ColumnPath column_path,
+              3:required i64 timestamp,
+              4:ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+       throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+  /**
+   * Remove a counter at the specified location.
+   * Note that counters have limited support for deletes: if you remove a counter, you must wait to issue any following update
+   * until the delete has reached all the nodes and all of them have been fully compacted.
+   */
+  void remove_counter(1:required binary key,
+                      2:required ColumnPath path,
+                      3:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+      throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+
+
+  /**
+    Mutate many columns or super columns for many row keys. See also: Mutation.
+    mutation_map maps key to column family to a list of Mutation objects to take place at that scope.
+  **/
+  void batch_mutate(1:required map<binary, map<string, list<Mutation>>> mutation_map,
+                    2:required ConsistencyLevel consistency_level=ConsistencyLevel.ONE)
+       throws (1:InvalidRequestException ire, 2:UnavailableException ue, 3:TimedOutException te),
+       
+  /**
+   Truncate will mark and entire column family as deleted.
+   From the user's perspective a successful call to truncate will result complete data deletion from cfname.
+   Internally, however, disk space will not be immediatily released, as with all deletes in cassandra, this one
+   only marks the data as deleted.
+   The operation succeeds only if all hosts in the cluster at available and will throw an UnavailableException if 
+   some hosts are down.
+  */
+  void truncate(1:required string cfname)
+       throws (1: InvalidRequestException ire, 2: UnavailableException ue, 3: TimedOutException te),
+
+
+    
+  // Meta-APIs -- APIs to get information about the node or cluster,
+  // rather than user data.  The nodeprobe program provides usage examples.
+  
+  /** 
+   * for each schema version present in the cluster, returns a list of nodes at that version.
+   * hosts that do not respond will be under the key DatabaseDescriptor.INITIAL_VERSION. 
+   * the cluster is all on the same version if the size of the map is 1. 
+   */
+  map<string, list<string>> describe_schema_versions()
+       throws (1: InvalidRequestException ire),
+
+  /** list the defined keyspaces in this cluster */
+  list<KsDef> describe_keyspaces()
+    throws (1:InvalidRequestException ire),
+
+  /** get the cluster name */
+  string describe_cluster_name(),
+
+  /** get the thrift api version */
+  string describe_version(),
+
+  /** get the token ring: a map of ranges to host addresses,
+      represented as a set of TokenRange instead of a map from range
+      to list of endpoints, because you can't use Thrift structs as
+      map keys:
+      https://issues.apache.org/jira/browse/THRIFT-162 
+      for the same reason, we can't return a set here, even though
+      order is neither important nor predictable. */
+  list<TokenRange> describe_ring(1:required string keyspace)
+                   throws (1:InvalidRequestException ire),
+
+  /** get the mapping between token->node ip
+      without taking replication into consideration
+      https://issues.apache.org/jira/browse/CASSANDRA-4092 */
+  map<string, string> describe_token_map()
+                    throws (1:InvalidRequestException ire),
+  
+  /** returns the partitioner used by this cluster */
+  string describe_partitioner(),
+
+  /** returns the snitch used by this cluster */
+  string describe_snitch(),
+
+  /** describe specified keyspace */
+  KsDef describe_keyspace(1:required string keyspace)
+    throws (1:NotFoundException nfe, 2:InvalidRequestException ire),
+
+  /** experimental API for hadoop/parallel query support.  
+      may change violently and without warning. 
+      returns list of token strings such that first subrange is (list[0], list[1]],
+      next is (list[1], list[2]], etc. */
+  list<string> describe_splits(1:required string cfName,
+                               2:required string start_token, 
+                               3:required string end_token,
+                               4:required i32 keys_per_split)
+    throws (1:InvalidRequestException ire),
+
+  /** adds a column family. returns the new schema id. */
+  string system_add_column_family(1:required CfDef cf_def)
+    throws (1:InvalidRequestException ire, 2:SchemaDisagreementException sde),
+    
+  /** drops a column family. returns the new schema id. */
+  string system_drop_column_family(1:required string column_family)
+    throws (1:InvalidRequestException ire, 2:SchemaDisagreementException sde), 
+  
+  /** adds a keyspace and any column families that are part of it. returns the new schema id. */
+  string system_add_keyspace(1:required KsDef ks_def)
+    throws (1:InvalidRequestException ire, 2:SchemaDisagreementException sde),
+  
+  /** drops a keyspace and any column families that are part of it. returns the new schema id. */
+  string system_drop_keyspace(1:required string keyspace)
+    throws (1:InvalidRequestException ire, 2:SchemaDisagreementException sde),
+  
+  /** updates properties of a keyspace. returns the new schema id. */
+  string system_update_keyspace(1:required KsDef ks_def)
+    throws (1:InvalidRequestException ire, 2:SchemaDisagreementException sde),
+        
+  /** updates properties of a column family. returns the new schema id. */
+  string system_update_column_family(1:required CfDef cf_def)
+    throws (1:InvalidRequestException ire, 2:SchemaDisagreementException sde),
+  
+  /**
+   * Executes a CQL (Cassandra Query Language) statement and returns a
+   * CqlResult containing the results.
+   */
+  CqlResult execute_cql_query(1:required binary query, 2:required Compression compression)
+    throws (1:InvalidRequestException ire,
+            2:UnavailableException ue,
+            3:TimedOutException te,
+            4:SchemaDisagreementException sde)
+            
+            
+  /**
+   * Prepare a CQL (Cassandra Query Language) statement by compiling and returning
+   * - the type of CQL statement
+   * - an id token of the compiled CQL stored on the server side.
+   * - a count of the discovered bound markers in the statement 
+   */
+  CqlPreparedResult prepare_cql_query(1:required binary query, 2:required Compression compression)
+    throws (1:InvalidRequestException ire)
+
+             
+  /**
+   * Executes a prepared CQL (Cassandra Query Language) statement by passing an id token and  a list of variables
+   * to bind and returns a CqlResult containing the results.
+   */
+  CqlResult execute_prepared_cql_query(1:required i32 itemId, 2:required list<binary> values)
+    throws (1:InvalidRequestException ire,
+            2:UnavailableException ue,
+            3:TimedOutException te,
+            4:SchemaDisagreementException sde)
+
+  void set_cql_version(1: required string version) throws (1:InvalidRequestException ire)
+}

--- a/thrift/examples/eleme_test.thrift
+++ b/thrift/examples/eleme_test.thrift
@@ -1,0 +1,58 @@
+typedef map<string, map<string, i16>> T1
+
+typedef map<S1, string> T2
+
+exception E1 {
+  1: required string name,
+  2: required string message
+}
+
+struct S1 {
+  1: required i32 a
+}
+
+struct Args {
+  1: required list<S1> list1,
+  2: required T1 map1,
+  3: required T2 map2
+}
+
+struct DefResArg {
+  1: i32 i = 233,
+  2: string s = "hehe"
+}
+
+struct I64Data {
+  1: i64 data
+}
+
+service Test {
+
+  Args test(1: list<S1> list1, 2: T1 map1, 3: T2 map2) throws (1: E1 exception1);
+
+  void void_call();
+
+  oneway void oneway_set_hehe(1: double hehe);
+  double get_hehe();
+
+  binary bin(1: binary data);
+
+  i64 bignumber(1: i64 data);
+
+  bool unknown();
+
+  void required_a(1: required i32 a);
+
+  void arr(1: list<i32> arr);
+
+  S1 response_a();
+
+  map<i32,string> def_req_arg(1: i32 i = 233, 2: string s = "hehe");
+
+  DefResArg def_res_arg();
+
+  map<string,i32> zero(1: i32 zero);
+
+  I64Data readi64(1: i64 data);
+
+}

--- a/thrift/examples/eleme_test2.thrift
+++ b/thrift/examples/eleme_test2.thrift
@@ -1,0 +1,58 @@
+typedef map<string, map<string, i16>> T1
+
+typedef map<S1, string> T2
+
+exception E1 {
+  1: required string name,
+  2: required string message
+}
+
+struct S1 {
+  1: required i32 a
+}
+
+struct Args {
+  1: required list<S1> list1,
+  2: required T1 map1,
+  3: required T2 map2
+}
+
+struct DefResArg {
+  1: i32 i = 233,
+  2: string s = "hehe"
+}
+
+struct I64Data {
+  1: i64 data
+}
+
+service Test {
+
+  Args test(1: list<S1> list1, 2: T1 map1, 3: T2 map2) throws (1: E1 exception1);
+
+  void void_call();
+
+  oneway void oneway_set_hehe(1: double hehe);
+  double get_hehe();
+
+  binary bin(1: binary data);
+
+  i64 bignumber(1: i64 data);
+
+  bool unknown();
+
+  void required_a(1: required i32 a);
+
+  void arr(1: list<i32> arr);
+
+  S1 response_a();
+
+  map<i32,string> def_req_arg(1: i32 i = 233, 2: string s = "hehe");
+
+  DefResArg def_res_arg();
+
+  map<string,i32> zero(1: i32 zero);
+
+  I64Data readi64(1: i64 data);
+
+}

--- a/thrift/examples/thrift_project/AnnotationTest.thrift
+++ b/thrift/examples/thrift_project/AnnotationTest.thrift
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+typedef list<i32> ( cpp.template = "std::list" ) int_linked_list
+
+struct foo {
+  1: i32 bar ( presence = "required" );
+  2: i32 baz ( presence = "manual", cpp.use_pointer = "", );
+  3: i32 qux;
+  4: i32 bop;
+} (
+  cpp.type = "DenseFoo",
+  python.type = "DenseFoo",
+  java.final = "",
+  annotation.without.value,
+)
+
+exception foo_error {
+  1: i32 error_code ( foo="bar" )
+  2: string error_msg
+} (foo = "bar")
+
+typedef string ( unicode.encoding = "UTF-16" ) non_latin_string (foo="bar")
+typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
+
+enum weekdays {
+  SUNDAY ( weekend = "yes" ),
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY ( weekend = "yes" )
+} (foo.bar="baz")
+
+/* Note that annotations on senum values are not supported. */
+senum seasons {
+  "Spring",
+  "Summer",
+  "Fall",
+  "Winter"
+} ( foo = "bar" )
+
+struct ostr_default {
+  1: i32 bar;
+}
+
+struct ostr_custom {
+  1: i32 bar;
+} (cpp.customostream)
+
+
+service foo_service {
+  void foo() ( foo = "bar" )
+} (a.b="c")
+

--- a/thrift/examples/thrift_project/BrokenConstants.thrift
+++ b/thrift/examples/thrift_project/BrokenConstants.thrift
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const i64 myint = 68719476736
+const i64 broken = 9876543210987654321  // A little over 2^63
+
+enum foo {
+  bar = 68719476736
+}

--- a/thrift/examples/thrift_project/ConstantsDemo.thrift
+++ b/thrift/examples/thrift_project/ConstantsDemo.thrift
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp yozone
+namespace erl consts_
+
+struct thing {
+  1: i32 hello,
+  2: i32 goodbye
+}
+
+enum enumconstants {
+  ONE = 1,
+  TWO = 2
+}
+
+// struct thing2 {
+//   /** standard docstring */
+//   1: enumconstants val = TWO
+// }
+
+typedef i32 myIntType
+const myIntType myInt = 3
+
+//const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
+
+const i32 hex_const = 0x0001F
+const i32 negative_hex_constant = -0x0001F
+
+const i32 GEN_ME = -3523553
+const double GEn_DUB = 325.532
+const double GEn_DU = 085.2355
+const string GEN_STRING = "asldkjasfd"
+
+const double e10 = 1e10   // fails with 0.9.3 and earlier
+const double e11 = -1e10  
+
+const map<i32,i32> GEN_MAP = { 35532 : 233, 43523 : 853 }
+const list<i32> GEN_LIST = [ 235235, 23598352, 3253523 ]
+
+const map<i32, map<i32, i32>> GEN_MAPMAP = { 235 : { 532 : 53255, 235:235}}
+
+const map<string,i32> GEN_MAP2 = { "hello" : 233, "lkj98d" : 853, 'lkjsdf' : 098325 }
+
+const thing GEN_THING = { 'hello' : 325, 'goodbye' : 325352 }
+
+const map<i32,thing> GEN_WHAT = { 35 : { 'hello' : 325, 'goodbye' : 325352 } }
+
+const set<i32> GEN_SET = [ 235, 235, 53235 ]
+
+exception Blah {
+  1:  i32 bing }
+
+exception Gak {}
+
+service yowza {
+  void blingity(),
+  i32 blangity() throws (1: Blah hoot )
+}

--- a/thrift/examples/thrift_project/DebugProtoTest.thrift
+++ b/thrift/examples/thrift_project/DebugProtoTest.thrift
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace c_glib TTest
+namespace cpp thrift.test.debug
+namespace java thrift.test
+namespace rb thrift.test
+
+struct Doubles {
+ 1: double nan,
+ 2: double inf,
+ 3: double neginf,
+ 4: double repeating,
+ 5: double big,
+ 6: double tiny,
+ 7: double zero,
+ 8: double negzero,
+}
+
+struct OneOfEach {
+  1: bool im_true,
+  2: bool im_false,
+  3: i8 a_bite = 0x7f,
+  4: i16 integer16 = 0x7fff,
+  5: i32 integer32,
+  6: i64 integer64 = 10000000000,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+  11: binary base64,
+  12: list<i8> byte_list = [1, 2, 3],
+  13: list<i16> i16_list = [1,2,3],
+  14: list<i64> i64_list = [1,2,3]
+}
+
+struct Bonk {
+  1: i32 type,
+  2: string message,
+}
+
+struct Nesting {
+  1: Bonk my_bonk,
+  2: OneOfEach my_ooe,
+}
+
+struct HolyMoley {
+  1: list<OneOfEach> big,
+  2: set<list<string> (python.immutable = "")> contain,
+  3: map<string,list<Bonk>> bonks,
+}
+
+struct Backwards {
+  2: i32 first_tag2,
+  1: i32 second_tag1,
+}
+
+struct Empty {
+} (
+  python.immutable = "",
+)
+
+struct Wrapper {
+  1: Empty foo
+} (
+  python.immutable = "",
+)
+
+struct RandomStuff {
+  1: i32 a,
+  2: i32 b,
+  3: i32 c,
+  4: i32 d,
+  5: list<i32> myintlist,
+  6: map<i32,Wrapper> maps,
+  7: i64 bigint,
+  8: double triple,
+}
+
+struct Base64 {
+  1: i32 a,
+  2: binary b1,
+  3: binary b2,
+  4: binary b3,
+  5: binary b4,
+  6: binary b5,
+  7: binary b6,
+}
+
+struct CompactProtoTestStruct {
+  // primitive fields
+  1: i8     a_byte;
+  2: i16    a_i16;
+  3: i32    a_i32;
+  4: i64    a_i64;
+  5: double a_double;
+  6: string a_string;
+  7: binary a_binary;
+  8: bool   true_field;
+  9: bool   false_field;
+  10: Empty empty_struct_field;
+
+  // primitives in lists
+  11: list<i8>      byte_list;
+  12: list<i16>     i16_list;
+  13: list<i32>     i32_list;
+  14: list<i64>     i64_list;
+  15: list<double>  double_list;
+  16: list<string>  string_list;
+  17: list<binary>  binary_list;
+  18: list<bool>    boolean_list;
+  19: list<Empty>   struct_list;
+
+  // primitives in sets
+  20: set<i8>       byte_set;
+  21: set<i16>      i16_set;
+  22: set<i32>      i32_set;
+  23: set<i64>      i64_set;
+  24: set<double>   double_set;
+  25: set<string>   string_set;
+  26: set<binary>   binary_set;
+  27: set<bool>     boolean_set;
+  28: set<Empty>    struct_set;
+
+  // maps
+  // primitives as keys
+  29: map<i8, i8>               byte_byte_map;
+  30: map<i16, i8>              i16_byte_map;
+  31: map<i32, i8>              i32_byte_map;
+  32: map<i64, i8>              i64_byte_map;
+  33: map<double, i8>           double_byte_map;
+  34: map<string, i8>           string_byte_map;
+  35: map<binary, i8>           binary_byte_map;
+  36: map<bool, i8>             boolean_byte_map;
+  // primitives as values
+  37: map<i8, i16>              byte_i16_map;
+  38: map<i8, i32>              byte_i32_map;
+  39: map<i8, i64>              byte_i64_map;
+  40: map<i8, double>           byte_double_map;
+  41: map<i8, string>           byte_string_map;
+  42: map<i8, binary>           byte_binary_map;
+  43: map<i8, bool>             byte_boolean_map;
+  // collections as keys
+  44: map<list<i8> (python.immutable = ""), i8>       list_byte_map;
+  45: map<set<i8> (python.immutable = ""), i8>        set_byte_map;
+  46: map<map<i8,i8> (python.immutable = ""), i8>     map_byte_map;
+  // collections as values
+  47: map<i8, map<i8,i8>>     byte_map_map;
+  48: map<i8, set<i8>>        byte_set_map;
+  49: map<i8, list<i8>>       byte_list_map;
+}
+
+// To be used to test the serialization of an empty map
+struct SingleMapTestStruct {
+  1: required map<i32, i32>       i32_map;
+}
+
+const CompactProtoTestStruct COMPACT_TEST = {
+  'a_byte'             : 127,
+  'a_i16'              : 32000,
+  'a_i32'              : 1000000000,
+  'a_i64'              : 0xffffffffff,
+  'a_double'           : 5.6789,
+  'a_string'           : "my string",
+//'a_binary,'
+  'true_field'         : 1,
+  'false_field'        : 0,
+  'empty_struct_field' : {},
+  'byte_list'          : [-127, -1, 0, 1, 127],
+  'i16_list'           : [-1, 0, 1, 0x7fff],
+  'i32_list'           : [-1, 0, 0xff, 0xffff, 0xffffff, 0x7fffffff],
+  'i64_list'           : [-1, 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffff, 0xffffffffffff, 0xffffffffffffff, 0x7fffffffffffffff],
+  'double_list'        : [0.1, 0.2, 0.3],
+  'string_list'        : ["first", "second", "third"],
+//'binary_list,'
+  'boolean_list'       : [1, 1, 1, 0, 0, 0],
+  'struct_list'        : [{}, {}],
+  'byte_set'           : [-127, -1, 0, 1, 127],
+  'i16_set'            : [-1, 0, 1, 0x7fff],
+  'i32_set'            : [1, 2, 3],
+  'i64_set'            : [-1, 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffff, 0xffffffffffff, 0xffffffffffffff, 0x7fffffffffffffff],
+  'double_set'         : [0.1, 0.2, 0.3],
+  'string_set'         : ["first", "second", "third"],
+//'binary_set,'
+  'boolean_set'        : [1, 0],
+  'struct_set'         : [{}],
+  'byte_byte_map'      : {1 : 2},
+  'i16_byte_map'       : {1 : 1, -1 : 1, 0x7fff : 1},
+  'i32_byte_map'       : {1 : 1, -1 : 1, 0x7fffffff : 1},
+  'i64_byte_map'       : {0 : 1,  1 : 1, -1 : 1, 0x7fffffffffffffff : 1},
+  'double_byte_map'    : {-1.1 : 1, 1.1 : 1},
+  'string_byte_map'    : {"first" : 1, "second" : 2, "third" : 3, "" : 0},
+//'binary_byte_map,'
+  'boolean_byte_map'   : {1 : 1, 0 : 0},
+  'byte_i16_map'       : {1 : 1, 2 : -1, 3 : 0x7fff},
+  'byte_i32_map'       : {1 : 1, 2 : -1, 3 : 0x7fffffff},
+  'byte_i64_map'       : {1 : 1, 2 : -1, 3 : 0x7fffffffffffffff},
+  'byte_double_map'    : {1 : 0.1, 2 : -0.1, 3 : 1000000.1},
+  'byte_string_map'    : {1 : "", 2 : "blah", 3 : "loooooooooooooong string"},
+//'byte_binary_map,'
+  'byte_boolean_map'   : {1 : 1, 2 : 0},
+  'list_byte_map'      : {[1, 2, 3] : 1, [0, 1] : 2, [] : 0},
+  'set_byte_map'       : {[1, 2, 3] : 1, [0, 1] : 2, [] : 0},
+  'map_byte_map'       : {{1 : 1} : 1, {2 : 2} : 2, {} : 0},
+  'byte_map_map'       : {0 : {}, 1 : {1 : 1}, 2 : {1 : 1, 2 : 2}},
+  'byte_set_map'       : {0 : [], 1 : [1], 2 : [1, 2]},
+  'byte_list_map'      : {0 : [], 1 : [1], 2 : [1, 2]},
+}
+
+
+const i32 MYCONST = 2
+
+
+exception ExceptionWithAMap {
+  1: string blah;
+  2: map<string, string> map_field;
+}
+
+service ServiceForExceptionWithAMap {
+  void methodThatThrowsAnException() throws (1: ExceptionWithAMap xwamap);
+}
+
+service Srv {
+  i32 Janky(1: i32 arg);
+
+  // return type only methods
+
+  void voidMethod();
+  i32 primitiveMethod();
+  CompactProtoTestStruct structMethod();
+
+  void methodWithDefaultArgs(1: i32 something = MYCONST);
+
+  oneway void onewayMethod();
+
+  bool declaredExceptionMethod(1: bool shouldThrow) throws (1: ExceptionWithAMap xwamap);
+}
+
+service Inherited extends Srv {
+  i32 identity(1: i32 arg)
+}
+
+service EmptyService {}
+
+// The only purpose of this thing is to increase the size of the generated code
+// so that ZlibTest has more highly compressible data to play with.
+struct BlowUp {
+  1: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b1;
+  2: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b2;
+  3: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b3;
+  4: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b4;
+}
+
+
+struct ReverseOrderStruct {
+  4: string first;
+  3: i16 second;
+  2: i32 third;
+  1: i64 fourth;
+}
+
+service ReverseOrderService {
+  void myMethod(4: string first, 3: i16 second, 2: i32 third, 1: i64 fourth);
+}
+
+enum SomeEnum {
+  ONE = 1
+  TWO = 2
+}
+
+/** This is a docstring on a constant! */
+const SomeEnum MY_SOME_ENUM = SomeEnum.ONE
+
+const SomeEnum MY_SOME_ENUM_1 = 1
+/*const SomeEnum MY_SOME_ENUM_2 = 7*/
+
+const map<SomeEnum,SomeEnum> MY_ENUM_MAP = {
+  SomeEnum.ONE : SomeEnum.TWO
+}
+
+struct StructWithSomeEnum {
+  1: SomeEnum blah;
+}
+
+const map<SomeEnum,StructWithSomeEnum> EXTRA_CRAZY_MAP = {
+  SomeEnum.ONE : {"blah" : SomeEnum.TWO}
+}
+
+union TestUnion {
+  /**
+   * A doc string
+   */
+  1: string string_field;
+  2: i32 i32_field;
+  3: OneOfEach struct_field;
+  4: list<RandomStuff> struct_list;
+  5: i32 other_i32_field;
+  6: SomeEnum enum_field;
+  7: set<i32> i32_set;
+  8: map<i32, i32> i32_map;
+}
+
+union TestUnionMinusStringField {
+  2: i32 i32_field;
+  3: OneOfEach struct_field;
+  4: list<RandomStuff> struct_list;
+  5: i32 other_i32_field;
+  6: SomeEnum enum_field;
+  7: set<i32> i32_set;
+  8: map<i32, i32> i32_map;
+}
+
+union ComparableUnion {
+  1: string string_field;
+  2: binary binary_field;
+}
+
+struct StructWithAUnion {
+  1: TestUnion test_union;
+}
+
+struct PrimitiveThenStruct {
+  1: i32 blah;
+  2: i32 blah2;
+  3: Backwards bw;
+}
+
+typedef map<i32,i32> SomeMap
+
+struct StructWithASomemap {
+  1: required SomeMap somemap_field;
+}
+
+struct BigFieldIdStruct {
+  1: string field1;
+  45: string field2;
+}
+
+struct BreaksRubyCompactProtocol {
+  1: string field1;
+  2: BigFieldIdStruct field2;
+  3: i32 field3;
+}
+
+struct TupleProtocolTestStruct {
+  optional i32 field1;
+  optional i32 field2;
+  optional i32 field3;
+  optional i32 field4;
+  optional i32 field5;
+  optional i32 field6;
+  optional i32 field7;
+  optional i32 field8;
+  optional i32 field9;
+  optional i32 field10;
+  optional i32 field11;
+  optional i32 field12;
+}
+
+struct ListDoublePerf {
+  1: list<double> field;
+}

--- a/thrift/examples/thrift_project/DenseLinkingTest.thrift
+++ b/thrift/examples/thrift_project/DenseLinkingTest.thrift
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+../compiler/cpp/thrift -gen cpp:dense DebugProtoTest.thrift
+../compiler/cpp/thrift -gen cpp:dense DenseLinkingTest.thrift
+g++ -Wall -g -I../lib/cpp/src -I/usr/local/include/boost-1_33_1 \
+  DebugProtoTest.cpp gen-cpp/DebugProtoTest_types.cpp \
+  gen-cpp/DenseLinkingTest_types.cpp \
+  ../lib/cpp/.libs/libthrift.a -o DebugProtoTest
+./DebugProtoTest
+*/
+
+/*
+The idea of this test is that everything is structurally identical to DebugProtoTest.
+If I messed up the naming of the reflection local typespecs,
+then compiling this should give errors because of doubly defined symbols.
+*/
+
+namespace cpp thrift.test
+namespace java thrift.test
+
+struct OneOfEachZZ {
+  1: bool im_true,
+  2: bool im_false,
+  3: byte a_bite,
+  4: i16 integer16,
+  5: i32 integer32,
+  6: i64 integer64,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+}
+
+struct BonkZZ {
+  1: i32 type,
+  2: string message,
+}
+
+struct NestingZZ {
+  1: BonkZZ my_bonk,
+  2: OneOfEachZZ my_ooe,
+}
+
+struct HolyMoleyZZ {
+  1: list<OneOfEachZZ> big,
+  2: set<list<string>> contain,
+  3: map<string,list<BonkZZ>> bonks,
+}
+
+struct BackwardsZZ {
+  2: i32 first_tag2,
+  1: i32 second_tag1,
+}
+
+struct EmptyZZ {
+}
+
+struct WrapperZZ {
+  1: EmptyZZ foo
+}
+
+struct RandomStuffZZ {
+  1: i32 a,
+  2: i32 b,
+  3: i32 c,
+  4: i32 d,
+  5: list<i32> myintlist,
+  6: map<i32,WrapperZZ> maps,
+  7: i64 bigint,
+  8: double triple,
+}
+
+service Srv {
+  i32 Janky(1: i32 arg)
+}
+
+service UnderscoreSrv {
+  i64 some_rpc_call(1: string message)
+}
+

--- a/thrift/examples/thrift_project/DocTest.thrift
+++ b/thrift/examples/thrift_project/DocTest.thrift
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Program doctext.
+ *
+ * Seriously, this is the documentation for this whole program.
+ */
+
+namespace java thrift.test
+namespace cpp thrift.test
+
+// C++ comment
+/* c style comment */
+
+# the new unix comment
+
+/** Some doc text goes here.  Wow I am [nesting these] (no more nesting.) */
+enum Numberz
+{
+
+  /** This is how to document a parameter */
+  ONE = 1,
+
+  /** And this is a doc for a parameter that has no specific value assigned */
+  TWO,
+
+  THREE,
+  FIVE = 5,
+  SIX,
+  EIGHT = 8
+}
+
+/** This is how you would do a typedef doc */
+typedef i64 UserId
+
+/** And this is where you would document a struct */
+struct Xtruct
+{
+
+  /** And the members of a struct */
+  1:  string string_thing
+
+  /** doct text goes before a comma */
+  4:  i8     byte_thing,
+
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+/**
+ * You can document constants now too.  Yeehaw!
+ */
+const i32 INT32CONSTANT = 9853
+const i16 INT16CONSTANT = 1616
+/** Everyone get in on the docu-action! */
+const map<string,string> MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}
+
+struct Xtruct2
+{
+  1: i8     byte_thing,
+  2: Xtruct struct_thing,
+  3: i32    i32_thing
+}
+
+/** Struct insanity */
+struct Insanity
+{
+
+  /** This is doc for field 1 */
+  1: map<Numberz, UserId> userMap,
+
+  /** And this is doc for field 2 */
+  2: list<Xtruct> xtructs
+}
+
+exception Xception {
+  1: i32 errorCode,
+  2: string message
+}
+
+exception Xception2 {
+  1: i32 errorCode,
+  2: Xtruct struct_thing
+}
+
+/* C1 */
+/** Doc */
+/* C2 */
+/* C3 */
+struct EmptyStruct {}
+
+struct OneField {
+  1: EmptyStruct field
+}
+
+/** This is where you would document a Service */
+service ThriftTest
+{
+
+  /** And this is how you would document functions in a service */
+  void         testVoid(),
+  string       testString(1: string thing),
+  i8           testByte(1: byte thing),
+  i32          testI32(1: i32 thing),
+
+  /** Like this one */
+  i64          testI64(1: i64 thing),
+  double       testDouble(1: double thing),
+  Xtruct       testStruct(1: Xtruct thing),
+  Xtruct2      testNest(1: Xtruct2 thing),
+  map<i32,i32> testMap(1: map<i32,i32> thing),
+  set<i32>     testSet(1: set<i32> thing),
+  list<i32>    testList(1: list<i32> thing),
+
+  /** This is an example of a function with params documented */
+  Numberz      testEnum(
+
+    /** This param is a thing */
+    1: Numberz thing
+
+  ),
+
+  UserId       testTypedef(1: UserId thing),
+
+  map<i32,map<i32,i32>> testMapMap(1: i32 hello),
+
+  /* So you think you've got this all worked, out eh? */
+  map<UserId, map<Numberz,Insanity>> testInsanity(1: Insanity argument),
+
+}
+
+/// This style of Doxy-comment doesn't work.
+typedef i32 SorryNoGo
+
+/**
+ * This is a trivial example of a multiline docstring.
+ */
+typedef i32 TrivialMultiLine
+
+/**
+ * This is the canonical example
+ * of a multiline docstring.
+ */
+typedef i32 StandardMultiLine
+
+/**
+ * The last line is non-blank.
+ * I said non-blank! */
+typedef i32 LastLine
+
+/** Both the first line
+ * are non blank. ;-)
+ * and the last line */
+typedef i32 FirstAndLastLine
+
+/**
+ *    INDENTED TITLE
+ * The text is less indented.
+ */
+typedef i32 IndentedTitle
+
+/**       First line indented.
+ * Unfortunately, this does not get indented.
+ */
+typedef i32 FirstLineIndent
+
+
+/**
+ * void code_in_comment() {
+ *   printf("hooray code!");
+ * }
+ */
+typedef i32 CodeInComment
+
+    /**
+     * Indented Docstring.
+     * This whole docstring is indented.
+     *   This line is indented further.
+     */
+typedef i32 IndentedDocstring
+
+/** Irregular docstring.
+ * We will have to punt
+  * on this thing */
+typedef i32 Irregular1
+
+/**
+ * note the space
+ * before these lines
+* but not this
+ * one
+ */
+typedef i32 Irregular2
+
+/**
+* Flush against
+* the left.
+*/
+typedef i32 Flush
+
+/**
+  No stars in this one.
+  It should still work fine, though.
+    Including indenting.
+    */
+typedef i32 NoStars
+
+/** Trailing whitespace   
+Sloppy trailing whitespace   
+is truncated.   */
+typedef i32 TrailingWhitespace
+
+/**
+ * This is a big one.
+ *
+ * We'll have some blank lines in it.
+ * 
+ * void as_well_as(some code) {
+ *   puts("YEEHAW!");
+ * }
+ */
+typedef i32 BigDog
+
+/**
+*
+*
+*/
+typedef i32 TotallyDegenerate
+
+/**no room for newline here*/
+
+/* * / */
+typedef i32 TestFor3501a
+
+/**
+ * /
+ */
+typedef i32 TestFor3501b
+
+
+/* Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_00 { /* ? */ 1: i32 foo }
+/* Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_01 { /* ? */ 1: i32 foo }
+/* Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_02 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_03 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_04 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_05 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_06 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_07 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_08 { /* ? */ 1: i32 foo }
+
+struct TestFor3709 {
+  /** This is a comment */
+  1: required string id,
+  /** This is also a comment **/
+  2: required string typeId,
+  /** Yet another comment! */
+  3: required i32 endTimestamp
+}
+
+
+/* THE END */

--- a/thrift/examples/thrift_project/EnumContainersTest.thrift
+++ b/thrift/examples/thrift_project/EnumContainersTest.thrift
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test.enumcontainers
+
+enum GreekGodGoddess {
+    ARES,
+    APHRODITE,
+    ZEUS,
+    POSEIDON,
+    HERA,
+}
+
+typedef GreekGodGoddess GreekGodGoddessType
+typedef i32 Power
+
+struct GodBean {
+    1: optional map<GreekGodGoddessType, Power> power,
+    2: optional set<GreekGodGoddessType> goddess,
+    3: optional map<string, GreekGodGoddess> byAlias,
+    4: optional set<string> images,
+}
+
+const map<GreekGodGoddessType, string> ATTRIBUTES =
+{
+    GreekGodGoddess.ZEUS: "lightning bolt",
+    GreekGodGoddess.POSEIDON: "trident",
+}
+
+const set<GreekGodGoddessType> BEAUTY = [ GreekGodGoddess.APHRODITE, GreekGodGoddess.HERA ]

--- a/thrift/examples/thrift_project/EnumTest.thrift
+++ b/thrift/examples/thrift_project/EnumTest.thrift
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+
+enum MyEnum1 {
+  ME1_0 = 0,
+  ME1_1 = 1,
+  ME1_2,
+  ME1_3,
+  ME1_5 = 5,
+  ME1_6,
+}
+
+enum MyEnum2 {
+  ME2_0,
+  ME2_1,
+  ME2_2,
+}
+
+enum MyEnum2_again {
+  // enum value identifiers may appear again in another enum type
+  ME0_1,
+  ME1_1,
+  ME2_1,
+  ME3_1,
+}
+
+enum MyEnum3 {
+  ME3_0,
+  ME3_1,
+  ME3_N2 = -2,
+  ME3_N1,
+  ME3_D0,
+  ME3_D1,
+  ME3_9 = 9,
+  ME3_10,
+}
+
+enum MyEnum4 {
+  ME4_A = 0x7ffffffd
+  ME4_B
+  ME4_C
+  // attempting to define another enum value here fails
+  // with an overflow error, as we overflow values that can be
+  // represented with an i32.
+}
+
+enum MyEnum5 {
+  e1        // fails with 0.9.3 and earlier
+  e2 = 42   // fails with 0.9.3 and earlier
+}
+
+enum MyEnumWithCustomOstream {
+  custom1 = 1,
+  CustoM2
+} (cpp.customostream)
+
+struct MyStruct {
+  1: MyEnum2 me2_2 = MyEnum1.ME2_2
+  2: MyEnum3 me3_n2 = MyEnum3.ME3_N2
+  3: MyEnum3 me3_d1 = MyEnum3.ME3_D1
+}
+
+struct EnumTestStruct {
+  1: MyEnum3 a_enum;
+  2: list<MyEnum3> enum_list;
+  3: set<MyEnum3> enum_set;
+  4: map<MyEnum3, MyEnum3> enum_enum_map;
+  // collections as keys
+  44: map<list<MyEnum3> (python.immutable = ""), MyEnum3> list_enum_map;
+  45: map<set<MyEnum3> (python.immutable = ""), MyEnum3> set_enum_map;
+  46: map<map<MyEnum3,MyEnum3> (python.immutable = ""), MyEnum3> map_enum_map;
+  // collections as values
+  47: map<MyEnum3, map<MyEnum3, MyEnum3>> enum_map_map;
+  48: map<MyEnum3, set<MyEnum3>> enum_set_map;
+  49: map<MyEnum3, list<MyEnum3>> enum_list_map;
+}
+
+const EnumTestStruct ENUM_TEST = {
+  'a_enum': MyEnum3.ME3_D1,
+  'enum_list': [MyEnum3.ME3_D1, MyEnum3.ME3_0, MyEnum3.ME3_N2],
+  'enum_set': [MyEnum3.ME3_D1, MyEnum3.ME3_N1],
+  'enum_enum_map': {MyEnum3.ME3_D1: MyEnum3.ME3_0, MyEnum3.ME3_0: MyEnum3.ME3_D1},
+  'list_enum_map': {[MyEnum3.ME3_D1, MyEnum3.ME3_0]: MyEnum3.ME3_0, [MyEnum3.ME3_D1]: MyEnum3.ME3_0, [MyEnum3.ME3_0]: MyEnum3.ME3_D1},
+  'set_enum_map': {[MyEnum3.ME3_D1, MyEnum3.ME3_0]: MyEnum3.ME3_0, [MyEnum3.ME3_D1]: MyEnum3.ME3_0},
+  'map_enum_map': {{MyEnum3.ME3_N1: MyEnum3.ME3_10}: MyEnum3.ME3_1},
+  'enum_map_map': {MyEnum3.ME3_N1: {MyEnum3.ME3_D1: MyEnum3.ME3_D1}},
+  'enum_set_map': {MyEnum3.ME3_N2: [MyEnum3.ME3_D1, MyEnum3.ME3_N1], MyEnum3.ME3_10: [MyEnum3.ME3_D1, MyEnum3.ME3_N1]},
+  'enum_list_map': {MyEnum3.ME3_D1: [MyEnum3.ME3_10], MyEnum3.ME3_0: [MyEnum3.ME3_9, MyEnum3.ME3_10]},
+}
+
+service EnumTestService {
+  MyEnum3 testEnum(1: MyEnum3 enum1),
+  list<MyEnum3> testEnumList(1: list<MyEnum3> enum1),
+  set<MyEnum3> testEnumSet(1: set<MyEnum3> enum1),
+  map<MyEnum3, MyEnum3> testEnumMap(1: map<MyEnum3, MyEnum3> enum1),
+  EnumTestStruct testEnumStruct(1: EnumTestStruct enum1),
+}

--- a/thrift/examples/thrift_project/FullCamelTest.thrift
+++ b/thrift/examples/thrift_project/FullCamelTest.thrift
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test.fullcamel
+
+struct OneOfEachZZ {
+  1: bool im_true,
+  2: bool im_false,
+  3: byte a_bite,
+  4: i16 integer16,
+  5: i32 integer32,
+  6: i64 integer64,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+}
+
+service UnderscoreSrv {
+  i64 some_rpc_call(1: string message)
+}
+

--- a/thrift/examples/thrift_project/Include.thrift
+++ b/thrift/examples/thrift_project/Include.thrift
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+include "ThriftTest.thrift"
+
+struct IncludeTest {
+  1: required ThriftTest.Bools bools
+}

--- a/thrift/examples/thrift_project/JavaBeansTest.thrift
+++ b/thrift/examples/thrift_project/JavaBeansTest.thrift
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test
+
+struct OneOfEachBeans {
+  1: bool boolean_field,
+  2: byte a_bite,
+  3: i16 integer16,
+  4: i32 integer32,
+  5: i64 integer64,
+  6: double double_precision,
+  7: string some_characters,
+  8: binary base64,
+  9: list<byte> byte_list,
+  10: list<i16> i16_list,
+  11: list<i64> i64_list
+}
+
+
+service Service {
+  i64 mymethod(i64 blah);
+}

--- a/thrift/examples/thrift_project/JavaDeepCopyTest.thrift
+++ b/thrift/examples/thrift_project/JavaDeepCopyTest.thrift
@@ -1,0 +1,19 @@
+include "JavaTypes.thrift"
+
+namespace java thrift.test
+
+struct DeepCopyFoo {
+  1: optional list<DeepCopyBar> l,
+  2: optional set<DeepCopyBar> s,
+  3: optional map<string, DeepCopyBar> m,
+  4: optional list<JavaTypes.Object> li,
+  5: optional set<JavaTypes.Object> si,
+  6: optional map<string, JavaTypes.Object> mi,
+  7: optional DeepCopyBar bar,
+}
+
+struct DeepCopyBar {
+  1: optional string a,
+  2: optional i32 b,
+  3: optional bool c,
+}

--- a/thrift/examples/thrift_project/JavaTypes.thrift
+++ b/thrift/examples/thrift_project/JavaTypes.thrift
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test
+
+struct Integer {
+  1: i32 val
+}
+
+struct String {
+  1: string val
+}
+
+struct Boolean {
+  1: bool val
+}
+
+struct Double {
+  1: double val
+}
+
+struct Long {
+  1: i64 val
+}
+
+struct Byte {
+  1: byte val
+}
+
+struct Float {
+  1: double val
+}
+
+struct List {
+  1: list<string> vals
+}
+
+struct ArrayList {
+  1: list<string> vals
+}
+
+struct SortedMap {
+  1: map<string, string> vals
+}
+
+struct TreeMap {
+  1: map<string, string> vals
+}
+
+struct HashMap {
+  1: map<string, String> vals
+}
+
+struct Map {
+  1: map<double, Double> vals
+}
+
+struct Object {
+  1: Integer integer,
+  2: String str,
+  3: Boolean boolean_field,
+  4: Double dbl,
+  5: Byte bite,
+  6: map<i32, Integer> intmap,
+  7: Map somemap,
+}
+
+exception Exception {
+  1: string msg
+}
+
+service AsyncNonblockingService {
+  Object mymethod(
+    1: Integer integer,
+    2: String str,
+    3: Boolean boolean_field,
+    4: Double dbl,
+    5: Byte bite,
+    6: map<i32, Integer> intmap,
+    7: Map somemap,
+  ) throws (1:Exception ex);
+}

--- a/thrift/examples/thrift_project/JsDeepConstructorTest.thrift
+++ b/thrift/examples/thrift_project/JsDeepConstructorTest.thrift
@@ -1,0 +1,18 @@
+struct Simple {
+  1: string value
+}
+
+struct Complex {
+  1: Simple struct_field
+  2: list<Simple> struct_list_field
+  3: set<Simple> struct_set_field
+  4: map<string,Simple> struct_map_field
+  5: list<set<map<string,list<Simple>>>> struct_nested_containers_field
+  6: map<string, list<map<string,Simple>> > struct_nested_containers_field2
+  7: list<list<string>> list_of_list_field
+  8: list<list<list<string>>> list_of_list_of_list_field
+}
+
+struct ComplexList {
+  1: list<Complex> struct_list_field;
+}

--- a/thrift/examples/thrift_project/ManyOptionals.thrift
+++ b/thrift/examples/thrift_project/ManyOptionals.thrift
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The java codegenerator has a few different codepaths depending
+// on how many optionals the struct has; this attempts to exercise
+// them.
+
+namespace java thrift.test
+
+struct Opt4 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+}
+
+struct Opt13 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+}
+
+struct Opt30 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+}
+
+struct Opt64 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+  31: i32 def31;
+  32: i32 def32;
+  33: i32 def33;
+  34: i32 def34;
+  35: i32 def35;
+  36: i32 def36;
+  37: i32 def37;
+  38: i32 def38;
+  39: i32 def39;
+  40: i32 def40;
+  41: i32 def41;
+  42: i32 def42;
+  43: i32 def43;
+  44: i32 def44;
+  45: i32 def45;
+  46: i32 def46;
+  47: i32 def47;
+  48: i32 def48;
+  49: i32 def49;
+  50: i32 def50;
+  51: i32 def51;
+  52: i32 def52;
+  53: i32 def53;
+  54: i32 def54;
+  55: i32 def55;
+  56: i32 def56;
+  57: i32 def57;
+  58: i32 def58;
+  59: i32 def59;
+  60: i32 def60;
+  61: i32 def61;
+  62: i32 def62;
+  63: i32 def63;
+  64: i32 def64;
+}
+
+struct Opt80 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+  31: i32 def31;
+  32: i32 def32;
+  33: i32 def33;
+  34: i32 def34;
+  35: i32 def35;
+  36: i32 def36;
+  37: i32 def37;
+  38: i32 def38;
+  39: i32 def39;
+  40: i32 def40;
+  41: i32 def41;
+  42: i32 def42;
+  43: i32 def43;
+  44: i32 def44;
+  45: i32 def45;
+  46: i32 def46;
+  47: i32 def47;
+  48: i32 def48;
+  49: i32 def49;
+  50: i32 def50;
+  51: i32 def51;
+  52: i32 def52;
+  53: i32 def53;
+  54: i32 def54;
+  55: i32 def55;
+  56: i32 def56;
+  57: i32 def57;
+  58: i32 def58;
+  59: i32 def59;
+  60: i32 def60;
+  61: i32 def61;
+  62: i32 def62;
+  63: i32 def63;
+  64: i32 def64;
+  65: i32 def65;
+  66: i32 def66;
+  67: i32 def67;
+  68: i32 def68;
+  69: i32 def69;
+  70: i32 def70;
+  71: i32 def71;
+  72: i32 def72;
+  73: i32 def73;
+  74: i32 def74;
+  75: i32 def75;
+  76: i32 def76;
+  77: i32 def77;
+  78: i32 def78;
+  79: i32 def79;
+  80: i32 def80;
+}
+

--- a/thrift/examples/thrift_project/ManyTypedefs.thrift
+++ b/thrift/examples/thrift_project/ManyTypedefs.thrift
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This is to make sure you don't mess something up when you change typedef code.
+// Generate it with the old and new thrift and make sure they are the same.
+/*
+rm -rf gen-* orig-*
+mkdir old new
+thrift --gen cpp --gen java --gen php --gen phpi --gen py --gen rb --gen xsd --gen perl --gen ocaml --gen erl --gen hs --strict ManyTypedefs.thrift
+mv gen-* old
+../compiler/cpp/thrift --gen cpp --gen java --gen php --gen phpi --gen py --gen rb --gen xsd --gen perl --gen ocaml --gen erl --gen hs --strict ManyTypedefs.thrift
+mv gen-* new
+diff -ur old new
+rm -rf old new
+# There should be no output.
+*/
+
+typedef i32 int32
+typedef list<map<int32, string>> biglist
+
+struct struct1 {
+  1: int32 myint;
+  2: biglist mylist;
+}
+
+exception exception1 {
+  1: biglist alist;
+  2: struct1 mystruct;
+}
+
+service AService {
+  struct1 method1(1: int32 myint) throws (1: exception1 exn);
+  biglist method2();
+}

--- a/thrift/examples/thrift_project/NameConflictTest.thrift
+++ b/thrift/examples/thrift_project/NameConflictTest.thrift
@@ -1,0 +1,110 @@
+// Naming testcases, sepcifically for these tickets (but not limited to them)
+// THRIFT-2508 Uncompileable C# code due to language keywords in IDL
+// THRIFT-2557 error CS0542 member names cannot be the same as their enclosing type
+
+
+struct using {
+    1: double single
+    2: double integer
+}
+
+struct delegate {
+    1: string partial
+    2: delegate delegate
+}
+
+struct get {
+    1: bool sbyte
+}
+
+struct partial {
+    1: using using
+    2: bool read
+    3: bool write
+}
+
+enum Maybe {
+  JUST = 1,
+  TRUE = 2,
+  FALSE = 3
+}
+
+enum Either {
+  LEFT = 1,
+  RIGHT = 2
+}
+
+struct foldr {
+  1: string id
+}
+
+struct of {
+  1: string let
+  2: string where
+}
+
+struct ofOf {
+  1: of Of
+}
+
+
+struct ClassAndProp {
+  1: bool ClassAndProp
+  2: bool ClassAndProp_
+  3: bool ClassAndProp__
+  4: bool ClassAndProper
+}
+
+struct second_chance {
+  1: bool SECOND_CHANCE
+  2: bool SECOND_CHANCE_
+  3: bool SECOND_CHANCE__
+  4: bool SECOND_CHANCES
+}
+
+struct NOW_EAT_THIS {
+  1: bool now_eat_this
+  2: bool now_eat_this_
+  3: bool now_eat_this__
+  4: bool now_eat_this_and_this
+}
+
+struct TheEdgeCase {
+  1: bool theEdgeCase
+  2: bool theEdgeCase_
+  3: bool theEdgeCase__
+  4: bool TheEdgeCase
+  5: bool TheEdgeCase_
+  6: bool TheEdgeCase__
+}
+
+struct Tricky_ {
+  1: bool tricky
+  2: bool Tricky
+}
+
+struct Nested {
+  1: ClassAndProp ClassAndProp
+  2: second_chance second_chance
+  3: NOW_EAT_THIS NOW_EAT_THIS
+  4: TheEdgeCase TheEdgeCase
+  5: Tricky_ Tricky_
+  6: Nested Nested
+}
+
+exception Problem_ {
+  1: bool problem
+  2: bool Problem
+}
+
+
+service extern {
+    delegate event(1: partial get)
+    void Foo(1: Nested Foo_args) throws (1: Problem_ Foo_result)
+}
+
+service qualified {
+    Maybe maybe(1: Maybe foldr)
+    Either either(1: foldr of)
+}
+// eof

--- a/thrift/examples/thrift_project/OptionalRequiredTest.thrift
+++ b/thrift/examples/thrift_project/OptionalRequiredTest.thrift
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+namespace cpp thrift.test
+namespace java thrift.test
+
+struct OldSchool {
+  1: i16    im_int;
+  2: string im_str;
+  3: list<map<i32,string>> im_big;
+}
+
+struct Simple {
+  1: /* :) */ i16 im_default;
+  2: required i16 im_required;
+  3: optional i16 im_optional;
+}
+
+struct Tricky1 {
+  1: /* :) */ i16 im_default;
+}
+
+struct Tricky2 {
+  1: optional i16 im_optional;
+}
+
+struct Tricky3 {
+  1: required i16 im_required;
+}
+
+struct OptionalDefault {
+  1: optional i16 opt_int = 1234;
+  2: optional string opt_str = "default";
+}
+
+struct Complex {
+  1:          i16 cp_default;
+  2: required i16 cp_required;
+  3: optional i16 cp_optional;
+  4:          map<i16,Simple> the_map;
+  5: required Simple req_simp;
+  6: optional Simple opt_simp;
+}
+
+struct ManyOpt {
+  1: optional i32 opt1;
+  2: optional i32 opt2;
+  3: optional i32 opt3;
+  4:          i32 def4;
+  5: optional i32 opt5;
+  6: optional i32 opt6;
+}
+
+struct JavaTestHelper {
+  1: required i32    req_int;
+  2: optional i32    opt_int;
+  3: required string req_obj;
+  4: optional string opt_obj;
+  5: required binary req_bin;
+  6: optional binary opt_bin;
+}
+
+struct Binaries {
+  4: binary bin;
+  5: required binary req_bin;
+  6: optional binary opt_bin;
+}

--- a/thrift/examples/thrift_project/ReuseObjects.thrift
+++ b/thrift/examples/thrift_project/ReuseObjects.thrift
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The java codegenerator has option to reuse objects for deserialization
+
+namespace java thrift.test
+
+include "ThriftTest.thrift"
+
+struct Reuse {
+  1: i32 val1;
+  2: set<string> val2;
+}
+

--- a/thrift/examples/thrift_project/SmallTest.thrift
+++ b/thrift/examples/thrift_project/SmallTest.thrift
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+namespace rb TestNamespace
+
+struct Goodbyez {
+  1: i32 val = 325;
+}
+
+senum Thinger {
+  "ASDFKJ",
+  "r32)*F#@",
+  "ASDFLJASDF"
+}
+
+struct BoolPasser {
+  1: bool value = 1
+}
+
+struct Hello {
+  1: i32 simple = 53,
+  2: map<i32,i32> complex = {23:532, 6243:632, 2355:532},
+  3: map<i32, map<i32,i32>> complexer,
+  4: string words = "words",
+  5: Goodbyez thinz = {'val' : 36632}
+}
+
+const map<i32,map<i32,i32>> CMAP = { 235: {235:235}, 53:{53:53} }
+const i32 CINT = 325;
+const Hello WHOA = {'simple' : 532}
+
+exception Goodbye {
+  1: i32 simple,
+  2: map<i32,i32> complex,
+  3: map<i32, map<i32,i32>> complexer,
+}
+
+service SmallService {
+  Thinger testThinger(1:Thinger bootz),
+  Hello testMe(1:i32 hello=64, 2: Hello wonk) throws (1: Goodbye g),
+  void testVoid() throws (1: Goodbye g),
+  i32 testI32(1:i32 boo)
+}

--- a/thrift/examples/thrift_project/StressTest.thrift
+++ b/thrift/examples/thrift_project/StressTest.thrift
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp test.stress
+namespace d thrift.test.stress
+namespace go stress
+
+service Service {
+
+  void echoVoid(),
+  i8 echoByte(1: i8 arg),
+  i32 echoI32(1: i32 arg),
+  i64 echoI64(1: i64 arg),
+  string echoString(1: string arg),
+  list<i8>  echoList(1: list<i8> arg),
+  set<i8>  echoSet(1: set<i8> arg),
+  map<i8, i8>  echoMap(1: map<i8, i8> arg),
+}
+

--- a/thrift/pom.xml
+++ b/thrift/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>thrift</artifactId>
+	<packaging>jar</packaging>
+	<name>Apache Thrift IDL grammar</name>
+	<parent>
+		<groupId>com.antlr.grammarsv4</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<grammars>Thrift.g4</grammars>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>true</verbose>
+					<showTree>true</showTree>
+					<entryPoint>document</entryPoint>
+					<grammarName>Thrift</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Hi all,
I'm working in the field of fast RPC implementations, my actual project is to provide a translator between different fast RPC schema languages.

During my work I created three ANTLR4 grammars which were helpful for me, and I wanted to share them:
1. Apache Thrift interface description language: https://thrift.apache.org/docs/idl
2. Cap'n Proto schema language: https://capnproto.org/language.html
3. Google FlatBuffers schema language: http://google.github.io/flatbuffers/flatbuffers_grammar.html

The three ANTLR4 grammars come together with many examples, passing grammar unit testing.
The three local pom.xml files are provided -- may I ask someone from the maintainers to add them too the global pom.xml if everything is working fine?

Enjoy, Andreas
gidl-community@gmx.de