### PR TITLE
xpath: fix qName/functionName rules

### DIFF
--- a/xpath/examples/example-function.txt
+++ b/xpath/examples/example-function.txt
@@ -1,0 +1,1 @@
+foo:comment()

--- a/xpath/examples/example-variable.txt
+++ b/xpath/examples/example-variable.txt
@@ -1,0 +1,1 @@
+$comment

--- a/xpath/xpath.g4
+++ b/xpath/xpath.g4
@@ -120,8 +120,11 @@ unaryExprNoRoot
 qName  :  nCName (':' nCName)?
   ;
 
+// Does not match NodeType, as per spec.
 functionName
-  :  qName  // Does not match nodeType, as per spec.
+  :  nCName ':' nCName
+  |  NCName
+  |  AxisName
   ;
 
 variableReference
@@ -135,6 +138,7 @@ nameTest:  '*'
 
 nCName  :  NCName
   |  AxisName
+  |  NodeType
   ;
 
 NodeType:  'comment'


### PR DESCRIPTION
Parser grammar is incorrect in its definition of QName, which is
taken to be constrained the way FunctionName is -- to exclude
NodeType. This means that NameTest and VariableReference do not
accept legal values.

Fix this by having nCName rule contain NodeType, automatically
fixing all users of qName rule and breaking functionName.
functionName is reformulated without using qName and spelling out
the two alternatives of PrefixedName and UnprefixedName -- excluding
NodeType from UnprefixedName case.

Signed-off-by: Robert Varga <nite@hq.sk>