### PR TITLE
[javascript] fix naive implementation of #1137

### DIFF
--- a/javascript/JavaScriptLexer.g4
+++ b/javascript/JavaScriptLexer.g4
@@ -671,7 +671,9 @@ fragment UnicodeConnectorPunctuation
     ;
 
 fragment RegularExpressionFirstChar
-    : ~'*'
+    : ~[*\r\n\u2028\u2029\\/[]
+    | RegularExpressionBackslashSequence
+    | '[' RegularExpressionClassChar* ']'
     ;
 
 fragment RegularExpressionChar


### PR DESCRIPTION
Current implementation allows illegal characters in the `RegularExpressionFirstChar` rule.