### PR TITLE
Parse model responses

### DIFF
--- a/smtlibv2/SMTLIBv2.g4
+++ b/smtlibv2/SMTLIBv2.g4
@@ -473,12 +473,13 @@ PK_Version
     : ':version'
     ;
 
+RS_Model //  for model responses
+    : 'model'
+    ;
+
 UndefinedSymbol:
     Sym (Digit | Sym)*;
 
-ModelResponse
-    : 'model'
-    ;
 
 // Parser Rules Start
 
@@ -505,6 +506,7 @@ generalReservedWord
     | GRW_Numeral
     | GRW_Par
     | GRW_String
+    | RS_Model
     ;
 
 
@@ -1046,7 +1048,8 @@ get_info_response
     ;
 
 get_model_response
-    : ParOpen ModelResponse model_response* ParClose
+    : ParOpen RS_Model model_response* ParClose
+    | ParOpen model_response* ParClose
     ;
 
 get_option_response

--- a/smtlibv2/SMTLIBv2.g4
+++ b/smtlibv2/SMTLIBv2.g4
@@ -476,7 +476,9 @@ PK_Version
 UndefinedSymbol:
     Sym (Digit | Sym)*;
 
-
+ModelResponse
+    : 'model'
+    ;
 
 // Parser Rules Start
 
@@ -997,8 +999,10 @@ model_response
     : ParOpen CMD_DefineFun function_def ParClose
     | ParOpen CMD_DefineFunRec function_def ParClose
     // cardinalitiees for function_dec and term have to be n+1
-    | ParOpen CMD_DefineFunsRec ParOpen function_dec+ ParClose ParOpen term+
-    ParClose ParClose
+    | ParOpen CMD_DefineFunsRec
+    ParOpen function_dec+ ParClose
+    ParOpen term+ ParClose
+    ParClose
     ;
 
 info_response
@@ -1042,7 +1046,7 @@ get_info_response
     ;
 
 get_model_response
-    : ParOpen model_response* ParClose
+    : ParOpen ModelResponse model_response* ParClose
     ;
 
 get_option_response

--- a/smtlibv2/SMTLIBv2.g4
+++ b/smtlibv2/SMTLIBv2.g4
@@ -998,13 +998,9 @@ reason_unknown
     ;
 
 model_response
-    : ParOpen CMD_DefineFun function_def ParClose
-    | ParOpen CMD_DefineFunRec function_def ParClose
-    // cardinalitiees for function_dec and term have to be n+1
-    | ParOpen CMD_DefineFunsRec
-    ParOpen function_dec+ ParClose
-    ParOpen term+ ParClose
-    ParClose
+    : ParOpen cmd_defineFun ParClose
+    | ParOpen cmd_defineFunRec ParClose
+    | ParOpen cmd_defineFunsRec ParClose
     ;
 
 info_response

--- a/smtlibv2/examples/response1.smt2
+++ b/smtlibv2/examples/response1.smt2
@@ -1,0 +1,5 @@
+; get_assertions_response
+(
+false
+true
+)

--- a/smtlibv2/examples/test12.smt2
+++ b/smtlibv2/examples/test12.smt2
@@ -1,4 +1,4 @@
-(
+(model
   (define-fun b () Int
     1)
   (define-fun a () String


### PR DESCRIPTION
Though it is not part of the SMT spec, most solvers parse their `get-model-response` like this
```smt
(model
  (define-fun b () Int
    1)
  (define-fun a () String
    "\x00")
)
```

instead of  the following, for better readability.
```smt
(
  (define-fun b () Int
    1)
  (define-fun a () String
    "\x00")
)
```
This PR adds support for both responses