### PR TITLE
Support full table name in rename

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -611,7 +611,7 @@ alterSpecification
     | DROP FOREIGN KEY uid                                          #alterByDropForeignKey
     | DISABLE KEYS                                                  #alterByDisableKeys
     | ENABLE KEYS                                                   #alterByEnableKeys
-    | RENAME renameFormat=(TO | AS)? uid                            #alterByRename
+    | RENAME renameFormat=(TO | AS)? (uid | fullId)                 #alterByRename
     | ORDER BY uidList                                              #alterByOrder
     | CONVERT TO CHARACTER SET charsetName
       (COLLATE collationName)?                                      #alterByConvertCharset

--- a/mysql/examples/ddl_alter.sql
+++ b/mysql/examples/ddl_alter.sql
@@ -10,6 +10,7 @@ alter table t3 drop index t3_i1;
 alter table childtable drop index fk_idParent_parentTable;
 alter table t2 drop primary key;
 alter table t3 rename to table3column;
+alter table db2.t3 rename to db2.table3column;
 alter table childtable add constraint `fk1` foreign key (idParent) references parenttable(id) on delete restrict on update cascade;
 alter table table3column default character set = cp1251;
 alter table with_check add constraint check (c1 in (1, 2, 3, 4));


### PR DESCRIPTION
When fulltable name was used in `rename to` the parser has failed as the dot was unxpected character.