### PR TITLE
Fix  duplicated `Typeid()` function declarations problem

### DIFF
--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -172,8 +172,20 @@ postfixexpression
 	| Static_cast '<' thetypeid '>' '(' expression ')'
 	| Reinterpret_cast '<' thetypeid '>' '(' expression ')'
 	| Const_cast '<' thetypeid '>' '(' expression ')'
-	| Typeid '(' expression ')'
-	| Typeid '(' thetypeid ')'
+	| typeidofthetypeid '(' expression ')'
+	| typeidofthetypeid '(' thetypeid ')'
+;
+
+/*
+add a middle layer to eliminate duplicated function declarations
+*/
+typeidofexpr
+:
+	Typeid
+;
+typeidofthetypeid
+:
+	Typeid
 ;
 
 expressionlist


### PR DESCRIPTION
[issue](https://github.com/antlr/antlr4/issues/2353)
we would get a redeclaration error since the differences between old two functions are just return type, that's not enought to distinguish them by compiler