### PR TITLE
Changed a semantic predicate to check on the next token

### DIFF
--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -424,11 +424,11 @@ bigintLiteral
     ;
 
 getter
-    : identifier {this.p("get")}? propertyName
+    : {this.n("get")}? identifier propertyName
     ;
 
 setter
-    : identifier {this.p("set")}? propertyName
+    : {this.n("set")}? identifier propertyName
     ;
 
 identifierName


### PR DESCRIPTION
The grammar fails the following generated test case:

```js
class test { set id() {} }
```

The parser throws the following error:

```
line 1:17 rule getter failed predicate: {this.p("get")}?
```

predicate on the getter and setter rules 

```g4
methodDefinition
    : '*'? '#'? propertyName '(' formalParameterList? ')' '{' functionBody '}'
    | '*'? '#'? getter '(' ')' '{' functionBody '}'
    | '*'? '#'? setter '(' formalParameterList? ')' '{' functionBody '}'
    ;
...
getter : identifier {this.p("get")}? propertyName ;
setter : identifier {this.p("set")}? propertyName ;
```

swapping the order of getter and setter rules in method definition to:

```g4
methodDefinition
    : '*'? '#'? propertyName '(' formalParameterList? ')' '{' functionBody '}'
     | '*'? '#'? setter '(' formalParameterList? ')' '{' functionBody '}'
     | '*'? '#'? getter '(' ')' '{' functionBody '}'
    ;
```

The test case we saw earlier parses successfully but fails on the following test case:

```js
class test { get id() {} }
```

with the message 

```
line 1:17 rule setter failed predicate: {this.p("set")}?
```

Changing the predicate on getter and setter rules to check on the next token  seems to solve this issue:

```js
getter : {this.n("get")}? identifier  propertyName ;
setter : {this.n("set")}? identifier propertyName ;
```
