### PR TITLE
Added JavaScript support for javascript grammar

### DIFF
--- a/javascript/JavaScript/JavaScriptBaseLexer.js
+++ b/javascript/JavaScript/JavaScriptBaseLexer.js
@@ -1,0 +1,97 @@
+const antlr4 = require("antlr4/index");
+const JavaScriptLexer = require("./JavaScriptLexer");
+
+function JavaScriptBaseLexer(input) {
+    antlr4.Lexer.call(this, input);
+
+    this.scopeStrictModes = new Array();
+    this.lastToken = null;
+    this.useStrictDefault = false;
+    this.useStrictCurrent = false;
+}
+
+JavaScriptBaseLexer.prototype = Object.create(antlr4.Lexer.prototype);
+
+JavaScriptBaseLexer.prototype.getStrictDefault = function() {
+    return this.useStrictDefault;
+};
+
+JavaScriptBaseLexer.prototype.setUseStrictDefault = function(value) {
+    this.useStrictDefault = value;
+    this.useStrictCurrent = value;
+};
+
+JavaScriptBaseLexer.prototype.IsSrictMode = function() {
+    return this.useStrictCurrent;
+};
+
+JavaScriptBaseLexer.prototype.getCurrentToken = function() {
+    return antlr4.Lexer.prototype.nextToken.call(this);
+};
+
+JavaScriptBaseLexer.prototype.nextToken = function() {
+    var next = antlr4.Lexer.prototype.nextToken.call(this);
+
+    if (next.channel === antlr4.Token.DEFAULT_CHANNEL) {
+        this.lastToken = next;
+    }
+    return next;
+};
+
+JavaScriptBaseLexer.prototype.ProcessOpenBrace = function() {
+    this.useStrictCurrent =
+        this.scopeStrictModes.length > 0 && this.scopeStrictModes[0]
+            ? true
+            : this.useStrictDefault;
+    this.scopeStrictModes.push(this.useStrictCurrent);
+};
+
+JavaScriptBaseLexer.prototype.ProcessCloseBrace = function() {
+    this.useStrictCurrent =
+        this.scopeStrictModes.length > 0
+            ? this.scopeStrictModes.pop()
+            : this.useStrictDefault;
+};
+
+JavaScriptBaseLexer.prototype.ProcessStringLiteral = function() {
+    if (
+        this.lastToken !== undefined &&
+        (this.lastToken === null ||
+            this.lastToken.type === JavaScriptLexer.OpenBrace)
+    ) {
+        const text = this._input.strdata.slice(0, "use strict".length);
+        if (text === '"use strict"' || text === "'use strict'") {
+            if (this.scopeStrictModes.length > 0) {
+                this.scopeStrictModes.pop();
+            }
+            this.useStrictCurrent = true;
+            this.scopeStrictModes.push(this.useStrictCurrent);
+        }
+    }
+};
+
+JavaScriptBaseLexer.prototype.IsRegexPossible = function() {
+    if (this.lastToken === null) {
+        return true;
+    }
+
+    switch (this.lastToken.type) {
+        case JavaScriptLexer.Identifier:
+        case JavaScriptLexer.NullLiteral:
+        case JavaScriptLexer.BooleanLiteral:
+        case JavaScriptLexer.This:
+        case JavaScriptLexer.CloseBracket:
+        case JavaScriptLexer.CloseParen:
+        case JavaScriptLexer.OctalIntegerLiteral:
+        case JavaScriptLexer.DecimalLiteral:
+        case JavaScriptLexer.HexIntegerLiteral:
+        case JavaScriptLexer.StringLiteral:
+        case JavaScriptLexer.PlusPlus:
+        case JavaScriptLexer.MinusMinus:
+            return false;
+        default:
+            return true;
+    }
+};
+
+module.exports.JavaScriptBaseLexer = JavaScriptBaseLexer;

--- a/javascript/JavaScript/JavaScriptBaseParser.js
+++ b/javascript/JavaScript/JavaScriptBaseParser.js
@@ -1,0 +1,70 @@
+const antlr4 = require("antlr4/index");
+const JavaScriptParser = require("./JavaScriptParser");
+
+function JavaScriptBaseParser(input) {
+    antlr4.Parser.call(this, input);
+}
+
+JavaScriptBaseParser.prototype = Object.create(antlr4.Parser.prototype);
+
+JavaScriptBaseParser.prototype.p = function(str) {
+    return this.prev(str);
+};
+
+JavaScriptBaseParser.prototype.prev = function(str) {
+    const source = this._input.LT(-1).source[1].strdata;
+    const start = this._input.LT(-1).start;
+    const stop = this._input.LT(-1).stop;
+    const prev = source.slice(start, stop + 1);
+    return prev === str;
+};
+
+JavaScriptBaseParser.prototype.notLineTerminator = function() {
+    return !this.here(JavaScriptParser.LineTerminator);
+};
+
+JavaScriptBaseParser.prototype.notOpenBraceAndNotFunction = function() {
+    const nextTokenType = this._input.LT(1).type;
+    return (
+        nextTokenType !== JavaScriptParser.OpenBrace &&
+        nextTokenType !== JavaScriptParser.Function
+    );
+};
+
+JavaScriptBaseParser.prototype.closeBrace = function() {
+    return this._input.LT(1).type === JavaScriptParser.CloseBrace;
+};
+
+JavaScriptBaseParser.prototype.here = function(type) {
+    const possibleIndexEosToken = this.getCurrentToken().tokenIndex - 1;
+    const ahead = this._input.get(possibleIndexEosToken);
+    return ahead.channel === antlr4.Lexer.HIDDEN && ahead.type === type;
+};
+
+JavaScriptBaseParser.prototype.lineTerminatorAhead = function() {
+    let possibleIndexEosToken = this.getCurrentToken().tokenIndex - 1;
+    let ahead = this._input.get(possibleIndexEosToken);
+    if (ahead.channel !== antlr4.Lexer.HIDDEN) {
+        return false;
+    }
+
+    if (ahead.type === JavaScriptParser.LineTerminator) {
+        return true;
+    }
+
+    if (ahead.type === JavaScriptParser.WhiteSpaces) {
+        possibleIndexEosToken = this.getCurrentToken().getTokenIndex() - 2;
+        ahead = this._input.get(possibleIndexEosToken);
+    }
+
+    const text = ahead.type;
+    const type = ahead.type;
+
+    return (
+        (type === JavaScriptParser.MultiLineComment &&
+            (text.includes("\r") || text.includes("\n"))) ||
+        type === JavaScriptParser.LineTerminator
+    );
+};
+
+module.exports.JavaScriptBaseParser = JavaScriptBaseParser;

--- a/javascript/JavaScriptLexer.g4
+++ b/javascript/JavaScriptLexer.g4
@@ -34,14 +34,14 @@ options { superClass=JavaScriptBaseLexer; }
 
 MultiLineComment:               '/*' .*? '*/'             -> channel(HIDDEN);
 SingleLineComment:              '//' ~[\r\n\u2028\u2029]* -> channel(HIDDEN);
-RegularExpressionLiteral:       '/' RegularExpressionChar+ {IsRegexPossible()}? '/' IdentifierPart*;
+RegularExpressionLiteral:       '/' RegularExpressionChar+ {this.IsRegexPossible()}? '/' IdentifierPart*;
 
 OpenBracket:                    '[';
 CloseBracket:                   ']';
 OpenParen:                      '(';
 CloseParen:                     ')';
-OpenBrace:                      '{' {ProcessOpenBrace();};
-CloseBrace:                     '}' {ProcessCloseBrace();};
+OpenBrace:                      '{' {this.ProcessOpenBrace();};
+CloseBrace:                     '}' {this.ProcessCloseBrace();};
 SemiColon:                      ';';
 Comma:                          ',';
 Assign:                         '=';
@@ -106,7 +106,7 @@ DecimalLiteral:                 DecimalIntegerLiteral '.' [0-9]* ExponentPart?
 /// Numeric Literals
 
 HexIntegerLiteral:              '0' [xX] HexDigit+;
-OctalIntegerLiteral:            '0' [0-7]+ {!IsSrictMode()}?;
+OctalIntegerLiteral:            '0' [0-7]+ {!this.IsSrictMode()}?;
 OctalIntegerLiteral2:           '0' [oO] [0-7]+;
 BinaryIntegerLiteral:           '0' [bB] [01]+;
 
@@ -152,15 +152,15 @@ Import:                         'import';
 /// The following tokens are also considered to be FutureReservedWords 
 /// when parsing strict mode
 
-Implements:                     'implements' {IsSrictMode()}?;
-Let:                            'let' {IsSrictMode()}?;
-Private:                        'private' {IsSrictMode()}?;
-Public:                         'public' {IsSrictMode()}?;
-Interface:                      'interface' {IsSrictMode()}?;
-Package:                        'package' {IsSrictMode()}?;
-Protected:                      'protected' {IsSrictMode()}?;
-Static:                         'static' {IsSrictMode()}?;
-Yield:                          'yield' {IsSrictMode()}?;
+Implements:                     'implements' {this.IsSrictMode()}?;
+Let:                            'let' {this.IsSrictMode()}?;
+Private:                        'private' {this.IsSrictMode()}?;
+Public:                         'public' {this.IsSrictMode()}?;
+Interface:                      'interface' {this.IsSrictMode()}?;
+Package:                        'package' {this.IsSrictMode()}?;
+Protected:                      'protected' {this.IsSrictMode()}?;
+Static:                         'static' {this.IsSrictMode()}?;
+Yield:                          'yield' {this.IsSrictMode()}?;
 
 /// Identifier Names and Identifiers
 
@@ -168,7 +168,7 @@ Identifier:                     IdentifierStart IdentifierPart*;
 
 /// String Literals
 StringLiteral:                 ('"' DoubleStringCharacter* '"'
-             |                  '\'' SingleStringCharacter* '\'') {ProcessStringLiteral();}
+             |                  '\'' SingleStringCharacter* '\'') {this.ProcessStringLiteral();}
              ;
 
 TemplateStringLiteral:          '`' ('\\`' | ~'`')* '`';

--- a/javascript/JavaScriptParser.g4
+++ b/javascript/JavaScriptParser.g4
@@ -86,7 +86,7 @@ emptyStatement
     ;
 
 expressionStatement
-    : {notOpenBraceAndNotFunction()}? expressionSequence eos
+    : {this.notOpenBraceAndNotFunction()}? expressionSequence eos
     ;
 
 ifStatement
@@ -95,13 +95,13 @@ ifStatement
 
 
 iterationStatement
-    : Do statement While '(' expressionSequence ')' eos                                                 # DoStatement
-    | While '(' expressionSequence ')' statement                                                        # WhileStatement
-    | For '(' expressionSequence? ';' expressionSequence? ';' expressionSequence? ')' statement         # ForStatement
+    : Do statement While '(' expressionSequence ')' eos                                                         # DoStatement
+    | While '(' expressionSequence ')' statement                                                                # WhileStatement
+    | For '(' expressionSequence? ';' expressionSequence? ';' expressionSequence? ')' statement                 # ForStatement
     | For '(' varModifier variableDeclarationList ';' expressionSequence? ';' expressionSequence? ')'
-          statement                                                                                     # ForVarStatement
-    | For '(' singleExpression (In | Identifier{p("of")}?) expressionSequence ')' statement             # ForInStatement
-    | For '(' varModifier variableDeclaration (In | Identifier{p("of")}?) expressionSequence ')' statement      # ForVarInStatement
+          statement                                                                                             # ForVarStatement
+    | For '(' singleExpression (In | Identifier{this.p("of")}?) expressionSequence ')' statement                # ForInStatement
+    | For '(' varModifier variableDeclaration (In | Identifier{this.p("of")}?) expressionSequence ')' statement # ForVarInStatement
     ;
 
 varModifier  // let, const - ECMAScript 6
@@ -111,15 +111,15 @@ varModifier  // let, const - ECMAScript 6
     ;
 
 continueStatement
-    : Continue ({notLineTerminator()}? Identifier)? eos
+    : Continue ({this.notLineTerminator()}? Identifier)? eos
     ;
 
 breakStatement
-    : Break ({notLineTerminator()}? Identifier)? eos
+    : Break ({this.notLineTerminator()}? Identifier)? eos
     ;
 
 returnStatement
-    : Return ({notLineTerminator()}? expressionSequence)? eos
+    : Return ({this.notLineTerminator()}? expressionSequence)? eos
     ;
 
 withStatement
@@ -151,7 +151,7 @@ labelledStatement
     ;
 
 throwStatement
-    : Throw {notLineTerminator()}? expressionSequence eos
+    : Throw {this.notLineTerminator()}? expressionSequence eos
     ;
 
 tryStatement
@@ -275,8 +275,8 @@ singleExpression
     | singleExpression '.' identifierName                                    # MemberDotExpression
     | singleExpression arguments                                             # ArgumentsExpression
     | New singleExpression arguments?                                        # NewExpression
-    | singleExpression {notLineTerminator()}? '++'                           # PostIncrementExpression
-    | singleExpression {notLineTerminator()}? '--'                           # PostDecreaseExpression
+    | singleExpression {this.notLineTerminator()}? '++'                      # PostIncrementExpression
+    | singleExpression {this.notLineTerminator()}? '--'                      # PostDecreaseExpression
     | Delete singleExpression                                                # DeleteExpression
     | Void singleExpression                                                  # VoidExpression
     | Typeof singleExpression                                                # TypeofExpression
@@ -411,16 +411,16 @@ keyword
     ;
 
 getter
-    : Identifier{p("get")}? propertyName
+    : Identifier{this.p("get")}? propertyName
     ;
 
 setter
-    : Identifier{p("set")}? propertyName
+    : Identifier{this.p("set")}? propertyName
     ;
 
 eos
     : SemiColon
     | EOF
-    | {lineTerminatorAhead()}?
-    | {closeBrace()}?
+    | {this.lineTerminatorAhead()}?
+    | {this.closeBrace()}?
     ;


### PR DESCRIPTION
This PR adds JavaScript support for the `javascript` grammar.

There is one catch, which I would like to discuss. Adding support for JavaScript requires prefixing `this.` to function calls within the grammar (`.g4`) files.  

I am wondering if this will completely break the existing `Java` and `CSharpSharwell` implementations or not.

I will elaborate on this more in another comment why `this.` needs to be prefixed to calls in the grammar files, but in short, it has to do with the way JavaScript targets are generated by ANTLR4. 

If the proposed changes to the grammar files will break existing implementations, I would like to discuss ways to make this work. 

**How to test**
**Step 1:** Save this code to `test.js`
```

const antlr4 = require("antlr4/index");
const fs = require("fs");

const { JavaScriptLexer } = require("./JavaScriptLexer");
const { JavaScriptParser } = require("./JavaScriptParser");

function readJavaScriptFile(file) {
    const filePath = `${__dirname}/${file}`;
    if (!fs.existsSync(filePath)) {
        console.log(`ERROR: Unable to locate "${filePath}"`);
        return null;
    }
    const script = fs.readFileSync(filePath, "utf8");
    return script;
}

let tests = [];
if (process.argv.length <= 2) {
    console.log(`Usage: node ${process.argv[1]} <file1, file2, ...>`);
    process.exit(-1);
} else {
    tests = [...process.argv].splice(2);
}

tests.forEach(s => {
    console.log(`Analyzing file '${s}'`);
    const script = readJavaScriptFile(s);
    if (script) {
        const inputStream = new antlr4.InputStream(script);
        const lexer = new JavaScriptLexer(inputStream);
        lexer.strictMode = false;
        const tokens = new antlr4.CommonTokenStream(lexer);
        const parser = new JavaScriptParser(tokens);
        parser.buildParseTrees = true;
        const tree = parser.program();

        // Print the LISP-formatted tree
        console.log(tree.toStringTree(parser.ruleNames));
    }
});
```

**Step 2:** Run the following commands (have node.js installed)
```
cd grammars-v4/javascript
cp JavaScript/*.js .
antlr4 -Dlanguage=JavaScript JavaScriptLexer.g4
antlr4 -Dlanguage=JavaScript JavaScriptParser.g4
npm init
npm install antlr4
node test.js examples/ArrowFunctions.js
```
