### PR TITLE
Asn

### DIFF
--- a/asn/ASN.g4
+++ b/asn/ASN.g4
@@ -369,6 +369,8 @@ builtinType :
  | setOfType
  | objectidentifiertype
  | objectClassFieldType
+ | BOOLEAN_LITERAL
+ | NULL_LITERAL
 
 	;
 

--- a/asn/ASN.g4
+++ b/asn/ASN.g4
@@ -45,6 +45,8 @@ If you have some comments/improvements, send me an e-mail.
 
 grammar ASN;
 
+modules: moduleDefinition+;
+
 moduleDefinition :  IDENTIFIER (L_BRACE (IDENTIFIER L_PARAN NUMBER R_PARAN)* R_BRACE)?
      DEFINITIONS_LITERAL
      tagDefault

--- a/asn/ASN.g4
+++ b/asn/ASN.g4
@@ -443,6 +443,7 @@ builtinValue :
 	|	objectIdentifierValue
 	|	booleanValue
 	|   CSTRING
+	|   BSTRING
  ;
 
 objectIdentifierValue : L_BRACE /*(definedValue)?*/ objIdComponentsList R_BRACE

--- a/asn/ASN.g4
+++ b/asn/ASN.g4
@@ -425,6 +425,18 @@ contentsConstraint :
    CONTAINING_LITERAL asnType
  |  ENCODED_LITERAL BY_LITERAL value
  |  CONTAINING_LITERAL asnType ENCODED_LITERAL BY_LITERAL value
+ |  WITH_LITERAL COMPONENTS_LITERAL L_BRACE componentPresenceLists R_BRACE
+;
+
+componentPresenceLists:
+   componentPresenceList? (EXTENSTIONENDMARKER (COMMA componentPresenceList)?)?
+  |  ELLIPSIS (COMMA componentPresenceList)?
+;
+
+componentPresenceList: (componentPresence) (COMMA componentPresence)*
+;
+
+componentPresence: IDENTIFIER (ABSENT_LITERAL | PRESENT_LITERAL)
 ;
 
 


### PR DESCRIPTION
```
modules: moduleDefinition+;
```

One file may have multiple module definitions

```
 | BOOLEAN_LITERAL
 | NULL_LITERAL
```

`BOOLEAN` and `NULL` are also builtin types

```
 |  WITH_LITERAL COMPONENTS_LITERAL L_BRACE componentPresenceLists R_BRACE
;

componentPresenceLists:
   componentPresenceList? (EXTENSTIONENDMARKER (COMMA componentPresenceList)?)?
  |  ELLIPSIS (COMMA componentPresenceList)?
;

componentPresenceList: (componentPresence) (COMMA componentPresence)*
;

componentPresence: IDENTIFIER (ABSENT_LITERAL | PRESENT_LITERAL)
```

Constraint expression `Blahblah(WITH COMPONENTS{Something PRESENT, ..., Something ABSENT})`

```
	|   BSTRING
```

Default value can have `BIT STRING`