### PR TITLE
Improve CHECK constraint processing

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -365,7 +365,8 @@ tableConstraint
     | (CONSTRAINT name=uid?)?
       FOREIGN KEY index=uid? indexColumnNames
       referenceDefinition                                           #foreignKeyTableConstraint
-    | CHECK '(' expression ')'                                      #checkTableConstraint
+    | (CONSTRAINT name=uid?)?
+      CHECK '(' expression ')'                                      #checkTableConstraint
     ;
 
 referenceDefinition
@@ -593,6 +594,7 @@ alterSpecification
       indexColumnNames indexOption*                                 #alterByAddSpecialIndex
     | ADD (CONSTRAINT name=uid?)? FOREIGN KEY
       indexName=uid? indexColumnNames referenceDefinition           #alterByAddForeignKey
+    | ADD (CONSTRAINT name=uid?)? CHECK '(' expression ')'          #alterByAddCheckTableConstraint
     | ALGORITHM '='? algType=(DEFAULT | INPLACE | COPY)             #alterBySetAlgorithm
     | ALTER COLUMN? uid
       (SET DEFAULT defaultValue | DROP DEFAULT)                     #alterByChangeDefault

--- a/mysql/examples/ddl_alter.sql
+++ b/mysql/examples/ddl_alter.sql
@@ -11,6 +11,9 @@ alter table t2 drop primary key;
 alter table t3 rename to table3column;
 alter table childtable add constraint `fk1` foreign key (idParent) references parenttable(id) on delete restrict on update cascade;
 alter table table3column default character set = cp1251;
+alter table with_check add constraint check (c1 in (1, 2, 3, 4));
+alter table with_check add constraint c2 check (c1 in (1, 2, 3, 4));
+alter table with_check add check (c1 in (1, 2, 3, 4));
 #end
 #begin
 -- Alter database

--- a/mysql/examples/ddl_create.sql
+++ b/mysql/examples/ddl_create.sql
@@ -24,6 +24,7 @@ create table ts_table(
   ts8 TIMESTAMP(6) NOT NULL,
   ts9 TIMESTAMP(6) NOT NULL DEFAULT NOW(6) ON UPDATE NOW(6)
 );
+create table with_check (c1 integer not null,c2 varchar(22),constraint c1 check (c2 in ('a', 'b', 'c')));
 #end
 #begin
 -- Rename table


### PR DESCRIPTION
Supports the name for CHECK constraint.
CHECK contraints are ignored by storages in ALTER TABLE but the DDL is valid and still parsed by the database.