### PR TITLE
Update PlSqlBaseLexer.py

### DIFF
--- a/plsql/Python3/PlSqlBaseLexer.py
+++ b/plsql/Python3/PlSqlBaseLexer.py
@@ -4,4 +4,4 @@ class PlSqlBaseLexer(Lexer):
 
     def IsNewlineAtPos(self, pos):
         la = self._input.LA(pos)
-        return la == -1 or la == '\n'
+        return la == -1 or la == 10 


### PR DESCRIPTION
LA(x) returns an int for python (on other targets returns string/char). ASCII int for newline '\n' is 10. Another alternative could be using chr(la) == '\n' or la == ord('\n')