### PR TITLE
Add support for multiline comments

### DIFF
--- a/terraform/examples/example4.txt
+++ b/terraform/examples/example4.txt
@@ -1,0 +1,9 @@
+/* This is
+   a multiline
+   comment */
+
+variable "var" {
+  // single line comment
+  # single line comment
+  type = string
+}

--- a/terraform/terraform.g4
+++ b/terraform/terraform.g4
@@ -143,10 +143,13 @@ IDENTIFIER
    ;
 
 COMMENT
-   : ('#' | '//') ~ [\r\n]* -> skip
-   ;
+  : ('#' | '//') ~ [\r\n]* -> channel(HIDDEN)
+  ;
+
+BLOCKCOMMENT
+  : '/*' .*? '*/' -> channel(HIDDEN)
+  ;
 
 WS
    : [ \r\n\t]+ -> skip
    ;
-


### PR DESCRIPTION
Add rule for multline comments.

Move comments into the "hidden" channel instead of skipping them. This 
way they are returned to the caller.

Closes #1782 