### PR TITLE
Support DEFAULT character set for CREATE DATABASE/TABLE statements

### DIFF
--- a/mysql/Positive-Technologies/MySqlParser.g4
+++ b/mysql/Positive-Technologies/MySqlParser.g4
@@ -246,7 +246,7 @@ createView
 // details
 
 createDatabaseOption
-    : DEFAULT? (CHARACTER SET | CHARSET) '='? charsetName
+    : DEFAULT? (CHARACTER SET | CHARSET) '='? (charsetName | DEFAULT)
     | DEFAULT? COLLATE '='? collationName
     ;
 
@@ -406,7 +406,7 @@ tableOption
     : ENGINE '='? engineName                                        #tableOptionEngine
     | AUTO_INCREMENT '='? decimalLiteral                            #tableOptionAutoIncrement
     | AVG_ROW_LENGTH '='? decimalLiteral                            #tableOptionAverage
-    | DEFAULT? (CHARACTER SET | CHARSET) '='? charsetName           #tableOptionCharset
+    | DEFAULT? (CHARACTER SET | CHARSET) '='? (charsetName|DEFAULT) #tableOptionCharset
     | (CHECKSUM | PAGE_CHECKSUM) '='? boolValue=('0' | '1')         #tableOptionChecksum
     | DEFAULT? COLLATE '='? collationName                           #tableOptionCollate
     | COMMENT '='? STRING_LITERAL                                   #tableOptionComment

--- a/mysql/Positive-Technologies/examples/ddl_create.sql
+++ b/mysql/Positive-Technologies/examples/ddl_create.sql
@@ -47,6 +47,8 @@ CREATE TABLE serval4 (id SMALLINT(5) UNSIGNED SERIAL DEFAULT VALUE NOT NULL, val
 CREATE TABLE serial (serial INT);
 CREATE TABLE float_table (f1 FLOAT, f2 FLOAT(10), f3 FLOAT(7,4));
 CREATE TABLE USER (INTERNAL BOOLEAN DEFAULT FALSE);
+create table table_with_character_set_eq (id int, data varchar(50)) character set = default;
+create table table_with_character_set (id int, data varchar(50)) character set default;
 #end
 #begin
 -- Rename table
@@ -70,6 +72,8 @@ create schema `select` default character set = utf8;
 create database if not exists `current_date` character set cp1251;
 create database super default character set utf8 collate = utf8_bin character set utf8 collate utf8_bin;
 create database super_cs default charset utf8 collate = utf8_bin character set utf8 collate utf8_bin;
+create database db_with_character_set_eq character set = default;
+create database db_with_character_set character set default;
 #end
 #begin
 -- Create event 1


### PR DESCRIPTION
Porting changes upstream from https://github.com/debezium/debezium/pull/1022

In MySQL 5.6, the `CREATE DATABASE` and `CREATE TABLE` grammer statements allow the user to specify `CHARACTER SET ['='] DEFAULT` as a database or table option.  The current grammar does not allow this when being parsed and this PR adds that support.