### PR TITLE
Add missing function IIF (Instant IF)

### DIFF
--- a/tsql/TSqlLexer.g4
+++ b/tsql/TSqlLexer.g4
@@ -178,6 +178,7 @@ IDENTITY:                              'IDENTITY';
 IDENTITYCOL:                           'IDENTITYCOL';
 IDENTITY_INSERT:                       'IDENTITY_INSERT';
 IF:                                    'IF';
+IIF:                                   'IIF';
 IN:                                    'IN';
 INCLUDE:                               'INCLUDE';
 INCREMENT:                             'INCREMENT';

--- a/tsql/TSqlParser.g4
+++ b/tsql/TSqlParser.g4
@@ -3172,6 +3172,8 @@ function_call
     | ISNULL '(' expression ',' expression ')'          #ISNULL
     // https://docs.microsoft.com/en-us/sql/t-sql/xml/xml-data-type-methods
     | xml_data_type_methods                             #XML_DATA_TYPE_FUNC
+    // https://docs.microsoft.com/en-us/sql/t-sql/functions/logical-functions-iif-transact-sql
+    | IIF '(' search_condition ',' expression ',' expression ')'
     ;
 
 xml_data_type_methods


### PR DESCRIPTION
Missing Function Instant If is basically the ternary operator of TSQL.

Imagine expression in c#
`a < b ? c  : d`

translates into TSQL
`IIF(a<b, c,d)`