### PR TITLE
Subprogram body inside package declaration

### DIFF
--- a/vhdl/vhdl.g4
+++ b/vhdl/vhdl.g4
@@ -1055,6 +1055,7 @@ package_declaration
 
 package_declarative_item
   : subprogram_declaration
+  | subprogram_body
   | type_declaration
   | subtype_declaration
   | constant_declaration


### PR DESCRIPTION
Don't know about the LRM, but having small subprograms with body inside the declarative part of a package is generally used in my experience.