### PR TITLE
Schema not allowed in server and database triggers

### DIFF
--- a/tsql/TSqlParser.g4
+++ b/tsql/TSqlParser.g4
@@ -1890,7 +1890,7 @@ dml_trigger_operation
     ;
 
 create_or_alter_ddl_trigger
-    : ((CREATE (OR ALTER)?) | ALTER) TRIGGER simple_name
+    : ((CREATE (OR ALTER)?) | ALTER) TRIGGER simple_id
       ON (ALL SERVER | DATABASE)
       (WITH dml_trigger_option (',' dml_trigger_option)* )?
       (FOR | AFTER) ddl_trigger_operation (',' dml_trigger_operation)*


### PR DESCRIPTION
Inspired by #1110 I noticed that schema is not allowed in server and database triggers (see [documentation](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql?view=sql-server-2017#remarks-for-ddl-triggers))