### PR TITLE
Fix xpath unicode TODO

### DIFF
--- a/xpath/xpath.g4
+++ b/xpath/xpath.g4
@@ -274,9 +274,7 @@ NCNameStartChar
   |  '\u3001'..'\uD7FF'
   |  '\uF900'..'\uFDCF'
   |  '\uFDF0'..'\uFFFD'
-// Unfortunately, java escapes can't handle this conveniently,
-// as they're limited to 4 hex digits. TODO.
-//  |  '\U010000'..'\U0EFFFF'
+  |  '\u{10000}'..'\u{EFFFF}'
   ;
 
 fragment


### PR DESCRIPTION
antlr-4.7 can handle unicode larger than U+FFFF, use the appropriate
syntax to express them -- thus addressing a leftover TODO.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>