### PR TITLE
mysql: allow adding multiple partitions in single statement

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -621,7 +621,10 @@ alterSpecification
     | IMPORT TABLESPACE                                             #alterByImportTablespace
     | FORCE                                                         #alterByForce
     | validationFormat=(WITHOUT | WITH) VALIDATION                  #alterByValidate
-    | ADD PARTITION '(' partitionDefinition ')'                     #alterByAddPartition
+    | ADD PARTITION
+        '('
+          partitionDefinition (',' partitionDefinition)*
+        ')'                                                         #alterByAddPartition
     | DROP PARTITION uidList                                        #alterByDropPartition
     | DISCARD PARTITION (uidList | ALL) TABLESPACE                  #alterByDiscardPartition
     | IMPORT PARTITION (uidList | ALL) TABLESPACE                   #alterByImportPartition

--- a/mysql/examples/ddl_alter.sql
+++ b/mysql/examples/ddl_alter.sql
@@ -17,6 +17,7 @@ alter table with_check add constraint check (c1 in (1, 2, 3, 4));
 alter table with_check add constraint c2 check (c1 in (1, 2, 3, 4));
 alter table with_check add check (c1 in (1, 2, 3, 4));
 alter table with_partition add partition (partition p201901 values less than (737425) engine = InnoDB);
+alter table with_partition add partition (partition p1 values less than (837425) engine = InnoDB, partition p2 values less than (MAXVALUE) engine = InnoDB);
 
 #end
 #begin


### PR DESCRIPTION
The mysql parser currently supports:
```
ALTER TABLE test ADD PARTITION (
PARTITION p1 VALUES LESS THAN (10)
);
ALTER TABLE test ADD PARTITION (
PARTITION p2 VALUES LESS THAN MAXVALUE
);
```
But it does not support:
```
ALTER TABLE test ADD PARTITION (
PARTITION p1 VALUES LESS THAN (10),
PARTITION p2 VALUES LESS THAN MAXVALUE
);
```
