### PR TITLE
Fixed detection of Decimal.

### DIFF
--- a/php/PhpLexer.g4
+++ b/php/PhpLexer.g4
@@ -298,7 +298,7 @@ BackQuote:          '`';
 VarName:            '$' [a-zA-Z_][a-zA-Z_0-9]*;
 Label:              [a-zA-Z_][a-zA-Z_0-9]*;
 Octal:              '0' [0-7]+;
-Decimal:            Digit+;
+Decimal:            '0' | NonZeroDigit Digit*;
 Real:               (Digit+ '.' Digit* | '.' Digit+) ExponentPart?
     |               Digit+ ExponentPart;
 Hex:                '0x' HexDigit+;
@@ -362,5 +362,6 @@ fragment NameStartChar
     | '\uFDF0'..'\uFFFD'
     ;
 fragment ExponentPart:         'e' [+-]? Digit+;
+fragment NonZeroDigit:         [1-9_];
 fragment Digit:                [0-9_];
 fragment HexDigit:             [a-fA-F0-9_];


### PR DESCRIPTION
'0' is legal, but '00', '000' and so on - aren't.
Still '00' and others will be picked up by the rule Octal:
Octal:              '0' [0-7]+;