### PR TITLE
Extended Dart grammar to properly parse strings.

### DIFF
--- a/dart2/Dart2.g4
+++ b/dart2/Dart2.g4
@@ -342,58 +342,49 @@ booleanLiteral
   | 'false'
   ;
 
-//stringLiteral: (MultilineString | SingleLineString)+;
-stringLiteral: SingleLineString;
-//stringLiteral: SingleLineString;
+stringLiteral: (MultiLineString | SingleLineString)+;
+
 SingleLineString
-  : '"' (~[\\"] | '\\\\' | ESCAPE_SEQUENCE | '\\"')* '"'
-  | '\'' (~[\\'] | '\\\\' | ESCAPE_SEQUENCE | '\\\'')* '\''
-//  | 'r\'' (~('\'' | NEWLINE))* '\'' // TODO
-//  | 'r"' (~('\'' | NEWLINE))* '"'
+  : '"' StringContentDQ* '"'
+  | '\'' StringContentSQ* '\''
+  | 'r\'' (~('\'' | '\n' | '\r'))* '\''
+  | 'r"' (~('"' | '\n' | '\r'))* '"'
   ;
 
-//MultilineString
-//  : '"""' StringContentTDQ* '"""'
-//  | '\'\'\'' StringContentTDQ* '\'\'\''
-//  | 'r"""' (~'"""')* '"""' // TODO
-//  | 'r\'\'\'' (~'\'\'\'')* '\'\'\''
-//  ;
-//StringContentSQ: .;// TODO
-//StringContentTDQ: .;// TODO
 fragment
-ESCAPE_SEQUENCE
-  : '\\n'
-  | '\\r'
-  | '\\f'
-  | '\\b'
-  | '\\t'
-  | '\\v'
-  | '\\x' HEX_DIGIT HEX_DIGIT
-  | '\\u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
-  | '\\u{' HEX_DIGIT_SEQUENCE '}'
-  | '\\$'
+StringContentDQ
+  : ~('\\' | '"' /*| '$'*/ | '\n' | '\r')
+  | '\\' ~('\n' | '\r')
+  //| stringInterpolation
   ;
+
 fragment
-HEX_DIGIT_SEQUENCE
-  : HEX_DIGIT HEX_DIGIT? HEX_DIGIT?
-    HEX_DIGIT? HEX_DIGIT? HEX_DIGIT?
+StringContentSQ
+  : ~('\\' | '\'' /*| '$'*/ | '\n' | '\r')
+  | '\\' ~('\n' | '\r')
+  //| stringInterpolation
   ;
-/*TODO
-<stringContentDQ> ::= \~{}( `\\' | `"' | `$' | <NEWLINE> )
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
 
-<stringContentSQ> ::= \~{}( `\\' | `\'' | `$' | <NEWLINE> )
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
-<stringContentTDQ> ::= \~{}( `\\' | `"""' | `$')
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
+MultiLineString
+  : '"""' StringContentTDQ* '"""'
+  | '\'\'\'' StringContentTSQ* '\'\'\''
+  | 'r"""' (~'"' | '"' ~'"' | '""' ~'"')* '"""'
+  | 'r\'\'\'' (~'\'' | '\'' ~'\'' | '\'\'' ~'\'')* '\'\'\''
+  ;
 
-<stringContentTSQ> ::= \~{}( `\\' | `\'\'\'' | `$')
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
-*/
+fragment
+StringContentTDQ
+  : ~('\\' | '"' /*| '$'*/)
+  | '"' ~'"' | '""' ~'"'
+  //| stringInterpolation
+  ;
+
+fragment StringContentTSQ
+  : ~('\\' | '\'' /*| '$'*/)
+  | '\'' ~'\'' | '\'\'' ~'\''
+  //| stringInterpolation
+  ;
+
 NEWLINE
   : '\n'
   | '\r'

--- a/dart2/examples/regex.dart
+++ b/dart2/examples/regex.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final regex = new RegExp(r'^--([a-zA-Z\-_0-9]+)(=(.*))?$');
+}

--- a/dart2/examples/regex2.dart
+++ b/dart2/examples/regex2.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final regex = new RegExp(r"(^[a-zA-Z][-+.a-zA-Z\d]*://|[^/])$");
+}

--- a/dart2/examples/regex3.dart
+++ b/dart2/examples/regex3.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final regex = new RegExp(r'''[ \t\r\n"'\\/]''');
+}

--- a/dart2/examples/string_with_backslashes.dart
+++ b/dart2/examples/string_with_backslashes.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final stringWithBackslashes = "Escaping\ spaces\ should work";
+}


### PR DESCRIPTION
This is based on the Dart grammar at https://github.com/chalin/dart-spec-and-grammar/blob/master/doc/grammar-AUTOGENERATED-DO-NOT-EDIT.txt.