### PR TITLE
[JavaScript/Cpp] C++ port for JavaScript grammar

### DIFF
--- a/javascript/Cpp/JavaScriptBaseLexer.cpp
+++ b/javascript/Cpp/JavaScriptBaseLexer.cpp
@@ -1,0 +1,95 @@
+#include "JavaScriptLexer.h"
+
+using namespace antlr4;
+
+JavaScriptBaseLexer::JavaScriptBaseLexer(CharStream *input) : Lexer(input)
+{
+}
+
+bool JavaScriptBaseLexer::getStrictDefault()
+{
+    return useStrictDefault;
+}
+
+void JavaScriptBaseLexer::setUseStrictDefault(bool value)
+{
+    useStrictDefault = value;
+    useStrictCurrent = value;
+}
+
+bool JavaScriptBaseLexer::IsSrictMode()
+{
+    return useStrictCurrent;
+}
+
+std::unique_ptr<antlr4::Token> JavaScriptBaseLexer::nextToken() {
+    auto next = Lexer::nextToken();
+
+    if (next->getChannel() == Token::DEFAULT_CHANNEL) {
+        // Keep track of the last token on the default channel.
+        lastToken = true;
+        lastTokenType = next->getType();
+    }
+
+    return next;
+}
+
+void JavaScriptBaseLexer::ProcessOpenBrace()
+{
+    useStrictCurrent = scopeStrictModes.size() > 0 && scopeStrictModes.top() ? true : useStrictDefault;
+    scopeStrictModes.push(useStrictCurrent);
+}
+
+void JavaScriptBaseLexer::ProcessCloseBrace()
+{
+    if (scopeStrictModes.size() > 0) {
+        useStrictCurrent = scopeStrictModes.top();
+        scopeStrictModes.pop();
+    } else {
+        useStrictCurrent = useStrictDefault;
+    }
+}
+
+void JavaScriptBaseLexer::ProcessStringLiteral()
+{
+    if (lastToken || lastTokenType == JavaScriptLexer::OpenBrace)
+    {
+        std::string text = getText();
+        if (text == "\"use strict\"" || text == "'use strict'")
+        {
+            if (scopeStrictModes.size() > 0)
+                scopeStrictModes.pop();
+            useStrictCurrent = true;
+            scopeStrictModes.push(useStrictCurrent);
+        }
+    }
+}
+
+bool JavaScriptBaseLexer::IsRegexPossible()
+{
+    if (lastToken) {
+        // No token has been produced yet: at the start of the input,
+        // no division is possible, so a regex literal _is_ possible.
+        return true;
+    }
+    
+    switch (lastTokenType) {
+        case JavaScriptLexer::Identifier:
+        case JavaScriptLexer::NullLiteral:
+        case JavaScriptLexer::BooleanLiteral:
+        case JavaScriptLexer::This:
+        case JavaScriptLexer::CloseBracket:
+        case JavaScriptLexer::CloseParen:
+        case JavaScriptLexer::OctalIntegerLiteral:
+        case JavaScriptLexer::DecimalLiteral:
+        case JavaScriptLexer::HexIntegerLiteral:
+        case JavaScriptLexer::StringLiteral:
+        case JavaScriptLexer::PlusPlus:
+        case JavaScriptLexer::MinusMinus:
+            // After any of the tokens above, no regex literal can follow.
+            return false;
+        default:
+            // In all other cases, a regex literal _is_ possible.
+            return true;
+    }
+}

--- a/javascript/Cpp/JavaScriptBaseLexer.h
+++ b/javascript/Cpp/JavaScriptBaseLexer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stack>
+
+#include "antlr4-runtime.h"
+
+class JavaScriptBaseLexer : public antlr4::Lexer {
+public:
+    JavaScriptBaseLexer(antlr4::CharStream *input);
+
+    std::stack<bool> scopeStrictModes;
+    
+    bool lastToken = false;
+    size_t lastTokenType = 0;
+
+    bool useStrictDefault = false;
+    bool useStrictCurrent = false;
+
+    bool getStrictDefault();
+    void setUseStrictDefault(bool value);
+    bool IsSrictMode();
+    virtual std::unique_ptr<antlr4::Token> nextToken() override;
+    void ProcessOpenBrace();
+    void ProcessCloseBrace();
+    void ProcessStringLiteral();
+    bool IsRegexPossible();
+};

--- a/javascript/Cpp/JavaScriptBaseParser.cpp
+++ b/javascript/Cpp/JavaScriptBaseParser.cpp
@@ -1,0 +1,86 @@
+#include "JavaScriptParser.h"
+
+using namespace antlr4;
+
+JavaScriptBaseParser::JavaScriptBaseParser(TokenStream *input) : Parser(input)
+{
+}
+
+bool JavaScriptBaseParser::p(std::string str)
+{
+    return prev(str);
+}
+
+bool JavaScriptBaseParser::prev(std::string str)
+{
+    return _input->LT(-1)->getText() == str;
+}
+
+bool JavaScriptBaseParser::n(std::string str)
+{
+    return next(str);
+}
+
+bool JavaScriptBaseParser::next(std::string str)
+{
+    return _input->LT(1)->getText() == str;
+}
+
+bool JavaScriptBaseParser::notLineTerminator()
+{
+    return !here(JavaScriptParser::LineTerminator);
+}
+
+bool JavaScriptBaseParser::notOpenBraceAndNotFunction()
+{
+    int nextTokenType = _input->LT(1)->getType();
+    return nextTokenType != JavaScriptParser::OpenBrace && nextTokenType != JavaScriptParser::Function;
+
+}
+
+bool JavaScriptBaseParser::closeBrace()
+{
+    return _input->LT(1)->getType() == JavaScriptParser::CloseBrace;
+}
+
+bool JavaScriptBaseParser::here(int type)
+{
+    // Get the token ahead of the current index.
+    int possibleIndexEosToken = this->getCurrentToken()->getTokenIndex() - 1;
+    auto ahead = _input->get(possibleIndexEosToken);
+
+    // Check if the token resides on the HIDDEN channel and if it's of the
+    // provided type.
+    return (ahead->getChannel() == Lexer::HIDDEN) && (ahead->getType() == type);
+}
+
+bool JavaScriptBaseParser::lineTerminatorAhead()
+{
+    // Get the token ahead of the current index.
+    int possibleIndexEosToken = this->getCurrentToken()->getTokenIndex() - 1;
+    auto ahead = _input->get(possibleIndexEosToken);
+
+    if (ahead->getChannel() != Lexer::HIDDEN) {
+        // We're only interested in tokens on the HIDDEN channel.
+        return false;
+    }
+
+    if (ahead->getType() == JavaScriptParser::LineTerminator) {
+        // There is definitely a line terminator ahead.
+        return true;
+    }
+
+    if (ahead->getType() == JavaScriptParser::WhiteSpaces) {
+        // Get the token ahead of the current whitespaces.
+        possibleIndexEosToken = this->getCurrentToken()->getTokenIndex() - 2;
+        ahead = _input->get(possibleIndexEosToken);
+    }
+
+    // Get the token's text and type.
+    std::string text = ahead->getText();
+    int type = ahead->getType();
+
+    // Check if the token is, or contains a line terminator.
+    return (type == JavaScriptParser::MultiLineComment && (text.find("\r") != std::string::npos || text.find("\n") != std::string::npos)) ||
+            (type == JavaScriptParser::LineTerminator);
+}

--- a/javascript/Cpp/JavaScriptBaseParser.h
+++ b/javascript/Cpp/JavaScriptBaseParser.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "antlr4-runtime.h"
+
+class JavaScriptBaseParser : public antlr4::Parser {
+public:
+    JavaScriptBaseParser(antlr4::TokenStream *input);
+    bool p(std::string str);
+    bool prev(std::string str);
+    bool n(std::string str);
+    bool next(std::string str);
+    bool notLineTerminator();
+    bool notOpenBraceAndNotFunction();
+    bool closeBrace();
+    bool here(int type);
+    bool lineTerminatorAhead();
+};

--- a/javascript/Cpp/README.md
+++ b/javascript/Cpp/README.md
@@ -1,0 +1,21 @@
+# C++ port
+
+**NOTE**: To use the C++ version you **MUST** make following modifications:
+
+* In `JavaScriptLexer.g4`, add the following code after `options { ... }` block
+
+    ```
+    @header {
+        #include "JavaScriptBaseLexer.h"
+    }
+    ```
+
+* In `JavaScriptParser.g4`, add the following code after `options { ... }` block
+
+    ```
+    @header {
+        #include "JavaScriptBaseParser.h"
+    }
+    ```
+
+* In both `JavaScriptLexer.g4` and `JavaScriptParser.g4`, replace all `this.` ocurrences with `this->`


### PR DESCRIPTION
Hello, I ported JavaScript grammar to C++. The usage instructions are in `javascript/C++/README.md`.