### PR TITLE
Adding Mysql 8.0 specific rename column constructs to MysqlParser

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -601,6 +601,7 @@ alterSpecification
     | CHANGE COLUMN? oldColumn=uid
       newColumn=uid columnDefinition
       (FIRST | AFTER afterColumn=uid)?                              #alterByChangeColumn
+    | RENAME COLUMN oldColumn=uid TO newColumn=uid                  #alterByRenameColumn
     | LOCK '='? lockType=(DEFAULT | NONE | SHARED | EXCLUSIVE)      #alterByLock
     | MODIFY COLUMN?
       uid columnDefinition (FIRST | AFTER uid)?                     #alterByModifyColumn

--- a/mysql/examples/ddl_alter.sql
+++ b/mysql/examples/ddl_alter.sql
@@ -4,6 +4,7 @@ alter table ship_class add column ship_spec varchar(150) first, add somecol int 
 alter table t3 add column (c2 decimal(10, 2) comment 'comment`' null, c3 enum('abc', 'cba', 'aaa')), add index t3_i1 using btree (c2) comment 'some index';
 alter table t2 add constraint t2_pk_constraint primary key (1c), alter column `_` set default 1;
 alter table ship_class change column somecol col_for_del tinyint first;
+alter table t5 rename column old to new;
 alter table ship_class drop col_for_del;
 alter table t3 drop index t3_i1;
 alter table childtable drop index fk_idParent_parentTable;


### PR DESCRIPTION
Hi, In Mysql 8.0,  it's now possible to rename a column without repeating its definition. Something like this:

```sql
ALTER TABLE foo RENAME COLUMN old TO new;
```

Creating a PR to address expand the grammar for the same. Have added an example as well.
