### PR TITLE
Add single dot to function definition and calls

### DIFF
--- a/r/R.g4
+++ b/r/R.g4
@@ -44,7 +44,7 @@ $ java TestR sample.R
 */
 grammar R;
 
-prog:   (   expr (';'|NL)
+prog:   (   expr (';'|NL)*
         |   NL
         )*
         EOF
@@ -110,6 +110,7 @@ formlist : form (',' form)* ;
 form:   ID
     |   ID '=' expr
     |   '...'
+    |   '.'
     ;
 
 sublist : sub (',' sub)* ;
@@ -122,6 +123,7 @@ sub :   expr
     |   'NULL' '='
     |   'NULL' '=' expr
     |   '...'
+    |   '.'
     |
     ;
 


### PR DESCRIPTION
An expression such as "function (.) x" or "myFunction(.)"

Also the ';' or NL are not always necessary in an expression (it was throwing warnings on files without a terminating NL or ';')