### PR TITLE
Fixed the ANTLRv4 lexer to exit correctly from prequel constructs

### DIFF
--- a/antlr4/examples/issue1165.g4
+++ b/antlr4/examples/issue1165.g4
@@ -1,0 +1,7 @@
+grammar issue1165;
+
+@parser::members{
+	public int xxx;
+}
+
+WS		:	[ \t]+ -> skip;

--- a/antlr4/examples/issue1165_2.g4
+++ b/antlr4/examples/issue1165_2.g4
@@ -1,0 +1,7 @@
+grammar issue1165_2;
+
+options {
+ foo = {};
+}
+
+WS: [ \t\r\n]+ -> skip ;

--- a/antlr4/examples/issue1165_3.g4
+++ b/antlr4/examples/issue1165_3.g4
@@ -1,0 +1,7 @@
+grammar issue1165_3;
+
+tokens {
+ foo, bar
+}
+
+WS: [ \t\r\n]+ -> skip ;

--- a/antlr4/examples/issue1165_4.g4
+++ b/antlr4/examples/issue1165_4.g4
@@ -1,0 +1,6 @@
+lexer grammar issue1165_4;
+
+channels {
+ foo, bar
+}
+WS: [ \t\r\n]+ -> skip ;

--- a/antlr4/src/main/java/org/antlr/parser/antlr4/LexerAdaptor.java
+++ b/antlr4/src/main/java/org/antlr/parser/antlr4/LexerAdaptor.java
@@ -7,6 +7,9 @@ import org.antlr.v4.runtime.misc.Interval;
 
 public abstract class LexerAdaptor extends Lexer {
 
+	// Generic type for OPTIONS, TOKENS and CHANNELS
+	private static int PREQUEL_CONSTRUCT = -10;
+
 	public LexerAdaptor(CharStream input) {
 		super(input);
 	}
@@ -75,7 +78,16 @@ public abstract class LexerAdaptor extends Lexer {
 
 	@Override
 	public Token emit() {
-		if (_type == ANTLRv4Lexer.ID) {
+		if ((_type == ANTLRv4Lexer.OPTIONS || _type == ANTLRv4Lexer.TOKENS || _type == ANTLRv4Lexer.CHANNELS)
+				&& _currentRuleType == Token.INVALID_TYPE) { // enter prequel construct ending with an RBRACE
+			_currentRuleType = PREQUEL_CONSTRUCT;
+		} else if (_type == ANTLRv4Lexer.RBRACE && _currentRuleType == PREQUEL_CONSTRUCT) { // exit prequel construct
+			_currentRuleType = Token.INVALID_TYPE;
+		} else if (_type == ANTLRv4Lexer.AT && _currentRuleType == Token.INVALID_TYPE) { // enter action
+			_currentRuleType = ANTLRv4Lexer.AT;
+		} else if (_type == ANTLRv4Lexer.END_ACTION && _currentRuleType == ANTLRv4Lexer.AT) { // exit action
+			_currentRuleType = Token.INVALID_TYPE;
+		} else if (_type == ANTLRv4Lexer.ID) {
 			String firstChar = _input.getText(Interval.of(_tokenStartCharIndex, _tokenStartCharIndex));
 			if (Character.isUpperCase(firstChar.charAt(0))) {
 				_type = ANTLRv4Lexer.TOKEN_REF;


### PR DESCRIPTION
This is a fix for #1165 (similar to [what was done in the IntelliJ plugin](https://github.com/antlr/intellij-plugin-v4/commit/ab388c97e972757b874d38748732cd2eecf05791)).