### PR TITLE
Added python scripts for JS

### DIFF
--- a/javascript/javascript/Python/JavaScriptBaseLexer.py
+++ b/javascript/javascript/Python/JavaScriptBaseLexer.py
@@ -1,0 +1,101 @@
+
+from antlr4 import *
+
+relativeImport = False
+if __name__ is not None and "." in __name__:
+    relativeImport = True
+
+class JavaScriptBaseLexer(Lexer):
+    def __init__(self, *args, **kwargs):
+        print("JavaScriptBaseLexerInit")
+        super(JavaScriptBaseLexer, self).__init__(*args, **kwargs)
+
+        """Stores values of nested modes. By default mode is strict or
+        defined externally (useStrictDefault)"""
+        self.scopeStrictModes = []
+        self.lastToken: Token = None
+
+        """Default value of strict mode
+        Can be defined externally by setUseStrictDefault"""
+        self.useStrictDefault = False
+
+        """Current value of strict mode
+        Can be defined during parsing, see StringFunctions.js and StringGlobal.js samples"""
+        self.useStrictCurrent = False
+
+    def getStrictDefault(self) -> bool:
+        return self.useStrictDefault
+
+    def setUseStrictDefault(self, value: bool):
+        self.useStrictDefault = value
+        self.useStrictCurrent = value
+
+    def isStrictMode(self):
+        return self.useStrictCurrent
+
+    def isStartOfFile(self):
+        return self.lastToken is None
+
+    def nextToken(self) -> Token:
+        """Return the next token from the character stream and records this last
+        token in case it resides on the default channel. This recorded token
+        is used to determine when the lexer could possibly match a regex
+        literal. Also changes scopeStrictModes stack if tokenize special
+        string 'use strict';
+
+        :return the next token from the character stream."""
+        next_token: Token = super(JavaScriptBaseLexer, self).nextToken()
+
+        if next_token.channel == Token.DEFAULT_CHANNEL:
+            self.lastToken = next_token
+
+        return next_token
+
+    def processOpenBrace(self):
+        self.useStrictCurrent = bool(self.scopeStrictModes) and (True if self.scopeStrictModes[-1] else self.useStrictDefault)
+        self.scopeStrictModes.append(self.useStrictCurrent)
+
+    def processCloseBrace(self):
+        self.useStrictCurrent = bool(self.scopeStrictModes) and (True if self.scopeStrictModes.pop(-1) else self.useStrictDefault)
+
+    def processStringLiteral(self):
+        if relativeImport:
+            from .JavaScriptLexer import JavaScriptLexer
+        else:
+            from JavaScriptLexer import JavaScriptLexer
+        if not self.lastToken or self.lastToken.type == JavaScriptLexer.OpenBrace:
+            text = self.text
+            if text == '"use strict"' or text == "'use strict'":
+                if self.scopeStrictModes:
+                    self.scopeStrictModes.pop(-1)
+                self.useStrictCurrent = True
+                self.scopeStrictModes.append(self.useStrictCurrent)
+
+    def isRegexPossible(self) -> bool:
+        """Returns {@code true} if the lexer can match a regex literal. """
+        if relativeImport:
+            from .JavaScriptLexer import JavaScriptLexer
+        else:
+            from JavaScriptLexer import JavaScriptLexer
+
+        if not self.lastToken:
+            # No token has been produced yet: at the start of the input,
+            # no division is possible, so a regex literal _is_ possible.
+            return True
+
+        if self.lastToken.type in [
+                JavaScriptLexer.Identifier,
+                JavaScriptLexer.NullLiteral,
+                JavaScriptLexer.BooleanLiteral,
+                JavaScriptLexer.This,
+                JavaScriptLexer.CloseBracket,
+                JavaScriptLexer.CloseParen,
+                JavaScriptLexer.OctalIntegerLiteral,
+                JavaScriptLexer.DecimalLiteral,
+                JavaScriptLexer.HexIntegerLiteral,
+                JavaScriptLexer.StringLiteral,
+                JavaScriptLexer.PlusPlus,
+                JavaScriptLexer.MinusMinus]:
+            return False
+
+        return True

--- a/javascript/javascript/Python/JavaScriptBaseParser.py
+++ b/javascript/javascript/Python/JavaScriptBaseParser.py
@@ -1,0 +1,103 @@
+
+from antlr4 import *
+
+relativeImport = False
+if __name__ is not None and "." in __name__:
+    relativeImport = True
+
+class JavaScriptBaseParser(Parser):
+    @staticmethod
+    def parser():
+        if relativeImport:
+            from .JavaScriptParser import JavaScriptParser
+        else:
+            from JavaScriptParser import JavaScriptParser
+        return JavaScriptParser
+
+    def p(self, s : str) -> bool:
+        return self.prev(s)
+
+    def prev(self, s : str) -> bool:
+        return self._input.LT(-1).text == s
+
+    def n(self, s : str) -> bool:
+        return self.next(s)
+
+    def next(self, s: str) -> bool:
+        return self._input.LT(1).text == s
+
+    def notLineTerminator(self) -> bool:
+        JavaScriptParser = self.parser()
+
+        return not self.here(JavaScriptParser.LineTerminator)
+
+    def notOpenBraceAndNotFunction(self) -> bool:
+        JavaScriptParser = self.parser()
+
+        nextTokenType = self._input.LT(1).type
+        return nextTokenType != JavaScriptParser.OpenBrace and nextTokenType != JavaScriptParser.Function
+
+    def closeBrace(self) -> bool:
+        JavaScriptParser = self.parser()
+
+        return self._input.LT(1).type == JavaScriptParser.CloseBrace
+
+    def here(self, tokenType: int) -> bool:
+        """
+        Returns {@code true} iff on the current index of the parser's
+        token stream a token of the given {@code type} exists on the
+        {@code HIDDEN} channel.
+        :param:type:
+                   the type of the token on the {@code HIDDEN} channel
+                   to check.
+        :return:{@code true} iff on the current index of the parser's
+            token stream a token of the given {@code type} exists on the
+            {@code HIDDEN} channel.
+        """
+        # Get the token ahead of the current index.
+        assert isinstance(self.getCurrentToken(), Token)
+        possibleIndexEosToken: Token = self.getCurrentToken().tokenIndex - 1
+        ahead = self._input.get(possibleIndexEosToken)
+
+        # Check if the token resides on the HIDDEN channel and if it's of the
+        # provided type.
+        return (ahead.channel == Lexer.HIDDEN) and (ahead.type == tokenType)
+
+    def lineTerminatorAhead(self) -> bool:
+        """
+        Returns {@code true} iff on the current index of the parser's
+        token stream a token exists on the {@code HIDDEN} channel which
+        either is a line terminator, or is a multi line comment that
+        contains a line terminator.
+
+        :return: {@code true} iff on the current index of the parser's
+        token stream a token exists on the {@code HIDDEN} channel which
+        either is a line terminator, or is a multi line comment that
+        contains a line terminator.
+        """
+        JavaScriptParser = self.parser()
+
+        # Get the token ahead of the current index.
+        possibleIndexEosToken: Token = self.getCurrentToken().tokenIndex - 1
+        ahead: Token = self._input.get(possibleIndexEosToken)
+
+        if ahead.channel != Lexer.HIDDEN:
+            # We're only interested in tokens on the HIDDEN channel.
+            return False
+
+        if ahead.type == JavaScriptParser.LineTerminator:
+            # There is definitely a line terminator ahead.
+            return True
+
+        if ahead.type == JavaScriptParser.WhiteSpaces:
+            # Get the token ahead of the current whitespaces.
+            possibleIndexEosToken = self.getCurrentToken().tokenIndex - 2
+            ahead = self._input.get(possibleIndexEosToken)
+
+        # Get the token's text and type.
+        text = ahead.text
+        tokenType = ahead.type
+
+        # Check if the token is, or contains a line terminator.
+        return ((tokenType == JavaScriptParser.MultiLineComment and (text.contains("\r") or text.contains("\n"))) or
+                (tokenType == JavaScriptParser.LineTerminator))

--- a/javascript/javascript/Python/README.md
+++ b/javascript/javascript/Python/README.md
@@ -1,0 +1,41 @@
+# Python base Lexer and Parser for JavaScript
+---
+This is a base lexer and parser for the JavaScript language for Antlr4
+
+Baecause the Lexer and Parser use special commands you first need to transform the grammar files:
+
+- python transformGrammar.py JavaScriptParser.g4
+- python transformGrammar.py JavaScriptLexer.g4
+
+Then do the antlr thing:
+- antlr4 -Dlanguage=Python3 -o gen *.g4
+
+I have tested with the below code with a sampling of example JavaScript files from the examples directory.
+
+```python
+import sys
+from antlr4 import *
+import JavaScriptLexer
+import JavaScriptParser
+
+JSL = JavaScriptLexer.JavaScriptLexer
+JSP = JavaScriptParser.JavaScriptParser
+
+class WriteTreeListener(ParseTreeListener):
+    def visitTerminal(self, node:TerminalNode):
+        print ("Visit Terminal: " + str(node) + " - " + repr(node))
+
+def main(argv):
+    input_stream = FileStream(argv[1])
+    print("Test started for: " + argv[1])
+    lexer = JSL(input_stream)
+    stream = CommonTokenStream(lexer)
+    parser = JSP(stream)
+    print("Created parsers")
+    tree = parser.program()
+    ParseTreeWalker.DEFAULT.walk(WriteTreeListener(), tree)
+
+if __name__ == '__main__':
+    print("Running")
+    main(sys.argv)
+```

--- a/javascript/javascript/Python/transformGrammar.py
+++ b/javascript/javascript/Python/transformGrammar.py
@@ -1,0 +1,44 @@
+import sys, os, re, shutil
+
+if __name__ == "__main__":
+    print("Python utility to transform the JavaScript Parser and Lexer grammars to work with a python output")
+    if len(sys.argv) == 1:
+        print(f"""Please run this script as {sys.argv[0]} <grammar>.g4""")
+        sys.exit(0)
+    file_path = sys.argv[1]
+    if not os.path.exists(file_path):
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    parts = os.path.split(file_path)
+    file_name = parts[-1]
+
+    if file_name.lower() not in ["javascriptparser.g4", "javascriptlexer.g4"]:
+        print("Could not determine which grammar you have specified, please specify either the Paarser or the Lexer")
+        sys.exit(1)
+
+    shutil.move(file_path, file_path + ".bak")
+    input_file = open(file_path + ".bak",'r')
+    output_file = open(file_path, 'w')
+    if file_name.lower() == "javascriptparser.g4":
+        for x in input_file:
+            if 'this.' in x:
+                x = x.replace('this.', 'self.')
+            output_file.write(x)
+            output_file.flush()
+    elif file_name.lower() == "javascriptlexer.g4":
+        for x in input_file:
+            if '!this.IsStrictMode' in x:
+                x = x.replace('!this.Is', 'not self.is')
+            if 'this.Is' in x:
+                x = x.replace('this.Is', 'self.is')
+            if 'this.ProcessOpenBrace();' in x:
+                x = x.replace('this.ProcessOpenBrace();', 'self.processOpenBrace()')
+            if 'this.ProcessCloseBrace();' in x:
+                x = x.replace('this.ProcessCloseBrace();', 'self.processCloseBrace()')
+            if 'this.ProcessStringLiteral();' in x:
+                x = x.replace('this.ProcessStringLiteral();', 'self.processStringLiteral()')
+            output_file.write(x)
+            output_file.flush()
+
+    input_file.close()
+    output_file.close()


### PR DESCRIPTION
- Base classes for Parser / Lexer
- Transformer script for grammar

As discussed in #1246, this is a PR for the python base class Lexer and Parser, but also needs a transformation script to make the java/c# in the Lexer and Parser compatible with python.

As noted in the Antlr4 python docs, you cannot make the code compatible with python without having to change every other language to suit (self insead of this), so i thought a transformation was better in this case.

However, i see the problem in this PR, and am totally expecting it to be closed.
I have a repo of transformed grammars here: https://github.com/Anoyomouse/Antlr4-Grammar-JavaScript-Py