### PR TITLE
IDL.g4 replace literal '*' with lexer rule

### DIFF
--- a/idl/IDL.g4
+++ b/idl/IDL.g4
@@ -218,7 +218,7 @@ add_expr
    ;
 
 mult_expr
-   : unary_expr (('*' | SLASH | PERCENT) unary_expr)*
+   : unary_expr ((STAR | SLASH | PERCENT) unary_expr)*
    ;
 
 unary_expr


### PR DESCRIPTION
The lexer ruler STAR exists in the grammar and was previous unused.