### PR TITLE
antlr4: support action blocks inside options spec (fixes #1567)

### DIFF
--- a/antlr4/ANTLRv4Lexer.g4
+++ b/antlr4/ANTLRv4Lexer.g4
@@ -396,7 +396,8 @@ OPT_LINE_COMMENT
    ;
 
 OPT_LBRACE
-   : LBrace -> type (LBRACE)
+   : LBrace
+   { handleOptionsLBrace(); }
    ;
 
 OPT_RBRACE

--- a/antlr4/examples/Issue1567.g4
+++ b/antlr4/examples/Issue1567.g4
@@ -1,0 +1,11 @@
+grammar Sample;
+
+options {
+ foo = {};
+}
+
+@members {
+    int method() {
+        return 1;
+    }
+}

--- a/antlr4/src/main/java/org/antlr/parser/antlr4/LexerAdaptor.java
+++ b/antlr4/src/main/java/org/antlr/parser/antlr4/LexerAdaptor.java
@@ -25,6 +25,8 @@ public abstract class LexerAdaptor extends Lexer {
 	 */
 	private int _currentRuleType = Token.INVALID_TYPE;
 
+	private boolean insideOptionsBlock = false;
+
 	public int getCurrentRuleType() {
 		return _currentRuleType;
 	}
@@ -50,9 +52,24 @@ public abstract class LexerAdaptor extends Lexer {
 	}
 
 	protected void handleEndAction() {
-		popMode();
-		if (_modeStack.size() > 0) {
+	    int oldMode = _mode;
+        int newMode = popMode();
+        boolean isActionWithinAction = _modeStack.size() > 0
+            && newMode == ANTLRv4Lexer.Action
+            && oldMode == newMode;
+
+		if (isActionWithinAction) {
 			setType(ANTLRv4Lexer.ACTION_CONTENT);
+		}
+	}
+
+	protected void handleOptionsLBrace() {
+		if (insideOptionsBlock) {
+			setType(ANTLRv4Lexer.BEGIN_ACTION);
+			pushMode(ANTLRv4Lexer.Action);
+		} else {
+			setType(ANTLRv4Lexer.LBRACE);
+			insideOptionsBlock = true;
 		}
 	}
 


### PR DESCRIPTION
Here's my attempt at fixing #1567.

I suppose it could also be fixed by introducing a new mode like this:
```antlr
mode Options;
...
OPT_LBRACE
   : LBrace -> type (LBRACE) , pushMode (OptionsBlock)
   ;
...

mode OptionsBlock;
...
OPT_BEGIN_ACTION
   : LBrace -> type (BEGIN_ACTION) , pushMode (Action)
   ;
...
```
But the grammar feels less readable with an extra mode.

I wonder if you guys can find a better alternative?

Also, I have only adapted `LexerAdaptor.java` at the moment. I'll wait for your feedback before trying to modify other target languages.