### PR TITLE
fix issue 1492

### DIFF
--- a/plsql/PlSqlParser.g4
+++ b/plsql/PlSqlParser.g4
@@ -3486,7 +3486,7 @@ model_column
     ;
 
 model_rules_clause
-    : model_rules_part? '(' model_rules_element? (',' model_rules_element)* ')'
+    : model_rules_part? '(' (model_rules_element (',' model_rules_element)*)? ')'
     ;
 
 model_rules_part
@@ -4304,11 +4304,11 @@ keep_clause
     ;
 
 function_argument
-    : '(' argument? (',' argument)* ')' keep_clause?
+    : '(' (argument (',' argument)*)? ')' keep_clause?
     ;
 
 function_argument_analytic
-    : '(' (argument respect_or_ignore_nulls?)? (',' argument respect_or_ignore_nulls?)* ')' keep_clause?
+    : '(' (argument respect_or_ignore_nulls? (',' argument respect_or_ignore_nulls?)*)? ')' keep_clause?
     ;
 
 function_argument_modeling

--- a/plsql/PlSqlParser.g4
+++ b/plsql/PlSqlParser.g4
@@ -3304,12 +3304,13 @@ subquery_operation_part
     ;
 
 query_block
-    : SELECT (DISTINCT | UNIQUE | ALL)? (ASTERISK | selected_element (',' selected_element)*)
+    : SELECT (DISTINCT | UNIQUE | ALL)? selected_list
       into_clause? from_clause where_clause? hierarchical_query_clause? group_by_clause? model_clause?
     ;
 
-selected_element
-    : select_list_elements column_alias?
+selected_list
+    : '*'
+    | select_list_elements (',' select_list_elements)*
     ;
 
 from_clause
@@ -3318,7 +3319,7 @@ from_clause
 
 select_list_elements
     : tableview_name '.' ASTERISK
-    | (regular_id '.')? expressions
+    | expression column_alias?
     ;
 
 table_ref_list
@@ -3994,7 +3995,7 @@ using_clause
     ;
 
 using_element
-    : (IN OUT? | OUT)? select_list_elements column_alias?
+    : (IN OUT? | OUT)? select_list_elements
     ;
 
 collect_order_by_part


### PR DESCRIPTION
fix #1492 with the solution given by @small-cat .

`SELECT o.item.line_item_id, o.item.quantity FROM short_orders o`

## Before

```
(sql_script 
    (unit_statement 
        (data_manipulation_language_statements 
            (select_statement 
                (subquery 
                    (subquery_basic_elements 
                        (query_block SELECT 
                            (selected_element 
                                (select_list_elements 
                                    (regular_id O)
                                    . (expressions     //  all selected_elements were parsed to a single seleced_element
                                        (expression 
                                        (logical_expression 
                                        (unary_logical_expression 
                                        (multiset_expression 
                                        (relational_expression 
                                        (compound_expression 
                                        (concatenation 
                                        (model_expression 
                                        (unary_expression 
                                        (atom 
                                        (general_element 
                                        (general_element_part 
                                            (id_expression (regular_id ITEM)) 
                                            . (id_expression (regular_id LINE_ITEM_ID))
                                        )))))))))))) , 
// the second select_list_element was parsed as a expression
                                        (expression 
                                        (logical_expression 
                                        (unary_logical_expression 
                                        (multiset_expression 
                                        (relational_expression 
                                        (compound_expression 
                                        (concatenation 
                                        (model_expression 
                                        (unary_expression 
                                        (atom 
                                        (general_element 
                                        (general_element_part 
                                            (id_expression (regular_id O)) . 
                                            (id_expression (regular_id ITEM)) . 
                                            (id_expression (regular_id QUANTITY))))))))))))))
                                    )
                                )) 
                            (from_clause FROM 
                                (table_ref_list 
                                (table_ref 
                                (table_ref_aux 
                                (table_ref_aux_internal 
                                (dml_table_expression_clause 
                                (tableview_name 
                                (identifier 
                                (id_expression 
                                    (regular_id SHORT_ORDERS)))))) 
                                (table_alias 
                                (identifier 
                                (id_expression 
                                    (regular_id O)))))))
                            )
                        )
                    )
                )
            )
        )
    ) 
<EOF>
)
```

## After

```
(sql_script 
    (unit_statement 
        (data_manipulation_language_statements 
            (select_statement 
                (subquery 
                    (subquery_basic_elements 
                        (query_block SELECT 
                            (selected_list 
                                (select_list_elements 
                                    (expression 
                                    (logical_expression 
                                    (unary_logical_expression 
                                    (multiset_expression 
                                    (relational_expression 
                                    (compound_expression 
                                    (concatenation 
                                    (model_expression 
                                    (unary_expression 
                                    (atom 
                                    (general_element 
                                    (general_element_part 
                                        (id_expression (regular_id O)) . 
                                        (id_expression (regular_id ITEM)) . 
                                        (id_expression (regular_id LINE_ITEM_ID))
                                    ))))))))))))) , 

                                (selected_list_element 
                                    (expression 
                                    (logical_expression 
                                    (unary_logical_expression 
                                    (multiset_expression 
                                    (relational_expression 
                                    (compound_expression 
                                    (concatenation 
                                    (model_expression 
                                    (unary_expression 
                                    (atom 
                                    (general_element 
                                    (general_element_part 
                                        (id_expression (regular_id O)) . 
                                        (id_expression (regular_id ITEM)) . 
                                        (id_expression (regular_id QUANTITY))
                                    )))))))))))))) 
                            (from_clause FROM 
                                (table_ref_list 
                                    (table_ref 
                                    (table_ref_aux 
                                    (table_ref_aux_internal 
                                    (dml_table_expression_clause 
                                    (tableview_name 
                                    (identifier 
                                    (id_expression 
                                        (regular_id SHORT_ORDERS)))))) 
                                    (table_alias 
                                        (identifier (id_expression (regular_id O)))
                                    ))))
                            )
                        )
                    )
                )
            )
        )
    ) 
<EOF>
)
```