### PR TITLE
Python NEWLINEs at EOF are no longer stripped

### DIFF
--- a/python3-cs/Python3.g4
+++ b/python3-cs/Python3.g4
@@ -353,8 +353,11 @@ NEWLINE
 		var newLine = (new Regex("[^\r\n\f]+")).Replace(Text, "");
 		var spaces = (new Regex("[\r\n\f]+")).Replace(Text, "");
 
+		// Strip newlines inside open clauses except if we are near EOF. We keep NEWLINEs near EOF to
+		// satisfy the final newline needed by the single_put rule used by the REPL.
 		int next = _input.La(1);
-		if (Opened > 0 || next == '\r' || next == '\n' || next == '\f' || next == '#')
+		int nextnext = _input.La(2);
+		if (Opened > 0 || (nextnext != -1 && (next == '\r' || next == '\n' || next == '\f' || next == '#')))
 		{
 			// If we're inside a list or on a blank line, ignore all indents, 
 			// dedents and line breaks.

--- a/python3-js/Python3.g4
+++ b/python3-js/Python3.g4
@@ -739,9 +739,12 @@ NEWLINE
    ) {
      let newLine = this.text.replace(/[^\r\n]+/g, '');
      let spaces = this.text.replace(/[\r\n]+/g, '');
-     let next = this._input.LA(1);
 
-     if (this.opened > 0 || next === 13 /* '\r' */ || next === 10 /* '\n' */ || next === 35 /* '#' */) {
+     // Strip newlines inside open clauses except if we are near EOF. We keep NEWLINEs near EOF to
+     // satisfy the final newline needed by the single_put rule used by the REPL.
+     let next = this._input.LA(1);
+     let nextnext = this._input.LA(2);
+     if (this.opened > 0 || (nextnext != -1 /* EOF */ && (next === 13 /* '\r' */ || next === 10 /* '\n' */ || next === 35 /* '#' */))) {
        // If we're inside a list or on a blank line, ignore all indents,
        // dedents and line breaks.
        this.skip();

--- a/python3-py/Python3.g4
+++ b/python3-py/Python3.g4
@@ -360,7 +360,17 @@ try:
 except ValueError:          # End of file
     pass
 
-if self.opened > 0 or la_char == '\r' or la_char == '\n' or la_char == '\f' or la_char == '#':
+# Strip newlines inside open clauses except if we are near EOF. We keep NEWLINEs near EOF to
+# satisfy the final newline needed by the single_put rule used by the REPL.
+try:
+    nextnext_la = self._input.LA(2)
+    nextnext_la_char = chr(nextnext_la)
+except ValueError:
+    nextnext_eof = True
+else:
+    nextnext_eof = False
+
+if self.opened > 0 or nextnexteof is False and (la_char == '\r' or la_char == '\n' or la_char == '\f' or la_char == '#'):
     self.skip()
 else:
     indent = self.getIndentationCount(spaces)

--- a/python3-ts/Python3.g4
+++ b/python3-ts/Python3.g4
@@ -754,9 +754,12 @@ NEWLINE
    ) {
      let newLine = this.text.replace(/[^\r\n]+/g, '');
      let spaces = this.text.replace(/[\r\n]+/g, '');
-     let next = this.inputStream.LA(1);
 
-     if (this.opened > 0 || next === 13 /* '\r' */ || next === 10 /* '\n' */ || next === 35 /* '#' */) {
+     // Strip newlines inside open clauses except if we are near EOF. We keep NEWLINEs near EOF to
+     // satisfy the final newline needed by the single_put rule used by the REPL.
+     let next = this.inputStream.LA(1);
+     let nextnext = this.inputStream.LA(2);
+     if (this.opened > 0 || (nextnext != -1 /* EOF */ && (next === 13 /* '\r' */ || next === 10 /* '\n' */ || next === 35 /* '#' */))) {
        // If we're inside a list or on a blank line, ignore all indents,
        // dedents and line breaks.
        this.skip();

--- a/python3/Python3.g4
+++ b/python3/Python3.g4
@@ -334,8 +334,12 @@ NEWLINE
    {
      String newLine = getText().replaceAll("[^\r\n\f]+", "");
      String spaces = getText().replaceAll("[\r\n\f]+", "");
+	 
+     // Strip newlines inside open clauses except if we are near EOF. We keep NEWLINEs near EOF to
+     // satisfy the final newline needed by the single_put rule used by the REPL.
      int next = _input.LA(1);
-     if (opened > 0 || next == '\r' || next == '\n' || next == '\f' || next == '#') {
+     int nextnext = _input.LA(2);
+     if (opened > 0 || (nextnext != -1 && (next == '\r' || next == '\n' || next == '\f' || next == '#'))) {
        // If we're inside a list or on a blank line, ignore all indents, 
        // dedents and line breaks.
        skip();

--- a/python3alt/AltPython3.g4
+++ b/python3alt/AltPython3.g4
@@ -866,9 +866,12 @@ NEWLINE
    {
      String newLine = getText().replaceAll("[^\r\n\f]+", "");
      String spaces = getText().replaceAll("[\r\n\f]+", "");
-     int next = _input.LA(1);
 
-     if (opened > 0 || next == '\r' || next == '\n' || next == '\f' || next == '#') {
+     // Strip newlines inside open clauses except if we are near EOF. We keep NEWLINEs near EOF to
+     // satisfy the final newline needed by the single_put rule used by the REPL.
+     int next = _input.LA(1);
+     int nextnext = _input.LA(2);
+     if (opened > 0 || (nextnext != -1 && (next == '\r' || next == '\n' || next == '\f' || next == '#'))) {
        // If we're inside a list or on a blank line, ignore all indents, 
        // dedents and line breaks.
        skip();


### PR DESCRIPTION
This should address this issue:
https://github.com/antlr/grammars-v4/issues/1570

The lexer rule for NEWLINEs strips spurious newline characters inside of
various declarations like lists and dictionary declarations--anything being
that triggered Opened++ or Opened--. The parser rules for these declarations
don't accommodate NEWLINEs. Generally, this works when parsing using
file_input as the initial rule.

However, the single_input rule requires a NEWLINE at the end of its input.
This is the parser rule used by the Python REPL. The lexer code would strip
out these NEWLINEs. A solution that seems to work is to particularly avoid
stripping a NEWLINE right before EOF.