### PR TITLE
MySQL grammar - triggers with SET NEW.___ and functions returning strings with collation

### DIFF
--- a/mysql/MySqlParser.g4
+++ b/mysql/MySqlParser.g4
@@ -1657,6 +1657,7 @@ setStatement
     | setPasswordStatement                                          #setPassword
     | setTransactionStatement                                       #setTransaction
     | setAutocommitStatement                                        #setAutocommit
+    | SET fullId ('=' | ':=') expression                            #setNewValueInsideTrigger
     ;
 
 showStatement
@@ -1987,7 +1988,8 @@ dataType
        | NCHAR | NVARCHAR
       )
       lengthOneDimension? BINARY?
-      ((CHARACTER SET | CHARSET) charsetName)?                      #stringDataType
+      ((CHARACTER SET | CHARSET) charsetName)?
+      (COLLATE collationName)?                                      #stringDataType
     | NATIONAL typeName=(VARCHAR | CHARACTER)
       lengthOneDimension? BINARY?                                   #nationalStringDataType
     | NCHAR typeName=VARCHAR

--- a/mysql/examples/ddl_create.sql
+++ b/mysql/examples/ddl_create.sql
@@ -119,6 +119,11 @@ create trigger trg_my1 before delete on test.t1 for each row begin insert into l
 create definer = current_user() trigger trg_my2 after insert on test.t2 for each row insert into log_table values (concat("inserted into table test.t2 values: (1c, _) = (", cast(NEW.col1 as char(100)), ", ", convert(new.`_`, char(100)), ")"));
 #end
 #begin
+-- Create trigger 3
+-- delimiter //
+CREATE TRIGGER mask_private_data BEFORE INSERT ON users FOR EACH ROW BEGIN SET NEW.phone = CONCAT('555', NEW.id); END; -- //-- delimiter ;
+#end
+#begin
 -- Create view
 create or replace view my_view1 as select 1 union select 2 limit 0,5;
 create algorithm = merge view my_view2(col1, col2) as select * from t2 with check option;
@@ -126,4 +131,12 @@ create or replace definer = 'ivan'@'%' view my_view3 as select count(*) from t3;
 create or replace definer = current_user sql security invoker view my_view4(c1, 1c, _, c1_2) 
 	as select * from  (t1 as tt1, t2 as tt2) inner join t1 on t1.col1 = tt1.col1;
 
+#end
+#begin
+-- Create function
+-- delimiter //
+CREATE FUNCTION `fivenumbers`() RETURNS varchar(5) CHARSET utf8 COLLATE utf8_unicode_ci DETERMINISTIC
+BEGIN
+	RETURN '12345';
+END; -- //-- delimiter ;
 #end


### PR DESCRIPTION
This PR contains fixes for 2 MySQL DDL statements:
1. Setting collation on return type of created functions, which is parsed well by MySQL 8.0.16
```
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 13
Server version: 8.0.16 MySQL Community Server - GPL

Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> use mysql;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> delimiter //
mysql> CREATE FUNCTION `fivenumbers`() RETURNS varchar(5) CHARSET utf8 COLLATE utf8_unicode_ci DETERMINISTIC begin return '12345'; end; //
Query OK, 0 rows affected, 2 warnings (0.22 sec)

mysql> delimiter ;
mysql> select fivenumbers();
+---------------+
| fivenumbers() |
+---------------+
| 12345         |
+---------------+
1 row in set, 2 warnings (0.00 sec)
```

2. Allowing `SET NEW.[variable_name]` inside triggers, documented here: https://dev.mysql.com/doc/refman/8.0/en/trigger-syntax.html:

> You can refer to a column named with NEW if you have the SELECT privilege for it. In a BEFORE trigger, you can also change its value with SET NEW.col_name = value if you have the UPDATE privilege for it. This means you can use a trigger to modify the values to be inserted into a new row or used to update a row.