### PR TITLE
GraphQL - Give BOOLEAN literal precedence over NAME token

### DIFF
--- a/graphql/GraphQL.g4
+++ b/graphql/GraphQL.g4
@@ -149,11 +149,6 @@ array
    ;
 
 
-NAME
-   : [_A-Za-z] [_0-9A-Za-z]*
-   ;
-
-
 STRING
    : '"' ( ESC | ~ ["\\] )* '"'
    ;
@@ -161,6 +156,11 @@ STRING
 
 BOOLEAN
    : 'true' | 'false'
+   ;
+
+
+NAME
+   : [_A-Za-z] [_0-9A-Za-z]*
    ;
 
 


### PR DESCRIPTION
A literal boolean argument was tokenized incorrectly as a `NAME` token. This PR gives the `BOOLEAN` literal precedence over the `NAME` token.