### PR TITLE
Fix `range` and `type` symbol conflicts for Python 3

### DIFF
--- a/protobuf3/Protobuf3.g4
+++ b/protobuf3/Protobuf3.g4
@@ -145,10 +145,10 @@ reserved
     ;
 
 ranges
-    :   range (',' range)*
+    :   rangeRule (',' rangeRule)*
     ;
 
-    range
+    rangeRule
     :   IntLit
     |   IntLit 'to' IntLit
     ;
@@ -161,7 +161,7 @@ fieldNames
 // Fields
 //
 
-type
+typeRule
     :   (   'double'
         |   'float'
         |   'int32'
@@ -188,7 +188,7 @@ fieldNumber
 // Normal field
 
 field
-    :   'repeated'? type fieldName '=' fieldNumber ('[' fieldOptions ']')? ';'
+    :   'repeated'? typeRule fieldName '=' fieldNumber ('[' fieldOptions ']')? ';'
     ;
 
 fieldOptions
@@ -206,13 +206,13 @@ oneof
     ;
 
 oneofField
-    :   type fieldName '=' fieldNumber ('[' fieldOptions ']')? ';'
+    :   typeRule fieldName '=' fieldNumber ('[' fieldOptions ']')? ';'
     ;
 
 // Map field
 
 mapField
-    :   'map' '<' keyType ',' type '>' mapName '=' fieldNumber ('[' fieldOptions ']')? ';'
+    :   'map' '<' keyType ',' typeRule '>' mapName '=' fieldNumber ('[' fieldOptions ']')? ';'
     ;
 
 keyType


### PR DESCRIPTION
Errors:
error(134): grammars-v4/protobuf3/Protobuf3.g4:151:4: symbol range conflicts with generated code in target language or runtime
error(134): grammars-v4/protobuf3/Protobuf3.g4:164:0: symbol type conflicts with generated code in target language or runtime
error(134): grammars-v4/protobuf3/Protobuf3.g4:148:8: symbol range conflicts with generated code in target language or runtime
error(134): grammars-v4/protobuf3/Protobuf3.g4:191:20: symbol type conflicts with generated code in target language or runtime
error(134): grammars-v4/protobuf3/Protobuf3.g4:209:8: symbol type conflicts with generated code in target language or runtime
error(134): grammars-v4/protobuf3/Protobuf3.g4:215:30: symbol type conflicts with generated code in target language or runtime
error(134): grammars-v4/protobuf3/Protobuf3.g4:148:19: symbol range conflicts with generated code in target language or runtime