### PR TITLE
BugFix: Type cast expression with custom types cannot be recognized.

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -89,9 +89,9 @@ unaryOperator
     ;
 
 castExpression
-    :   unaryExpression
-    |   '(' typeName ')' castExpression
+    :   '(' typeName ')' castExpression
     |   '__extension__' '(' typeName ')' castExpression
+    |   unaryExpression
     |   DigitSequence // for
     ;
 

--- a/c/C.g4
+++ b/c/C.g4
@@ -478,8 +478,8 @@ blockItemList
     ;
 
 blockItem
-    :   declaration
-    |   statement
+    :   statement
+    |   declaration
     ;
 
 expressionStatement

--- a/c/examples/FuncCallwithVarArgs.c
+++ b/c/examples/FuncCallwithVarArgs.c
@@ -1,0 +1,25 @@
+/*
+Func call with various arg numbers.
+And func forward declarations.
+And func call as func call argument.
+*/
+
+void aX(void);
+int a1(int param1);
+int a2(int param1, param2);
+void a3();
+void a3(void);
+void a4(int, ...);
+void a4(int param1, ...);
+
+
+int f(int arg1, char arg2)
+{
+	a1(arg1);
+	a2(arg1, arg2);
+	a3();
+	a1(a1());
+	a1(a1(), a2(a1(), x1));
+}
+
+

--- a/c/examples/TypeCast.c
+++ b/c/examples/TypeCast.c
@@ -1,0 +1,8 @@
+f()
+{
+	a1 = (int)(b1);
+	a2 = (CustomType)(b2);
+	a3 = (CustomType *)(b3);
+	a4 = (CustomType **)(b4);
+	a5 = b5();
+}


### PR DESCRIPTION
There are 2 commits for this PR:

- For commit f53d9b7: Not much comment. It just complements the 38465f3.
- For commit 798a1f7, please see below.

For this input:

```
f()
{
	a1 = (int)(b1);
	a2 = (CustomType)(b2);
	a3 = b3();
}
```



With the buggy version:

![bug_typecast_vs_unaryexpression](https://user-images.githubusercontent.com/999318/37567025-d0a5d256-2afb-11e8-9eef-19e89b159e11.png)


With the fixed version:
![bugfix_typecast_vs_unaryexpression](https://user-images.githubusercontent.com/999318/37567027-d7d6118a-2afb-11e8-8569-c331b179e958.png)


