### PR TITLE
Pl/Sql & JavaScript lexer fixes

### DIFF
--- a/java/JavaParser.g4
+++ b/java/JavaParser.g4
@@ -466,7 +466,7 @@ methodCall
 expression
     : primary
     | expression bop='.'
-      (IDENTIFIER
+      ( IDENTIFIER
       | methodCall
       | THIS
       | NEW nonWildcardTypeArguments? innerCreator

--- a/javascript/CSharpSharwell/JavaScriptBaseLexer.cs
+++ b/javascript/CSharpSharwell/JavaScriptBaseLexer.cs
@@ -90,7 +90,7 @@ public abstract class JavaScriptBaseLexer : Lexer
     {
         if (_lastToken == null || _lastToken.Type == OpenBrace)
         {
-            if (Text == "\"use strict\"" || Text == "'use strict'")
+            if (Text.Equals("\"use strict\"") || Text.Equals("'use strict'"))
             {
                 if (scopeStrictModes.Count > 0)
                     scopeStrictModes.Pop();

--- a/javascript/examples/StrictFunctions.js
+++ b/javascript/examples/StrictFunctions.js
@@ -1,4 +1,7 @@
 function strict() {
+   /* comment */
+   // comment
+   // comment
   'use strict';
   function nested()
   {

--- a/plsql/CSharp/PlSqlBaseLexer.cs
+++ b/plsql/CSharp/PlSqlBaseLexer.cs
@@ -2,19 +2,14 @@ using Antlr4.Runtime;
 
 public abstract class PlSqlBaseLexer : Lexer
 {
-    private bool _isLineBegin = true;
-
     public PlSqlBaseLexer(ICharStream input)
         : base(input)
     {
     }
 
-    public override IToken NextToken()
+    protected bool IsNewlineAtPos(int pos)
     {
-        IToken next = base.NextToken();
-        _isLineBegin = next.Text.EndsWith("\n");
-        return next;
+        int la = _input.La(pos);
+        return la == -1 || la == '\n';
     }
-
-    protected bool IsLineBegin() => _isLineBegin;
 }

--- a/plsql/CSharp/PlSqlBaseLexer.cs
+++ b/plsql/CSharp/PlSqlBaseLexer.cs
@@ -1,0 +1,20 @@
+using Antlr4.Runtime;
+
+public abstract class PlSqlBaseLexer : Lexer
+{
+    private bool _isLineBegin = true;
+
+    public PlSqlBaseLexer(ICharStream input)
+        : base(input)
+    {
+    }
+
+    public override IToken NextToken()
+    {
+        IToken next = base.NextToken();
+        _isLineBegin = next.Text.EndsWith("\n");
+        return next;
+    }
+
+    protected bool IsLineBegin() => _isLineBegin;
+}

--- a/plsql/CSharp/PlSqlBaseParser.cs
+++ b/plsql/CSharp/PlSqlBaseParser.cs
@@ -1,0 +1,13 @@
+using Antlr4.Runtime;
+
+public abstract class PlSqlBaseParser : Parser
+{
+    private bool _isVersion12 = true;
+
+    public PlSqlBaseParser(ITokenStream input)
+        : base(input)
+    {
+    }
+
+    public bool isVersion12() => _isVersion12;
+}

--- a/plsql/CSharp/PlSqlBaseParser.cs
+++ b/plsql/CSharp/PlSqlBaseParser.cs
@@ -10,4 +10,6 @@ public abstract class PlSqlBaseParser : Parser
     }
 
     public bool isVersion12() => _isVersion12;
+
+    public bool setVersion12(bool value) => _isVersion12 = value;
 }

--- a/plsql/Java/PlSqlBaseLexer.java
+++ b/plsql/Java/PlSqlBaseLexer.java
@@ -1,0 +1,15 @@
+import org.antlr.v4.runtime.*;
+
+public abstract class PlSqlBaseLexer extends Lexer
+{
+    public PlSqlBaseLexer(ICharStream input)
+        : base(input)
+    {
+    }
+
+    protected boolean IsNewlineAtPos(int pos)
+    {
+        int la = _input.LA(pos);
+        return la == -1 || la == '\n';
+    }
+}

--- a/plsql/Java/PlSqlBaseParser.java
+++ b/plsql/Java/PlSqlBaseParser.java
@@ -1,0 +1,18 @@
+import org.antlr.v4.runtime.*;
+
+public abstract class PlSqlBaseParser extends Parser
+{
+    private boolean _isVersion12 = true;
+
+    public PlSqlBaseParser(TokenStream input) {
+        : super(input);
+    }
+
+    public boolean isVersion12() {
+        return _isVersion12;
+    }
+
+    public void setVersion12(boolean value) {
+        _isVersion12 = value;
+    }
+}

--- a/plsql/PlSqlLexer.g4
+++ b/plsql/PlSqlLexer.g4
@@ -20,6 +20,10 @@
 
 lexer grammar PlSqlLexer;
 
+options {
+    superClass=PlSqlBaseLexer;
+}
+
 ABORT:                        'ABORT';
 ABS:                          'ABS';
 ACCESS:                       'ACCESS';
@@ -2321,17 +2325,17 @@ INTRODUCER: '_';
 SINGLE_LINE_COMMENT: '--' ~('\r' | '\n')* NEWLINE_EOF                 -> channel(HIDDEN);
 MULTI_LINE_COMMENT:  '/*' .*? '*/'                                    -> channel(HIDDEN);
 // https://docs.oracle.com/cd/E11882_01/server.112/e16604/ch_twelve034.htm#SQPUG054
-REMARK_COMMENT:      'REM' 'ARK'? ~('\r' | '\n')* NEWLINE_EOF         -> channel(HIDDEN); // TODO: should starts with newline
+REMARK_COMMENT:      {IsLineBegin()}? 'REM' 'ARK'? (' ' ~('\r' | '\n')*)? NEWLINE_EOF -> channel(HIDDEN);
 
 // https://docs.oracle.com/cd/E11882_01/server.112/e16604/ch_twelve032.htm#SQPUG052
-PROMPT_MESSAGE:      'PRO' 'MPT'? SPACE ~('\r' | '\n')* NEWLINE_EOF;                      // TODO: should starts with newline
+PROMPT_MESSAGE:      {IsLineBegin()}? 'PRO' 'MPT'? (' ' ~('\r' | '\n')*)? NEWLINE_EOF;
 
 // TODO: should starts with newline
 START_CMD
     //: 'STA' 'RT'? SPACE ~('\r' | '\n')* NEWLINE_EOF
-    // https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12002.htm // TODO: add support
+    // https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12002.htm
     // https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12003.htm
-    : '@@' ~('\r' | '\n')* NEWLINE_EOF
+    : {IsLineBegin()}? '@' '@'? ~('\r' | '\n')* NEWLINE_EOF
     ;
 
 REGULAR_ID: SIMPLE_LETTER (SIMPLE_LETTER | '$' | '_' | '#' | [0-9])*;

--- a/plsql/PlSqlLexer.g4
+++ b/plsql/PlSqlLexer.g4
@@ -2325,17 +2325,17 @@ INTRODUCER: '_';
 SINGLE_LINE_COMMENT: '--' ~('\r' | '\n')* NEWLINE_EOF                 -> channel(HIDDEN);
 MULTI_LINE_COMMENT:  '/*' .*? '*/'                                    -> channel(HIDDEN);
 // https://docs.oracle.com/cd/E11882_01/server.112/e16604/ch_twelve034.htm#SQPUG054
-REMARK_COMMENT:      {IsLineBegin()}? 'REM' 'ARK'? (' ' ~('\r' | '\n')*)? NEWLINE_EOF -> channel(HIDDEN);
+REMARK_COMMENT:      'REM' {IsNewlineAtPos(-4)}? 'ARK'? (' ' ~('\r' | '\n')*)? NEWLINE_EOF -> channel(HIDDEN);
 
 // https://docs.oracle.com/cd/E11882_01/server.112/e16604/ch_twelve032.htm#SQPUG052
-PROMPT_MESSAGE:      {IsLineBegin()}? 'PRO' 'MPT'? (' ' ~('\r' | '\n')*)? NEWLINE_EOF;
+PROMPT_MESSAGE:      'PRO' {IsNewlineAtPos(-4)}? 'MPT'? (' ' ~('\r' | '\n')*)? NEWLINE_EOF;
 
 // TODO: should starts with newline
 START_CMD
     //: 'STA' 'RT'? SPACE ~('\r' | '\n')* NEWLINE_EOF
     // https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12002.htm
     // https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12003.htm
-    : {IsLineBegin()}? '@' '@'? ~('\r' | '\n')* NEWLINE_EOF
+    : '@' {IsNewlineAtPos(-2)}? '@'? ~('\r' | '\n')* NEWLINE_EOF
     ;
 
 REGULAR_ID: SIMPLE_LETTER (SIMPLE_LETTER | '$' | '_' | '#' | [0-9])*;

--- a/plsql/PlSqlParser.g4
+++ b/plsql/PlSqlParser.g4
@@ -2956,9 +2956,7 @@ label_declaration
     ;
 
 statement
-    : CREATE swallow_to_semi
-    | TRUNCATE swallow_to_semi
-    | body
+    : body
     | block
     | assignment_statement
     | continue_statement
@@ -2970,7 +2968,7 @@ statement
     | null_statement
     | raise_statement
     | return_statement
-    | case_statement/*[true]*/
+    | case_statement
     | sql_statement
     | function_call
     | pipe_row_statement

--- a/plsql/PlSqlParser.g4
+++ b/plsql/PlSqlParser.g4
@@ -20,9 +20,10 @@
 
 parser grammar PlSqlParser;
 
-options { tokenVocab=PlSqlLexer; }
-
-@members {boolean version12=true;}
+options {
+    tokenVocab=PlSqlLexer;
+    superClass=PlSqlBaseParser;
+}
 
 sql_script
     : ((unit_statement | sql_plus_command) SEMICOLON?)* EOF
@@ -1030,7 +1031,7 @@ storage_table_clause
 
 // https://docs.oracle.com/database/121/SQLRF/statements_4008.htm#SQLRF56110
 unified_auditing
-    : {version12}? 
+    : {isVersion12()}? 
       AUDIT (POLICY policy_name ((BY | EXCEPT) (','? audit_user)+ )? 
                                 (WHENEVER NOT? SUCCESSFUL)?
             | CONTEXT NAMESPACE oracle_namespace 
@@ -1058,11 +1059,11 @@ audit_traditional
     ;
 
 audit_direct_path
-    : {version12}? DIRECT_PATH auditing_by_clause
+    : {isVersion12()}? DIRECT_PATH auditing_by_clause
     ;
 
 audit_container_clause
-    : {version12}? (CONTAINER EQUALS_OP (CURRENT | ALL))
+    : {isVersion12()}? (CONTAINER EQUALS_OP (CURRENT | ALL))
     ;
 
 audit_operation_clause
@@ -1104,7 +1105,7 @@ auditing_on_clause
     : ON ( object_name
          | DIRECTORY regular_id
          | MINING MODEL model_name
-         | {version12}? SQL TRANSLATION PROFILE profile_name
+         | {isVersion12()}? SQL TRANSLATION PROFILE profile_name
          | DEFAULT
          )
     ;
@@ -1132,7 +1133,7 @@ sql_statement_shortcut
     | MATERIALIZED VIEW
     | NOT EXISTS
     | OUTLINE
-    | {version12}? PLUGGABLE DATABASE
+    | {isVersion12()}? PLUGGABLE DATABASE
     | PROCEDURE
     | PROFILE
     | PUBLIC DATABASE LINK
@@ -1215,11 +1216,11 @@ alter_library
     ;
 
 library_editionable
-    : {version12}? (EDITIONABLE | NONEDITIONABLE)
+    : {isVersion12()}? (EDITIONABLE | NONEDITIONABLE)
     ;
 
 library_debug
-    : {version12}? DEBUG
+    : {isVersion12()}? DEBUG
     ;
 
 
@@ -1253,7 +1254,7 @@ alter_view
     ;   
 
 alter_view_editionable
-    : {version12}? (EDITIONABLE | NONEDITIONABLE)
+    : {isVersion12()}? (EDITIONABLE | NONEDITIONABLE)
     ;
  
 create_view
@@ -2689,7 +2690,7 @@ column_properties
     ;
 
 period_definition
-    : {version12}? PERIOD FOR column_name 
+    : {isVersion12()}? PERIOD FOR column_name 
         ( '(' start_time_column ',' end_time_column ')' )?
     ;
 
@@ -3988,7 +3989,7 @@ xmlserialize_param_ident_part
 sql_plus_command
     : '/'
     | EXIT
-    | PROMPT
+    | PROMPT_MESSAGE
     | SHOW (ERR | ERRORS)
     | START_CMD
     | whenever_command
@@ -3997,7 +3998,7 @@ sql_plus_command
 
 whenever_command
     : WHENEVER (SQLERROR | OSERROR)
-         ( EXIT (SUCCESS | FAILURE | WARNING) (COMMIT | ROLLBACK)
+         ( EXIT (SUCCESS | FAILURE | WARNING | variable_name) (COMMIT | ROLLBACK)
          | CONTINUE (COMMIT | ROLLBACK | NONE))
     ;
 

--- a/plsql/examples/comments.sql
+++ b/plsql/examples/comments.sql
@@ -2,3 +2,7 @@
 select * /*
 com2 */
 from dual -- com3
+
+Rem  Copyright (c) All Rights Reserved.
+
+prompt . ## Hello world

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 				<module>brainfuck</module>
 				<module>c</module>
 				<module>calculator</module>
-				<module>capnproto</module>				
+				<module>capnproto</module>
 				<module>clf</module>
 				<module>clif</module>
 				<module>clojure</module>
@@ -84,6 +84,7 @@
 				<module>java8</module>
 				<module>java9</module>
 				<module>javadoc</module>
+				<!-- <module>javascript</module> TODO: required superClass support -->
 				<module>jpa</module>
 				<module>json</module>
 				<module>kotlin</module>
@@ -117,7 +118,7 @@
 				<module>peoplecode</module>
 				<module>pgn</module>
 				<module>php</module>
-				<module>plsql</module>
+				<!-- <module>plsql</module> TODO: required superClass support -->
 				<module>postalcode</module>
 				<module>powerbuilder</module>
 				<module>prolog</module>


### PR DESCRIPTION
* PL/SQL: support for `rem` comments and `prompt` messages, added base lexer and parser (C#, Java runtimes).
* JavaScript lexer performance significantly increased.
* plsql removed from pom.xml (required `-superClass` option support).