### PR TITLE
[BugFix]: [C] Function call with single argument should be recognized as "statement" but actually as "declaration".

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -478,8 +478,8 @@ blockItemList
     ;
 
 blockItem
-    :   declaration
-    |   statement
+    :   statement
+    |   declaration
     ;
 
 expressionStatement

--- a/c/examples/FuncCallAsFuncArgument.c
+++ b/c/examples/FuncCallAsFuncArgument.c
@@ -1,0 +1,22 @@
+/*
+Func call with various arg numbers.
+And func forward declarations.
+And func call as func call argument.
+*/
+
+void aX(void);
+int a1(int param1);
+int a2(int param1, param2);
+void a3();
+void a3(void);
+
+int f(int arg1, char arg2)
+{
+	a1(arg1);
+	a2(arg1, arg2);
+	a3();
+	a1(a1());
+	a1(a1(), a2(a1(), x1));
+}
+
+

--- a/c/examples/FuncForwardDeclaration.c
+++ b/c/examples/FuncForwardDeclaration.c
@@ -1,0 +1,19 @@
+/*
+Func call with various arg numbers.
+And func forward declarations.
+*/
+
+void aX(void);
+int a1(int param1);
+int a2(int param1, param2);
+void a3();
+void a3(void);
+
+int f(int arg1, char arg2)
+{
+	a1(arg1);
+	a2(arg1, arg2);
+	a3();
+}
+
+

--- a/c/examples/FunctionCall.c
+++ b/c/examples/FunctionCall.c
@@ -1,0 +1,6 @@
+int f(int arg1, char arg2)
+{
+	a1(arg1);
+	a2(arg1, arg2);
+	a3();
+}


### PR DESCRIPTION
This is to fix Issue https://github.com/antlr/grammars-v4/issues/1082.
With the old C.g4, the function call with single argument will be mistakenly recognized as `declaration`. The correct recognization result should be `statement`.
E.g.
For this input:

```
int f(int arg1, char arg2)
{
	a1(arg1);
	a2(arg1, arg2);
	a3();
}
```


**The buggy version:**
![bug_funccallwithsinglearg](https://user-images.githubusercontent.com/999318/37466001-a080e054-2897-11e8-81c4-e058e61c737c.png)

**The fixed version:**
![bugfix_funccallwithsinglearg](https://user-images.githubusercontent.com/999318/37466066-d0f7ffe2-2897-11e8-8df1-00b89317c42b.png)


**（The commits include the fix and 3 example files.）**
