### PR TITLE
Several TSQL fixes

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -2982,8 +2982,7 @@ for_clause
     ;
 
 xml_common_directives
-    : ',' (BINARY_BASE64 | TYPE)
-    | (COMMA ROOT ('(' STRING ')')?)
+      : ',' (BINARY_BASE64 | TYPE | ROOT ('(' STRING ')')?)
     ;
 
 order_by_expression

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -2982,7 +2982,8 @@ for_clause
     ;
 
 xml_common_directives
-    : ',' (BINARY_BASE64 | TYPE | ROOT)
+    : ',' (BINARY_BASE64 | TYPE)
+    | (COMMA ROOT ('(' STRING ')')?)
     ;
 
 order_by_expression

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3162,8 +3162,6 @@ function_call
     // https://msdn.microsoft.com/en-us/library/ms187928.aspx
     | CAST '(' expression AS data_type ')'              #CAST
     | CONVERT '(' convert_data_type=data_type ','convert_expression=expression (',' style=expression)? ')'                              #CONVERT
-    // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-convert-transact-sql
-    | TRY_CONVERT '(' convert_data_type=data_type ','convert_expression=expression (',' style=expression)? ')'                       #TRY_CONVERT
     // https://msdn.microsoft.com/en-us/library/ms189788.aspx
     | CHECKSUM '(' '*' ')'                              #CHECKSUM
     // https://msdn.microsoft.com/en-us/library/ms190349.aspx

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3081,7 +3081,7 @@ table_source_item
     | rowset_function             as_table_alias?
     | derived_table              (as_table_alias column_alias_list?)?
     | change_table                as_table_alias
-    | function_call               as_table_alias?
+    | function_call              (as_table_alias column_alias_list?)?
     | LOCAL_ID                    as_table_alias?
     | LOCAL_ID '.' function_call (as_table_alias column_alias_list?)?
     | open_xml


### PR DESCRIPTION
`TRY_CONVERT` was introduced without Lexer `TOKEN`, but was already covered with `CONVERT` token in the lexer. And see commit messages for further info. 