### PR TITLE
Allow object values with multiple fields

### DIFF
--- a/graphql/GraphQL.g4
+++ b/graphql/GraphQL.g4
@@ -122,9 +122,7 @@ listValue: '[' ']'
     ;
 
 //https://spec.graphql.org/June2018/#sec-Input-Object-Values
-objectValue: '{' '}'
-    | '{' objectField '}'
-    ;
+objectValue: '{' objectField* '}';
 
 objectField: name ':' value;
 


### PR DESCRIPTION
Current grammar allows only 0 or 1 fields on an object value, but according to spec there is no such limitation (object values are allowed to contain any number of fields).

Beacuse of this an executable definition such as [Example № 30](https://spec.graphql.org/June2018/#example-09646) from the spec can't be parsed:

```graphql
{
  nearestThing(location: { lon: 12.43, lat: -53.211 })
}
```