### PR TITLE
dot: skip all lines beginning with a '#' character

### DIFF
--- a/dot/DOT.g4
+++ b/dot/DOT.g4
@@ -172,7 +172,7 @@ LINE_COMMENT
 /** "a '#' character is considered a line output from a C preprocessor (e.g.,
  *  # 34 to indicate line 34 ) and discarded"
  */ PREPROC
-   : '#' .*? '\n' -> skip
+   : '#' ~[\r\n]* -> skip
    ;
 
 


### PR DESCRIPTION
The following rule doesn't work if there is no `\n` at the end of the line:
```
'#' .*? '\n'
```

I change it to:
```
'#' ~[\r\n]*
```

Signed-off-by: Hao Lee <haolee.swjtu@gmail.com>