### PR TITLE
fix a bug for golang grammar

### DIFF
--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -909,7 +909,7 @@ fragment RAW_STRING_LIT
 
 //interpreted_string_lit = `"` { unicode_value | byte_value } `"` .
 fragment INTERPRETED_STRING_LIT
-    : '"' ( UNICODE_VALUE | BYTE_VALUE )* '"'
+    : '"' ( UNICODE_VALUE | BYTE_VALUE )*? '"'
     ;
 
 

--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -909,7 +909,7 @@ fragment RAW_STRING_LIT
 
 //interpreted_string_lit = `"` { unicode_value | byte_value } `"` .
 fragment INTERPRETED_STRING_LIT
-    : '"' ( UNICODE_VALUE | BYTE_VALUE )*? '"'
+    : '"' ( '\\"' | UNICODE_VALUE | BYTE_VALUE )*? '"'
     ;
 
 

--- a/golang/examples/map_with_string.go
+++ b/golang/examples/map_with_string.go
@@ -1,0 +1,34 @@
+package test_controller
+
+import (
+        "aa.bb.com/facility/assert"
+        "aa.bb.com/xxx/post/internal/controller"
+        "aa.bb.com/xxx/post/pkg/cerror"
+        ctx2 "aa.bb.com/xxx/post/test/tools/ctx"
+        "aa.bb.com/xxx/post/thrift_gen/base"
+        "aa.bb.com/xxx/post/thrift_gen/something/xxx/post"
+        "aa.bb.com/gopkg/logs"
+)
+
+func newUpdateCommentRequest() *post.UpdateCommentRequest {
+        req := post.NewUpdateCommentRequest()
+        req.CommentId = 18
+        fields := map[string]interface{}{
+                "extra": `{"test_update_fields":"update_fields_by_test"}`,
+        }
+        req.UpdateFields, _ = json.MarshalToString(fields)
+        req.Base = &base.Base{
+                Caller: "some.interface.withip",
+        }
+        return req
+}
+
+func TestUpdateComment() {
+        ctx := ctx2.MockKiteContext("contextname", "")
+        req := newUpdateCommentRequest()
+        resp, err := controller.UpdateComment(ctx, req)
+        logs.Info("%+v %+v %+v", req, resp, err)
+        assert.IsNil(err)
+        assert.EqualInt32(resp.BaseResp.StatusCode, cerror.ErrNo_Success.Int32())
+}
+


### PR DESCRIPTION
golang grammar would fail when parse code

`
fields := map[string]interface{}{
                "extra": `{"test_update_fields":"update_fields_by_test"}`,
}
`