### PR TITLE
Javascript: Fix issue with function "n" in go

### DIFF
--- a/javascript/JavaScriptParser.g4
+++ b/javascript/JavaScriptParser.g4
@@ -184,7 +184,7 @@ classTail
     ;
 
 classElement
-    : (Static | {n("static")}? Identifier)? methodDefinition
+    : (Static | {this.n("static")}? Identifier)? methodDefinition
     | emptyStatement
     ;
 


### PR DESCRIPTION
I was having an issue with javascript grammar on go target. Function `n` (called like `n("static")`) is undefined.
```
parser/javascript_parser.go:5740:9: undefined: n
parser/javascript_parser.go:13228:10: undefined: n
```

The issue is with `classElement` rule:
https://github.com/antlr/grammars-v4/blob/79a105d2a0d2788aea3d57f1707f2a3cfd0216bc/javascript/JavaScriptParser.g4#L186-L189

`n` is a method of `JavaScriptParser` and should have a `this` receiver. It seems that `this` is resolved implicitly on other targets, but on Go target, it cannot be resolved.

So I added an explicit receiver.