### PR TITLE
fix balancedtoken rule.

### DIFF
--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -709,6 +709,7 @@ balancedtoken
    : '(' balancedtokenseq ')'
    | '[' balancedtokenseq ']'
    | '{' balancedtokenseq '}'
+   | ~('('|')'|'{'|'}'|'['|']')+
    ;
 /*Declarators*/
 


### PR DESCRIPTION
should match any token other than bracket, brace, parenthesis.