### PR TITLE
Accept SQL variable in LIMIT

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -871,7 +871,7 @@ singleDeleteStatement
     FROM tableName
       (PARTITION '(' uidList ')' )?
       (WHERE expression)?
-      orderByClause? (LIMIT decimalLiteral)?
+      orderByClause? (LIMIT limitClauseAtom)?
     ;
 
 multipleDeleteStatement
@@ -896,12 +896,12 @@ handlerReadIndexStatement
         comparisonOperator '(' constants ')'
         | moveOrder=(FIRST | NEXT | PREV | LAST)
       )
-      (WHERE expression)? (LIMIT decimalLiteral)?
+      (WHERE expression)? (LIMIT limitClauseAtom)?
     ;
 
 handlerReadStatement
     : HANDLER tableName READ moveOrder=(FIRST | NEXT)
-      (WHERE expression)? (LIMIT decimalLiteral)?
+      (WHERE expression)? (LIMIT limitClauseAtom)?
     ;
 
 handlerCloseStatement


### PR DESCRIPTION
Replace `LIMIT decimalLiteral` by `LIMIT limitClauseAtom` to accept SQL variable. For example:

```sql
DELETE FROM table
WHERE id < 10
LIMIT @limit;
```