### PR TITLE
Revert "mysql lexer, enable lower case letters in variables"

### DIFF
--- a/mysql/MySqlLexer.g4
+++ b/mysql/MySqlLexer.g4
@@ -1128,14 +1128,14 @@ STRING_USER_NAME:                    (
                                      );
 LOCAL_ID:                            '@'
                                 (
-                                  [a-zA-Z0-9._$]+ 
+                                  [A-Z0-9._$]+ 
                                   | SQUOTA_STRING
                                   | DQUOTA_STRING
                                   | BQUOTA_STRING
                                 );
 GLOBAL_ID:                           '@' '@' 
                                 (
-                                  [a-zA-Z0-9._$]+ 
+                                  [A-Z0-9._$]+ 
                                   | BQUOTA_STRING
                                 );
 

--- a/mysql/examples/dml_select.sql
+++ b/mysql/examples/dml_select.sql
@@ -62,9 +62,7 @@ select 'abc' ' bcd' ' \' \' ' as col, \N c2, -.1e-3;
 
 #begin
 -- -- Variables
-SET @varNum= 1;
-SET @varstring='foo', @varString2='bar', @VARSTRING3='baz';
-SELECT @myvar, @varNum;
+SELECT @myvar;
 #end
 
 #begin


### PR DESCRIPTION
Reverts antlr/grammars-v4#1197

Everyone has to use [CaseChangingCharStream](https://github.com/parrt/antlr4/blob/case-insensitivity-doc/doc/resources/CaseChangingCharStream.java) for lexing MySql at least for now. See detail and other targets here: https://github.com/antlr/antlr4/blob/master/doc/case-insensitive-lexing.md