### PR TITLE
JSON.g4 parser generation leads to symbol conflict (array)

### DIFF
--- a/json/JSON.g4
+++ b/json/JSON.g4
@@ -17,7 +17,7 @@ pair
    : STRING ':' value
    ;
 
-array
+arr
    : '[' value (',' value)* ']'
    | '[' ']'
    ;
@@ -26,7 +26,7 @@ value
    : STRING
    | NUMBER
    | obj
-   | array
+   | arr
    | 'true'
    | 'false'
    | 'null'


### PR DESCRIPTION
antlr4 -Dlanguage=PHP JSON.g4

error(134): JSON.g4:20:0: symbol array conflicts with generated code in target language or runtime

Replacing (array) to (arr) in JSON.g4 worked