### PR TITLE
[ecmascript] Fix expressionStatement condition

### DIFF
--- a/ecmascript/CSharp/ECMAScript.g4
+++ b/ecmascript/CSharp/ECMAScript.g4
@@ -178,7 +178,7 @@ sourceElements
 ///     Statement
 ///     FunctionDeclaration
 sourceElement
- : statement
+ : {this.InputStream.LA(1) != Function}? statement
  | functionDeclaration
  ;
 
@@ -202,7 +202,7 @@ statement
  : block
  | variableStatement
  | emptyStatement
- | expressionStatement
+ | {this.InputStream.LA(1) != OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
  | continueStatement
@@ -263,7 +263,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(this.InputStream.LA(1) != OpenBrace) && (this.InputStream.LA(1) != Function)}? expressionSequence eos
+ : expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/CSharpSharwell/ECMAScript.g4
+++ b/ecmascript/CSharpSharwell/ECMAScript.g4
@@ -178,7 +178,7 @@ sourceElements
 ///     Statement
 ///     FunctionDeclaration
 sourceElement
- : statement
+ : {_input.LA(1) != Function}? statement
  | functionDeclaration
  ;
 
@@ -202,7 +202,7 @@ statement
  : block
  | variableStatement
  | emptyStatement
- | expressionStatement
+ | {_input.LA(1) != OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
  | continueStatement
@@ -263,7 +263,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence eos
+ : expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/ECMAScript.g4
+++ b/ecmascript/ECMAScript.g4
@@ -198,7 +198,7 @@ sourceElements
 ///     Statement
 ///     FunctionDeclaration
 sourceElement
- : statement
+ : {_input.LA(1) != Function}? statement
  | functionDeclaration
  ;
 
@@ -222,7 +222,7 @@ statement
  : block
  | variableStatement
  | emptyStatement
- | expressionStatement
+ | {_input.LA(1) != OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
  | continueStatement
@@ -283,7 +283,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(_input.LA(1) != OpenBrace) && (_input.LA(1) != Function)}? expressionSequence eos
+ : expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/Go/ECMAScript.g4
+++ b/ecmascript/Go/ECMAScript.g4
@@ -169,7 +169,7 @@ sourceElements
 ///     Statement
 ///     FunctionDeclaration
 sourceElement
- : statement
+ : {p.GetInputStream().LA(1) != ECMAScriptParserFunction}? statement
  | functionDeclaration
  ;
 
@@ -193,7 +193,7 @@ statement
  : block
  | variableStatement
  | voidStatement
- | expressionStatement
+ | {p.GetInputStream().LA(1) != ECMAScriptParserOpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
  | continueStatement
@@ -254,7 +254,7 @@ voidStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(p.GetInputStream().LA(1) != ECMAScriptParserOpenBrace) && (p.GetInputStream().LA(1) != ECMAScriptParserFunction)}? expressionSequence eos
+ : expressionSequence eos
  ;
 
 /// IfStatement :

--- a/ecmascript/JavaScript/ECMAScript.g4
+++ b/ecmascript/JavaScript/ECMAScript.g4
@@ -158,7 +158,7 @@ sourceElements
 ///     Statement
 ///     FunctionDeclaration
 sourceElement
- : statement
+ : {this._input.LA(1).type != ECMAScriptParser.Function}? statement
  | functionDeclaration
  ;
 
@@ -182,7 +182,7 @@ statement
  : block
  | variableStatement
  | emptyStatement
- | expressionStatement
+ | {this._input.LA(1).type != ECMAScriptParser.OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
  | continueStatement

--- a/ecmascript/Python/ECMAScript.g4
+++ b/ecmascript/Python/ECMAScript.g4
@@ -182,7 +182,7 @@ sourceElements
 ///     Statement
 ///     FunctionDeclaration
 sourceElement
- : statement
+ : {self._input.LA(1) != ECMAScriptParser.Function}? statement
  | functionDeclaration
  ;
 
@@ -206,7 +206,7 @@ statement
  : block
  | variableStatement
  | emptyStatement
- | expressionStatement
+ | {self._input.LA(1) != ECMAScriptParser.OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
  | continueStatement
@@ -267,7 +267,7 @@ emptyStatement
 /// ExpressionStatement :
 ///     [lookahead ∉ {{, function}] Expression ;
 expressionStatement
- : {(self._input.LA(1) != ECMAScriptParser.OpenBrace) and (self._input.LA(1) != ECMAScriptParser.Function)}? expressionSequence eos
+ : expressionSequence eos
  ;
 
 /// IfStatement :


### PR DESCRIPTION
Fix the condition of `expressionStatement` in ecmascript grammar which prevents parsing nested functions. The lookahead which looks for Function token should guide the decision between `functionDeclaration` and `statement`.