### PR TITLE
T-SQL - Reorder Function Rule

### DIFF
--- a/tsql/TSqlParser.g4
+++ b/tsql/TSqlParser.g4
@@ -3144,12 +3144,8 @@ derived_table
     ;
 
 function_call
-    : ranking_windowed_function                         #RANKING_WINDOWED_FUNC
-    | aggregate_windowed_function                       #AGGREGATE_WINDOWED_FUNC
-    | analytic_windowed_function                        #ANALYTIC_WINDOWED_FUNC
-    | scalar_function_name '(' expression_list? ')'     #SCALAR_FUNCTION
-    // https://msdn.microsoft.com/en-us/library/ms173784.aspx
-    | BINARY_CHECKSUM '(' '*' ')'                       #BINARY_CHECKSUM
+    : // https://msdn.microsoft.com/en-us/library/ms173784.aspx
+     BINARY_CHECKSUM '(' '*' ')'                       #BINARY_CHECKSUM
     // https://msdn.microsoft.com/en-us/library/hh231076.aspx
     // https://msdn.microsoft.com/en-us/library/ms187928.aspx
     | CAST '(' expression AS data_type ')'              #CAST
@@ -3192,6 +3188,10 @@ function_call
     | xml_data_type_methods                             #XML_DATA_TYPE_FUNC
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/logical-functions-iif-transact-sql
     | IIF '(' search_condition ',' expression ',' expression ')'   #IFF
+    | ranking_windowed_function                         #RANKING_WINDOWED_FUNC
+    | aggregate_windowed_function                       #AGGREGATE_WINDOWED_FUNC
+    | analytic_windowed_function                        #ANALYTIC_WINDOWED_FUNC
+    | scalar_function_name '(' expression_list? ')'     #SCALAR_FUNCTION
     ;
 
 xml_data_type_methods


### PR DESCRIPTION
> Reorder function rules in t-sql grammar so that the specialized alternatives are matched in preference to #SCALAR_FUNCTION.