### PR TITLE
fix Tsql asterisk

### DIFF
--- a/tsql/TSqlParser.g4
+++ b/tsql/TSqlParser.g4
@@ -3006,8 +3006,7 @@ udt_method_arguments
 
 // https://docs.microsoft.com/ru-ru/sql/t-sql/queries/select-clause-transact-sql
 asterisk
-    : '*'
-    | table_name '.' asterisk
+    : (table_name '.')? '*'
     ;
 
 column_elem


### PR DESCRIPTION
change asterisk from `asterisk : '*' | table_name '.' asterisk` to `asterisk : (table_name '.')? '*'` 
Before this change, `selected_list_elem` could be something like `table1.table1.table1.*`. Actually only things like `table1.*` or `*` are valid.
Please refer to issue: https://github.com/antlr/grammars-v4/issues/1532