### PR TITLE
golang: Fixed issue parsing structures with functionType parameters

### DIFF
--- a/golang/Golang.g4
+++ b/golang/Golang.g4
@@ -164,7 +164,7 @@ grammar Golang;
 
 //SourceFile       = PackageClause ";" { ImportDecl ";" } { TopLevelDecl ";" } .
 sourceFile
-    : packageClause eos ( importDecl eos )* ( topLevelDecl eos)*
+    : packageClause eos ( importDecl eos )* ( topLevelDecl eos )*
     ;
 
 //PackageClause  = "package" PackageName .
@@ -553,7 +553,8 @@ functionType
     ;
 
 signature
-    : parameters result?
+    : {noTerminatorAfterParams(1)}? parameters result
+    | parameters
     ;
 
 result

--- a/golang/examples/struct_with_func_type.go
+++ b/golang/examples/struct_with_func_type.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+type Person struct {
+    work func()
+    name string
+    age int32
+}
+
+func main() {
+    person := Person{work: nil, name: "Michał", age: 29}
+    fmt.Println(person)  // {<nil> Michał 29}
+}


### PR DESCRIPTION
The `signature` of `functionType` was improperly picking up its optional result from the next line and consequently failing with "no viable alternative at input ...". In this case the parser should ignore anything after the line feed. Correction simply invoked the existing predicate to verify no line terminator exists after function parameters and providing an alternative that has no result. Example `struct_with_func_type.go` provided.