### PR TITLE
Dart grammar now supports strings containing escaped quotes.

### DIFF
--- a/dart2/Dart2.g4
+++ b/dart2/Dart2.g4
@@ -346,8 +346,8 @@ booleanLiteral
 stringLiteral: SingleLineString;
 //stringLiteral: SingleLineString;
 SingleLineString
-  : '"' ~["]* '"'
-  | '\'' ~[']* '\''
+  : '"' (~["] | '\\"')* '"'
+  | '\'' (~['] | '\\\'')* '\''
 //  | 'r\'' (~('\'' | NEWLINE))* '\'' // TODO
 //  | 'r"' (~('\'' | NEWLINE))* '"'
   ;

--- a/dart2/examples/escaped_string.dart
+++ b/dart2/examples/escaped_string.dart
@@ -1,0 +1,9 @@
+class MyClass<T> {
+  final T a;
+  final String b;
+
+  const MyClass({@required this.a, @required this.b});
+
+  @override
+  String toString() => "$runtimeType(a: $a, b: \"$b\")";
+}


### PR DESCRIPTION
See pmd/pmd#1791.

Example:
`"$a(b: $b, c: \"$c\")"`