### PR TITLE
Haskell Grammar: add extensions and fix some bugs

### DIFF
--- a/haskell/HaskellLexer.g4
+++ b/haskell/HaskellLexer.g4
@@ -42,6 +42,155 @@ WS : [\u0020\u00a0\u1680\u2000\u200a\u202f\u205f\u3000]+ {
     this.processWSToken();
 } ;
 
+AS            : 'as'               ;
+CASE          : 'case'             ;
+CLASS         : 'class'            ;
+DATA          : 'data'             ;
+DEFAULT       : 'default'          ;
+DERIVING      : 'deriving'         ;
+DO            : 'do'               ;
+ELSE          : 'else'             ;
+HIDING        : 'hiding'           ;
+IF            : 'if'               ;
+IMPORT        : 'import'           ;
+IN            : 'in'               ;
+INFIX         : 'infix'            ;
+INFIXL        : 'infixl'           ;
+INFIXR        : 'infixr'           ;
+INSTANCE      : 'instance'         ;
+LET           : 'let'              ;
+MODULE        : 'module'           ;
+NEWTYPE       : 'newtype'          ;
+OF            : 'of'               ;
+QUALIFIED     : 'qualified'        ;
+THEN          : 'then'             ;
+TYPE          : 'type'             ;
+WHERE         : 'where'            ;
+WILDCARD      : '_'                ;
+
+FORALL        : 'forall'           ;
+FOREIGN       : 'foreign'          ;
+EXPORT        : 'export'           ;
+SAFE          : 'safe'             ;
+INTERRUPTIBLE : 'interruptible'    ;
+UNSAFE        : 'unsafe'           ;
+MDO           : 'mdo'              ;
+FAMILY        : 'family'           ;
+ROLE          : 'role'             ;
+STDCALL       : 'stdcall'          ;
+CCALL         : 'ccall'            ;
+CAPI          : 'capi'             ;
+CPPCALL       : 'cplusplus'        ;
+JSCALL        : 'javascript'       ;
+REC           : 'rec'              ;
+GROUP         : 'group'            ;
+BY            : 'by'               ;
+USING         : 'using'            ;
+PATTERN       : 'pattern'          ;
+STOCK         : 'stock'            ;
+ANYCLASS      : 'anyclass'         ;
+VIA           : 'via'              ;
+
+LANGUAGE      : 'LANGUAGE'         ;
+OPTIONS_GHC   : 'OPTIONS_GHC'      ;
+OPTIONS       : 'OPTIONS'          ;
+INLINE        : 'INLINE'           ;
+NOINLINE      : 'NOINLINE'         ;
+SPECIALISE    : 'SPECIALISE'       ;
+SPECINLINE    : 'SPECIALISE_INLINE';
+SOURCE        : 'SOURCE'           ;
+RULES         : 'RULES'            ;
+SCC           : 'SCC'              ;
+DEPRECATED    : 'DEPRECATED'       ;
+WARNING       : 'WARNING'          ;
+UNPACK        : 'UNPACK'           ;
+NOUNPACK      : 'NOUNPACK'         ;
+ANN           : 'ANN'              ;
+MINIMAL       : 'MINIMAL'          ;
+CTYPE         : 'CTYPE'            ;
+OVERLAPPING   : 'OVERLAPPING'      ;
+OVERLAPPABLE  : 'OVERLAPPABLE'     ;
+OVERLAPS      : 'OVERLAPS'         ;
+INCOHERENT    : 'INCOHERENT'       ;
+COMPLETE      : 'COMPLETE'         ;
+
+
+LCASE       : '\\' (NEWLINE | WS)* 'case'   ;
+
+fragment SYMBOL : ASCSYMBOL | UNISYMBOL;
+DoubleArrow        : '=>'  ;
+DoubleColon        : '::'  ;
+Arrow              : '->'  ;
+Revarrow           : '<-'  ;
+LarrowTail         : '-<'  ;
+RarrowTail         : '>-'  ;
+LLarrowTail        : '-<<' ;
+RRarrowTail        : '>>-' ;
+Hash               : '#'   ;
+Less               : '<'   ;
+Greater            : '>'   ;
+Ampersand          : '&'   ;
+Pipe               : '|'   ;
+Bang               : '!'   ;
+Caret              : '^'   ;
+Plus               : '+'   ;
+Minus              : '-'   ;
+Asterisk           : '*'   ;
+Percent            : '%'   ;
+Divide             : '/'   ;
+Tilde              : '~'   ;
+Atsign             : '@'   ;
+DDollar            : '$$'  ;
+Dollar             : '$'   ;
+DoubleDot          : '..'  ;
+Dot                : '.'   ;
+Semi               : ';'   ;
+QuestionMark       : '?'   ;
+Comma              : ','   ;
+Colon              : ':'   ;
+Eq                 : '='   ;
+Quote              : '\''  ;
+DoubleQuote        : '\'\'';
+ReverseSlash       : '\\'  ;
+BackQuote          : '`'   ;
+AopenParen         :'(|' WS;
+AcloseParen        :WS '|)';
+TopenTexpQuote     : '[||' ;
+TcloseTExpQoute    : '||]' ;
+TopenExpQuote      : '[|'  ;
+TopenPatQuote      : '[p|' ;
+TopenTypQoute      : '[t|' ;
+TopenDecQoute      : '[d|' ;
+TcloseQoute        : '|]'  ;
+OpenBoxParen       : '(#'  ;
+CloseBoxParen      : '#)'  ;
+OpenRoundBracket   : '('   ;
+CloseRoundBracket  : ')'   ;
+OpenSquareBracket  : '['   ;
+CloseSquareBracket : ']'   ;
+
+
+CHAR : '\'' (' ' | DECIMAL | SMALL | LARGE
+              | SYMBOL | DIGIT | ',' | ';' | '(' | ')'
+              | '[' | ']' | '`' | '"') '\'';
+
+STRING : '"' (' ' | DECIMAL | SMALL | LARGE
+              | SYMBOL | DIGIT | ',' | ';' | '(' | ')'
+              | '[' | ']' | '`' | '\'')* '"';
+
+VARID : SMALL (SMALL | LARGE | DIGIT | '\'' )* '#'*;
+CONID : LARGE (SMALL | LARGE | DIGIT | '\'' )* '#'*;
+
+OpenPragmaBracket : '{-#';
+ClosePragmaBracket: '#-}';
+
+// For CPP extension
+// read about
+// https://medium.com/swiftify/parsing-preprocessor-directives-in-objective-c-714a3dde570
+// directives are skip now
+// MultiLineMacro : '#' (~ [\n]*? '\\' '\r'? '\n')+ ~ [\n]+ -> skip;
+// Directive : '#' ~ [\n]* -> skip;
+
 COMMENT  : '--' (~[\r\n])* -> skip;
 NCOMMENT : '{-'~[#] .*? '-}' -> skip;
 
@@ -51,95 +200,7 @@ VOCURLY : 'VOCURLY' { setChannel(HIDDEN); };
 VCCURLY : 'VCCURLY' { setChannel(HIDDEN); };
 SEMI    : 'SEMI'    { setChannel(HIDDEN); };
 
-CASE     : 'case'    ;
-CLASS    : 'class'   ;
-DATA     : 'data'    ;
-DEFAULT  : 'default' ;
-DERIVING : 'deriving';
-DO       : 'do'      ;
-ELSE     : 'else'    ;
-EXPORT   : 'export'  ;
-FOREIGN  : 'foreign' ;
-IF       : 'if'      ;
-IMPORT   : 'import'  ;
-IN       : 'in'      ;
-INFIX    : 'infix'   ;
-INFIXL   : 'infixl'  ;
-INFIXR   : 'infixr'  ;
-INSTANCE : 'instance';
-LET      : 'let'     ;
-MODULE   : 'module'  ;
-NEWTYPE  : 'newtype' ;
-OF       : 'of'      ;
-THEN     : 'then'    ;
-TYPE     : 'type'    ;
-WHERE    : 'where'   ;
-WILDCARD : '_'       ;
-QUALIFIED: 'qualified';
 
-AS     : 'as';
-HIDING : 'hiding';
-
-LANGUAGE  : 'LANGUAGE';
-INLINE    : 'INLINE';
-NOINLINE  : 'NOINLINE';
-SPECIALIZE: 'SPECIALIZE';
-
-CCALL     : 'ccall';
-STDCALL   : 'stdcall';
-CPPCALL   : 'cplusplus';
-JVMCALL   : 'jvm';
-DOTNETCALL: 'dotnet';
-
-SAFE  : 'safe';
-UNSAFE: 'unsafe';
-
-DoubleArrow        : '=>';
-DoubleColon        : '::';
-Arrow              : '->';
-Revarrow           : '<-';
-Hash               : '#';
-Less               : '<';
-Greater            : '>';
-Ampersand          : '&';
-Pipe               : '|';
-Bang               : '!';
-Caret              : '^';
-Plus               : '+';
-Minus              : '-';
-Asterisk           : '*';
-Percent            : '%';
-Divide             : '/';
-Tilde              : '~';
-Atsign             : '@';
-Dollar             : '$';
-Dot                : '.';
-Semi               : ';';
-DoubleDot          :  '..';
-QuestionMark       : '?';
-OpenRoundBracket   :   '(';
-CloseRoundBracket  :  ')';
-OpenSquareBracket  :  '[';
-CloseSquareBracket : ']';
-OpenCommentBracket : '{-#';
-CloseCommentBracket: '#-}';
-Comma              : ',';
-Colon              : ':';
-Eq                 : '=';
-Quote              : '\'';
-DoubleQuote        : '\\';
-BackQuote          :'`';
-
-CHAR : '\'' (' ' | DECIMAL | SMALL | LARGE
-              | ASCSYMBOL | DIGIT | ',' | ';' | '(' | ')'
-              | '[' | ']' | '`' | '"') '\'';
-
-STRING : '"' (' ' | DECIMAL | SMALL | LARGE
-              | ASCSYMBOL | DIGIT | ',' | ';' | '(' | ')'
-              | '[' | ']' | '`' | '\'')* '"';
-
-VARID : SMALL (SMALL | LARGE | DIGIT | '\'' )*;
-CONID : LARGE (SMALL | LARGE | DIGIT | '\'' )*;
 
 DECIMAL 	: DIGIT+;
 OCTAL   	: '0' [oO] OCTIT+;
@@ -1396,13 +1457,16 @@ fragment UNISMALL
     | '\uff41'..'\uff5a'       // Halfwidth_and_Fullwidth_Forms
 ;
 
-ASCSYMBOL : '!' | '#' | '$' | '%' | '&' | '*' | '+'
+
+
+fragment ASCSYMBOL : '!' | '#' | '$' | '%' | '&' | '*' | '+'
         | '.' | '/' | '<' | '=' | '>' | '?' | '@'
         | '\\' | '^' | '|' | '-' | '~' | ':' ;
 
-UNISYMBOL :
+fragment UNISYMBOL
+    :
     CLASSIFY_Sc | CLASSIFY_Sk | CLASSIFY_Sm | CLASSIFY_So
-;
+    ;
 
 fragment CLASSIFY_Sc:
       '\u0024'                 // Basic_Latin

--- a/haskell/HaskellParser.g4
+++ b/haskell/HaskellParser.g4
@@ -30,7 +30,22 @@ parser grammar HaskellParser;
 
 options { tokenVocab=HaskellLexer; }
 
-module :  semi* pragmas? semi* ((MODULE modid exports? WHERE open body close semi*) | body) EOF;
+module :  OCURLY? semi* pragmas? semi* (module_content | body) CCURLY? semi? EOF;
+
+module_content
+    :
+    'module' modid exports? where_module
+    ;
+
+where_module
+    :
+    'where' module_body
+    ;
+
+module_body
+    :
+    open body close semi*
+    ;
 
 pragmas
     :
@@ -39,12 +54,29 @@ pragmas
 
 pragma
     :
-    '{-#' 'LANGUAGE'  extension (',' extension)* '#-}'
+    language_pragma
+    | options_ghc
+    | simple_options
+    ;
+
+language_pragma
+    :
+    '{-#' 'LANGUAGE'  extension (',' extension)* '#-}' semi?
+    ;
+
+options_ghc
+    :
+    '{-#' 'OPTIONS_GHC' ('-' (varid | conid))* '#-}' semi?
+    ;
+
+simple_options
+    :
+    '{-#' 'OPTIONS' ('-' (varid | conid))* '#-}' semi?
     ;
 
 extension
     :
-    conid
+    CONID
     ;
 
 body
@@ -69,25 +101,25 @@ exprt
     qvar
     | ( qtycon ( ('(' '..' ')') | ('(' (cname (',' cname)*)? ')') )? )
     | ( qtycls ( ('(' '..' ')') | ('(' (qvar (',' qvar)*)? ')') )? )
-    | ( MODULE modid )
+    | ( 'module' modid )
     ;
 
 impdecl
     :
-    IMPORT QUALIFIED? modid ('as' modid)? impspec? semi+
+    'import' 'qualified'? modid ('as' modid)? impspec? semi+
     ;
 
 impspec
     :
     ('(' (himport (',' himport)* ','?)? ')')
     | ( 'hiding' '(' (himport (',' himport)* ','?)? ')' )
-     ;
+    ;
 
 himport
     :
     var
     | ( tycon ( ('(' '..' ')') | ('(' (cname (',' cname)*)? ')') )? )
-    | ( tycls ( ('(' '..' ')') | ('(' (var (',' var)*)? ')') )? )
+    | ( tycls ( ('(' '..' ')') | ('(' sig_vars? ')') )? )
     ;
 
 cname
@@ -95,211 +127,996 @@ cname
     var | con
     ;
 
-topdecls : ((topdecl semi+) | NEWLINE | semi)+;
+// -------------------------------------------
+// Fixity Declarations
+
+fixity: 'infix' | 'infixl' | 'infixr';
+
+ops : op (',' op)*;
+
+// -------------------------------------------
+// Top-Level Declarations
+topdecls : (topdecl semi+| NEWLINE | semi)+;
 
 topdecl
     :
-    (TYPE simpletype '=' type)
-    | (DATA (typecontext '=>')? simpletype ('=' constrs)? deriving?)
-    | (NEWTYPE (typecontext '=>')? simpletype '=' newconstr deriving?)
-    | (CLASS (scontext '=>')? tycls tyvar (WHERE cdecls)?)
-    | (INSTANCE (scontext '=>')? qtycls inst (WHERE idecls)?)
-    | (DEFAULT '(' (type (',' type)*)? ')' )
-    | (FOREIGN fdecl)
-    | decl;
-
-decls
-    :
-    open ((decl semi+)* decl semi*)? close
+    cl_decl
+    | ty_decl
+    // Check KindSignatures
+    | standalone_kind_sig
+    | inst_decl
+    | standalone_deriving
+    | role_annot
+    | ('default' '(' comma_types? ')' )
+    | ('foreign' fdecl)
+    | ('{-#' 'DEPRECATED' deprecations? '#-}')
+    | ('{-#' 'WARNING' warnings? '#-}')
+    | ('{-#' 'RULES' rules? '#-}')
+    | annotation
+    | decl_no_th
+    // -- Template Haskell Extension
+    //  The $(..) form is one possible form of infixexp
+    //  but we treat an arbitrary expression just as if
+    //  it had a $(..) wrapped around it
+    | infixexp
     ;
 
-decl
+// Type classes
+//
+cl_decl
     :
-    '{-#' 'INLINE' qvar '#-}'
-    | '{-#' 'NOINLINE' qvar '#-}'
-    | '{-#' 'SPECIALIZE' specs '#-}'
-    | gendecl
-    | ((funlhs | pat) rhs)
-    | semi+
+    'class' tycl_hdr fds? where_cls?
     ;
 
-specs
+// Type declarations (toplevel)
+//
+ty_decl
     :
-    spec (',' spec)*
+    // ordinary type synonyms
+    'type' type '=' ktypedoc
+    // type family declarations
+    | 'type' 'family' type opt_tyfam_kind_sig? opt_injective_info? where_type_family?
+    // ordinary data type or newtype declaration
+    | 'data' capi_ctype? tycl_hdr constrs derivings?
+    | 'newtype' capi_ctype? tycl_hdr constrs derivings?
+    // ordinary GADT declaration
+    | 'data' capi_ctype? tycl_hdr opt_kind_sig? gadt_constrlist? derivings?
+    | 'newtype' capi_ctype? tycl_hdr opt_kind_sig? gadt_constrlist? derivings?
+    // data/newtype family
+    | 'data' 'family' type opt_datafam_kind_sig?
     ;
 
-spec
+// standalone kind signature
+
+standalone_kind_sig
     :
-    vars '::' type
+    'type' sks_vars '::' ktypedoc
     ;
 
-cdecls
+// See also: sig_vars
+sks_vars
     :
-    open ((cdecl semi+)* cdecl semi*)? close
+    oqtycon (',' oqtycon)*
     ;
 
-cdecl
+inst_decl
     :
-    gendecl
-    | ((funlhs | var) rhs)
+    ('instance' overlap_pragma? inst_type where_inst?)
+    | ('type' 'instance' ty_fam_inst_eqn)
+    // 'constrs' in the end of this rules in GHC
+    // This parser no use docs
+    | ('data' 'instance' capi_ctype? tycl_hdr_inst derivings?)
+    | ('newtype' 'instance' capi_ctype? tycl_hdr_inst derivings?)
+    // For GADT
+    | ('data' 'instance' capi_ctype? tycl_hdr_inst opt_kind_sig? gadt_constrlist? derivings?)
+    | ('newtype' 'instance' capi_ctype? tycl_hdr_inst opt_kind_sig? gadt_constrlist? derivings?)
     ;
 
-idecls
+overlap_pragma
     :
-    open ((idecl semi+)* idecl semi*)? close
+      '{-#' 'OVERLAPPABLE' '#-}'
+    | '{-#' 'OVERLAPPING' '#-}'
+    | '{-#' 'OVERLAPS' '#-}'
+    | '{-#' 'INCOHERENT' '#-}'
     ;
 
-idecl
+
+deriv_strategy_no_via
     :
-    (funlhs | var) rhs
+      'stock'
+    | 'anyclass'
+    | 'newtype'
     ;
 
-gendecl
+deriv_strategy_via
     :
-    vars '::' (typecontext '=>')? type
-    | (fixity (DECIMAL)? ops)
+    'via' ktype
     ;
 
-ops
+deriv_standalone_strategy
     :
-    op (',' op)*
+      'stock'
+    | 'anyclass'
+    | 'newtype'
+    | deriv_strategy_via
+    ;
+
+// Injective type families
+
+opt_injective_info
+    :
+    '|' injectivity_cond
+    ;
+
+injectivity_cond
+    :
+    // but in GHC new tyvarid rule
+    tyvarid '->' inj_varids
+    ;
+
+inj_varids
+    :
+    tyvarid+
+    ;
+
+// Closed type families
+
+where_type_family
+    :
+    'where' ty_fam_inst_eqn_list
+    ;
+
+ty_fam_inst_eqn_list
+    :
+    (open ty_fam_inst_eqns? close)
+    | ('{' '..' '}')
+    | (open '..' close)
+    ;
+
+ty_fam_inst_eqns
+    :
+    ty_fam_inst_eqn (semi+ ty_fam_inst_eqn)* semi*
+    ;
+
+ty_fam_inst_eqn
+    :
+    'forall' tv_bndrs? '.' type '=' ktype
+    | type '=' ktype
+    ;
+
+//  Associated type family declarations
+
+//  * They have a different syntax than on the toplevel (no family special
+//    identifier).
+
+//  * They also need to be separate from instances; otherwise, data family
+//    declarations without a kind signature cause parsing conflicts with empty
+//    data declarations.
+
+at_decl_cls
+    :
+    ('data' 'family'? type opt_datafam_kind_sig?)
+    | ('type' 'family'? type opt_at_kind_inj_sig?)
+    | ('type' 'instance'? ty_fam_inst_eqn)
+    ;
+
+// Associated type instances
+//
+at_decl_inst
+    :
+    // type instance declarations, with optional 'instance' keyword
+    ('type' 'instance'? ty_fam_inst_eqn)
+    // data/newtype instance declaration, with optional 'instance' keyword
+    | ('data' 'instance'? capi_ctype? tycl_hdr_inst constrs derivings?)
+    | ('newtype' 'instance'? capi_ctype? tycl_hdr_inst constrs derivings?)
+    // GADT instance declaration, with optional 'instance' keyword
+    | ('data' 'instance'? capi_ctype? tycl_hdr_inst opt_kind_sig? gadt_constrlist? derivings?)
+    | ('newtype' 'instance'? capi_ctype? tycl_hdr_inst opt_kind_sig? gadt_constrlist? derivings?)
+    ;
+
+// Family result/return kind signatures
+
+opt_kind_sig
+    :
+    '::' kind
+    ;
+
+opt_datafam_kind_sig
+    :
+    '::' kind
+    ;
+
+opt_tyfam_kind_sig
+    :
+    ('::' kind)
+    | ('=' tv_bndr)
+    ;
+
+opt_at_kind_inj_sig
+    :
+    ('::' kind)
+    | ('=' tv_bndr_no_braces '|' injectivity_cond)
+    ;
+
+tycl_hdr
+    :
+    (tycl_context '=>' type)
+    | type
+    ;
+
+tycl_hdr_inst
+    :
+    ('forall' tv_bndrs? '.' tycl_context '=>' type)
+    | ('forall' tv_bndrs? '.' type)
+    | (tycl_context '=>' type)
+    | type
+    ;
+
+capi_ctype
+    :
+    ('{-#' 'CTYPE' STRING STRING '#-}')
+    | ('{-#' 'CTYPE' STRING '#-}')
+    ;
+
+// -------------------------------------------
+// Stand-alone deriving
+
+standalone_deriving
+    :
+    'deriving' deriv_standalone_strategy? 'instance' overlap_pragma? inst_type
+    ;
+
+// -------------------------------------------
+// Role annotations
+
+role_annot
+    :
+    'type' 'role' oqtycon roles?
+    ;
+
+roles
+    :
+    role+
+    ;
+
+role
+    :
+    varid | '_'
+    ;
+
+
+// -------------------------------------------
+// Pattern synonyms
+pattern_synonym_decl
+    :
+    ('pattern' pattern_synonym_lhs '=' pat)
+    | ('pattern' pattern_synonym_lhs '<-' pat where_decls?)
+    ;
+
+pattern_synonym_lhs
+    :
+    (con vars?)
+    | (varid conop varid)
+    | (con '{' cvars '}')
     ;
 
 vars
     :
+    varid+
+    ;
+
+cvars
+    :
     var (',' var)*
     ;
 
-fixity
+where_decls
     :
-    INFIX | INFIXL | INFIXL
+    'where' open decls? close
     ;
 
-type
+pattern_synonym_sig
     :
-    btype ('->' type)?
+    'pattern' con_list '::' sigtypedoc
     ;
 
-btype
+// -------------------------------------------
+// Nested declaration
+
+// Declaration in class bodies
+
+decl_cls
     :
-    atype+
+    at_decl_cls
+    | decl
+    | 'default' infixexp '::' sigtypedoc
     ;
 
-atype
+decls_cls
     :
-    gtycon
-    | varid
-    | ( '(' type (',' type)* ')' )
-    | ( '[' type ']' )
-    | ( '(' type ')' )
+    decl_cls (semi+ decl_cls)* semi*
     ;
 
-gtycon
+decllist_cls
     :
-    qtycon
-    | ( '(' ')' )
-    | ( '[' ']' )
-    | ( '(' '->' ')' )
-    | ( '(' ',' '{' ',' '}' ')' )
+    open decls_cls? close
     ;
 
-typecontext
+// Class body
+//
+where_cls
     :
-    cls
-    | ( '(' cls (',' cls)* ')' )
+    'where' decllist_cls
     ;
 
-cls
+// Declarations in instance bodies
+//
+decl_inst
     :
-    (conid varid)
-    | ( qtycls '(' tyvar (atype (',' atype)*) ')' )
+    at_decl_inst
+    | decl
     ;
 
-scontext
+decls_inst
     :
-    simpleclass
-    | ( '(' (simpleclass (',' simpleclass)*)? ')' )
+    decl_inst (semi+ decl_inst)* semi*
     ;
 
-simpleclass
+decllist_inst
     :
-    qtycls tyvar
+    open decls_inst? close
     ;
 
-simpletype
+// Instance body
+//
+where_inst
     :
-    tycon tyvar*
+    'where' decllist_inst
     ;
 
-constrs
+// Declarations in binding groups other than classes and instances
+//
+decls
     :
-    constr ('|' constr)*
+    decl (semi+ decl)* semi*
     ;
 
-constr
+decllist
     :
-    (con ('!'? atype)*)
-    | ((btype | ('!' atype)) conop (btype | ('!' atype)))
-    | (con '{' (fielddecl (',' fielddecl)* )? '}')
+    open decls? close
     ;
 
-newconstr
+// Binding groups other than those of class and instance declarations
+//
+binds
     :
-    (con atype)
-    | (con '{' var '::' type '}')
+    decllist
+    | (open dbinds? close)
     ;
 
-fielddecl
+wherebinds
     :
-    vars '::' (type | ('!' atype))
+    'where' binds
     ;
 
-deriving
+
+// -------------------------------------------
+// Transformation Rules
+
+rules
     :
-    DERIVING (dclass | ('(' (dclass (',' dclass)*)? ')' ))
+    pragma_rule (semi pragma_rule)* semi?
     ;
 
-dclass
+pragma_rule
     :
-    qtycls
+    pstring rule_activation? rule_foralls? infixexp '=' exp
     ;
 
-inst
+rule_activation_marker
     :
-    gtycon
-    | ( '(' gtycon tyvar* ')' )
-    | ( '(' gtycon tycon* ')' )
-    | ( '(' tyvar ',' tyvar (',' tyvar)* ')')
-    | ( '[' tyvar ']')
-    | ( '(' tyvar '->' tyvar ')' )
+    '~' | varsym
     ;
+
+rule_activation
+    :
+    ('[' integer ']')
+    | ('[' rule_activation_marker integer ']')
+    | ('[' rule_activation_marker ']')
+    ;
+
+rule_foralls
+    :
+    ('forall' rule_vars? '.' ('forall' rule_vars? '.')?)
+    ;
+
+rule_vars
+    :
+    rule_var+
+    ;
+
+rule_var
+    :
+    varid
+    | ('(' varid '::' ctype ')')
+    ;
+
+// -------------------------------------------
+// Warnings and deprecations (c.f. rules)
+
+warnings
+    :
+    pragma_warning (semi pragma_warning)* semi?
+    ;
+
+pragma_warning
+    :
+    namelist strings
+    ;
+
+deprecations
+    :
+    pragma_deprecation (semi pragma_deprecation)* semi?
+    ;
+
+pragma_deprecation
+    :
+    namelist strings
+    ;
+
+strings
+    :
+    pstring
+    | ('[' stringlist? ']')
+    ;
+
+stringlist
+    :
+    pstring (',' pstring)*
+    ;
+
+// -------------------------------------------
+// Annotations
+
+annotation
+    :
+      ('{-#' 'ANN' name_var aexp '#-}')
+    | ('{-#' 'ANN' tycon aexp '#-}')
+    | ('{-#' 'ANN' 'module' aexp '#-}')
+    ;
+
+// -------------------------------------------
+// Foreign import and export declarations
 
 fdecl
     :
-    (IMPORT callconv safety? impent var '::' type)
-    | (EXPORT callconv expent var '::' type)
+    ('import' callconv safety? fspec)
+    | ('export' callconv fspec)
     ;
 
 callconv
     :
-    'ccall' | 'stdcall' | 'cplusplus' | 'jvm' | 'dotnet'
+    'ccall' | 'stdcall' | 'cplusplus' | 'javascript'
     ;
 
-impent : pstring;
-expent : pstring;
-safety : 'unsafe' | 'safe';
+safety : 'unsafe' | 'safe' | 'interruptible';
 
-funlhs
+fspec
     :
-    (var apat+)
-    | (pat varop pat)
-    | ( '(' funlhs ')' apat+)
+    pstring? var '::' sigtypedoc
+    ;
+
+// -------------------------------------------
+// Type signatures
+
+opt_sig : '::' sigtype;
+
+opt_tyconsig : '::' gtycon;
+
+sigtype
+    :
+    ctype
+    ;
+
+sigtypedoc
+    :
+    ctypedoc
+    ;
+
+sig_vars
+    :
+    var (',' var)*
+    ;
+
+sigtypes1
+    :
+    sigtype (',' sigtype)*
+    ;
+
+// -------------------------------------------
+// Types
+
+unpackedness
+    :
+      ('{-#' 'UNPACK'   '#-}')
+    | ('{-#' 'NOUNPACK' '#-}')
+    ;
+
+forall_vis_flag
+    :
+    '.'
+    | '->'
+    ;
+
+// A ktype/ktypedoc is a ctype/ctypedoc, possibly with a kind annotation
+ktype
+    :
+    ctype
+    | (ctype '::' kind)
+    ;
+
+ktypedoc
+    :
+    ctypedoc
+    | ctypedoc '::' kind
+    ;
+
+// A ctype is a for-all type
+ctype
+    :
+    'forall' tv_bndrs? forall_vis_flag ctype
+    | btype '=>' ctype
+    | var '::' type // not sure about this rule
+    | type
+    ;
+
+// -- Note [ctype and ctypedoc]
+// -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// -- It would have been nice to simplify the grammar by unifying `ctype` and
+// -- ctypedoc` into one production, allowing comments on types everywhere (and
+// -- rejecting them after parsing, where necessary).  This is however not possible
+// -- since it leads to ambiguity. The reason is the support for comments on record
+// -- fields:
+// --         data R = R { field :: Int -- ^ comment on the field }
+// -- If we allow comments on types here, it's not clear if the comment applies
+// -- to 'field' or to 'Int'. So we must use `ctype` to describe the type.
+
+
+ctypedoc
+    :
+    'forall' tv_bndrs? forall_vis_flag ctypedoc
+    | tycl_context '=>' ctypedoc
+    | var '::' type
+    | typedoc
+    ;
+
+// In GHC this rule is context
+tycl_context
+    :
+    btype
+    ;
+
+// constr_context rule
+
+// {- Note [GADT decl discards annotations]
+// ~~~~~~~~~~~~~~~~~~~~~
+// The type production for
+
+//     btype `->`         ctypedoc
+//     btype docprev `->` ctypedoc
+
+// add the AnnRarrow annotation twice, in different places.
+
+// This is because if the type is processed as usual, it belongs on the annotations
+// for the type as a whole.
+
+// But if the type is passed to mkGadtDecl, it discards the top level SrcSpan, and
+// the top-level annotation will be disconnected. Hence for this specific case it
+// is connected to the first type too.
+// -}
+
+constr_context
+    :
+    constr_btype
+    ;
+
+// {- Note [GADT decl discards annotations]
+// ~~~~~~~~~~~~~~~~~~~~~
+// The type production for
+
+//     btype `->`         ctypedoc
+//     btype docprev `->` ctypedoc
+
+// add the AnnRarrow annotation twice, in different places.
+
+// This is because if the type is processed as usual, it belongs on the annotations
+// for the type as a whole.
+
+// But if the type is passed to mkGadtDecl, it discards the top level SrcSpan, and
+// the top-level annotation will be disconnected. Hence for this specific case it
+// is connected to the first type too.
+// -}
+
+type
+    :
+    btype
+    | btype '->' ctype
+    ;
+
+typedoc
+    :
+    btype
+    | btype '->' ctypedoc
+    ;
+
+constr_btype
+    :
+    constr_tyapps
+    ;
+
+constr_tyapps
+    :
+    constr_tyapp+
+    ;
+
+constr_tyapp
+    :
+    tyapp
+    ;
+
+btype
+    :
+    tyapps
+    ;
+
+tyapps
+    :
+    tyapp+
+    ;
+
+tyapp
+    :
+    atype
+    | ('@' atype)
+    | qtyconop
+    | tyvarop
+    | ('\'' qconop)
+    | ('\'' varop)
+    | unpackedness
+    ;
+
+atype
+    :
+    ntgtycon
+    | tyvar
+    | '*'
+    | ('~' atype)
+    | ('!' atype)
+    | ('{' fielddecls? '}')
+    | ('(' ')')
+    | ('(' ktype ',' comma_types ')')
+    | ('(#' '#)')
+    | ('(#' comma_types '#)')
+    | ('(#' bar_types2 '#)')
+    | ('[' ktype ']')
+    | ('(' ktype ')')
+    | quasiquote
+    | splice_untyped
+    | ('\'' qcon_nowiredlist)
+    | ('\'' '(' ktype ',' comma_types ')')
+    | ('\'' '[' comma_types? ']')
+    | ('\'' var)
+    // Two or more [ty, ty, ty] must be a promoted list type, just as
+    // if you had written '[ty, ty, ty]
+    // (One means a list type, zero means the list type constructor,
+    // so you have to quote those.)
+    | ('[' ktype ',' comma_types ']')
+    | integer
+    | pstring
+    | '_'
+    ;
+
+inst_type
+    :
+    sigtype
+    ;
+
+deriv_types
+    :
+    ktypedoc (',' ktypedoc)*
+    ;
+
+comma_types
+    :
+    ktype (',' ktype)*
+    ;
+
+bar_types2
+    :
+    ktype '|' ktype ('|' ktype)*
+    ;
+
+tv_bndrs
+    :
+    tv_bndr+
+    ;
+
+tv_bndr
+    :
+    tv_bndr_no_braces
+    | ('{' tyvar '}')
+    | ('{' tyvar '::' kind '}')
+    ;
+
+tv_bndr_no_braces
+    :
+    tyvar
+    | ('(' tyvar '::' kind ')')
+    ;
+
+fds
+    :
+    '|' fds1
+    ;
+
+fds1
+    :
+    fd (',' fd)*
+    ;
+
+fd
+    :
+    varids0? '->' varids0?
+    ;
+
+varids0
+    :
+    tyvar+
+    ;
+
+
+// -------------------------------------------
+// Kinds
+
+kind
+    :
+    ctype
+    ;
+
+// {- Note [Promotion]
+//    ~~~~~~~~~~~~~~~~
+
+// - Syntax of promoted qualified names
+// We write 'Nat.Zero instead of Nat.'Zero when dealing with qualified
+// names. Moreover ticks are only allowed in types, not in kinds, for a
+// few reasons:
+//   1. we don't need quotes since we cannot define names in kinds
+//   2. if one day we merge types and kinds, tick would mean look in DataName
+//   3. we don't have a kind namespace anyway
+
+// - Name resolution
+// When the user write Zero instead of 'Zero in types, we parse it a
+// HsTyVar ("Zero", TcClsName) instead of HsTyVar ("Zero", DataName). We
+// deal with this in the renamer. If a HsTyVar ("Zero", TcClsName) is not
+// bounded in the type level, then we look for it in the term level (we
+// change its namespace to DataName, see Note [Demotion] in GHC.Types.Names.OccName).
+// And both become a HsTyVar ("Zero", DataName) after the renamer.
+
+// -}
+
+// -------------------------------------------
+// Datatype declarations
+
+gadt_constrlist
+    :
+    'where' open gadt_constrs? semi* close
+    ;
+
+gadt_constrs
+    :
+    gadt_constr_with_doc (semi gadt_constr_with_doc)*
+    ;
+
+// We allow the following forms:
+//      C :: Eq a => a -> T a
+//      C :: forall a. Eq a => !a -> T a
+//      D { x,y :: a } :: T a
+//      forall a. Eq a => D { x,y :: a } :: T a
+
+gadt_constr_with_doc
+    :
+    gadt_constr
+    ;
+
+gadt_constr
+    :
+    con_list '::' sigtypedoc
+    ;
+
+
+// {- Note [Difference in parsing GADT and data constructors]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// GADT constructors have simpler syntax than usual data constructors:
+// in GADTs, types cannot occur to the left of '::', so they cannot be mixed
+// with constructor names (see Note [Parsing data constructors is hard]).
+
+// Due to simplified syntax, GADT constructor names (left-hand side of '::')
+// use simpler grammar production than usual data constructor names. As a
+// consequence, GADT constructor names are restricted (names like '(*)' are
+// allowed in usual data constructors, but not in GADTs).
+// -}
+
+// NOT AS IN GHC
+// constrs
+//     :
+//     constr ('|' constr)*
+//     ;
+
+constrs
+    :
+    '=' constrs1
+    ;
+
+constrs1
+    :
+    constr ('|' constr)*
+    ;
+
+// {- Note [Constr variations of non-terminals]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// In record declarations we assume that 'ctype' used to parse the type will not
+// consume the trailing docprev:
+
+//   data R = R { field :: Int -- ^ comment on the field }
+
+// In 'R' we expect the comment to apply to the entire field, not to 'Int'. The
+// same issue is detailed in Note [ctype and ctypedoc].
+
+// So, we do not want 'ctype'  to consume 'docprev', therefore
+//     we do not want 'btype'  to consume 'docprev', therefore
+//     we do not want 'tyapps' to consume 'docprev'.
+
+// At the same time, when parsing a 'constr', we do want to consume 'docprev':
+
+//   data T = C Int  -- ^ comment on Int
+//              Bool -- ^ comment on Bool
+
+// So, we do want 'constr_stuff' to consume 'docprev'.
+
+// The problem arises because the clauses in 'constr' have the following
+// structure:
+
+//   (a)  context '=>' constr_stuff   (e.g.  data T a = Ord a => C a)
+//   (b)               constr_stuff   (e.g.  data T a =          C a)
+
+// and to avoid a reduce/reduce conflict, 'context' and 'constr_stuff' must be
+// compatible. And for 'context' to be compatible with 'constr_stuff', it must
+// consume 'docprev'.
+
+// So, we want 'context'  to consume 'docprev', therefore
+//     we want 'btype'    to consume 'docprev', therefore
+//     we want 'tyapps'   to consume 'docprev'.
+
+// Our requirements end up conflicting: for parsing record types, we want 'tyapps'
+// to leave 'docprev' alone, but for parsing constructors, we want it to consume
+// 'docprev'.
+
+// As the result, we maintain two parallel hierarchies of non-terminals that
+// either consume 'docprev' or not:
+
+//   tyapps      constr_tyapps
+//   btype       constr_btype
+//   context     constr_context
+//   ...
+
+// They must be kept identical except for their treatment of 'docprev'.
+
+// -}
+
+// constr
+//     :
+//     (con ('!'? atype)*)
+//     | ((btype | ('!' atype)) conop (btype | ('!' atype)))
+//     | (con '{' fielddecls? '}')
+//     ;
+
+constr
+    :
+    forall? (constr_context '=>')? constr_stuff
+    ;
+
+forall
+    :
+    'forall' tv_bndrs? '.'
+    ;
+
+constr_stuff
+    :
+    constr_tyapps
+    ;
+
+fielddecls
+    :
+    fielddecl (',' fielddecl)*
+    ;
+
+fielddecl
+    :
+    sig_vars '::' ctype
+    ;
+
+// A list of one or more deriving clauses at the end of a datatype
+derivings
+    :
+    deriving+
+    ;
+
+// The outer Located is just to allow the caller to
+// know the rightmost extremity of the 'deriving' clause
+deriving
+    :
+    ('deriving' deriv_clause_types)
+    | ('deriving' deriv_strategy_no_via deriv_clause_types)
+    | ('deriving' deriv_clause_types deriv_strategy_via)
+    ;
+
+deriv_clause_types
+    :
+    qtycon
+    | '(' ')'
+    | '(' deriv_types ')'
+    ;
+
+// -------------------------------------------
+// Value definitions (CHECK!!!)
+
+// {- Note [Declaration/signature overlap]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// There's an awkward overlap with a type signature.  Consider
+//         f :: Int -> Int = ...rhs...
+//    Then we can't tell whether it's a type signature or a value
+//    definition with a result signature until we see the '='.
+//    So we have to inline enough to postpone reductions until we know.
+// -}
+
+// {-
+//   ATTENTION: Dirty Hackery Ahead! If the second alternative of vars is var
+//   instead of qvar, we get another shift/reduce-conflict. Consider the
+//   following programs:
+
+//      { (^^) :: Int->Int ; }          Type signature; only var allowed
+
+//      { (^^) :: Int->Int = ... ; }    Value defn with result signature;
+//                                      qvar allowed (because of instance decls)
+
+//   We can't tell whether to reduce var to qvar until after we've read the signatures.
+// -}
+
+decl_no_th
+    :
+    sigdecl
+    | (infixexp opt_sig? rhs)
+    | pattern_synonym_decl
+    // | docdecl
+    | semi+
+    ;
+
+decl
+    :
+    decl_no_th
+
+    // Why do we only allow naked declaration splices in top-level
+    // declarations and not here? Short answer: because readFail009
+    // fails terribly with a panic in cvBindsAndSigs otherwise.
+    | splice_exp
+    | semi+
     ;
 
 rhs
     :
-    ('=' exp (WHERE decls)?)
-    | (gdrhs (WHERE decls)?);
+    ('=' exp wherebinds?)
+    | (gdrhs wherebinds?);
 
 gdrhs
     :
@@ -311,6 +1128,259 @@ gdrh
     '|' guards '=' exp
     ;
 
+sigdecl
+    :
+    (infixexp '::' sigtypedoc)
+    | (var ',' sig_vars '::' sigtypedoc)
+    | (fixity integer? ops)
+    | (pattern_synonym_sig)
+    | ('{-#' 'COMPLETE' con_list opt_tyconsig? '#-}')
+    | ('{-#' 'INLINE' activation? qvar '#-}')
+    | ('{-#' 'SCC' qvar pstring? '#-}')
+    | ('{-#' 'SPECIALISE' activation? qvar '::' sigtypes1 '#-}')
+    | ('{-#' 'SPECIALISE_INLINE' activation? qvar '::' sigtypes1 '#-}')
+    | ('{-#' 'SPECIALISE' 'instance' inst_type '#-}')
+    | ('{-#' 'MINIMAL' '#-}' name_boolformula_opt? '#-}')
+    |(semi+)
+    ;
+
+activation
+    :
+    ('[' integer ']')
+    | ('[' rule_activation_marker integer ']')
+    ;
+
+// -------------------------------------------
+// Expressions
+
+th_quasiquote
+    :
+    '[' varid '|'
+    ;
+
+th_qquasiquote
+    :
+    '[' qvarid '|'
+    ;
+
+quasiquote
+    :
+    th_quasiquote
+    | th_qquasiquote
+    ;
+
+exp
+    :
+    (infixexp '::' sigtype)
+    | (infixexp '-<' exp)
+    | (infixexp '>-' exp)
+    | (infixexp '-<<' exp)
+    | (infixexp '>>-' exp)
+    | infixexp
+    ;
+
+infixexp
+    :
+    exp10 (qop exp10p)*
+    ;
+
+exp10p
+    :
+    exp10
+    ;
+
+exp10
+    :
+    '-'? fexp
+    ;
+
+fexp
+    :
+    aexp+ ('@' atype)?
+    ;
+
+aexp
+    :
+    (qvar '@' aexp)
+    | ('~' aexp)
+    | ('!' aexp)
+    | ('\\' apats '->' exp)
+    | ('let' decllist 'in' exp)
+    | (LCASE alts)
+    | ('if' exp semi? 'then' exp semi? 'else' exp)
+    | ('if' ifgdpats)
+    | ('case' exp 'of' alts)
+    | ('do' stmtlist)
+    | ('mdo' stmtlist)
+    | aexp1
+    ;
+
+aexp1
+    :
+    aexp2 ('{' fbinds? '}')*
+    ;
+
+aexp2
+    :
+    qvar
+    | qcon
+    | varid
+    | literal
+    | pstring
+    | integer
+    | pfloat
+    // N.B.: sections get parsed by these next two productions.
+    // This allows you to write, e.g., '(+ 3, 4 -)', which isn't
+    // correct Haskell (you'd have to write '((+ 3), (4 -))')
+    // but the less cluttered version fell out of having texps.
+    | ('(' texp ')')
+    | ('(' tup_exprs ')')
+    | ('(#' texp '#)')
+    | ('(#' tup_exprs '#)')
+    | ('[' list ']')
+    | '_'
+    // Template Haskell
+    | splice_untyped
+    | splice_typed
+    | ('\'' qvar)
+    | ('\'' qcon)
+    | ('\'\'' tyvar)
+    | ('\'\'' gtycon)
+    | '\'\''
+    | '[|' exp '|]'
+    | '[||' exp '||]'
+    | '[t|' ktype '|]'
+    | '[p|' infixexp '|]'
+    | '[d|' cvtopbody '|]'
+    | quasiquote
+    | (AopenParen aexp cmdargs? AopenParen)
+    ;
+
+splice_exp
+    :
+    splice_typed
+    | splice_untyped
+    ;
+
+splice_untyped
+    :
+    '$' aexp
+    ;
+
+splice_typed
+    :
+    '$$' aexp
+    ;
+
+cmdargs
+    :
+    acmd+
+    ;
+
+acmd
+    :
+    aexp
+    ;
+
+cvtopbody
+    :
+    open cvtopdecls0? close
+    ;
+
+cvtopdecls0
+    :
+    topdecls semi*
+    ;
+
+// -------------------------------------------
+// Tuple expressions
+
+texp
+    :
+    exp
+    | (infixexp qop)
+    | (qopm infixexp)
+    | (exp '->' texp)
+    ;
+
+tup_exprs
+    :
+    (texp commas_tup_tail)
+    | (texp bars)
+    | (commas tup_tail?)
+    | (bars texp bars?)
+    ;
+
+commas_tup_tail
+    :
+    commas tup_tail?
+    ;
+
+tup_tail
+    :
+    texp commas_tup_tail
+    | texp
+    ;
+
+// -------------------------------------------
+// List expressions
+
+list
+    :
+    texp
+    | lexps
+    | texp '..'
+    | texp ',' exp '..'
+    | texp '..' exp
+    | texp ',' exp '..' exp
+    | texp '|' flattenedpquals
+    ;
+
+lexps
+    :
+    texp ',' texp (',' texp)*
+    ;
+
+
+// -------------------------------------------
+// List Comprehensions
+
+flattenedpquals
+    :
+    pquals
+    ;
+
+pquals
+    :
+    squals ('|' squals)*
+    ;
+
+squals
+    :
+    transformqual (',' transformqual)*
+    | transformqual (',' qual)*
+    | qual (',' transformqual)*
+    | qual (',' qual)*
+    ;
+
+transformqual
+    :
+    'then' exp
+    | 'then' exp 'by' exp
+    | 'then' 'group' 'using' exp
+    | 'then' 'group' 'by' exp 'using' exp
+    ;
+
+// Note that 'group' is a special_id, which means that you can enable
+// TransformListComp while still using Data.List.group. However, this
+// introduces a shift/reduce conflict. Happy chooses to resolve the conflict
+// in by choosing the "group by" variant, which is what we want.
+
+
+
+// -------------------------------------------
+// Guards (Different from GHC)
+
 guards
     :
     guard (',' guard)*
@@ -319,72 +1389,32 @@ guards
 guard
     :
     pat '<-' infixexp
-    | LET decls
+    | 'let' decllist
     | infixexp
     ;
 
-exp
-    :
-    (infixexp '::' (typecontext '=>')? type)
-    | infixexp
-    ;
-
-infixexp
-    :
-    (lexp qop infixexp)
-    | ('-' infixexp)
-    | lexp
-    ;
-
-lexp
-    :
-    ('\\' apat+ '->' exp)
-    | (LET decls IN exp)
-    | (IF exp semi? THEN exp semi? ELSE exp)
-    | (IF ifgdpats)
-    | (CASE exp OF alts)
-    | (DO stmts)
-    | fexp
-    ;
-
-fexp
-    :
-    aexp+
-    ;
-
-aexp
-    :
-    qvar
-    | gcon
-    | literal
-    | ( '(' exp ')' )
-    | ( '(' exp ',' exp (',' exp)* ')' )
-    | ( '[' exp (',' exp)* ']' )
-    | ( '[' exp (',' exp)? '..' exp? ']' )
-    | ( '[' exp '|' qual (',' qual)* ']' )
-    | ( '(' infixexp qop ')' )
-    | ( '(' qop infixexp ')' )
-    | ( qcon '{' (fbind (',' fbind))? '}' )
-    | ('{' fbind (',' fbind)* '}')+
-    ;
-
-qual
-    :
-    (pat '<-' exp)
-    | (LET decls)
-    | exp
-    ;
+// -------------------------------------------
+// Case alternatives
 
 alts
     :
-    open (alt semi+)+ close
+    (open (alt semi*)+ close)
+    | (open close)
     ;
 
-alt
+alt : pat alt_rhs ;
+
+alt_rhs
     :
-    (pat '->' exp (WHERE decls)?)
-    | (pat gdpats (WHERE decls)?)
+    ralt wherebinds?
     ;
+
+ralt
+    :
+    ('->' exp)
+    | gdpats
+    ;
+
 
 gdpats
     :
@@ -392,9 +1422,7 @@ gdpats
     ;
 
 // In ghc parser on GitLab second rule is 'gdpats close'
-// Unclearly possible errors with this implemmentation
-
-// Now extension is always works (follow semantic predicate in 'lexp' rule)
+// Unclearly, is there possible errors with this implemmentation
 ifgdpats
     :
     '{' gdpats '}'
@@ -406,48 +1434,24 @@ gdpat
     '|' guards '->' exp
     ;
 
-stmts
-    :
-    open (stmt)* exp semi* close
-    ;
-
-stmt
-    :
-    (exp semi+)
-    | (pat '<-' exp semi+)
-    | (LET decls semi+)
-    | semi+
-    ;
-
-fbind
-    :
-    qvar '=' exp
-    ;
-
 pat
     :
-    (lpat qconop pat)
-    | lpat
+    exp
     ;
 
-lpat
+bindpat
     :
-    apat
-    | ('-' (integer | pfloat))
-    | (gcon apat+)
+    exp
     ;
 
 apat
     :
-    (var ('@' apat)?)
-    | gcon
-    | (qcon '{' (fpat (',' fpat)*)? '}')
-    | literal
-    | '_'
-    | ('(' pat ')')
-    | ('(' pat ',' pat (',' pat)* ')')
-    | ('[' pat (',' pat)* ']')
-    | ('~'apat)
+    aexp
+    ;
+
+apats
+    :
+    apat+
     ;
 
 fpat
@@ -455,55 +1459,315 @@ fpat
     qvar '=' pat
     ;
 
-gcon
+// -------------------------------------------
+// Statement sequences
+
+stmtlist
     :
-    ('(' ')')
-    | ('[' ']')
-    | ('(' (',')+ ')')
-    | qcon
+    open stmts? close
     ;
 
-var	:    varid   | ( '(' varsym ')' );
-qvar:    qvarid  | ( '(' qvarsym ')');
-con :    conid   | ( '(' consym ')' );
-qcon:    qconid  | ( '(' gconsym ')');
-varop:   varsym  | ('`' varid '`')   ;
-qvarop:  qvarsym | ('`' qvarid '`')	 ;
-conop:   consym  | ('`' conid '`')	 ;
-qconop:  gconsym | ('`' qconid '`')	 ;
-op:      varop   | conop			 ;
-qop:     qvarop  | qconop			 ;
+stmts
+    :
+    stmt (semi+ stmt)* semi*
+    ;
+
+stmt
+    : qual
+    | ('rec' stmtlist)
+    | semi+
+    ;
+
+
+qual
+    :
+    bindpat '<-' exp
+    | exp
+    | 'let' binds
+    ;
+
+// -------------------------------------------
+// Record Field Update/Construction
+
+fbinds
+    :
+    (fbind (',' fbind)*)
+    | ('..')
+    ;
+
+// In GHC 'texp', not 'exp'
+
+// 1) RHS is a 'texp', allowing view patterns (#6038)
+// and, incidentally, sections.  Eg
+// f (R { x = show -> s }) = ...
+//
+// 2) In the punning case, use a place-holder
+// The renamer fills in the final value
+fbind
+    :
+    (qvar '=' exp)
+    | qvar
+    ;
+
+// -------------------------------------------
+// Implicit Parameter Bindings
+
+dbinds
+    :
+    dbind (semi+ dbind) semi*
+    ;
+
+dbind
+    :
+    varid '=' exp
+    ;
+
+// -------------------------------------------
+
+// Warnings and deprecations
+
+name_boolformula_opt
+    :
+    name_boolformula_and ('|' name_boolformula_and)*
+    ;
+
+name_boolformula_and
+    :
+    name_boolformula_and_list
+    ;
+
+name_boolformula_and_list
+    :
+    name_boolformula_atom (',' name_boolformula_atom)*
+    ;
+
+name_boolformula_atom
+    :
+    ('(' name_boolformula_opt ')')
+    | name_var
+    ;
+
+namelist
+    :
+    name_var (',' name_var)*
+    ;
+
+name_var
+    :
+    var | con
+    ;
+
+// -------------------------------------------
+// Data constructors
+// There are two different productions here as lifted list constructors
+// are parsed differently.
+
+qcon_nowiredlist : gen_qcon | sysdcon_nolist;
+
+qcon  : gen_qcon | sysdcon;
+
+gen_qcon : qconid | ( '(' qconsym ')' );
+
+con    : conid   | ( '(' consym ')' ) | sysdcon;
+
+con_list : con (',' con)*;
+
+sysdcon_nolist
+    :
+    ('(' ')')
+    | ('(' commas ')')
+    | ('(#' '#)')
+    | ('(#' commas '#)')
+    ;
+
+sysdcon
+    :
+    sysdcon_nolist
+    | ('[' ']')
+    ;
+
+conop  : consym  | ('`' conid '`')	 ;
+
+qconop : gconsym | ('`' qconid '`')	 ;
+
 gconsym: ':'  	 | qconsym			 ;
+
+// -------------------------------------------
+// Type constructors (Be careful!!!)
+
+gtycon
+    :
+    ntgtycon
+    | ('('  ')')
+    | ('(#' '#)')
+    ;
+
+ntgtycon
+    :
+    oqtycon
+    | ('(' commas ')')
+    | ('(#' commas '#)')
+    | ('(' '->' ')')
+    | ('[' ']')
+    ;
+
+oqtycon
+    :
+    qtycon
+    | ('(' qtyconsym ')')
+    ;
+
+// {- Note [Type constructors in export list]
+// ~~~~~~~~~~~~~~~~~~~~~
+// Mixing type constructors and data constructors in export lists introduces
+// ambiguity in grammar: e.g. (*) may be both a type constructor and a function.
+
+// -XExplicitNamespaces allows to disambiguate by explicitly prefixing type
+// constructors with 'type' keyword.
+
+// This ambiguity causes reduce/reduce conflicts in parser, which are always
+// resolved in favour of data constructors. To get rid of conflicts we demand
+// that ambiguous type constructors (those, which are formed by the same
+// productions as variable constructors) are always prefixed with 'type' keyword.
+// Unambiguous type constructors may occur both with or without 'type' keyword.
+
+// Note that in the parser we still parse data constructors as type
+// constructors. As such, they still end up in the type constructor namespace
+// until after renaming when we resolve the proper namespace for each exported
+// child.
+// -}
+
+qtyconop: qtyconsym | ('`' qtycon '`');
+
+qtycon : (modid '.')? tycon;
+
+tycon : conid;
+
+qtyconsym:qconsym | qvarsym | tyconsym;
+
+tyconsym: consym | varsym | ':' | '-' | '.';
+
+// -------------------------------------------
+// Operators
+
+op     : varop   | conop           ;
+
+varop  : varsym  | ('`' varid '`') ;
+
+qop    : qvarop  | qconop		   ;
+
+qopm   : qvaropm | qconop | hole_op;
+
+hole_op: '`' '_' '`';
+
+qvarop : qvarsym | ('`' qvarid '`');
+
+qvaropm: qvarsym_no_minus | ('`' qvarid '`');
+
+// -------------------------------------------
+// Type variables
+
+tyvar : varid;
+
+tyvarop: '`' tyvarid '`';
+
+// Expand this rule later
+// In GHC:
+// tyvarid : VARID | special_id | 'unsafe'
+//         | 'safe' | 'interruptible';
+
+tyvarid : varid | special_id | 'unsafe' | 'safe' | 'interruptible';
+
+tycls   : conid;
+
+qtycls  : (modid '.')? tycls;
+
+// -------------------------------------------
+// Variables
+
+var	   : varid   | ( '(' varsym ')' );
+
+qvar   : qvarid  | ( '(' qvarsym ')');
+
+// We've inlined qvarsym here so that the decision about
+// whether it's a qvar or a var can be postponed until
+// *after* we see the close paren
+qvarid : (modid '.')? varid;
+
+// Note that 'role' and 'family' get lexed separately regardless of
+// the use of extensions. However, because they are listed here,
+// this is OK and they can be used as normal varids.
+varid : (VARID | special_id) '#'*;
+
+qvarsym: (modid '.')? varsym;
+
+qvarsym_no_minus
+    : varsym_no_minus
+    | qvarsym
+    ;
+
+varsym : varsym_no_minus | '-';
+
+varsym_no_minus : ascSymbol+;
+
+// These special_ids are treated as keywords in various places,
+// but as ordinary ids elsewhere.   'special_id' collects all these
+// except 'unsafe', 'interruptible', 'forall', 'family', 'role', 'stock', and
+// 'anyclass', whose treatment differs depending on context
+special_id
+    : 'as'
+    | 'qualified'
+    | 'hiding'
+    | 'export'
+    | 'stdcall'
+    | 'ccall'
+    | 'capi'
+    | 'javascript'
+    | 'stock'
+    | 'anyclass'
+    | 'via'
+    ;
+
+// -------------------------------------------
+// Data constructors
+
+qconid : (modid '.')? conid;
+
+conid : CONID '#'*;
+
+qconsym: (modid '.')? consym;
+
+consym : ':' ascSymbol*;
+
+// -------------------------------------------
+// Literals
+
+literal : integer | pfloat | pchar | pstring;
+
+// -------------------------------------------
+// Layout
 
 open : VOCURLY | OCURLY;
 close : VCCURLY | CCURLY;
 semi : ';' | SEMI;
 
-literal : integer | pfloat | pchar | pstring;
-special : '(' | ')' | ',' | ';' | '[' | ']' | '`' | '{' | '}';
+// -------------------------------------------
+// Miscellaneous (mostly renamings)
 
-varid : (VARID | AS | HIDING) '#'*;
-conid : CONID '#'*;
+modid : (conid '.')* conid;
+
+commas: ','+;
+
+bars : '|'+;
+
+// -------------------------------------------
+
+special : '(' | ')' | ',' | ';' | '[' | ']' | '`' | '{' | '}';
 
 symbol: ascSymbol;
 ascSymbol: '!' | '#' | '$' | '%' | '&' | '*' | '+'
         | '.' | '/' | '<' | '=' | '>' | '?' | '@'
-        | '\\' | '^' | '|' | '-' | '~' | ':' ;
-
-varsym : ascSymbol+;
-consym : ':' ascSymbol*;
-
-tyvar : varid;
-tycon : conid;
-tycls : conid;
-modid : (conid '.')* conid;
-
-qvarid : (modid '.')? varid;
-qconid : (modid '.')? conid;
-qtycon : (modid '.')? tycon;
-qtycls : (modid '.')? tycls;
-qvarsym: (modid '.')? varsym;
-qconsym: (modid '.')? consym;
+        | '\\' | '^' | '|' | '~' | ':' ;
 
 integer
     :
@@ -513,6 +1777,6 @@ integer
     ;
 
 
-pfloat: FLOAT;
-pchar: CHAR;
+pfloat : FLOAT;
+pchar  : CHAR;
 pstring: STRING;

--- a/haskell/examples/DumpTypecheckedAst.hs
+++ b/haskell/examples/DumpTypecheckedAst.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DataKinds, PolyKinds, TypeOperators, TypeFamilies
+             , TypeApplications #-}
+
+module DumpTypecheckedAst where
+import Data.Kind
+
+data Peano = Zero | Succ Peano
+
+type family Length (as :: [k]) :: Peano where
+  Length (a : as) = Succ (Length as)
+  Length '[]      = Zero
+
+data T f (a :: k) = MkT (f a)
+
+type family F (a :: k) (f :: k -> Type) :: Type where
+  F @Peano a f = T @Peano f a
+
+main = putStrLn "hello"

--- a/haskell/examples/GADTs.hs
+++ b/haskell/examples/GADTs.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE GADTs #-}
+
+data Term a where
+    Lit    :: Int -> Term Int
+    Succ   :: Term Int -> Term Int
+    IsZero :: Term Int -> Term Bool
+    If     :: Term Bool -> Term a -> Term a -> Term a
+    Pair   :: Term a -> Term b -> Term (a,b)
+
+eval :: Term a -> a
+eval (Lit i)      = i
+eval (Succ t)     = 1 + eval t
+eval (IsZero t)   = eval t == 0
+eval (If b e1 e2) = if eval b then eval e1 else eval e2
+eval (Pair e1 e2) = (eval e1, eval e2)
+
+data T where

--- a/haskell/examples/MultiWayIf.hs
+++ b/haskell/examples/MultiWayIf.hs
@@ -1,9 +1,20 @@
 {-# LANGUAGE MultiWayIf #-}
 
-bmiTell :: Float -> String
-bmiTell bmi = if 
-  | bmi <= 18.5 -> if | bmi >= 10 -> "lala."
-                      | otherwise -> "lolo."
-  | bmi <= 25.0 -> "Average weight."
-  | bmi <= 30.0 -> "Overweight."
-  | otherwise   -> "Clinically overweight."
+module Main where
+
+x  = 10
+x1 = if | x < 10 -> "< 10" | otherwise -> ""
+x2 = if | x < 10 -> "< 10"
+        | otherwise -> ""
+x3 = if | x < 10 -> "< 10"
+        | otherwise -> ""
+x4 = if | True -> "yes"
+x5 = if | True -> if | False -> 1 | True -> 2
+
+x6 = if | x < 10 -> if | True -> "yes"
+                       | False -> "no"
+        | otherwise -> "maybe"
+
+x7 = (if | True -> 0)
+
+main = print $ x5 == 2 && x6 == "maybe" && x7 == 0

--- a/haskell/examples/RelaxedLayout.hs
+++ b/haskell/examples/RelaxedLayout.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE RelaxedLayout #-}
+
+module ShouldFail where
+
+f x = case x of
+         False -> do
+    { return x; }

--- a/haskell/examples/TemplateHaskell.hs
+++ b/haskell/examples/TemplateHaskell.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
+
+import System.IO
+import Proposal229f_instances
+
+-- Testing that we can parse $[...] and $"..."
+main = do
+  hPutStrLn stderr $['1','2','3']
+  hPutStrLn stderr $$['1','2','3']
+  hPutStrLn stderr $"123"
+  hPutStrLn stderr $$"123"

--- a/haskell/examples/negZero.hs
+++ b/haskell/examples/negZero.hs
@@ -1,0 +1,25 @@
+-- | Test for @NegativeLiterals@ extension (see GHC #13211)
+
+{-# LANGUAGE NegativeLiterals #-}
+
+floatZero0 = 0 :: Float
+floatZero1 = 0.0 :: Float
+
+floatNegZero0 = -0 :: Float
+floatNegZero1 = -0.0 :: Float
+
+doubleZero0 = 0 :: Double
+doubleZero1 = 0.0 :: Double
+
+doubleNegZero0 = -0 :: Double
+doubleNegZero1 = -0.0 :: Double
+
+main = do
+    print (isNegativeZero floatZero0)
+    print (isNegativeZero floatZero1)
+    print (isNegativeZero floatNegZero0)
+    print (isNegativeZero floatNegZero1)
+    print (isNegativeZero doubleZero0)
+    print (isNegativeZero doubleZero1)
+    print (isNegativeZero doubleNegZero0)
+    print (isNegativeZero doubleNegZero1)


### PR DESCRIPTION
Grammar was very changed, because when I was implementing a standard grammar, I relied on 'Haskell Language Report 2010', and [GHC official repo](https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser.y) was taken as a basis for extensions. But this grammars are very different about standard Haskell grammar implementation.

This version pass 98/122 tests from [GHC parser tests](https://gitlab.haskell.org/ghc/ghc/-/tree/master/testsuite%2Ftests%2Fparser%2Fshould_compile). 

Errors are similar: the lexer stops to process the token when it is not needed.
For example, I have lexer rule:
```
 AOpenBracket: '(|' 
```
Haskell allows to create your own operators:
```haskell
 (|:) :: Int -> Int -> Int 
```

So parser gets token stream like `AOpenBracket Colon CloseRoundBracket ...` - not what parser needs.

Could you tell, please, what to do in this situation?