### PR TITLE
Fix issue in GraphQL grammar limiting the enum value definition only to only one

### DIFF
--- a/graphql/GraphQL.g4
+++ b/graphql/GraphQL.g4
@@ -243,7 +243,7 @@ unionTypeExtension : 'extend' 'union' name directives? unionMemberTypes
 
 //https://spec.graphql.org/June2018/#sec-Enums
 enumTypeDefinition:  description? 'enum' name directives? enumValuesDefinition?;
-enumValuesDefinition: '{' enumValueDefinition  '}';
+enumValuesDefinition: '{' enumValueDefinition+  '}';
 enumValueDefinition: description? enumValue  directives?;
 
 //https://spec.graphql.org/June2018/#sec-Enum-Extensions


### PR DESCRIPTION
The current grammar will only allow one enum value definition. Thus, it's failing when parsing enums with multiple enum value definitions like:

```
enum TransportType {
   BICYCLE
   WALK
   CAR
}
```

This is the link to the GraphQL spec particular to `EnumValuesDefinition`: https://spec.graphql.org/draft/#sec-Enums