### PR TITLE
Fixing error in lexer NEWLINE action

### DIFF
--- a/python3-py/Python3.g4
+++ b/python3-py/Python3.g4
@@ -370,7 +370,7 @@ except ValueError:
 else:
     nextnext_eof = False
 
-if self.opened > 0 or nextnexteof is False and (la_char == '\r' or la_char == '\n' or la_char == '\f' or la_char == '#'):
+if self.opened > 0 or nextnext_eof is False and (la_char == '\r' or la_char == '\n' or la_char == '\f' or la_char == '#'):
     self.skip()
 else:
     indent = self.getIndentationCount(spaces)


### PR DESCRIPTION
The code referenced identifier "nextnexteof", which doesn't exist.
Changed to nextnext_eof, which is likely what was intended.