### PR TITLE
[javascript] Fix typo IsSrictMode -> IsStrictMode.

### DIFF
--- a/javascript/CSharpSharwell/JavaScriptBaseLexer.cs
+++ b/javascript/CSharpSharwell/JavaScriptBaseLexer.cs
@@ -46,7 +46,7 @@ public abstract class JavaScriptBaseLexer : Lexer
         }
     }
 
-    public bool IsSrictMode()
+    public bool IsStrictMode()
     {
         return _useStrictCurrent;
     }

--- a/javascript/Cpp/JavaScriptBaseLexer.cpp
+++ b/javascript/Cpp/JavaScriptBaseLexer.cpp
@@ -17,7 +17,7 @@ void JavaScriptBaseLexer::setUseStrictDefault(bool value)
     useStrictCurrent = value;
 }
 
-bool JavaScriptBaseLexer::IsSrictMode()
+bool JavaScriptBaseLexer::IsStrictMode()
 {
     return useStrictCurrent;
 }

--- a/javascript/Cpp/JavaScriptBaseLexer.h
+++ b/javascript/Cpp/JavaScriptBaseLexer.h
@@ -18,7 +18,7 @@ public:
 
     bool getStrictDefault();
     void setUseStrictDefault(bool value);
-    bool IsSrictMode();
+    bool IsStrictMode();
     virtual std::unique_ptr<antlr4::Token> nextToken() override;
     void ProcessOpenBrace();
     void ProcessCloseBrace();

--- a/javascript/Java/JavaScriptBaseLexer.java
+++ b/javascript/Java/JavaScriptBaseLexer.java
@@ -39,7 +39,7 @@ public abstract class JavaScriptBaseLexer extends Lexer
         useStrictCurrent = value;
     }
 
-    public boolean IsSrictMode() {
+    public boolean IsStrictMode() {
         return useStrictCurrent;
     }
 

--- a/javascript/JavaScript/JavaScriptBaseLexer.js
+++ b/javascript/JavaScript/JavaScriptBaseLexer.js
@@ -21,7 +21,7 @@ JavaScriptBaseLexer.prototype.setUseStrictDefault = function(value) {
     this.useStrictCurrent = value;
 };
 
-JavaScriptBaseLexer.prototype.IsSrictMode = function() {
+JavaScriptBaseLexer.prototype.IsStrictMode = function() {
     return this.useStrictCurrent;
 };
 


### PR DESCRIPTION
The same typos not mentioned in #1345 #1487 still exist in JavaScriptBaseLexer.