### PR TITLE
golang: Fixed issue with parsing interface and structure promotions

### DIFF
--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -110,7 +110,7 @@ grammar Golang;
         BufferedTokenStream stream = (BufferedTokenStream)_input;
         int leftParams = 1;
         int rightParams = 0;
-        string value;
+        String value;
 
         if (stream.LT(tokenOffset).getText().equals("(")) {
             // Scan past parameters

--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -73,6 +73,65 @@ grammar Golang;
         return (type == COMMENT && (text.contains("\r") || text.contains("\n"))) ||
                 (type == TERMINATOR);
     }
+
+     /**
+     * Returns {@code true} if no line terminator exists between the specified
+     * token offset and the prior one on the {@code HIDDEN} channel.
+     *
+     * @return {@code true} if no line terminator exists between the specified
+     * token offset and the prior one on the {@code HIDDEN} channel.
+     */
+    private boolean noTerminatorBetween(int tokenOffset) {
+        BufferedTokenStream stream = (BufferedTokenStream)_input;
+        List<Token> tokens = stream.getHiddenTokensToLeft(stream.LT(tokenOffset).getTokenIndex());
+        
+        if (tokens == null) {
+            return true;
+        }
+
+        for (Token token : tokens) {
+            if (token.getText().contains("\n"))
+                return false;
+        }
+
+        return true;
+    }
+
+     /**
+     * Returns {@code true} if no line terminator exists after any encounterd
+     * parameters beyond the specified token offset and the next on the
+     * {@code HIDDEN} channel.
+     *
+     * @return {@code true} if no line terminator exists after any encounterd
+     * parameters beyond the specified token offset and the next on the
+     * {@code HIDDEN} channel.
+     */
+    private boolean noTerminatorAfterParams(int tokenOffset) {
+        BufferedTokenStream stream = (BufferedTokenStream)_input;
+        int leftParams = 1;
+        int rightParams = 0;
+        string value;
+
+        if (stream.LT(tokenOffset).getText().equals("(")) {
+            // Scan past parameters
+            while (leftParams != rightParams) {
+                tokenOffset++;
+                value = stream.LT(tokenOffset).getText();
+
+                if (value.equals("(")) {
+                    leftParams++;
+                }
+                else if (value.equals(")")) {
+                    rightParams++;
+                }
+            }
+
+            tokenOffset++;
+            return noTerminatorBetween(tokenOffset);
+        }
+        
+        return true;
+    }
 }
 
 @lexer::members {
@@ -477,8 +536,9 @@ channelType
     ;
 
 methodSpec
-    : IDENTIFIER signature
+    : {noTerminatorAfterParams(2)}? IDENTIFIER parameters result
     | typeName
+    | IDENTIFIER parameters
     ;
 
 
@@ -607,7 +667,7 @@ structType
     ;
 
 fieldDecl
-    : (identifierList type | anonymousField) STRING_LIT?
+    : ({noTerminatorBetween(2)}? identifierList type | anonymousField) STRING_LIT?
     ;
 
 anonymousField

--- a/golang/examples/interface_inheritance.go
+++ b/golang/examples/interface_inheritance.go
@@ -1,0 +1,54 @@
+package main
+
+import "fmt"
+
+type T1 struct {
+    name string
+}
+
+func (t T1) M() {}
+func (t T1) N() {}
+func (t T1) String() string { return "" }
+func (t T1) Error() string { return "" }
+
+type T2 struct {
+    name string
+}
+
+func (t T2) M() {}
+func (t T2) N() {}
+func (t T2) String() string { return "" }
+func (t T2) Error() string { return "" }
+
+type I interface {
+    M()
+}
+
+// In the following interface declaration, error is an
+// inherited interface, not the "result" type of N()
+type V interface {
+    I
+    fmt.Stringer
+    N()
+    error
+}
+
+func main() {
+    m := make(map[I]int)
+    var i1 I = T1{"foo"}
+    var i2 I = T2{"bar"}
+    m[i1] = 1
+    m[i2] = 2
+    fmt.Println(m)
+
+    n := make(map[V]int)
+    var v1 V = T1{"foo"}
+    var v2 V = T2{"bar"}
+    v1.N()
+    v2.M()
+    v1.String()
+    v2.Error()
+    n[v1] = 3
+    n[v2] = 4
+    fmt.Println(n)
+}

--- a/golang/examples/struct_promotion.go
+++ b/golang/examples/struct_promotion.go
@@ -1,0 +1,43 @@
+package main
+
+import "fmt"
+
+type Person struct {
+    name string
+    age int32
+}
+
+func (p Person) IsAdult() bool {
+    return p.age >= 18
+}
+
+type Employee struct {
+    position string
+}
+
+func (e Employee) IsManager() bool {
+    return e.position == "manager"
+}
+
+// In the following structure declaration, Employee is a
+// promoted structure, not the "result" type of Person
+type Record struct {
+    Person
+    Employee
+}
+
+func main() {
+    person := Person{name: "Michal", age: 29}
+    fmt.Println(person)  // {Michal 29}
+    record := Record{}
+    record.name = "Michal"
+    record.age = 29
+    record.position = "software engineer"
+
+    fmt.Println(record) // {{Michal 29} {software engineer}}
+    fmt.Println(record.name) // Michal
+    fmt.Println(record.age) // 29
+    fmt.Println(record.position) // software engineer
+    fmt.Println(record.IsAdult()) // true
+    fmt.Println(record.IsManager()) // false
+}


### PR DESCRIPTION
Both methodSpec and fieldDecl were improperly ignoring new lines and
picking up declaration on the next line as the result type. Correction
required addition of a new semantic predicates and restructuring of
methodSpec since result is optional.