### PR TITLE
golang: Fixed issue with parsing multi-value type declarations

### DIFF
--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -223,7 +223,7 @@ expressionList
 
 //TypeDecl     = "type" ( TypeSpec | "(" { TypeSpec ";" } ")" ) .
 typeDecl
-    : 'type' ( typeSpec | '(' ( typeSpec ';' )* ')' )
+    : 'type' ( typeSpec | '(' ( typeSpec eos )* ')' )
     ;
 
 //TypeSpec     = identifier Type .

--- a/golang/examples/multiple_type_decl.go
+++ b/golang/examples/multiple_type_decl.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+type (
+	Abser interface {
+		Abs() float64
+	}
+	
+	MyError struct {
+		When time.Time
+		What string
+	}
+
+	MyCustomError struct {
+		Message string
+		Abser
+		MyError
+	}
+)
+
+// The following takes precedence over instance call to Abs()
+func (myErr *MyCustomError) Abs() float64 {
+	return 0.0
+}
+
+func main() {
+	a:= MyCustomError{"New One", nil, MyError{time.Now(), "Hello"}}
+	a.Abs()
+	a.Message = "New"
+	fmt.Println("MyCustomError method = %v", a.Abs())
+}


### PR DESCRIPTION
The typeDecl should accept both ';' and new line as valid terminators, i.e., `eos` , like all other declarations that accept multiple values within a parenthetical set.