### PR TITLE
Allow backticks in string literals

### DIFF
--- a/mysql/MySqlLexer.g4
+++ b/mysql/MySqlLexer.g4
@@ -1103,7 +1103,7 @@ FILESIZE_LITERAL:                    DEC_DIGIT+ ('K'|'M'|'G'|'T');
 
 
 START_NATIONAL_STRING_LITERAL:       'N' SQUOTA_STRING;
-STRING_LITERAL:                      DQUOTA_STRING | SQUOTA_STRING;
+STRING_LITERAL:                      DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;
 DECIMAL_LITERAL:                     DEC_DIGIT+;
 HEXADECIMAL_LITERAL:                 'X' '\'' (HEX_DIGIT HEX_DIGIT)+ '\''
                                      | '0X' HEX_DIGIT+;

--- a/mysql/examples/grant.sql
+++ b/mysql/examples/grant.sql
@@ -2,3 +2,6 @@ GRANT ALL ON tbl TO admin@localhost;
 GRANT ALL ON tbl TO admin;
 GRANT ALL PRIVILEGES ON tbl TO admin;
 GRANT ALL ON *.* TO admin;
+GRANT ALL ON *.* TO `admin`;
+GRANT ALL ON *.* TO 'admin';
+GRANT ALL ON *.* TO "admin";


### PR DESCRIPTION
This is a fix for unparsable grant queries, where the username was between backticks.