### PR TITLE
csharp: add 'out type' in argument

### DIFF
--- a/csharp/CSharpParser.g4
+++ b/csharp/CSharpParser.g4
@@ -77,7 +77,7 @@ argument_list
 	;
 
 argument
-	: (identifier ':')? refout=(REF | OUT)? expression
+	: (identifier ':')? refout=(REF | OUT)? (VAR | type)? expression
 	;
 
 expression


### PR DESCRIPTION
Support for `out var` and `out type`,

For example:

```csharp
if (_loggerAction.TryGetValue(level, out var loggingAction))
{
    loggingAction(message);
}
if (!Enum.TryParse(siteType, out SiteType site))
    throw new ArgumentException($"Unsupported site type: {siteType}.");
```