### PR TITLE
fix erase and string declaration

### DIFF
--- a/vba/examples/example1.bas
+++ b/vba/examples/example1.bas
@@ -1,4 +1,4 @@
 Public Sub Module()
     Dim sd As Boolean
-   
+    Erase array, list
 End Sub

--- a/vba/examples/example3erase.bas
+++ b/vba/examples/example3erase.bas
@@ -1,3 +1,3 @@
 Public Sub Module()
-    Dim sd As Boolean
+    Dim str As String * 3
 End Sub

--- a/vba/examples/example4fixedstring.bas
+++ b/vba/examples/example4fixedstring.bas
@@ -1,3 +1,3 @@
 Public Sub Module()
-    Dim sd As Boolean
+    Erase array, list
 End Sub

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -293,7 +293,7 @@ enumerationStmt:
 
 enumerationStmt_Constant : ambiguousIdentifier (WS? EQ WS? valueStmt)? endOfStatement;
 
-eraseStmt : ERASE WS valueStmt;
+eraseStmt : ERASE WS valueStmt (',' WS valueStmt)*?;
 
 errorStmt : ERROR WS valueStmt;
 

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -293,7 +293,7 @@ enumerationStmt:
 
 enumerationStmt_Constant : ambiguousIdentifier (WS? EQ WS? valueStmt)? endOfStatement;
 
-eraseStmt : ERASE WS valueStmt (',' WS valueStmt)*?;
+eraseStmt : ERASE WS valueStmt (',' WS? valueStmt)*?;
 
 errorStmt : ERROR WS valueStmt;
 
@@ -655,7 +655,7 @@ ambiguousIdentifier :
 
 asTypeClause : AS WS? (NEW WS)? type (WS? fieldLength)?;
 
-baseType : BOOLEAN | BYTE | COLLECTION | DATE | DOUBLE | INTEGER | LONG | SINGLE | STRING | VARIANT;
+baseType : BOOLEAN | BYTE | COLLECTION | DATE | DOUBLE | INTEGER | LONG | SINGLE | STRING (WS? MULT WS? valueStmt)? | VARIANT;
 
 certainIdentifier : 
 	IDENTIFIER (ambiguousKeyword | IDENTIFIER)*
@@ -926,7 +926,6 @@ HEXLITERAL : '&H' [0-9A-F]+ '&'?;
 SHORTLITERAL : (PLUS|MINUS)? DIGIT+ ('#' | '&' | '@')?;
 INTEGERLITERAL : SHORTLITERAL (E SHORTLITERAL)?;
 DOUBLELITERAL : (PLUS|MINUS)? DIGIT* '.' DIGIT+ (E SHORTLITERAL)?;
-
 DATELITERAL : '#' DATEORTIME '#';
 fragment DATEORTIME : DATEVALUE WS? TIMEVALUE | DATEVALUE | TIMEVALUE;
 fragment DATEVALUE : DATEVALUEPART DATESEPARATOR DATEVALUEPART (DATESEPARATOR DATEVALUEPART)?;
@@ -951,7 +950,6 @@ WS : ([ \t] | LINE_CONTINUATION)+;
 
 // identifier
 IDENTIFIER :  ~[\]()\r\n\t.,'"|!@#$%^&*\-+:=; ]+ | L_SQUARE_BRACKET (~[!\]\r\n])+ R_SQUARE_BRACKET;
-
 
 // letters
 fragment LETTER : [a-zA-Z_äöüÄÖÜ];


### PR DESCRIPTION
Hello, I have 2 things to correct the grammar. 

1. [Support multiple args for Erase](https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/erase-statement) 

ex) In vba, this is possible but the previous one is limited. So, I do change **eraseStmt** in vba.g4
```vba
Sub main()
    Erase array1, array2, array3
End Sub
```

2. [Support fixed length string declaration](https://www.example-code.com/vb/fixedLength.asp)

ex) In vba, there's special declaration for string type with fixed length. Please check out **baseType**.
```vba
Sub main()
    Dim str As String * 3
End Sub 
```

Thank you! Regards, 
Junhong