### PR TITLE
support multiple args for Erase statement

### DIFF
--- a/vba/examples/example1.bas
+++ b/vba/examples/example1.bas
@@ -1,4 +1,4 @@
 Public Sub Module()
     Dim sd As Boolean
-   
+    Erase array, list
 End Sub

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -293,7 +293,7 @@ enumerationStmt:
 
 enumerationStmt_Constant : ambiguousIdentifier (WS? EQ WS? valueStmt)? endOfStatement;
 
-eraseStmt : ERASE WS valueStmt;
+eraseStmt : ERASE WS valueStmt (',' WS valueStmt)*?;
 
 errorStmt : ERROR WS valueStmt;
 


### PR DESCRIPTION
In the VBA, Erase statement supports multiple args. 

So, modify grammar file and add a test case. 

``` VBA
Sub main()
    Erase array1, array2, array3
End Sub 
```

Reference is here
https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/erase-statement

Thank you, Regards
Junhong