### PR TITLE
Add new sample files for Python3-py grammar

### DIFF
--- a/python3-py/examples/new_features.py
+++ b/python3-py/examples/new_features.py
@@ -1,0 +1,20 @@
+def ls(self, msg, match):
+    """
+    A sample function to test the parsing of ** resolution
+    """
+    langs = list(map(lambda x: x.lower(), match.group(1).split()))
+
+    bears = client.list.bears.get().json()
+    bears = [{**{'name': bear}, **content}
+             for bear, content in bears.items()]
+
+# Asyncio example from https://stackabuse.com/python-async-await-tutorial/
+
+import asyncio
+
+async def ping_server(ip):  
+    pass
+
+@asyncio.coroutine
+def load_file(path):  
+    pass


### PR DESCRIPTION
A follow-up from https://github.com/antlr/grammars-v4/pull/1205

Sorry for the delay, I got busy with university and then forgot about the previous one.
Still I am not sure if the tests are being executed for the python target :sweat_smile: 
(I added a [fake python file with contents from java language](https://github.com/virresh/grammars-v4/commit/f6cdd76a91afa5019e4b64a01ea105091cfc764c) in the examples folder and still the [ci passed](https://travis-ci.org/virresh/grammars-v4), so am not sure if these files are being parsed using the python grammar for python target :sweat_smile: )