### PR TITLE
Extended Dart grammar to take escape sequences into account.

### DIFF
--- a/dart2/Dart2.g4
+++ b/dart2/Dart2.g4
@@ -346,8 +346,8 @@ booleanLiteral
 stringLiteral: SingleLineString;
 //stringLiteral: SingleLineString;
 SingleLineString
-  : '"' (~["] | '\\"')* '"'
-  | '\'' (~['] | '\\\'')* '\''
+  : '"' (~[\\"] | '\\\\' | ESCAPE_SEQUENCE | '\\"')* '"'
+  | '\'' (~[\\'] | '\\\\' | ESCAPE_SEQUENCE | '\\\'')* '\''
 //  | 'r\'' (~('\'' | NEWLINE))* '\'' // TODO
 //  | 'r"' (~('\'' | NEWLINE))* '"'
   ;
@@ -371,6 +371,7 @@ ESCAPE_SEQUENCE
   | '\\x' HEX_DIGIT HEX_DIGIT
   | '\\u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
   | '\\u{' HEX_DIGIT_SEQUENCE '}'
+  | '\\$'
   ;
 fragment
 HEX_DIGIT_SEQUENCE

--- a/dart2/examples/escape_sequences.dart
+++ b/dart2/examples/escape_sequences.dart
@@ -1,0 +1,5 @@
+class MyClass {
+  var newline = '\n';
+  var dollar = '$';
+  var escaped_dollar = "\$";
+}

--- a/dart2/examples/escaped_backslash.dart
+++ b/dart2/examples/escaped_backslash.dart
@@ -1,0 +1,4 @@
+class MyClass {
+  final separator = '\\';
+  final separators = const ['/', '\\'];
+}


### PR DESCRIPTION
See pmd/pmd#1803.

Example:
`"\\"`