### PR TITLE
Attempt to fix heredoc string lexing

### DIFF
--- a/php/JavaScript/PhpLexer.g4
+++ b/php/JavaScript/PhpLexer.g4
@@ -93,11 +93,13 @@ channels {
             if (token.type === this.HereDocText) {
                 if (this.CheckHeredocEnd(token.text)) {
                     this.popMode()
+                    const heredocIdentifier = this.GetHeredocEnd(token.text)
                     if (token.text.trim().endsWith(';')) {
-                        token = CommonToken(type=this.SemiColon);
-                        token.text = ';';
+                        token = new CommonToken(CommonToken.EMPTY_SOURCE, type=this.SemiColon);
+                        token.text = `${heredocIdentifier};\n`;
                     } else {
                         token = antlr4.Lexer.prototype.nextToken.call(this);
+                        token.text = `${heredocIdentifier}\n;`;
                     }
                 }
             }
@@ -112,9 +114,12 @@ channels {
         return token;
     };
 
+    PhpLexer.prototype.GetHeredocEnd = function(text) {
+        return text.trim().replace(/\;$/, "");
+    }
+
     PhpLexer.prototype.CheckHeredocEnd = function(text) {
-        const identifier = text.trim().replace(/\;$/, "");
-        return identifier === _heredocIdentifier;
+        return this.GetHeredocEnd(text) === this._heredocIdentifier;
     };
 
 }

--- a/php/PhpLexer.g4
+++ b/php/PhpLexer.g4
@@ -96,13 +96,16 @@ public Token nextToken()
                 if (CheckHeredocEnd(token.getText()))
                 {
                     popMode();
+
+                    String heredocIdentifier = GetHeredocIdentifier(token.getText());
                     if (token.getText().trim().endsWith(";"))
                     {
-                        token = new CommonToken(SemiColon);
+                        token = new CommonToken(SemiColon, heredocIdentifier + ";\n");
                     }
                     else
                     {
-                        token.setChannel(SkipChannel);
+                        token = (CommonToken)super.nextToken();
+                        token.setText(heredocIdentifier + "\n;");
                     }
                 }
                 break;
@@ -119,13 +122,16 @@ public Token nextToken()
     return token;
 }
 
+String GetHeredocIdentifier(String text)
+{
+    String trimmedText = text.trim();
+    boolean semi = (trimmedText.length() > 0) ? (trimmedText.charAt(trimmedText.length() - 1) == ';') : false;
+    return semi ? trimmedText.substring(0, trimmedText.length() - 1) : trimmedText;
+}
+
 boolean CheckHeredocEnd(String text)
 {
-    text = text.trim();
-    boolean semi = (text.length() > 0) ? (text.charAt(text.length() - 1) == ';') : false;
-    String identifier = semi ? text.substring(0, text.length() - 1) : text;
-    boolean result = identifier.equals(_heredocIdentifier);
-    return result;
+    return GetHeredocIdentifier(text).equals(_heredocIdentifier);
 }}
 
 SeaWhitespace:  [ \t\r\n]+ -> channel(HIDDEN);

--- a/php/Python/PhpLexer.g4
+++ b/php/Python/PhpLexer.g4
@@ -45,7 +45,7 @@ _phpScript = False
 _insideString = False
 
 def nextToken(self):
-    token = super(PhpLexer_Python, self).nextToken()
+    token = super(PhpLexer, self).nextToken()
 
     if token.type == self.PHPEnd or token.type == self.PHPEndSingleLineComment:
         if self._mode == self.SingleLineCommentMode:
@@ -64,7 +64,7 @@ def nextToken(self):
                 self._prevTokenType == self.Colon or \
                 self._prevTokenType == self.OpenCurlyBracket or \
                 self._prevTokenType == self.CloseCurlyBracket:
-                token = super(PhpLexer_Python, self).nextToken()
+                token = super(PhpLexer, self).nextToken()
             else:
                 token = CommonToken(type=self.SemiColon)
                 token.text = ';'
@@ -80,20 +80,25 @@ def nextToken(self):
         if token.type == self.HereDocText:
             if self.CheckHeredocEnd(token.text):
                 self.popMode()
+                heredoc_identifier = self.GetHeredocEnd(token.text)
                 if token.text.strip().endswith(';'):
+                    text = heredoc_identifier + ";\n"
                     token = CommonToken(type=self.SemiColon)
-                    token.text = ';'
+                    token.text = text
                 else:
-                    token = super(PhpLexer_Python, self).nextToken()
+                    token = super(PhpLexer, self).nextToken()
+                    token.text = heredoc_identifier + "\n;"
     elif self._mode == self.PHP:
         if self._channel == self.HIDDEN:
             self._prevTokenType = token.type
 
     return token
 
+def GetHeredocEnd(self, text):
+    return text.strip().rstrip(';')
+
 def CheckHeredocEnd(self, text):
-    identifier = text.strip().rstrip(';')
-    return identifier == self._heredocIdentifier
+    return self.GetHeredocEnd(text) == self._heredocIdentifier
 
 }
 


### PR DESCRIPTION
Resolution of https://github.com/antlr/grammars-v4/issues/1480

A second case has been checked and fixed by the modifications applied by this pull request :

```
<?php

# Heredoc string ends with a semicolon 
# on the line where the repeated heredoc identifier is
$heredocString = <<<TXT
HEREDOC TEXT
TXT;

# Heredoc string ends with a semicolon 
# on the line following the one of the repeated heredoc identifier
$heredocString = <<<TXT
HEREDOC TEXT
TXT
;

```