### PR TITLE
mysql : allow negative number in constant expr

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -1952,6 +1952,7 @@ nullNotnull
 
 constant
     : stringLiteral | decimalLiteral
+    | '-' decimalLiteral
     | hexadecimalLiteral | booleanLiteral
     | REAL_LITERAL | BIT_STRING
     | NOT? nullLiteral=(NULL_LITERAL | NULL_SPEC_LITERAL)

--- a/mysql/examples/ddl_create.sql
+++ b/mysql/examples/ddl_create.sql
@@ -12,6 +12,7 @@ create table child_table(id int unsigned auto_increment primary key, id_parent i
 create table `another some table $$` like `some table $$`;
 create table `actor` (`last_update` timestamp default CURRENT_TIMESTAMP, `birthday` datetime default CURRENT_TIMESTAMP ON UPDATE LOCALTIMESTAMP);
 create table boolean_table(c1 bool, c2 boolean default true);
+create table default_table(c1 int default 42, c2 int default -42);
 create table ts_table(
   ts1 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   ts2 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE LOCALTIME,


### PR DESCRIPTION
Negative numbers are not allowed in constant expression.

For example this could cause pb with default column value.