### PR TITLE
Edit the documentation comment show correct target

### DIFF
--- a/python2-js/Python2.g4
+++ b/python2-js/Python2.g4
@@ -7,7 +7,7 @@
  * Added lexer rules, and code to handle INDENT's, DEDENT's,
  * line continuations, etc.
  *
- * Compiles with ANTLR 4.7, generated lexer/parser for Python 2 target.
+ * Compiles with ANTLR 4.7, generated lexer/parser for JavaScript target.
  */
  
  grammar Python2;


### PR DESCRIPTION
The documentation said this file is for Python 2, most likely a copy-paste error.