### PR TITLE
Comma is optional in table options of ALTER

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -578,7 +578,7 @@ alterView
 // details
 
 alterSpecification
-    : tableOption                                                   #alterByTableOption
+    : tableOption (','? tableOption)*                               #alterByTableOption
     | ADD COLUMN? uid columnDefinition (FIRST | AFTER uid)?         #alterByAddColumn
     | ADD COLUMN?
         '('

--- a/mysql/examples/ddl_alter.sql
+++ b/mysql/examples/ddl_alter.sql
@@ -18,7 +18,8 @@ alter table with_check add constraint c2 check (c1 in (1, 2, 3, 4));
 alter table with_check add check (c1 in (1, 2, 3, 4));
 alter table with_partition add partition (partition p201901 values less than (737425) engine = InnoDB);
 alter table with_partition add partition (partition p1 values less than (837425) engine = InnoDB, partition p2 values less than (MAXVALUE) engine = InnoDB);
-
+alter table t1 stats_auto_recalc=default stats_sample_pages=50;
+alter table t1 stats_auto_recalc=default, stats_sample_pages=50;
 #end
 #begin
 -- Alter database


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/alter-table.html

```
table_options:
    table_option [[,] table_option] ...
```
The comma is not mandatory between table options and server does not require it.
