### PR TITLE
Add missing label to function_call IIF rule

### DIFF
--- a/tsql/TSqlParser.g4
+++ b/tsql/TSqlParser.g4
@@ -3173,7 +3173,7 @@ function_call
     // https://docs.microsoft.com/en-us/sql/t-sql/xml/xml-data-type-methods
     | xml_data_type_methods                             #XML_DATA_TYPE_FUNC
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/logical-functions-iif-transact-sql
-    | IIF '(' search_condition ',' expression ',' expression ')'
+    | IIF '(' search_condition ',' expression ',' expression ')'   #IFF
     ;
 
 xml_data_type_methods


### PR DESCRIPTION
https://github.com/antlr/grammars-v4/pull/1388 which was recently merged introduced a compilation issue where not all `function_call` rules were properly labeled.  This PR addresses that by adding the missing label.