### PR TITLE
HyperTalk grammar improvements

### DIFF
--- a/hypertalk/HyperTalk.g4
+++ b/hypertalk/HyperTalk.g4
@@ -63,18 +63,13 @@ handlerName
     | commandName   // Handlers can take the name of a command keyword (other keywords are disallowed)
     ;
 
-argumentList
-    : expression
-    | argumentList ',' expression
-    ;
-
 parameterList
     : ID
     | parameterList ',' ID
     ;
 
 statementList
-    : statement? NEWLINE statementList
+    : statement NEWLINE+ statementList
     | statement NEWLINE+
     ;
 
@@ -114,13 +109,13 @@ elseStatement
     ;
 
 repeatStatement
-    : 'repeat' repeatRange NEWLINE statementList 'end' 'repeat'
+    : 'repeat' repeatRange NEWLINE+ statementList 'end' 'repeat'
     | 'repeat' repeatRange NEWLINE+ 'end' 'repeat'
     ;
 
 messageStatement
     : ID
-    | ID argumentList
+    | ID listExpression
     ;
 
 commandStmnt
@@ -135,8 +130,8 @@ commandStmnt
     | 'beep' expression
     | 'choose' toolExpression 'tool'?
     | 'choose' 'tool' toolExpression
-    | 'click' 'at' expression
-    | 'click' 'at' expression 'with' argumentList
+    | 'click' 'at' listExpression
+    | 'click' 'at' listExpression 'with' listExpression
     | 'close' 'file' expression
     | 'convert' container 'to' convertible
     | 'convert' container 'from' convertible 'to' convertible
@@ -149,22 +144,29 @@ commandStmnt
     | 'divide' expression 'by' expression
     | 'do' expression
     | 'domenu' expression
-    | 'drag' 'from' expression 'to' expression
-    | 'drag' 'from' expression 'to' expression 'with' argumentList
+    | 'drag' 'from' listExpression 'to' listExpression
+    | 'drag' 'from' listExpression 'to' listExpression 'with' listExpression
+    | 'edit' 'the'? 'script' of expression
     | 'enable' expression
     | 'exit' handlerName
     | 'exit' 'repeat'
     | 'exit' 'to' 'hypercard'
-    | find expression
-    | find expression of expression
-    | find expression of 'marked' cards
-    | find expression of expression of 'marked' cards
+    | 'export' 'paint' 'to' 'file' expression
+    | 'find' expression? 'international'? expression of expression of 'marked' cards
+    | 'find' expression? 'international'? expression of expression
+    | 'find' expression? 'international'? expression of 'marked' cards
+    | 'find' expression? 'international'? expression
     | 'get' expression
     | 'go' 'to'? expression 'with' 'visual' expression
     | 'go' 'to'? expression
     | 'go' 'back'
     | 'go' 'back' 'with' 'visual' expression
     | 'hide' expression
+    | 'hide' card picture
+    | 'hide' background picture
+    | 'hide' picture of expression
+    | 'hide' 'titlebar'
+    | 'import' 'paint' 'from' 'file' expression
     | 'lock' 'screen'
     | 'multiply' expression 'by' expression
     | 'next' 'repeat'
@@ -174,8 +176,8 @@ commandStmnt
     | 'pop' card
     | 'push' card
     | 'push' expression
-    | 'put' expression
-    | 'put' expression preposition expression
+    | 'put' listExpression
+    | 'put' listExpression preposition expression
     | 'read' 'from' 'file' expression
     | 'read' 'from' 'file' expression 'for' expression
     | 'read' 'from' 'file' expression 'at' expression 'for' expression
@@ -190,8 +192,12 @@ commandStmnt
     | 'select' 'before' expression
     | 'select' 'after' expression
     | 'set' property 'to' propertyValue
-    | 'send' expression 'to' expression
+    | 'send' listExpression 'to' expression
     | 'show' expression
+    | 'show' card picture
+    | 'show' background picture
+    | 'show' picture of expression
+    | 'show' 'titlebar'
     | 'sort' sortChunkType expression sortDirection sortStyle
     | 'sort' sortChunkType expression sortDirection sortStyle 'by' expression
     | 'sort' sortDirection sortStyle 'by' expression
@@ -201,6 +207,9 @@ commandStmnt
     | 'sort' expression sortDirection sortStyle 'by' expression
     | 'sort' 'the'? cards of expression sortDirection sortStyle 'by' expression
     | 'sort' 'the'? 'marked' cards of expression sortDirection sortStyle 'by' expression
+    | 'speak' expression
+    | 'speak' expression 'with' gender=('male'|'female'|'neuter'|'robotic') 'voice'
+    | 'speak' expression 'with' 'voice' expression
     | 'subtract' expression 'from' expression
     | 'type' expression
     | 'type' expression 'with' ('commandkey' | 'cmdkey')
@@ -222,15 +231,15 @@ convertible
     ;
 
 conversionFormat
-    : 'seconds'
+    : seconds
     | 'dateitems'
-    | timeDateFormat 'date'
-    | timeDateFormat 'time'
+    | length 'date'
+    | length 'time'
     ;
 
-timeDateFormat
+length
     : ('english' | 'long')
-    | ('abbreviated' | 'abbrev')
+    | ('abbreviated' | 'abbrev' | 'abbr')
     | 'short'
     |
     ;
@@ -244,6 +253,8 @@ sortDirection
 sortChunkType
     : 'the'? line of
     | 'the'? item of
+    | 'the'? word of
+    | 'the'? character of
     |
     ;
 
@@ -316,7 +327,8 @@ globalProperty
     ;
 
 partProperty
-    : 'the'? propertyName of expression
+    : 'the'? propertyName of factor
+    | 'the'? length propertyName of factor
     ;
 
 part
@@ -328,25 +340,31 @@ part
     | fieldPart
     | bkgndPart
     | cardPart
+    | stackPart
+    ;
+
+stackPart
+    : 'this' stack
+    | stack factor
     ;
 
 buttonPart
     : card? button 'id' factor
-    | background? button 'id' factor
-    | background? button factor
-    | ordinal background? button
+    | background button 'id' factor
     | card? button factor
+    | background button factor
     | ordinal card? button
+    | ordinal background button
     | buttonPart of cardPart
     ;
 
 fieldPart
-    : card? field 'id' factor
+    : card field 'id' factor
     | background? field 'id' factor
+    | card field factor
     | background? field factor
+    | ordinal card field
     | ordinal background? field
-    | card? field factor
-    | ordinal card? field
     | fieldPart of cardPart
     ;
 
@@ -367,10 +385,16 @@ bkgndPart
     | position background
     ;
 
+listExpression
+    : expression
+    | expression ',' listExpression
+    ;
+
 expression
     : factor
     | 'not' expression
     | '-' expression
+    | op=('there is a'|'there is an'|'there is no'|'there is not a'|'there is not an') expression
     | expression '^' expression
     | expression op=('mod'| 'div'| '/'| '*') expression
     | expression op=('+'| '-') expression
@@ -394,6 +418,7 @@ factor
 container
     : ID
     | 'the'? 'selection'
+    | 'target'
     | property
     | menu
     | menuItem
@@ -430,14 +455,14 @@ effectExpression
 
 functionCall
     : builtInFunc
-    | ID '(' argumentList? ')'
+    | ID '(' listExpression? ')'
     ;
 
 builtInFunc
     : 'the' zeroArgFunc
     | 'the'? singleArgFunc of factor
-    | singleArgFunc '(' expression ')'
-    | multiArgFunc '(' argumentList ')'
+    | singleArgFunc '(' listExpression ')'
+    | multiArgFunc '(' listExpression ')'
     ;
 
 zeroArgFunc
@@ -448,10 +473,11 @@ zeroArgFunc
     | 'shiftkey'
     | 'optionkey'
     | 'ticks'
-    | 'seconds'
-    | timeDateFormat 'time'
-    | timeDateFormat 'date'
+    | seconds
+    | length 'time'
+    | length 'date'
     | 'tool'
+    | 'mouseclick'
     | 'number' 'of' card? 'parts'
     | 'number' 'of' background 'parts'
     | 'number' 'of' card? button
@@ -471,6 +497,9 @@ zeroArgFunc
     | 'selectedchunk'
     | 'selectedfield'
     | 'selectedline'
+    | 'target'
+    | 'speech'
+    | 'voices'
     | 'clicktext'
     | 'mouseh'
     | 'mousev'
@@ -530,9 +559,8 @@ literal
     | modifierKey
     | mouseState
     | knownType
+    | findType
     | LITERAL
-    | TWO_ITEM_LIST
-    | FOUR_ITEM_LIST
     ;
 
 preposition
@@ -613,12 +641,11 @@ knownType
     | 'bool'
     ;
 
-find
-    : 'find' 'word' 'international'?
-    | 'find' 'chars' 'international'?
-    | 'find' 'whole' 'international'?
-    | 'find' 'string' 'international'?
-    | 'find' 'international'?
+findType
+    : 'word'
+    | 'chars'
+    | 'whole'
+    | 'string'
     ;
 
 // Not all properties need to be enumerated here, only those sharing a name with another keyword.
@@ -638,6 +665,7 @@ propertyName
     | 'top'
     | 'center'
     | 'scroll'
+    | 'script'
     | ID
     ;
 
@@ -650,7 +678,7 @@ propertyValue
     | 'right'
     | 'top'
     | 'center'
-    | expression
+    | listExpression
     ;
 
 commandName
@@ -692,6 +720,20 @@ commandName
     | 'close'
     | 'select'
     | 'find'
+    | 'import'
+    | 'export'
+    ;
+
+picture
+    : 'picture'
+    | 'pict'
+    ;
+
+seconds
+    : 'seconds'
+    | 'secs'
+    | 'second'
+    | 'sec'
     ;
 
 speed
@@ -745,9 +787,7 @@ effect
 timeUnit
     : 'ticks'
     | 'tick'
-    | 'seconds'
-    | 'sec'
-    | 'second'
+    | seconds
     ;
 
 position
@@ -757,9 +797,7 @@ position
     ;
 
 message
-    : 'the'? ('message' | 'msg')
-    | 'the'? ('message' | 'msg') 'box'
-    | 'the'? ('message' | 'msg') 'window'
+    : 'the'? ('message' | 'msg') ('box' | 'window' | )
     ;
 
 cards
@@ -795,6 +833,10 @@ field
     | 'flds'
     ;
 
+stack
+    : 'stack'
+    ;
+
 character
     : 'character'
     | 'characters'
@@ -819,8 +861,8 @@ item
 
 of
     : 'of'
-    | 'in'
     | 'from'
+    | 'in'
     ;
 
 ID
@@ -828,7 +870,7 @@ ID
     ;
 
 BREAK
-    : ('|' | '¬') NEWLINE -> skip
+    : ('|' | '¬') WHITESPACE? COMMENT? WHITESPACE? NEWLINE -> skip
     ;
 
 LITERAL
@@ -849,14 +891,6 @@ NUMBER_LITERAL
 
 STRING_LITERAL
     : '"' ~('"' | '\r' | '\n')* '"'
-    ;
-
-TWO_ITEM_LIST
-    : (LITERAL ',' LITERAL)
-    ;
-
-FOUR_ITEM_LIST
-    : (LITERAL ',' LITERAL ',' LITERAL ',' LITERAL)
     ;
 
 ALPHA

--- a/hypertalk/README.md
+++ b/hypertalk/README.md
@@ -2,7 +2,7 @@
 
 An Antlr4 grammar for parsing HyperTalk, the scripting language of Apple's long-obsolete (but still insanely great) HyperCard. HyperTalk was created in 1987 by Dan Winkler and Bill Atkinson.
 
-This grammar is part of the [HyperTalk Java](https://github.com/defano/hypertalk-java) project, an open-sourced clone of HyperCard. A detailed description of this flavor of the language is [available here](https://github.com/defano/hypertalk-java#the-hypertalk-language).
+This grammar is part of the [WyldCard](https://github.com/defano/wyldcard) project, an open-sourced clone of HyperCard. A detailed description of this flavor of the language is [available here](https://github.com/defano/wyldcard#the-hypertalk-language).
 
 HyperTalk's elegant syntax mimics natural English (`sort the lines of field "Students" by the last word of each`), relying on a context-sensitive evaluation of terms (called _factors_) to eliminate referential and type formalities present in most programming languages. HyperTalk "does what I mean, not what I said."
 
@@ -27,14 +27,14 @@ Symbol      | Description
 -- stay within the bounds of the button named "Boundary".
 --
 on mouseDown
-	put the name of me into oldName
-	repeat while the mouse is down
-		if the mouseLoc is within the rect of card button "boundary" then
-			set the location of me to the mouseLoc
-			set the name of me to "(" & the mouseLoc & ")"
-		end if
-	end repeat
-	set the name of me to oldName
+  put the name of me into oldName
+  repeat while the mouse is down
+    if the mouseLoc is within the rect of card button "boundary" then
+      set the location of me to the mouseLoc
+      set the name of me to "(" & the mouseLoc & ")"
+    end if
+  end repeat
+  set the name of me to oldName
 end mouseDown
 ```
 

--- a/hypertalk/example-scripts/Script.txt
+++ b/hypertalk/example-scripts/Script.txt
@@ -108,6 +108,11 @@ on testLoops
         -- comment
     end repeat
 
+    repeat
+        -- comment
+        statement
+    end repeat
+
     repeat for x
 
     end repeat
@@ -143,9 +148,6 @@ on testProperties
     the itemdelimiter
     put "," into the itemdelimiter
     set the itemdelimiter to "|"
-    answer the selectedfield
-    put the selectedchunk
-    get the selectedline
 
     -- part properties
     set the name of me to x
@@ -154,9 +156,10 @@ on testProperties
     put "name" into me
     put "before" before the first word of the name of me   -- not legal in HyperCard, okay here
 
-    the selectedchunk of fld 1
-    the selectedline of cd fld id 32
-    the selectedline of fld "my field"
+    -- stack properties
+    get the name of this stack
+    get the name of stack "My Stack"
+    set the name of this stack to "Renamed"
 
 end testProperties
 
@@ -250,10 +253,6 @@ on testSingleArgFunctions
     the number of lines of x
     the number of menuitems of x
     the number of cards of x
-    the number of card field x
-    the number of fld x
-    the number of background button id y
-    the number of button "x"
 
     the random of x
     random(x)
@@ -427,6 +426,9 @@ on commandsTest
     drag from 10,10 to "100,100"
     drag from the mouseloc to 10,10 with shiftkey, optionkey
 
+    edit the script of cd btn 1
+    edit script of this card
+
     enable fld "My Field"
     enable menuitem "Undo" of menu "Edit"
     enable menu "File"
@@ -435,6 +437,9 @@ on commandsTest
     exit testCommands
     exit repeat
     exit to hypercard
+
+    export paint to file x
+    export paint to file "image.png"
 
     find x
     find x in card field 1
@@ -451,6 +456,9 @@ on commandsTest
     get char 3 of the middle word of item 11 of line 17 of theText
     get the number of bg button x
     get the number of the last card in this background
+    get the selectedchunk of x
+    get the selectedline of y
+    get the selectedtext of z
 
     go to card 1
     go to the last card
@@ -471,6 +479,19 @@ on commandsTest
 
     hide field "bananas"
     hide the third cd btn
+    hide card picture
+    hide bkgnd picture
+    hide picture of the last card
+    hide picture of background id 2
+
+    import paint from file "My Image.png"
+
+    show field "bananas"
+    show the third cd btn
+    show card picture
+    show bkgnd picture
+    show picture of the last card
+    show picture of background id 2
 
     lock screen
 
@@ -680,9 +701,9 @@ on operatorsTest
     x is in y
     9.99 is a number
     9 is an integer
-    10,10 is a point
-    10,10,20,20 is a rect
-    10,10,20,20 is a rectangle
+    "10,10" is a point
+    "10,10,20,20" is a rect
+    "10,10,20,20" is a rectangle
     "1/1/2012" is a date
     true is a logical
     false is a boolean
@@ -694,13 +715,17 @@ on operatorsTest
     x is not a logical
     x is not a boolean
     x is not a bool
-    100,100 is not in 10,10,20,20
+    "100,100" is not in "10,10,20,20"
     x = y
     x is not y
     x is y
     x is not within y
     x and y
     x or y
+    there is a card button "my button"
+    there is a card field id 2
+    there is not a first background
+    there is no field 13
 
 end operatorsTest
 
@@ -722,16 +747,15 @@ on literalsTest
     3-2
     -2-4
 
-    -- Point & Rect Literals
-    10,10
-    0,0,100,100
-
     -- Line wrapping
     answer "How are you?" |
         with "Choice 1"   |
         or "Choice 2"
 
     ask "Yes?" ¬
+        with "No"
+
+    ask "Yes?" ¬    -- Comments are acceptable here
         with "No"
 
     -- mouse states
@@ -867,9 +891,13 @@ end f
 --
 
 on answer
+    statement
+    -- comment
 end answer
 
 on ask
+    -- comment
+    statement
 end ask
 
 on put

--- a/hypertalk/pom.xml
+++ b/hypertalk/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>hypertalk</artifactId>
     <packaging>jar</packaging>
-    <name>HyperTalk Grammar</name>
+    <name>HyperTalk grammar</name>
     <parent>
         <groupId>com.antlr.grammarsv4</groupId>
         <artifactId>grammarsv4</artifactId>


### PR DESCRIPTION
* Adds support for adjective-modified properties (`the long name of me`)
* Improves support for literal list values (`set the textStyle of me to bold, italic`)
* Adds support for additional `hide` / `show` command forms
* Adds `edit the script of` command
* Adds `speak` command and `the speech` function
* Adds object existence operators (`there is a`, `there is not a`)
* Improves `find` command parsing
* Allows for comments following a soft-wrap