### PR TITLE
 add support of Python3 and JavaScript for PlSql

### DIFF
--- a/plsql/JavaScript/PlSqlBaseLexer.js
+++ b/plsql/JavaScript/PlSqlBaseLexer.js
@@ -1,0 +1,16 @@
+var Lexer = require('antlr4/index').Lexer;
+
+function PlSqlBaseLexer(...args) {
+    Lexer.call(this, ...args);
+    return this;
+}
+
+PlSqlBaseLexer.prototype = Object.create(Lexer.prototype);
+PlSqlBaseLexer.prototype.constructor = PlSqlBaseLexer;
+
+PlSqlBaseLexer.prototype.IsNewlineAtPos = function (pos) {
+    var la = this._input.LA(pos);
+    return la == -1 || la == '\n';
+}
+
+exports.PlSqlBaseLexer = PlSqlBaseLexer;

--- a/plsql/JavaScript/PlSqlBaseParser.js
+++ b/plsql/JavaScript/PlSqlBaseParser.js
@@ -1,0 +1,27 @@
+
+var Parser = require('antlr4/index').Parser;
+
+function PlSqlBaseParser(...args) {
+    Parser.call(this, ...args);
+    this._isVersion10 = false;
+    this._isVersion12 = true;
+    return this;
+}
+
+PlSqlBaseParser.prototype = Object.create(Parser.prototype);
+PlSqlBaseParser.prototype.constructor = PlSqlBaseParser;
+
+PlSqlBaseParser.prototype.isVersion10 = function () {
+    return this._isVersion10;
+}
+PlSqlBaseParser.prototype.isVersion12 = function () {
+    return this._isVersion12;
+}
+PlSqlBaseParser.prototype.setVersion10 = function (value) {
+    this._isVersion10 = value;
+}
+PlSqlBaseParser.prototype.setVersion12 = function (value) {
+    this._isVersion12 = value;
+}
+
+exports.PlSqlBaseParser = PlSqlBaseParser;

--- a/plsql/Python3/PlSqlBaseLexer.py
+++ b/plsql/Python3/PlSqlBaseLexer.py
@@ -1,0 +1,7 @@
+from antlr4 import *
+
+class PlSqlBaseLexer(Lexer):
+
+    def IsNewlineAtPos(self, pos):
+        la = self._input.LA(pos)
+        return la == -1 or la == '\n'

--- a/plsql/Python3/PlSqlBaseParser.py
+++ b/plsql/Python3/PlSqlBaseParser.py
@@ -1,0 +1,18 @@
+from antlr4 import *
+
+class PlSqlBaseParser(Parser):
+
+    _isVersion10 = False
+    _isVersion12 = True
+
+    def isVersion10(self):
+        return self._isVersion10
+
+    def isVersion12(self):
+        return self._isVersion12
+
+    def setVersion10(self, value):
+        self._isVersion10 = value
+
+    def setVersion12(self, value):
+        self._isVersion12 = value


### PR DESCRIPTION
Hi, I added the different runtime implementations of Python3 and JavaScript for PlSql grammar and have tested them by myself.
