### PR TITLE
RCS grammar fixes

### DIFF
--- a/rcs/RCS.g4
+++ b/rcs/RCS.g4
@@ -81,7 +81,7 @@ head
    ;
 
 branch
-   : LITERAL_BRANCH BRANCH SEMI
+   : LITERAL_BRANCH REVISION SEMI
    ;
 
 access
@@ -167,11 +167,6 @@ newphrase
 
 COMMA
    : 'COMMA'
-   ;
-
-
-BRANCH
-   : 'BRANCH'
    ;
 
 
@@ -284,27 +279,13 @@ INT
 
 
 REVISION
-   : INT '.' INT ( '.' INT '.' INT )*
+   : INT ( '.' INT )*
    ;
 
-// string literals
+
 
 STRING
-   : '@' (
-   /*	'\r' '\n' can be matched in one alternative or by matching
-				'\r' in one iteration and '\n' in another.  I am trying to
-				handle any flavor of newline that comes in, but the language
-				that allows both "\r\n" and "\r" and "\n" to all be valid
-				newline is ambiguous.  Consequently, the resulting grammar
-				must be ambiguous.  I'm shutting this warning off.
-			 */
-   /*			options {
-				generateAmbigWarnings=false;
-			}
-		:*/
-   //{ LA(2)!='@' }?  '@' '@' | ( '\r\n' | '\r' | '\n' ) | ~ ( '@' | '\n' | '\r' ) )* '@'
-   )
-   ;
+  : '@' (~[@] | '@@')* '@';
 
 
 SEMI


### PR DESCRIPTION
- BRANCH was erroneously the literal 'BRANCH' instead of a revision number
- STRING parsing was completely broken as relevant code was commented out
- REVISION was broken as it required additional pairs of version numbers

Fixes are based on the upstream RCS grammar
https://www.gnu.org/software/rcs/manual/html_node/comma_002dv-grammar.html
