### PR TITLE
FIX: prov-n grammar for default namespace

### DIFF
--- a/prov-n/PROV_N.g4
+++ b/prov-n/PROV_N.g4
@@ -37,6 +37,11 @@ defaultNamespaceDeclaration
    : 'default' IRI_REF
    ;
 
+/* TODO ambiquity with PREFIX token
+   prefix ex <http://mynamespace> -- is recognized as 'prefix' token QUALIFIED_NAME token and 'namespace' token
+   should check whether it matches PREFX as some chars are not allowed in PREFX
+
+*/
 namespaceDeclaration
    : 'prefix' PREFX namespace
    ;
@@ -50,7 +55,7 @@ bundle
    ;
 
 identifier
-   : QUALIFIED_NAME
+   : PREFX | QUALIFIED_NAME
    ;
 
 expression
@@ -74,7 +79,7 @@ attributeValuePair
    ;
 
 attribute
-   : QUALIFIED_NAME
+   : PREFX | QUALIFIED_NAME
    ;
 
 literal
@@ -87,7 +92,7 @@ typedLiteral
    ;
 
 datatype
-   : QUALIFIED_NAME
+   : PREFX | QUALIFIED_NAME
    ;
 
 convenienceNotation
@@ -221,7 +226,7 @@ membershipExpression
    ;
 
 extensibilityExpression
-   : QUALIFIED_NAME '(' optionalIdentifier extensibilityArgument (',' extensibilityArgument)* optionalAttributeValuePairs ')'
+   : (PREFX|QUALIFIED_NAME) '(' optionalIdentifier extensibilityArgument (',' extensibilityArgument)* optionalAttributeValuePairs ')'
    ;
 
 extensibilityArgument
@@ -285,11 +290,6 @@ GREATER
    ;
 
 
-PREFX
-   : PN_PREFIX
-   ;
-
-
 DOT
    : '.'
    ;
@@ -334,27 +334,31 @@ fragment DIGIT
    ;
 
 
+PREFX
+   : PN_PREFIX
+   ;
+
 QUALIFIED_NAME
    : (PN_PREFIX ':')? PN_LOCAL | PN_PREFIX ':'
    ;
 
 
-PN_LOCAL
+fragment PN_LOCAL
    : (PN_CHARS_U | DIGIT | PN_CHARS_OTHERS) ((PN_CHARS | DOT | PN_CHARS_OTHERS)* (PN_CHARS | PN_CHARS_OTHERS))?
    ;
 
 
-PN_CHARS_OTHERS
+fragment PN_CHARS_OTHERS
    : '/' | '@' | '~' | '&' | '+' | '*' | '?' | '#' | '$' | '!' | PERCENT | PN_CHARS_ESC
    ;
 
 
-PN_CHARS_ESC
+fragment PN_CHARS_ESC
    : '\\' ('=' | '\'' | '(' | ')' | ',' | '-' | ':' | ';' | '[' | ']' | '.')
    ;
 
 
-PERCENT
+fragment PERCENT
    : '%' HEX HEX
    ;
 

--- a/prov-n/examples/example3.provn
+++ b/prov-n/examples/example3.provn
@@ -1,0 +1,10 @@
+document
+  default <http://anotherexample.org/>
+  prefix ex <http://example.org/>
+  entity(e2, [ prov:type="File", ex:path="/shared/crime.txt", ex:creator="Alice", 
+               ex:content="There was a lot of crime in London last month."])
+               activity(a1, 2011-11-16T16:05:00, -, [prov:type="edit"])
+  wasGeneratedBy(e2, a1, -, [ex:fct="save"])     
+  wasAssociatedWith(a1, ag2, -, [prov:role="author"])
+  agent(ag2, [ prov:type='prov:Person', ex:name="Bob" ])
+endDocument

--- a/prov-n/examples/example4.provn
+++ b/prov-n/examples/example4.provn
@@ -1,0 +1,9 @@
+document
+  default <http://anotherexample.org/>
+  prefix ex <http://www.provbook.org/nonews/>
+
+  entity(e2)
+  agent(ag2)
+  entity(ex:e2)
+  agent(ex:ag2)
+endDocument


### PR DESCRIPTION
UPDATED prov-n grammar for default namespace, workaround for ambiquity with prefix/qualified name. ADDED appropriate examples