### PR TITLE
Fixed java embedded code

### DIFF
--- a/csharp/CSharpSharwell/CSharpLexer.g4
+++ b/csharp/CSharpSharwell/CSharpLexer.g4
@@ -181,9 +181,9 @@ if (interpolatedStringLevel > 0)
 {
     int ind = 1;
     bool switchToFormatString = true;
-    while ((char)_input.La(ind) != '}')
+    while ((char)InputStream.LA(ind) != '}')
     {
-        if (_input.La(ind) == ':' || _input.La(ind) == ')')
+        if (InputStream.LA(ind) == ':' || InputStream.LA(ind) == ')')
         {
             switchToFormatString = false;
             break;


### PR DESCRIPTION
Name of the input class in CSharp is `InputStream` rather than `_input`. And method name changes from `La` to `LA`. This way, grammar can be generated in C# without errors.