### PR TITLE
fix String_literal to work for antlr >= v4.6; rename None to work with python targets

### DIFF
--- a/system_verilog/SysVerilogHDL.g4
+++ b/system_verilog/SysVerilogHDL.g4
@@ -167,7 +167,7 @@ Module_keyword_only : 'module' ;
 Nand : 'nand' ;
 Negedge : 'negedge' ;
 Nmos : 'nmos' ;
-None : 'none' ;
+NONE : 'none' ;
 Nor : 'nor' ;
 Not : 'not' ;
 Notif0 : 'notif0' ;
@@ -254,11 +254,10 @@ ALPHA : [a-zA-Z_] ;
 fragment
 DIGIT : [0-9] ;
 
-//Broken_string_literal : '"' ('\\' [\\"nt\[\]\|] | ~[\\"\r\n])* '\n' ;
 Dollar_Identifier : '$' [a-zA-Z0-9_$] [a-zA-Z0-9_$]* ;
 Escaped_identifier : '\\' ~[ \r\t\n]* ;
 Simple_identifier : ALPHA (ALPHA | DIGIT)* ;
-String_literal : '"' ('\\' [\\"nt\[\]\|] | ~[\\"\r\n])* '"' ;
+String_literal : '"' (~('"'|'\n'|'\r') | '""')* '"'  ;
 
 
 // punctuation
@@ -711,7 +710,7 @@ net_type    :   Supply0
             |   Wire
             |   Wand
             |   Wor
-            |   None
+            |   NONE
             ;
 
 drive_strength  :   Open_parenthesis drive_strength_value_0 Comma drive_strength_value_1 Close_parenthesis ;


### PR DESCRIPTION
Existing grammar generated this error for antlr v4.7.2 for Java, Python2, Python3, etc targets

```
kbroch@barolo:/home/kbroch/projects/antlr/grammars-v4/system_verilog git:(master*) $ java -Xmx500M -cp /usr/local/lib/antlr-4.7.2-complete.jar org.antlr.v4.Tool -Dlanguage=Java -visitor -no-listener SysVerilogHDL.g4
warning(156): SysVerilogHDL.g4:261:27: invalid escape sequence \[
Exception in thread "main" java.lang.RuntimeException: set is empty
        at org.antlr.v4.runtime.misc.IntervalSet.getMaxElement(IntervalSet.java:421)
        at org.antlr.v4.runtime.atn.ATNSerializer.serialize(ATNSerializer.java:169)
        at org.antlr.v4.runtime.atn.ATNSerializer.getSerialized(ATNSerializer.java:601)
        at org.antlr.v4.Tool.generateInterpreterData(Tool.java:745)
        at org.antlr.v4.Tool.processNonCombinedGrammar(Tool.java:400)
        at org.antlr.v4.Tool.process(Tool.java:361)
        at org.antlr.v4.Tool.processGrammarsOnCommandLine(Tool.java:328)
        at org.antlr.v4.Tool.main(Tool.java:172)
```
Once I changed the `string_literal` definition the Java target passed but the Python targets complained that `None` was a keyword in the target language so I changed that to `NONE` and Python targets passed as well.

I tested target generation with the new grammar file and it passed on v4.5.3 and v4.7.2 for all targets I tried (CSharp, Python3, Python2, Java)


 