### PR TITLE
mysql lexer, enable lower case letters in variables

### DIFF
--- a/mysql/MySqlLexer.g4
+++ b/mysql/MySqlLexer.g4
@@ -1128,14 +1128,14 @@ STRING_USER_NAME:                    (
                                      );
 LOCAL_ID:                            '@'
                                 (
-                                  [A-Z0-9._$]+ 
+                                  [a-zA-Z0-9._$]+ 
                                   | SQUOTA_STRING
                                   | DQUOTA_STRING
                                   | BQUOTA_STRING
                                 );
 GLOBAL_ID:                           '@' '@' 
                                 (
-                                  [A-Z0-9._$]+ 
+                                  [a-zA-Z0-9._$]+ 
                                   | BQUOTA_STRING
                                 );
 

--- a/mysql/examples/dml_select.sql
+++ b/mysql/examples/dml_select.sql
@@ -62,7 +62,9 @@ select 'abc' ' bcd' ' \' \' ' as col, \N c2, -.1e-3;
 
 #begin
 -- -- Variables
-SELECT @myvar;
+SET @varNum= 1;
+SET @varstring='foo', @varString2='bar', @VARSTRING3='baz';
+SELECT @myvar, @varNum;
 #end
 
 #begin


### PR DESCRIPTION
Hi, 

According to https://dev.mysql.com/doc/refman/5.7/en/user-variables.html
variable names could contains lower case letters, yet the lexer does not permit that (only ```A-Z0-9._$```). 

Here a small pull request to fix that.