### PR TITLE
Add parser rule for alter table enum/set collection options.

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -2003,11 +2003,7 @@ dataType
     ;
 
 collectionOptions
-    : '(' collectionOption (',' collectionOption)* ')'
-    ;
-
-collectionOption
-    : STRING_LITERAL
+    : '(' STRING_LITERAL (',' STRING_LITERAL)* ')'
     ;
 
 convertedDataType

--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -1994,12 +1994,20 @@ dataType
       )
       lengthOneDimension?                                           #dimensionDataType
     | typeName=(ENUM | SET)
-      '(' STRING_LITERAL (',' STRING_LITERAL)* ')' BINARY?
+      collectionOptions BINARY?
       (CHARACTER SET charsetName)? (COLLATE collationName)?         #collectionDataType
     | typeName=(
         GEOMETRYCOLLECTION | LINESTRING | MULTILINESTRING
         | MULTIPOINT | MULTIPOLYGON | POINT | POLYGON
       )                                                             #spatialDataType
+    ;
+
+collectionOptions
+    : '(' collectionOption (',' collectionOption)* ')'
+    ;
+
+collectionOption
+    : STRING_LITERAL
     ;
 
 convertedDataType

--- a/mysql/examples/ddl_alter.sql
+++ b/mysql/examples/ddl_alter.sql
@@ -20,6 +20,7 @@ alter table with_partition add partition (partition p201901 values less than (73
 alter table with_partition add partition (partition p1 values less than (837425) engine = InnoDB, partition p2 values less than (MAXVALUE) engine = InnoDB);
 alter table t1 stats_auto_recalc=default stats_sample_pages=50;
 alter table t1 stats_auto_recalc=default, stats_sample_pages=50;
+alter table t1 modify column c1 enum('abc','cba','aaa') character set 'utf8' collate 'utf8_unicode_ci' not null default 'abc';
 #end
 #begin
 -- Alter database


### PR DESCRIPTION
During an alter table modify column statement, we found we needed a clear way to identify where the collection options for an enum/set started/stopped.  It made sense to add an additional parser rule that would identify those points in the statement syntax allowing the implementation to better facilitate handling the collection options combined with the optional `charsetName` and `collationName` fragments.