### PR TITLE
Fix for XPath31 grammar missing CR/LF as whitespace.

### DIFF
--- a/xpath/xpath31/XPath31.g4
+++ b/xpath/xpath31/XPath31.g4
@@ -385,7 +385,7 @@ fragment FragChar : '\u0009' | '\u000a' | '\u000d'
   | '\u{10000}'..'\u{10ffff}'
  ;
 
-// Per spec https://www.w3.org/TR/REC-xml/#NT-S
+// https://github.com/antlr/grammars-v4/blob/17d3db3fd6a8fc319a12176e0bb735b066ec0616/xpath/xpath31/XPath31.g4#L389
 Whitespace :  ('\u000d' | '\u000a' | '\u0020' | '\u0009')+ -> skip ;
 
 // Not per spec. Specified for testing.

--- a/xpath/xpath31/XPath31.g4
+++ b/xpath/xpath31/XPath31.g4
@@ -224,7 +224,8 @@ eqname : QName | URIQualifiedName
  | KW_UNION
  ;
 
-auxilary : (expr NL+ )+ EOF;
+// Not per spec. Specified for testing.
+auxilary : (expr SEMI )+ EOF;
 
 
 AT : '@' ;
@@ -384,6 +385,8 @@ fragment FragChar : '\u0009' | '\u000a' | '\u000d'
   | '\u{10000}'..'\u{10ffff}'
  ;
 
-NL : ('\u000d' | '\u000a')+;
+// Per spec https://www.w3.org/TR/REC-xml/#NT-S
+Whitespace :  ('\u000d' | '\u000a' | '\u0020' | '\u0009')+ -> skip ;
 
-Whitespace :  ('\u0020' | '\u0009')+ -> skip ;
+// Not per spec. Specified for testing.
+SEMI : ';' ;

--- a/xpath/xpath31/examples/expressions.txt
+++ b/xpath/xpath31/examples/expressions.txt
@@ -1,1364 +1,1364 @@
-//*[text()]
-text
-//*[text()='RBRACE']
-' #text'
-' 6 ' div 2
-' 6 '*div
-' x 4'
-'"eos'
-''
-'+'
-'....5....|'
-'0'=true()
-'001' = 1
-'1' and '0'
-'2'>'1'
-'200'
-'ABC'
-'abcdæfgh'
-'abcdèfgh'
-'ace' != 'abc'
-'ace' != 'ace'
-'ancestor-or-self::*'
-'ancestor::*'
-'Apply-templates'
-'b'
-'baseParam1Data'
-'baseSubParam0Data'
-'bug'
-'Call-template'
-'child::*'
-'condition false'
-'condition true'
-'correct'
-'CY'
-'Data'
-'default'
-'descendant-or-self::*'
-'descendant::*'
-'descending'
-'duh'
-'en'
-'error'
-'error1!'
-'error2!'
-'error3!'
-'error4!'
-'error5!'
-'error6!'
-'fallback'
-'first'
-'following-sibling::*'
-'following::*'
-'foo' and 'fop'
-'Gadzookz'
-'global'
-'H' != '  H'
-'H' != 'H  '
-'In Import: Testing '
-'In Include: Testing '
-'incorrect'
-'left'
-'level0'
-'level1'
-'level3'
-'local'
-'lower-first'
-'main stylesheet, should have highest precedence'
-'mdocs15a.xml'
-'number'
-'okay'
-'parent::*'
-'preceding-sibling::*'
-'preceding::*'
-'pvar1 default data'
-'pvar2 default data'
-'red'
-'root'
-'set in var29side, should have highest precedence'
-'should be wrapped'
-'string'
-'stylesheet-var'
-'subsheet, should be overridden by main sheet'
-'TableofContents'
-'templ'
-'test value set in final'
-'test value set in impfinal'
-'test value set in impmid'
-'test value set in mid'
-'test value set in var27side'
-'test'
-'Testing '
-'the same'
-'this'
-'titi'
-'Tommy'
-'top'
-'US'
-'value set in var30mid, should have highest precedence'
-'Wizard'
-'Xalan_URL_found'
-'z w x'
-'z w x'//@*
-((((((n3+5)*(3)+(((n2)+2)*(n1 - 6)))-(n4 - n2))+(-(4-6)))))
-(((ancestor::foo)[1])/@att1)
-((ancestor::*|self::*)/@att1)[last()]
-((ancestor::foo))[1]/@att1
-((div)[1]//span)[1]
-(* - 4) div 2
-(* - 4)**
-(2 + number('xxx'))
-(24 div 3 +2) div (40 div 8 -3)
-(5 mod 2 = 1) and (5 mod -2 = 1) and (-5 mod 2 = -1) and (-5 mod -2 = -1)
-(ancestor-or-self::*)/@att1[last()]
-(ancestor-or-self::*)[@att1][1]/@att1
-(ancestor-or-self::*/@att1)[last()]
-(ancestor::*|self::*)/@att1[last()]
-(ancestor::foo)[1]/@att1
-(ancestor::foo[1])/@att1
-(chapter//footnote)[2]
-(child::chapter/descendant-or-self::node())/footnote[2]
-(descendant-or-self::*/@att1)[last()]
-(following-sibling::ch[current()])[1]
-(n1*n2*n3*n4*n5*n6)div n7 div n8 div n9 div n10
-(n1/@attrib)*(n2/@attrib)
-(n1/@attrib)+(n2/@attrib)
-(number(1.75) = (0.109375 * 16))
-(number(1.75) = (7 div 4))
-(number(k) = (0.0001 * 4))
-(number(k) = (4 div 10000))
-(preceding-sibling::*|following-sibling::*)/ancestor::*[last()]/*[last()]
-(preceding-sibling::foo)[1]/@att1
-(preceding::foo)[1]/@att1
-(section//@title)[7]
-*
-* +3
-*//la | //Bflat | re
-*/p
-*[1]
-*[3]
-*[4]
-*[@test and position()=1]
-*[@test and position()=4]
-*[@test and position()=7]
-*[@test and position()=8]
-*[@test='true']
-*[@test][1]/num
-*[@test][3]/num
-*[@test][4]/num
-*[@test][position()=1]/num
-*[@test][position()=3]/num
-*[@test][position()=4]/num
-*[last()=position()]
-*[last()]
-*[local-name()='bar']
-*[not(@test)][last()=position()]
-*[not(@test)][last()]
-*[position()=1]
-*[position()=3]
-*[position()=4]
-*[starts-with(name(.),'f')]
-*|@*
-*|@*|comment()|processing-instruction()|text()
-*|@*|comment()|text()
--(n-2/@attrib) - -(n-1/@attrib)
--(n1|n2)
--.0000000000000000000000000000000000000000123456789
--.000000000000000000000000000000000000000123456789
--.00000000000000000000000000000000000000123456789
--.0000000000000000000000000000000000000123456789
--.000000000000000000000000000000000000123456789
--.00000000000000000000000000000000000123456789
--.0000000000000000000000000000000000123456789
--.000000000000000000000000000000000123456789
--.00000000000000000000000000000000123456789
--.0000000000000000000000000000000123456789
--.000000000000000000000000000000123456789
--.00000000000000000000000000000123456789
--.0000000000000000000000000000123456789
--.000000000000000000000000000123456789
--.00000000000000000000000000123456789
--.0000000000000000000000000123456789
--.000000000000000000000000123456789
--.00000000000000000000000123456789
--.0000000000000000000000123456789
--.000000000000000000000123456789
--.00000000000000000000123456789
--.0000000000000000000123456789
--.000000000000000000123456789
--.00000000000000000123456789
--.0000000000000000123456789
--.000000000000000123456789
--.00000000000000123456789
--.0000000000000123456789
--.000000000000123456789
--.00000000000123456789
--.0000000000123456789
--.000000000123456789
--.00000000123456789
--.0000000123456789
--.000000123456789
--.00000123456789
--.0000123456789
--.000123456789
--.00123456789
--.01
--.012
--.0123
--.01234
--.012345
--.0123456
--.01234567
--.012345678
--.0123456789
--.1
--.10123456789
--.101234567892
--.1012345678923
--.10123456789234
--.101234567892345
--.1012345678923456
--.10123456789234567
--.101234567892345678
--.1012345678923456789
--.10123456789234567893
--.123456789
--1
--12
--123
--1234
--12345
--123456
--1234567
--12345678
--123456789
--1234567890
--12345678901
--123456789012
--1234567890123
--12345678901234
--123456789012345
--1234567890123456
--12345678901234567
--123456789012345678
--7 --3
--9.87654321012345
--98.7654321012345
--987.654321012345
--9876.54321012345
--98765.4321012345
--987654.321012345
--9876543.21012345
--98765432.1012345
--987654321.012345
--9876543210.12345
--98765432101.2345
--987654321012.345
--9876543210123.45
--98765432101234.5
--n-2 --n-1
--n-2/@attrib --n-1/@attrib
-.
-.+6
-..
-../..
-../../a/b[1]
-..//foo
-..//text()
-../@id
-../@width
-../node()
-./*
-./*[name(.) = 'never']
-.//*[@so]
-.//a
-.//center
-.//comment()
-.//f
-.//near-south/preceding-sibling::*|following-sibling::east/ancestor-or-self::*[2]
-.//text()
-.//title
-./@id
-./@name
-./@theattrib
-./a/text()
-./comment()
-./Name
-./processing-instruction('*')
-./processing-instruction('a-pi')
-./processing-instruction()
-./processing-instruction()[2]
-./text()
-.0000000000000000000000000000000000000000123456789
-.000000000000000000000000000000000000000123456789
-.00000000000000000000000000000000000000123456789
-.0000000000000000000000000000000000000123456789
-.000000000000000000000000000000000000123456789
-.00000000000000000000000000000000000123456789
-.0000000000000000000000000000000000123456789
-.000000000000000000000000000000000123456789
-.00000000000000000000000000000000123456789
-.0000000000000000000000000000000123456789
-.000000000000000000000000000000123456789
-.00000000000000000000000000000123456789
-.0000000000000000000000000000123456789
-.000000000000000000000000000123456789
-.00000000000000000000000000123456789
-.0000000000000000000000000123456789
-.000000000000000000000000123456789
-.00000000000000000000000123456789
-.0000000000000000000000123456789
-.000000000000000000000123456789
-.00000000000000000000123456789
-.0000000000000000000123456789
-.000000000000000000123456789
-.00000000000000000123456789
-.0000000000000000123456789
-.000000000000000123456789
-.00000000000000123456789
-.0000000000000123456789
-.000000000000123456789
-.00000000000123456789
-.0000000000123456789
-.000000000123456789
-.00000000123456789
-.0000000123456789
-.000000123456789
-.00000123456789
-.0000123456789
-.000123456789
-.00123456789
-.01
-.012
-.0123
-.01234
-.012345
-.0123456
-.01234567
-.012345678
-.0123456789
-.1
-.10123456789
-.101234567892
-.1012345678923
-.10123456789234
-.101234567892345
-.1012345678923456
-.10123456789234567
-.101234567892345678
-.1012345678923456789
-.10123456789234567893
-.123456789
-/
-/*/@group
-/..
-//*
-//*[count(./*/*) > 0]
-//*[count(ancestor::*) >= 2]/../parent::*
-//@*
-//@x
-//a | //div
-//a[@name or @href]
-//ancestor::*
-//b
-//baz
-//button[contains(text(),"Go")]
-//button[text()="Submit"]
-//c/@x
-//center
-//center//processing-instruction('b-pi')
-//center/@center-attr-1
-//center/@center-attr-3
-//center/comment()
-//center/comment()[1]
-//center/text()[1]
-//child
-//child1
-//comment()
-//h1[not(@id)]
-//inc/node4
-//inner/following::node()
-//inner/preceding::node()
-//item[@type=current()/@name]
-//label[normalize-space(.)='Phone']/parent::lightning-input/parent::slot/parent::slot/parent::span/parent::div/parent::force-record-layout-item/parent::slot/parent::force-record-layout-row/parent::slot/parent::div/parent::div/parent::div/parent::force-record-layout-section/parent::slot/parent::force-record-layout-block/parent::forcegenerated-detailpanel_contact___012b0000000jhhvia4___full___view___recordlayout2/parent::records-lwc-record-layout/parent::slot/parent::records-record-layout-event-broker/parent::div/parent::div/following-sibling::force-form-footer//button
-//Level3
-//match
-//near-north
-//north/dup2 | south/preceding-sibling::*[4]/* | north/dup1 | north/*
-//OL
-//OL[@real='yes']
-//para[lang('en')]
-//processing-instruction('b-pi')
-//processing-instruction()
-//product[@price > 2.50]
-//section/title
-//Test/@a
-//Test/@b
-//text()
-//title
-//tr[count(./td) = 3]
-//ul[*]
-//ul[li]
-//X
-//xx/descendant::*
-/a (: comment :) /b
-/a/b/c
-/bookstore/book/price[text()]
-/bookstore/book/title
-/bookstore/book[1]/title
-/bookstore/book[price>35]/price
-/bookstore/book[price>35]/title
-/data/*/datum/@value
-/data/point
-/descendant::*
-/doc/*[@test='true']
-/doc/a
-/doc/a/b/@attr
-/doc/avj
-/doc/b
-/doc/b/bb/bbb
-/doc/critter[@type='cat']
-/doc/datum/@value
-/doc/foo
-/doc/mid/inner
-/doc/north
-/doc/num
-/doc/str
-/docs/a
-/far-north/north/near-north/center/ancestor-or-self::*
-/foo/*/test/text()
-/page/contents/avail/hotel
-/para/font[@color='green']
-/report/month
-/root/base
-/sss/sss/i
-0 = -0
-0 > -0
-0 div 0
-0 div 0 < 0
-0 div 0 >= 0
-0 or ''
-0000000000
-0=false()
-1
-1 != 1.00
-1 = '001'
-1 = 1.00
-1 div -0 = 1 div 0
-1 div -0 = 2 div -0
-1!=1
-1!=2
-1-2
-1.9999999 < 2
-1.9999999 < 2.0
-10
-10+5+25+20+15+50+35+40
-10+7
-100-9-7-4-17-18-5
-100-n6 -4-n1 -1-11
-12
-123
-1234
-12345
-123456
-1234567
-12345678
-123456789
-1234567890
-12345678901
-123456789012
-1234567890123
-12345678901234
-123456789012345
-1234567890123456
-12345678901234567
-123456789012345678
-16-div
-1<1
-1<2
-1<=1
-1<=2
-1=1
-1=2
-1>1
-1>2
-1>=2
-2
-2 * -number('xxx')
-2 - number('xxx')
-2 < 2.0
-2 div number('xxx')
-2 mod number('xxx')
-2*3
-2+n5+7+n3
-2.0000001 < 2.0
-20
-25-*
-256
-2<1
-2<=1
-2>1
-2>=1
-2>=2
-3
-3*2+5*4-4*2-1
-3+6
-3-1
-32
-4
-48 mod 17 - 2 mod 9 + 13 mod 5
-5
-5 mod 2
-5.*.
-5.+*
-54 div*
-555
-56 mod round(n5*2+1.444) - n6 mod 4 + 7 mod n4
-6
-6 div -2
-6 div 2
-60
-7
-7 - -3
-7+-3
-8
-80 div n2 + 12 div 2 - n4 div n2
-9
-9.87654321012345
-98.7654321012345
-987.654321012345
-9876.54321012345
-98765.4321012345
-987654.321012345
-9876543.21012345
-98765432.1012345
-987654321.012345
-9876543210
-9876543210.12345
-98765432101.2345
-987654321012.345
-9876543210123.45
-98765432101234.5
-@*
-@*-5
-@*/.
-@*/ancestor-or-self::*
-@*/ancestor::*
-@*/ancestor::*/near-north/*[4]/@*/following::node()
-@*/ancestor::*/near-north/*[4]/@*/preceding::*
-@*/ancestor::*/near-north/*[4]/@*/preceding::comment()
-@*/ancestor::*/near-north/*[4]/@*/preceding::node()
-@*/ancestor::*/near-north/*[4]/@*/preceding::processing-instruction()
-@*/ancestor::*/near-north/*[4]/@*/preceding::text()
-@*/child::*
-@*/descendant-or-self::node()
-@*/descendant::node()
-@*/following-sibling::*
-@*/following::*
-@*/following::comment()
-@*/following::processing-instruction()
-@*/following::text()
-@*/parent::*
-@*/preceding-sibling::node()
-@*/preceding::*
-@*/self::node()
-@*[2]
-@*|comment()|processing-instruction()|text()|*
-@*|node()
-@*|node()|comment()|processing-instruction()
-@*|node()|text()
-@att1
-@attr
-@attribute1
-@center-attr-2
-@div - 5
-@div -5
-@div-5
-@flag
-@group
-@h | @w
-@height*@width
-@id
-@key
-@level
-@mark
-@name
-@net
-@num
-@ordering
-@person
-@pos
-@repeat
-@s
-@seq
-@side
-@size
-@spot
-@state
-@test
-@title
-@val
-@value
-@width
-@xml:att1
-@xx
-@x|@z
-@z
-A
-a
-a-set
-a-set/a/text()
-a/*[last()]
-a/child::*[last()]
-a/child::comment()[last()]
-a/child::node()[last()]
-a/child::text()[last()]
-a/comment()
-a/descendant::*[last()]
-a/text()
-a/x
-a=b
-a[$third]
-a['3.5' < 4]
-a['target'!=descendant::*]
-a['target'=descendant::*]
-a[('target'=descendant::*) or @squish]
-a[(@squeesh or @squish) and @squash]
-a[*=9]
-a[0 < true()]
-a[0]
-a[1]
-a[3-2]
-a[3.0='3.0']
-a[3=following-sibling::*]
-a[3]
-a[4]
-a[@squeesh or (@squish and @squash)]
-a[@squeesh or @squish and @squash]
-a[descendant::*!='target']
-a[descendant::*='target']
-a[div=9]
-a[false()!=following-sibling::*]
-a[following-sibling::*!=false()]
-a[following-sibling::*=3]
-a[following-sibling::*=descendant::*]
-a[following-sibling::*=true()]
-a[not(('target'=descendant::*) or @squish)]
-a[not(@*)]
-a[number('3')]
-a[position() <=3]
-a[position()!=2]
-a[position()<3]
-a[position()=$first]
-a[position()=1]
-a[position()=3]
-a[position()=4]
-a[position()>2]
-a[position()>=2]
-a[true()='stringwithchars']
-a[true()=4]
-a[true()=following-sibling::*]
-affiliation
-alpha
-alternate/name/first
-alternate/name/last
-ancestor-or-self::*
-ancestor-or-self::*/@att1[last()]
-ancestor-or-self::*[1]
-ancestor-or-self::*[1]/text()
-ancestor-or-self::*[2]/text()
-ancestor-or-self::*[3]/text()
-ancestor-or-self::*[4]/text()
-ancestor-or-self::*[5]/text()
-ancestor-or-self::*[6]/text()
-ancestor-or-self::*[7]/text()
-ancestor-or-self::*[@att1][1]/@att1
-ancestor-or-self::*[@xml:lang]/@xml:lang
-ancestor-or-self::node()
-ancestor-or-self::sub | ancestor-or-self::sub-sub
-ancestor::*
-ancestor::*[3]
-ancestor::*[count(child::*) > 1]/*[not(. = current()/ancestor-or-self::*)]
-ancestor::foo[1]/@att1
-ancestor::node()
-ancestor::sub1|ancestor::sub2
-attribute :: *
-attribute :: div
-attribute*(div - 4)
-attribute::*
-attribute::*[2]
-attribute::center-attr-2
-av//*
-av//h
-av//j
-avj//k
-avj/bool/*
-avj/good/*
-avj/none
-b
-b/c
-bar
-bar[(@a='1' and @b='1') or (@c='1' and @d='1')]
-bar[(@a='1' or @b='1') and (@c='1' or @d='1')]
-bar[(@a='1' or @b='1') and @c='1']
-bar[@a='1' and (@b='1' or @c='1') and @d='1']
-bar[@a='1' and @b='1' or @c='1' and @d='1']
-bar[@a='1' and @b='1']
-bar[@a='1' or (@b='1' and @c='1') or @d='1']
-bar[@a='1' or @b='1' and @c='1' or @d='1']
-bar[@a='1' or @b='1' or @c='1']
-base//description
-birthday
-body
-bonus
-boolean('')
-boolean('0')
-boolean('1')
-boolean(-0)
-boolean(0 div 0)
-boolean(0)
-boolean(1 div 0)
-boolean(1)
-boolean(doc)
-boolean(foo)
-c
-c/b
-ceiling(-1.5)=-1
-ceiling(0.0)
-ceiling(1)=1
-ceiling(1.1)=2
-ceiling(1.54)
-ceiling(2.999999)
-ceiling(n0)
-ceiling(n1)
-ceiling(n2)
-ceiling(number('xxx'))
-center//*
-center//child::*
-center//descendant::*
-center/child::*
-center/descendant::*
-chapter
-chapter//footnote[1]
-chapter//footnote[2]
-chapter/descendant::footnote[6]
-chapter/note
-Child
-child
-child :: sub
-child1[child::child2]
-child::*
-child::*/child::*
-child::*/descendant::*
-child::*[2]
-child::near-south-west
-child::node()
-child::sub
-chooser
-CLASSIFICATION
-comment ()
-comment()
-concat("a","b","c","d","ef")
-concat("bc", string(23))
-concat("cd", "34")
-concat("cd", 34)
-concat(/*, /*[@attr='whatsup'])
-concat(a, 34)
-concat(a, b)
-concat(a, b, c, d, e)
-concat(false(),'ly')
-concat(left,right,orig)
-concat(team[1], ' versus ', team[2])
-concat(team[1]/@score, '-', team[2]/@score)
-contains('','')
-contains('ab', 'abc')
-contains('abc', '')
-contains('abc', 'bc')
-contains('abc', 'bcd')
-contains('ENCYCLOPEDIA', 'CYCL')
-contains('ENCYCLOPEDIA', 'TEST')
-contains('foo','o')
-contains('true()', 'e')
-contains(., '&')
-contains(., '°')
-contains(concat(.,'BC'),concat('A','B','C'))
-contains(doc, 'CYCL')
-contains(doc, 'TEST')
-contains(doc/@attr, 'amwi')
-contains(doc/@attr, 'TEST')
-contains(main,sub)
-count(*)
-count(*/z[2])
-count(.//@*)
-count(.//@title)
-count(.//comment())
-count(//@*)
-count(//@title)
-count(//section//@*)
-count(//section//@title)
-count(//tr)
-count(//tr[count(./td) = 3])
-count(/doc/alpha[last()]/h)
-count(/doc/chapter/note)
-count(a-set/a/text())
-count(a/@*)
-count(a/attribute::*)
-count(a/comment())
-count(a/text())
-count(a[@ex!=''])
-count(a[@ex=''])
-count(a[@ex])
-count(a[@why!='value'])
-count(a[@why='value'])
-count(a[not(@ex)])
-count(a[not(@ex='')])
-count(a[not(string-length(@ex)=0)])
-count(a[string-length(@ex) > 0])
-count(a[string-length(@ex)=0])
-count(alpha/*[last()][name()='z'])
-count(ancestor-or-self::*/@att1)
-count(ancestor-or-self::node())
-count(descendant-or-self::*)
-count(descendant-or-self::*/@att1)
-count(descendant-or-self::*/namespace::*)
-count(descendant::*)
-count(div)
-count(following-sibling::*)
-count(following::node()|following::*/@*)
-count(id('c'))
-count(id('d b c k'))
-count(id('k'))
-count(namespace::*[name(.)!='xml'])
-count(preceding::text())
-count(section[1]//@*)
-count(section[1]//@title)
-count(section[2]//@*)
-count(section[2]//@title)
-count(section[3]//@*)
-count(section[3]//@title)
-critter
-customers/customer
-d
-dat
-date
-day
-descendant-or-self::*
-descendant-or-self::*/@att1[last()]
-descendant-or-self::*[3]
-descendant-or-self::*[last()]/@att1
-descendant-or-self::center
-descendant-or-self::far-south
-descendant-or-self::sub1|descendant-or-self::sub2
-descendant::*
-descendant::*/child::*
-descendant::*[3]
-descendant::*[string-length(name(.))=1]
-descendant::child1|descendant::child2
-descendant::far-south
-dis
-display
-div +3
-div div mod
-div mod mod
-div/@attrib div mod/@attrib
-div/@attrib mod mod/@attrib
-div/para[lang('en')]
-doc
-doc/*
-doc//a3[../@pick='yes']
-doc//Q
-doc/@*
-doc/a
-doc/a//text()
-doc/alpha
-doc/av
-doc/av//*
-doc/body/para
-doc/c/d/e
-doc/comment()
-doc/element1[2]/child1[last()]
-doc/foo
-doc/memo
-doc/num
-doc/OL//tag
-doc/p
-doc1
-docs//d
-docs//d/text()
-docs/a/node()
-e
-element
-expense-report/total
-fa
-fa/../mi | Aflat/natural/la | Csharp//* | /doc/do | *//ti
-false()
-false() and 1 div 0
-false() and false()
-false() and true()
-false() or false()
-false() or true()
-false()!=false()
-false()!=true()
-false()=''
-false()=0
-file
-floor(-1.5)
-floor(-1.5)=-2
-floor(0.0)
-floor(1)=1
-floor(1.9)
-floor(1.9)=1
-floor(2.999999)
-floor(n0)
-floor(n1)
-floor(n2)
-floor(number('xxx'))
-following-sibling::*
-following-sibling::*/preceding-sibling::*
-following-sibling::*[1]
-following-sibling::*[2]
-following-sibling::*[2]/preceding-sibling::*
-following-sibling::*[2]/preceding-sibling::*[4]
-following-sibling::*[2]/preceding-sibling::*[4]/following-sibling::*[5]/preceding-sibling::*[4]/preceding-sibling::*[2]
-following-sibling::*[count(current())]
-following-sibling::ch[current()]
-following-sibling::east
-following-sibling::node()
-following::*
-following::*[4]
-following::*[4]/../*[2]
-following::out-yonder-east
-FOO
-foo
-foo/@test
-foo/a/num/@val
-foo[(bar[2])='this']
-foo[(bar[2][(baz[2])='goodbye'])]
-grandchild
-growth
-human
-id('c a d')
-id('c')/@id
-id('d b c')
-id('id0')/a/b
-id('id0')/c/c/a
-id('id10')/a
-id('id13')
-id('id2')/a | id('id5') | id('id15')/a
-id('id4')
-id('id8')/b/b
-id('id9')
-id('nomatch')/@id
-id(main/@list)
-id(main/b)
-inner
-item
-item[$n1]
-item[$n2]
-item[$n3]
-item[$n4]
-item[$n5]
-item[$n6]
-item[$n7]
-item[$n8]
-item[$n9]
-item[$n]
-item[1][last()]
-item[last()-1]
-item[last()-1][1]
-item[last()-1][last()]
-item[last()]
-item[last()][last()]
-item[position()=$n]
-j[@l='12'] != j[@l='17']
-j[@l='12'] != j[@w='33']
-j[@l='12'] != j[@w='45']
-j[@l='12'] = j[@l='17']
-j[@l='12'] = j[@w='33']
-j[@l='12'] = j[@w='45']
-j[@l='16'] != j[@w='78']
-keyword[@tag='sector']
-keyword[@tag='ticker']
-lang('en')
-last-bad
-letter
-link
-local-name()
-local-name(.)
-local-name(a/@at1)
-local-name(namespace::*[1])
-local-name(namespace::*[name(.)!='xml'])
-local-name(namespace::*[string()='http://www.w3.org/1999/XMLSchema-instance'])
-local-name(namespace::*[string()='test'])
-m
-main/a/descendant-or-self::*/@*
-main/size[@for='d']
-mark
-member
-mi | do | fa | re
-mi[@mi2='mi2'] | do | fa/so/@so | fa | mi/@* | re | fa/@fa | do/@do
-middle
-miles-earned
-month
-n
-n-2 - -n-1
-n-2 - n-1
-n-2+-n-1
-n0 div n1 div n2 div n3
-n0 div n1 div n2 div n3 div n4
-n0 div n1 div n2 div n3 div n4 div n5
-n1 div n2
-n1 mod n2
-n1*n2
-n1*n2*n3*n4
-n1*n2*n3*n4*n5*n6*n7*n8*n9*n10
-n1+n2
-n1/@attrib + n2/@attrib
-n1/@attrib div n2/@attrib
-n1/@attrib mod n2/@attrib
-n4
-n6*5-8*n2+5*2
-name
-name()
-name(*)
-name(.)
-name(..)
-name(/descendant-or-self::node()/child::near-north)
-name(/descendant-or-self::node()/descendant-or-self::north)
-name(/descendant-or-self::north)
-name(/descendant-or-self::north/child::near-north)
-name(/descendant-or-self::north/descendant-or-self::north)
-name(/descendant::near-north)
-name(/descendant::near-north/descendant-or-self::near-north)
-name(/descendant::node()/descendant-or-self::near-north)
-name(a/@at1)
-name(ancestor::*[1])
-name(ancestor::*[2])
-name(ancestor::*[3])
-name(descendant-or-self::node()/child::near-north)
-name(descendant-or-self::node()/child::node()/child::far-west)
-name(descendant-or-self::node()/child::node()/descendant-or-self::near-north)
-name(descendant-or-self::node()/descendant-or-self::node()/child::near-north)
-name(descendant-or-self::node()/descendant-or-self::node()/descendant-or-self::north)
-name(descendant-or-self::node()/descendant-or-self::north)
-name(descendant-or-self::node()/descendant::near-north)
-name(descendant-or-self::node()/descendant::node()/child::far-west)
-name(descendant-or-self::node()/descendant::node()/descendant-or-self::near-north)
-name(descendant-or-self::north/child::near-north)
-name(descendant-or-self::north/child::near-north/child::far-west)
-name(descendant-or-self::north/child::near-north/descendant-or-self::near-north)
-name(descendant-or-self::north/descendant-or-self::north)
-name(descendant-or-self::north/descendant-or-self::north/child::near-north)
-name(descendant-or-self::north/descendant-or-self::north/descendant-or-self::north)
-name(descendant-or-self::north/descendant::near-north)
-name(descendant-or-self::north/descendant::near-north/child::far-west)
-name(descendant-or-self::north/descendant::near-north/descendant-or-self::near-north)
-name(descendant::near-north/descendant-or-self::near-north)
-name(descendant::near-north/descendant-or-self::near-north/child::far-west)
-name(descendant::near-north/descendant-or-self::near-north/descendant-or-self::near-north)
-name(descendant::near-north/descendant::far-west)
-name(descendant::near-north/descendant::far-west/descendant-or-self::far-west)
-name(descendant::node()/descendant-or-self::near-north)
-name(descendant::node()/descendant-or-self::node()/child::far-west)
-name(descendant::node()/descendant-or-self::node()/descendant-or-self::near-north)
-name(descendant::node()/descendant::far-west)
-name(descendant::node()/descendant::node()/descendant-or-self::far-west)
-name(following-sibling::*[last()])
-name(following::*[last()])
-name(namespace::*[1])
-name(namespace::*[name(.)!='xml'])
-name(preceding-sibling::*[last()])
-name(preceding::*[last()])
-name(self::node()/descendant-or-self::node()/child::near-north)
-name(self::node()/descendant-or-self::node()/descendant-or-self::north)
-name(self::node()/descendant-or-self::north)
-name(self::node()/descendant-or-self::north/child::near-north)
-name(self::node()/descendant-or-self::north/descendant-or-self::north)
-name(self::node()/descendant::near-north)
-name(self::node()/descendant::near-north/child::far-west)
-name(self::node()/descendant::near-north/descendant-or-self::far-west)
-name(self::node()/descendant::node()/child::far-west)
-name(self::node()/descendant::node()/descendant-or-self::far-west)
-Name/@First
-name/first
-name/last
-name/last | primary/name/last
-namespace-uri()
-namespace-uri(*)
-namespace-uri(.)
-namespace-uri(a/@at1)
-namespace-uri(bogus)
-namespace-uri(namespace::*[name(.)!='xml'])
-namespace-uri(namespace::*[string()='http://www.w3.org/1999/XMLSchema-instance'])
-namespace-uri(namespace::*[string()='test'])
-namespace-uri(x)
-namespace::*
-namespace::* | attribute::*
-namespace::bdd
-namespace::node()
-namespace::ped
-node
-node()
-node()|@*
-normalize-space()
-normalize-space(.)
-normalize-space(a)
-normalize-space(text())
-normalize-space(url)
-north/* | north/dup1 | north/dup2
-north/dup2 | north/dup1 | north/*
-not('')
-not('0')
-not(false() = false())
-not(false())
-not(true() = false())
-not(true())
-note
-note[1]
-num
-number('')
-number('3')
-number('abc')
-number('xxx') - 10
-number('xxx') div 3
-number('xxx') mod 3
-number('xxx')=0
-number('xxx')=number('xxx')
-number()
-number(0.0001 * 4)
-number(0.109375 * 16)
-number(1.75)
-number(2)
-number(4 div 10000)
-number(7 div 4)
-number(false())=0
-number(foo)
-number(k)
-number(n1)
-number(string(1.0))=1
-number(true())=1
-OL
-OL//tag
-ol/item
-OL/OL/LI
-order
-p
-para[@id='1' and lang('en')]
-para[@id='3' and lang('en')]
-para[@id='4' and lang('en')]
-parent::*
-parent::*[1]
-parent::foo
-parent::near-north
-parent::node()
-person
-Personal_Information/Age
-pos-bad
-preceding-sibling::*
-preceding-sibling::*/following-sibling::*
-preceding-sibling::*[2]
-preceding-sibling::*[2]/following-sibling::*
-preceding-sibling::*[2]/following-sibling::*[4]
-preceding-sibling::*[2]/following-sibling::*[4]/preceding-sibling::*[5]/following-sibling::*[4]/following-sibling::*[2]
-preceding-sibling::*|following-sibling::*
-preceding-sibling::child1|//child3
-preceding-sibling::child1|following-sibling::child3
-preceding-sibling::foo[1]/@att1
-preceding-sibling::west
-preceding::*
-preceding::*[2]/../descendant::*[10]/following-sibling::east
-preceding::*[2]/../following::*
-preceding::*[4]
-preceding::foo[1]/@att1
-preceding::out-yonder-west
-preceding::text()
-preceding::text()[$this]
-primary/name/first
-primary/name/last
-processing-instruction()
-r
-revenue
-root/x
-round(-1.1)=-1
-round(-1.5)
-round(-1.9)=-2
-round(-2.5)=-2
-round(0.0)
-round(1.1)=1
-round(1.24)
-round(1.5)=2
-round(1.9)=2
-round(2.5)
-round(2.999999)
-round(n0)
-round(n1)
-round(n2)
-round(number('xxx'))
-row
-sales/division
-self::*
-self::*[1]
-self::*[@center-attr-2]
-self::*[near-south]
-self::center
-self::comment()
-self::foo
-self::node()
-self::node()|child::*
-self::processing-instruction()
-self::text()
-side
-Spr/State[. = 'Open']
-sss//i
-sss/sss
-starts-with('','')
-starts-with('ab', 'abc')
-starts-with('abc', '')
-starts-with('abc', 'bc')
-starts-with('ENCYCLOPEDIA', 'EN')
-starts-with('ENCYCLOPEDIA', 'EN')
-starts-with('ENCYCLOPEDIA', 'en')
-starts-with('ENCYCLOPEDIA', 'en')
-starts-with('ENCYCLOPEDIA', 'ENCY')
-starts-with('true()', 'tr')
-starts-with(doc, 'ENCY')
-starts-with(doc, 'test')
-starts-with(doc/@attr, 'slam')
-starts-with(doc/@attr, 'wich')
-string('!From m!')
-string('!From n!')
-string('!From o!')
-string('!From p!')
-string('!From ss2!')
-string('!From ss3!')
-string('!From ss4!')
-string('!From ss5!')
-string('')
-string('test')
-string()
-string(-1 * number(.))
-string(0)
-string(2)
-string(av//*)
-string(doc)
-string(foo)
-string(number(.))
-string-length ()
-string-length('This is a test')
-string-length()
-string-length(.)
-string-length(doc)
-string-length(doc/a)
-string-length(normalize-space(.))
-subj
-substring('1999/04/01', 1, 0)
-substring('1999/04/01', 1, 4)
-substring('abcdefghi',2,4)
-substring('abcdefghijk',0 div 0, 5)
-substring('abcdefghijk',4, 6)
-substring('ENCYCLOPEDIA', 8)
-substring('ENCYCLOPEDIA', 8, 3)
-substring('x',2,1)
-substring(@key,2,1)
-substring(doc, 1, 4)
-substring(doc/@attr, 1, 3)
-substring(doc/@attr, 2.5, 3.6)
-substring(doc/@attr, 4)
-substring(foo, 2, 2)
-substring-after('1999/04/01', '/')
-substring-after('1999/04/01', '1')
-substring-after('abcdefghijk','l')
-substring-after('ENCYCLOPEDIA', '/')
-substring-after('ENCYCLOPEDIA', 'C')
-substring-after(.,'-')
-substring-after(doc, '/')
-substring-after(doc/@attr, 'D')
-substring-after(doc/@attr, 'D')
-substring-after(doc/@attr, 'd')
-substring-after(doc/@attr, 'd')
-substring-after(doc/@attr, 'z')
-substring-after(foo, '/')
-substring-before('1999/04/01', '/')
-substring-before('a','z')
-substring-before('ENCYCLOPEDIA', '/')
-substring-before('ENCYCLOPEDIA', 'C')
-substring-before('ENCYCLOPEDIA', 'C')
-substring-before('ENCYCLOPEDIA', 'c')
-substring-before('ENCYCLOPEDIA', 'c')
-substring-before(doc, '/')
-substring-before(doc/@attr, 'D')
-substring-before(doc/@attr, 'D')
-substring-before(doc/@attr, 'd')
-substring-before(doc/@attr, 'd')
-substring-before(doc/@attr, 'z')
-substring-before(foo, '/')
-sum(a-set/a)
-sum(e)
-sum(n)
-sum(n/@attrib)
-sum(x)
-t
-td
-team[1]
-team[2]
-tee/s
-testfile.html
-text()
-text()[1]
-text()[3]
-time
-title
-town[generate-id() = generate-id(key('places',@state)[1])]
-translate("BAR","abc","ABC")
-translate("BAR","Rab","TxX")
-translate("bar","RAB","xyz")
-translate("ddaaadddd","abcd","ABCxy")
-translate("zzaaazzz","abcz","ABC")
-translate(.,'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')
-translate(a,"abc","ABC")
-translate(a/@attrib,"lo","IT")
-translate(b,"ABC","abc")
-translate(b/@attrib,"LO","it")
-translate(b/@attrib,"LO","it")
-translate(b/@attrib,"lo","it")
-translate(b/@attrib,"lo","it")
-true()
-true() and false()
-true() and true()
-true() or 1 div 0
-true() or false()
-true() or true()
-true()!=false()
-true()='0'
-true()=2
-width * depth
-z[1]
-zoneone
-("2000-01-01" cast as xs:date?)
-xs:date("2000-01-01")
-(($floatvalue * 0.2E-5) cast as xs:decimal?)
-xs:decimal($floatvalue * 0.2E-5)
-("P21D" cast as xs:dayTimeDuration?)
-xs:dayTimeDuration("P21D")
-17 cast as Q{}apple
-Q{}apple(17)
-17 cast as apple
-apple(17)
-$myaddress treat as element(*, USAddress)
-child::div1 / child::para / string() ! concat("id-", .)
-$emp ! (@first, @middle, @last)
-$docs ! ( //employee)
-avg( //employee / salary ! translate(., '$', '') ! number(.))
-fn:string-join((1 to $n)!"*")
-$values!(.*.) => fn:sum()
-string-join(ancestor::*!name(), '/')
-tokenize((normalize-unicode(upper-case($string))),"\s+")
-$string => upper-case() => normalize-unicode() => tokenize("\s+")
-some $x in $expr1 satisfies $x = 47
-//product[id = 47]
-if (doc-available('abc.xml')) then doc('abc.xml') else ()
-$N[@x castable as xs:date][xs:date(@x) gt xs:date("2000-01-01")]
-$N[if (@x castable as xs:date) then xs:date(@x) gt xs:date("2000-01-01") else false()]
-$myaddress treat as function(node()) as xs:string*
-$myaddress treat as (function(node()) as xs:string)*
-//label[normalize-space(.)='Phone']/parent::lightning-input/parent::slot/parent::slot/parent::span/parent::div/parent::force-record-layout-item/parent::slot/parent::force-record-layout-row/parent::slot/parent::div/parent::div/parent::div/parent::force-record-layout-section/parent::slot/parent::force-record-layout-block/parent::forcegenerated-detailpanel_contact___012b0000000jhhvia4___full___view___recordlayout2/parent::records-lwc-record-layout/parent::slot/parent::records-record-layout-event-broker/parent::div/parent::div/following-sibling::force-form-footer//button
+//*[text()];
+text;
+//*[text()='RBRACE'];
+' #text';
+' 6 ' div 2;
+' 6 '*div;
+' x 4';
+'"eos';
+'';
+'+';
+'....5....|';
+'0'=true();
+'001' = 1;
+'1' and '0';
+'2'>'1';
+'200';
+'ABC';
+'abcdæfgh';
+'abcdèfgh';
+'ace' != 'abc';
+'ace' != 'ace';
+'ancestor-or-self::*';
+'ancestor::*';
+'Apply-templates';
+'b';
+'baseParam1Data';
+'baseSubParam0Data';
+'bug';
+'Call-template';
+'child::*';
+'condition false';
+'condition true';
+'correct';
+'CY';
+'Data';
+'default';
+'descendant-or-self::*';
+'descendant::*';
+'descending';
+'duh';
+'en';
+'error';
+'error1!';
+'error2!';
+'error3!';
+'error4!';
+'error5!';
+'error6!';
+'fallback';
+'first';
+'following-sibling::*';
+'following::*';
+'foo' and 'fop';
+'Gadzookz';
+'global';
+'H' != '  H';
+'H' != 'H  ';
+'In Import: Testing ';
+'In Include: Testing ';
+'incorrect';
+'left';
+'level0';
+'level1';
+'level3';
+'local';
+'lower-first';
+'main stylesheet, should have highest precedence';
+'mdocs15a.xml';
+'number';
+'okay';
+'parent::*';
+'preceding-sibling::*';
+'preceding::*';
+'pvar1 default data';
+'pvar2 default data';
+'red';
+'root';
+'set in var29side, should have highest precedence';
+'should be wrapped';
+'string';
+'stylesheet-var';
+'subsheet, should be overridden by main sheet';
+'TableofContents';
+'templ';
+'test value set in final';
+'test value set in impfinal';
+'test value set in impmid';
+'test value set in mid';
+'test value set in var27side';
+'test';
+'Testing ';
+'the same';
+'this';
+'titi';
+'Tommy';
+'top';
+'US';
+'value set in var30mid, should have highest precedence';
+'Wizard';
+'Xalan_URL_found';
+'z w x';
+'z w x'//@*;
+((((((n3+5)*(3)+(((n2)+2)*(n1 - 6)))-(n4 - n2))+(-(4-6)))));
+(((ancestor::foo)[1])/@att1);
+((ancestor::*|self::*)/@att1)[last()];
+((ancestor::foo))[1]/@att1;
+((div)[1]//span)[1];
+(* - 4) div 2;
+(* - 4)**;
+(2 + number('xxx'));
+(24 div 3 +2) div (40 div 8 -3);
+(5 mod 2 = 1) and (5 mod -2 = 1) and (-5 mod 2 = -1) and (-5 mod -2 = -1);
+(ancestor-or-self::*)/@att1[last()];
+(ancestor-or-self::*)[@att1][1]/@att1;
+(ancestor-or-self::*/@att1)[last()];
+(ancestor::*|self::*)/@att1[last()];
+(ancestor::foo)[1]/@att1;
+(ancestor::foo[1])/@att1;
+(chapter//footnote)[2];
+(child::chapter/descendant-or-self::node())/footnote[2];
+(descendant-or-self::*/@att1)[last()];
+(following-sibling::ch[current()])[1];
+(n1*n2*n3*n4*n5*n6)div n7 div n8 div n9 div n10;
+(n1/@attrib)*(n2/@attrib);
+(n1/@attrib)+(n2/@attrib);
+(number(1.75) = (0.109375 * 16));
+(number(1.75) = (7 div 4));
+(number(k) = (0.0001 * 4));
+(number(k) = (4 div 10000));
+(preceding-sibling::*|following-sibling::*)/ancestor::*[last()]/*[last()];
+(preceding-sibling::foo)[1]/@att1;
+(preceding::foo)[1]/@att1;
+(section//@title)[7];
+*;
+* +3;
+*//la | //Bflat | re;
+*/p;
+*[1];
+*[3];
+*[4];
+*[@test and position()=1];
+*[@test and position()=4];
+*[@test and position()=7];
+*[@test and position()=8];
+*[@test='true'];
+*[@test][1]/num;
+*[@test][3]/num;
+*[@test][4]/num;
+*[@test][position()=1]/num;
+*[@test][position()=3]/num;
+*[@test][position()=4]/num;
+*[last()=position()];
+*[last()];
+*[local-name()='bar'];
+*[not(@test)][last()=position()];
+*[not(@test)][last()];
+*[position()=1];
+*[position()=3];
+*[position()=4];
+*[starts-with(name(.),'f')];
+*|@*;
+*|@*|comment()|processing-instruction()|text();
+*|@*|comment()|text();
+-(n-2/@attrib) - -(n-1/@attrib);
+-(n1|n2);
+-.0000000000000000000000000000000000000000123456789;
+-.000000000000000000000000000000000000000123456789;
+-.00000000000000000000000000000000000000123456789;
+-.0000000000000000000000000000000000000123456789;
+-.000000000000000000000000000000000000123456789;
+-.00000000000000000000000000000000000123456789;
+-.0000000000000000000000000000000000123456789;
+-.000000000000000000000000000000000123456789;
+-.00000000000000000000000000000000123456789;
+-.0000000000000000000000000000000123456789;
+-.000000000000000000000000000000123456789;
+-.00000000000000000000000000000123456789;
+-.0000000000000000000000000000123456789;
+-.000000000000000000000000000123456789;
+-.00000000000000000000000000123456789;
+-.0000000000000000000000000123456789;
+-.000000000000000000000000123456789;
+-.00000000000000000000000123456789;
+-.0000000000000000000000123456789;
+-.000000000000000000000123456789;
+-.00000000000000000000123456789;
+-.0000000000000000000123456789;
+-.000000000000000000123456789;
+-.00000000000000000123456789;
+-.0000000000000000123456789;
+-.000000000000000123456789;
+-.00000000000000123456789;
+-.0000000000000123456789;
+-.000000000000123456789;
+-.00000000000123456789;
+-.0000000000123456789;
+-.000000000123456789;
+-.00000000123456789;
+-.0000000123456789;
+-.000000123456789;
+-.00000123456789;
+-.0000123456789;
+-.000123456789;
+-.00123456789;
+-.01;
+-.012;
+-.0123;
+-.01234;
+-.012345;
+-.0123456;
+-.01234567;
+-.012345678;
+-.0123456789;
+-.1;
+-.10123456789;
+-.101234567892;
+-.1012345678923;
+-.10123456789234;
+-.101234567892345;
+-.1012345678923456;
+-.10123456789234567;
+-.101234567892345678;
+-.1012345678923456789;
+-.10123456789234567893;
+-.123456789;
+-1;
+-12;
+-123;
+-1234;
+-12345;
+-123456;
+-1234567;
+-12345678;
+-123456789;
+-1234567890;
+-12345678901;
+-123456789012;
+-1234567890123;
+-12345678901234;
+-123456789012345;
+-1234567890123456;
+-12345678901234567;
+-123456789012345678;
+-7 --3;
+-9.87654321012345;
+-98.7654321012345;
+-987.654321012345;
+-9876.54321012345;
+-98765.4321012345;
+-987654.321012345;
+-9876543.21012345;
+-98765432.1012345;
+-987654321.012345;
+-9876543210.12345;
+-98765432101.2345;
+-987654321012.345;
+-9876543210123.45;
+-98765432101234.5;
+-n-2 --n-1;
+-n-2/@attrib --n-1/@attrib;
+.;
+.+6;
+..;
+../..;
+../../a/b[1];
+..//foo;
+..//text();
+../@id;
+../@width;
+../node();
+./*;
+./*[name(.) = 'never'];
+.//*[@so];
+.//a;
+.//center;
+.//comment();
+.//f;
+.//near-south/preceding-sibling::*|following-sibling::east/ancestor-or-self::*[2];
+.//text();
+.//title;
+./@id;
+./@name;
+./@theattrib;
+./a/text();
+./comment();
+./Name;
+./processing-instruction('*');
+./processing-instruction('a-pi');
+./processing-instruction();
+./processing-instruction()[2];
+./text();
+.0000000000000000000000000000000000000000123456789;
+.000000000000000000000000000000000000000123456789;
+.00000000000000000000000000000000000000123456789;
+.0000000000000000000000000000000000000123456789;
+.000000000000000000000000000000000000123456789;
+.00000000000000000000000000000000000123456789;
+.0000000000000000000000000000000000123456789;
+.000000000000000000000000000000000123456789;
+.00000000000000000000000000000000123456789;
+.0000000000000000000000000000000123456789;
+.000000000000000000000000000000123456789;
+.00000000000000000000000000000123456789;
+.0000000000000000000000000000123456789;
+.000000000000000000000000000123456789;
+.00000000000000000000000000123456789;
+.0000000000000000000000000123456789;
+.000000000000000000000000123456789;
+.00000000000000000000000123456789;
+.0000000000000000000000123456789;
+.000000000000000000000123456789;
+.00000000000000000000123456789;
+.0000000000000000000123456789;
+.000000000000000000123456789;
+.00000000000000000123456789;
+.0000000000000000123456789;
+.000000000000000123456789;
+.00000000000000123456789;
+.0000000000000123456789;
+.000000000000123456789;
+.00000000000123456789;
+.0000000000123456789;
+.000000000123456789;
+.00000000123456789;
+.0000000123456789;
+.000000123456789;
+.00000123456789;
+.0000123456789;
+.000123456789;
+.00123456789;
+.01;
+.012;
+.0123;
+.01234;
+.012345;
+.0123456;
+.01234567;
+.012345678;
+.0123456789;
+.1;
+.10123456789;
+.101234567892;
+.1012345678923;
+.10123456789234;
+.101234567892345;
+.1012345678923456;
+.10123456789234567;
+.101234567892345678;
+.1012345678923456789;
+.10123456789234567893;
+.123456789;
+/;
+/*/@group;
+/..;
+//*;
+//*[count(./*/*) > 0];
+//*[count(ancestor::*) >= 2]/../parent::*;
+//@*;
+//@x;
+//a | //div;
+//a[@name or @href];
+//ancestor::*;
+//b;
+//baz;
+//button[contains(text(),"Go")];
+//button[text()="Submit"];
+//c/@x;
+//center;
+//center//processing-instruction('b-pi');
+//center/@center-attr-1;
+//center/@center-attr-3;
+//center/comment();
+//center/comment()[1];
+//center/text()[1];
+//child;
+//child1;
+//comment();
+//h1[not(@id)];
+//inc/node4;
+//inner/following::node();
+//inner/preceding::node();
+//item[@type=current()/@name];
+//label[normalize-space(.)='Phone']/parent::lightning-input/parent::slot/parent::slot/parent::span/parent::div/parent::force-record-layout-item/parent::slot/parent::force-record-layout-row/parent::slot/parent::div/parent::div/parent::div/parent::force-record-layout-section/parent::slot/parent::force-record-layout-block/parent::forcegenerated-detailpanel_contact___012b0000000jhhvia4___full___view___recordlayout2/parent::records-lwc-record-layout/parent::slot/parent::records-record-layout-event-broker/parent::div/parent::div/following-sibling::force-form-footer//button;
+//Level3;
+//match;
+//near-north;
+//north/dup2 | south/preceding-sibling::*[4]/* | north/dup1 | north/*;
+//OL;
+//OL[@real='yes'];
+//para[lang('en')];
+//processing-instruction('b-pi');
+//processing-instruction();
+//product[@price > 2.50];
+//section/title;
+//Test/@a;
+//Test/@b;
+//text();
+//title;
+//tr[count(./td) = 3];
+//ul[*];
+//ul[li];
+//X;
+//xx/descendant::*;
+/a (: comment :) /b;
+/a/b/c;
+/bookstore/book/price[text()];
+/bookstore/book/title;
+/bookstore/book[1]/title;
+/bookstore/book[price>35]/price;
+/bookstore/book[price>35]/title;
+/data/*/datum/@value;
+/data/point;
+/descendant::*;
+/doc/*[@test='true'];
+/doc/a;
+/doc/a/b/@attr;
+/doc/avj;
+/doc/b;
+/doc/b/bb/bbb;
+/doc/critter[@type='cat'];
+/doc/datum/@value;
+/doc/foo;
+/doc/mid/inner;
+/doc/north;
+/doc/num;
+/doc/str;
+/docs/a;
+/far-north/north/near-north/center/ancestor-or-self::*;
+/foo/*/test/text();
+/page/contents/avail/hotel;
+/para/font[@color='green'];
+/report/month;
+/root/base;
+/sss/sss/i;
+0 = -0;
+0 > -0;
+0 div 0;
+0 div 0 < 0;
+0 div 0 >= 0;
+0 or '';
+0000000000;
+0=false();
+1;
+1 != 1.00;
+1 = '001';
+1 = 1.00;
+1 div -0 = 1 div 0;
+1 div -0 = 2 div -0;
+1!=1;
+1!=2;
+1-2;
+1.9999999 < 2;
+1.9999999 < 2.0;
+10;
+10+5+25+20+15+50+35+40;
+10+7;
+100-9-7-4-17-18-5;
+100-n6 -4-n1 -1-11;
+12;
+123;
+1234;
+12345;
+123456;
+1234567;
+12345678;
+123456789;
+1234567890;
+12345678901;
+123456789012;
+1234567890123;
+12345678901234;
+123456789012345;
+1234567890123456;
+12345678901234567;
+123456789012345678;
+16-div;
+1<1;
+1<2;
+1<=1;
+1<=2;
+1=1;
+1=2;
+1>1;
+1>2;
+1>=2;
+2;
+2 * -number('xxx');
+2 - number('xxx');
+2 < 2.0;
+2 div number('xxx');
+2 mod number('xxx');
+2*3;
+2+n5+7+n3;
+2.0000001 < 2.0;
+20;
+25-*;
+256;
+2<1;
+2<=1;
+2>1;
+2>=1;
+2>=2;
+3;
+3*2+5*4-4*2-1;
+3+6;
+3-1;
+32;
+4;
+48 mod 17 - 2 mod 9 + 13 mod 5;
+5;
+5 mod 2;
+5.*.;
+5.+*;
+54 div*;
+555;
+56 mod round(n5*2+1.444) - n6 mod 4 + 7 mod n4;
+6;
+6 div -2;
+6 div 2;
+60;
+7;
+7 - -3;
+7+-3;
+8;
+80 div n2 + 12 div 2 - n4 div n2;
+9;
+9.87654321012345;
+98.7654321012345;
+987.654321012345;
+9876.54321012345;
+98765.4321012345;
+987654.321012345;
+9876543.21012345;
+98765432.1012345;
+987654321.012345;
+9876543210;
+9876543210.12345;
+98765432101.2345;
+987654321012.345;
+9876543210123.45;
+98765432101234.5;
+@*;
+@*-5;
+@*/.;
+@*/ancestor-or-self::*;
+@*/ancestor::*;
+@*/ancestor::*/near-north/*[4]/@*/following::node();
+@*/ancestor::*/near-north/*[4]/@*/preceding::*;
+@*/ancestor::*/near-north/*[4]/@*/preceding::comment();
+@*/ancestor::*/near-north/*[4]/@*/preceding::node();
+@*/ancestor::*/near-north/*[4]/@*/preceding::processing-instruction();
+@*/ancestor::*/near-north/*[4]/@*/preceding::text();
+@*/child::*;
+@*/descendant-or-self::node();
+@*/descendant::node();
+@*/following-sibling::*;
+@*/following::*;
+@*/following::comment();
+@*/following::processing-instruction();
+@*/following::text();
+@*/parent::*;
+@*/preceding-sibling::node();
+@*/preceding::*;
+@*/self::node();
+@*[2];
+@*|comment()|processing-instruction()|text()|*;
+@*|node();
+@*|node()|comment()|processing-instruction();
+@*|node()|text();
+@att1;
+@attr;
+@attribute1;
+@center-attr-2;
+@div - 5;
+@div -5;
+@div-5;
+@flag;
+@group;
+@h | @w;
+@height*@width;
+@id;
+@key;
+@level;
+@mark;
+@name;
+@net;
+@num;
+@ordering;
+@person;
+@pos;
+@repeat;
+@s;
+@seq;
+@side;
+@size;
+@spot;
+@state;
+@test;
+@title;
+@val;
+@value;
+@width;
+@xml:att1;
+@xx;
+@x|@z;
+@z;
+A;
+a;
+a-set;
+a-set/a/text();
+a/*[last()];
+a/child::*[last()];
+a/child::comment()[last()];
+a/child::node()[last()];
+a/child::text()[last()];
+a/comment();
+a/descendant::*[last()];
+a/text();
+a/x;
+a=b;
+a[$third];
+a['3.5' < 4];
+a['target'!=descendant::*];
+a['target'=descendant::*];
+a[('target'=descendant::*) or @squish];
+a[(@squeesh or @squish) and @squash];
+a[*=9];
+a[0 < true()];
+a[0];
+a[1];
+a[3-2];
+a[3.0='3.0'];
+a[3=following-sibling::*];
+a[3];
+a[4];
+a[@squeesh or (@squish and @squash)];
+a[@squeesh or @squish and @squash];
+a[descendant::*!='target'];
+a[descendant::*='target'];
+a[div=9];
+a[false()!=following-sibling::*];
+a[following-sibling::*!=false()];
+a[following-sibling::*=3];
+a[following-sibling::*=descendant::*];
+a[following-sibling::*=true()];
+a[not(('target'=descendant::*) or @squish)];
+a[not(@*)];
+a[number('3')];
+a[position() <=3];
+a[position()!=2];
+a[position()<3];
+a[position()=$first];
+a[position()=1];
+a[position()=3];
+a[position()=4];
+a[position()>2];
+a[position()>=2];
+a[true()='stringwithchars'];
+a[true()=4];
+a[true()=following-sibling::*];
+affiliation;
+alpha;
+alternate/name/first;
+alternate/name/last;
+ancestor-or-self::*;
+ancestor-or-self::*/@att1[last()];
+ancestor-or-self::*[1];
+ancestor-or-self::*[1]/text();
+ancestor-or-self::*[2]/text();
+ancestor-or-self::*[3]/text();
+ancestor-or-self::*[4]/text();
+ancestor-or-self::*[5]/text();
+ancestor-or-self::*[6]/text();
+ancestor-or-self::*[7]/text();
+ancestor-or-self::*[@att1][1]/@att1;
+ancestor-or-self::*[@xml:lang]/@xml:lang;
+ancestor-or-self::node();
+ancestor-or-self::sub | ancestor-or-self::sub-sub;
+ancestor::*;
+ancestor::*[3];
+ancestor::*[count(child::*) > 1]/*[not(. = current()/ancestor-or-self::*)];
+ancestor::foo[1]/@att1;
+ancestor::node();
+ancestor::sub1|ancestor::sub2;
+attribute :: *;
+attribute :: div;
+attribute*(div - 4);
+attribute::*;
+attribute::*[2];
+attribute::center-attr-2;
+av//*;
+av//h;
+av//j;
+avj//k;
+avj/bool/*;
+avj/good/*;
+avj/none;
+b;
+b/c;
+bar;
+bar[(@a='1' and @b='1') or (@c='1' and @d='1')];
+bar[(@a='1' or @b='1') and (@c='1' or @d='1')];
+bar[(@a='1' or @b='1') and @c='1'];
+bar[@a='1' and (@b='1' or @c='1') and @d='1'];
+bar[@a='1' and @b='1' or @c='1' and @d='1'];
+bar[@a='1' and @b='1'];
+bar[@a='1' or (@b='1' and @c='1') or @d='1'];
+bar[@a='1' or @b='1' and @c='1' or @d='1'];
+bar[@a='1' or @b='1' or @c='1'];
+base//description;
+birthday;
+body;
+bonus;
+boolean('');
+boolean('0');
+boolean('1');
+boolean(-0);
+boolean(0 div 0);
+boolean(0);
+boolean(1 div 0);
+boolean(1);
+boolean(doc);
+boolean(foo);
+c;
+c/b;
+ceiling(-1.5)=-1;
+ceiling(0.0);
+ceiling(1)=1;
+ceiling(1.1)=2;
+ceiling(1.54);
+ceiling(2.999999);
+ceiling(n0);
+ceiling(n1);
+ceiling(n2);
+ceiling(number('xxx'));
+center//*;
+center//child::*;
+center//descendant::*;
+center/child::*;
+center/descendant::*;
+chapter;
+chapter//footnote[1];
+chapter//footnote[2];
+chapter/descendant::footnote[6];
+chapter/note;
+Child;
+child;
+child :: sub;
+child1[child::child2];
+child::*;
+child::*/child::*;
+child::*/descendant::*;
+child::*[2];
+child::near-south-west;
+child::node();
+child::sub;
+chooser;
+CLASSIFICATION;
+comment ();
+comment();
+concat("a","b","c","d","ef");
+concat("bc", string(23));
+concat("cd", "34");
+concat("cd", 34);
+concat(/*, /*[@attr='whatsup']);
+concat(a, 34);
+concat(a, b);
+concat(a, b, c, d, e);
+concat(false(),'ly');
+concat(left,right,orig);
+concat(team[1], ' versus ', team[2]);
+concat(team[1]/@score, '-', team[2]/@score);
+contains('','');
+contains('ab', 'abc');
+contains('abc', '');
+contains('abc', 'bc');
+contains('abc', 'bcd');
+contains('ENCYCLOPEDIA', 'CYCL');
+contains('ENCYCLOPEDIA', 'TEST');
+contains('foo','o');
+contains('true()', 'e');
+contains(., '&');
+contains(., '°');
+contains(concat(.,'BC'),concat('A','B','C'));
+contains(doc, 'CYCL');
+contains(doc, 'TEST');
+contains(doc/@attr, 'amwi');
+contains(doc/@attr, 'TEST');
+contains(main,sub);
+count(*);
+count(*/z[2]);
+count(.//@*);
+count(.//@title);
+count(.//comment());
+count(//@*);
+count(//@title);
+count(//section//@*);
+count(//section//@title);
+count(//tr);
+count(//tr[count(./td) = 3]);
+count(/doc/alpha[last()]/h);
+count(/doc/chapter/note);
+count(a-set/a/text());
+count(a/@*);
+count(a/attribute::*);
+count(a/comment());
+count(a/text());
+count(a[@ex!='']);
+count(a[@ex='']);
+count(a[@ex]);
+count(a[@why!='value']);
+count(a[@why='value']);
+count(a[not(@ex)]);
+count(a[not(@ex='')]);
+count(a[not(string-length(@ex)=0)]);
+count(a[string-length(@ex) > 0]);
+count(a[string-length(@ex)=0]);
+count(alpha/*[last()][name()='z']);
+count(ancestor-or-self::*/@att1);
+count(ancestor-or-self::node());
+count(descendant-or-self::*);
+count(descendant-or-self::*/@att1);
+count(descendant-or-self::*/namespace::*);
+count(descendant::*);
+count(div);
+count(following-sibling::*);
+count(following::node()|following::*/@*);
+count(id('c'));
+count(id('d b c k'));
+count(id('k'));
+count(namespace::*[name(.)!='xml']);
+count(preceding::text());
+count(section[1]//@*);
+count(section[1]//@title);
+count(section[2]//@*);
+count(section[2]//@title);
+count(section[3]//@*);
+count(section[3]//@title);
+critter;
+customers/customer;
+d;
+dat;
+date;
+day;
+descendant-or-self::*;
+descendant-or-self::*/@att1[last()];
+descendant-or-self::*[3];
+descendant-or-self::*[last()]/@att1;
+descendant-or-self::center;
+descendant-or-self::far-south;
+descendant-or-self::sub1|descendant-or-self::sub2;
+descendant::*;
+descendant::*/child::*;
+descendant::*[3];
+descendant::*[string-length(name(.))=1];
+descendant::child1|descendant::child2;
+descendant::far-south;
+dis;
+display;
+div +3;
+div div mod;
+div mod mod;
+div/@attrib div mod/@attrib;
+div/@attrib mod mod/@attrib;
+div/para[lang('en')];
+doc;
+doc/*;
+doc//a3[../@pick='yes'];
+doc//Q;
+doc/@*;
+doc/a;
+doc/a//text();
+doc/alpha;
+doc/av;
+doc/av//*;
+doc/body/para;
+doc/c/d/e;
+doc/comment();
+doc/element1[2]/child1[last()];
+doc/foo;
+doc/memo;
+doc/num;
+doc/OL//tag;
+doc/p;
+doc1;
+docs//d;
+docs//d/text();
+docs/a/node();
+e;
+element;
+expense-report/total;
+fa;
+fa/../mi | Aflat/natural/la | Csharp//* | /doc/do | *//ti;
+false();
+false() and 1 div 0;
+false() and false();
+false() and true();
+false() or false();
+false() or true();
+false()!=false();
+false()!=true();
+false()='';
+false()=0;
+file;
+floor(-1.5);
+floor(-1.5)=-2;
+floor(0.0);
+floor(1)=1;
+floor(1.9);
+floor(1.9)=1;
+floor(2.999999);
+floor(n0);
+floor(n1);
+floor(n2);
+floor(number('xxx'));
+following-sibling::*;
+following-sibling::*/preceding-sibling::*;
+following-sibling::*[1];
+following-sibling::*[2];
+following-sibling::*[2]/preceding-sibling::*;
+following-sibling::*[2]/preceding-sibling::*[4];
+following-sibling::*[2]/preceding-sibling::*[4]/following-sibling::*[5]/preceding-sibling::*[4]/preceding-sibling::*[2];
+following-sibling::*[count(current())];
+following-sibling::ch[current()];
+following-sibling::east;
+following-sibling::node();
+following::*;
+following::*[4];
+following::*[4]/../*[2];
+following::out-yonder-east;
+FOO;
+foo;
+foo/@test;
+foo/a/num/@val;
+foo[(bar[2])='this'];
+foo[(bar[2][(baz[2])='goodbye'])];
+grandchild;
+growth;
+human;
+id('c a d');
+id('c')/@id;
+id('d b c');
+id('id0')/a/b;
+id('id0')/c/c/a;
+id('id10')/a;
+id('id13');
+id('id2')/a | id('id5') | id('id15')/a;
+id('id4');
+id('id8')/b/b;
+id('id9');
+id('nomatch')/@id;
+id(main/@list);
+id(main/b);
+inner;
+item;
+item[$n1];
+item[$n2];
+item[$n3];
+item[$n4];
+item[$n5];
+item[$n6];
+item[$n7];
+item[$n8];
+item[$n9];
+item[$n];
+item[1][last()];
+item[last()-1];
+item[last()-1][1];
+item[last()-1][last()];
+item[last()];
+item[last()][last()];
+item[position()=$n];
+j[@l='12'] != j[@l='17'];
+j[@l='12'] != j[@w='33'];
+j[@l='12'] != j[@w='45'];
+j[@l='12'] = j[@l='17'];
+j[@l='12'] = j[@w='33'];
+j[@l='12'] = j[@w='45'];
+j[@l='16'] != j[@w='78'];
+keyword[@tag='sector'];
+keyword[@tag='ticker'];
+lang('en');
+last-bad;
+letter;
+link;
+local-name();
+local-name(.);
+local-name(a/@at1);
+local-name(namespace::*[1]);
+local-name(namespace::*[name(.)!='xml']);
+local-name(namespace::*[string()='http://www.w3.org/1999/XMLSchema-instance']);
+local-name(namespace::*[string()='test']);
+m;
+main/a/descendant-or-self::*/@*;
+main/size[@for='d'];
+mark;
+member;
+mi | do | fa | re;
+mi[@mi2='mi2'] | do | fa/so/@so | fa | mi/@* | re | fa/@fa | do/@do;
+middle;
+miles-earned;
+month;
+n;
+n-2 - -n-1;
+n-2 - n-1;
+n-2+-n-1;
+n0 div n1 div n2 div n3;
+n0 div n1 div n2 div n3 div n4;
+n0 div n1 div n2 div n3 div n4 div n5;
+n1 div n2;
+n1 mod n2;
+n1*n2;
+n1*n2*n3*n4;
+n1*n2*n3*n4*n5*n6*n7*n8*n9*n10;
+n1+n2;
+n1/@attrib + n2/@attrib;
+n1/@attrib div n2/@attrib;
+n1/@attrib mod n2/@attrib;
+n4;
+n6*5-8*n2+5*2;
+name;
+name();
+name(*);
+name(.);
+name(..);
+name(/descendant-or-self::node()/child::near-north);
+name(/descendant-or-self::node()/descendant-or-self::north);
+name(/descendant-or-self::north);
+name(/descendant-or-self::north/child::near-north);
+name(/descendant-or-self::north/descendant-or-self::north);
+name(/descendant::near-north);
+name(/descendant::near-north/descendant-or-self::near-north);
+name(/descendant::node()/descendant-or-self::near-north);
+name(a/@at1);
+name(ancestor::*[1]);
+name(ancestor::*[2]);
+name(ancestor::*[3]);
+name(descendant-or-self::node()/child::near-north);
+name(descendant-or-self::node()/child::node()/child::far-west);
+name(descendant-or-self::node()/child::node()/descendant-or-self::near-north);
+name(descendant-or-self::node()/descendant-or-self::node()/child::near-north);
+name(descendant-or-self::node()/descendant-or-self::node()/descendant-or-self::north);
+name(descendant-or-self::node()/descendant-or-self::north);
+name(descendant-or-self::node()/descendant::near-north);
+name(descendant-or-self::node()/descendant::node()/child::far-west);
+name(descendant-or-self::node()/descendant::node()/descendant-or-self::near-north);
+name(descendant-or-self::north/child::near-north);
+name(descendant-or-self::north/child::near-north/child::far-west);
+name(descendant-or-self::north/child::near-north/descendant-or-self::near-north);
+name(descendant-or-self::north/descendant-or-self::north);
+name(descendant-or-self::north/descendant-or-self::north/child::near-north);
+name(descendant-or-self::north/descendant-or-self::north/descendant-or-self::north);
+name(descendant-or-self::north/descendant::near-north);
+name(descendant-or-self::north/descendant::near-north/child::far-west);
+name(descendant-or-self::north/descendant::near-north/descendant-or-self::near-north);
+name(descendant::near-north/descendant-or-self::near-north);
+name(descendant::near-north/descendant-or-self::near-north/child::far-west);
+name(descendant::near-north/descendant-or-self::near-north/descendant-or-self::near-north);
+name(descendant::near-north/descendant::far-west);
+name(descendant::near-north/descendant::far-west/descendant-or-self::far-west);
+name(descendant::node()/descendant-or-self::near-north);
+name(descendant::node()/descendant-or-self::node()/child::far-west);
+name(descendant::node()/descendant-or-self::node()/descendant-or-self::near-north);
+name(descendant::node()/descendant::far-west);
+name(descendant::node()/descendant::node()/descendant-or-self::far-west);
+name(following-sibling::*[last()]);
+name(following::*[last()]);
+name(namespace::*[1]);
+name(namespace::*[name(.)!='xml']);
+name(preceding-sibling::*[last()]);
+name(preceding::*[last()]);
+name(self::node()/descendant-or-self::node()/child::near-north);
+name(self::node()/descendant-or-self::node()/descendant-or-self::north);
+name(self::node()/descendant-or-self::north);
+name(self::node()/descendant-or-self::north/child::near-north);
+name(self::node()/descendant-or-self::north/descendant-or-self::north);
+name(self::node()/descendant::near-north);
+name(self::node()/descendant::near-north/child::far-west);
+name(self::node()/descendant::near-north/descendant-or-self::far-west);
+name(self::node()/descendant::node()/child::far-west);
+name(self::node()/descendant::node()/descendant-or-self::far-west);
+Name/@First;
+name/first;
+name/last;
+name/last | primary/name/last;
+namespace-uri();
+namespace-uri(*);
+namespace-uri(.);
+namespace-uri(a/@at1);
+namespace-uri(bogus);
+namespace-uri(namespace::*[name(.)!='xml']);
+namespace-uri(namespace::*[string()='http://www.w3.org/1999/XMLSchema-instance']);
+namespace-uri(namespace::*[string()='test']);
+namespace-uri(x);
+namespace::*;
+namespace::* | attribute::*;
+namespace::bdd;
+namespace::node();
+namespace::ped;
+node;
+node();
+node()|@*;
+normalize-space();
+normalize-space(.);
+normalize-space(a);
+normalize-space(text());
+normalize-space(url);
+north/* | north/dup1 | north/dup2;
+north/dup2 | north/dup1 | north/*;
+not('');
+not('0');
+not(false() = false());
+not(false());
+not(true() = false());
+not(true());
+note;
+note[1];
+num;
+number('');
+number('3');
+number('abc');
+number('xxx') - 10;
+number('xxx') div 3;
+number('xxx') mod 3;
+number('xxx')=0;
+number('xxx')=number('xxx');
+number();
+number(0.0001 * 4);
+number(0.109375 * 16);
+number(1.75);
+number(2);
+number(4 div 10000);
+number(7 div 4);
+number(false())=0;
+number(foo);
+number(k);
+number(n1);
+number(string(1.0))=1;
+number(true())=1;
+OL;
+OL//tag;
+ol/item;
+OL/OL/LI;
+order;
+p;
+para[@id='1' and lang('en')];
+para[@id='3' and lang('en')];
+para[@id='4' and lang('en')];
+parent::*;
+parent::*[1];
+parent::foo;
+parent::near-north;
+parent::node();
+person;
+Personal_Information/Age;
+pos-bad;
+preceding-sibling::*;
+preceding-sibling::*/following-sibling::*;
+preceding-sibling::*[2];
+preceding-sibling::*[2]/following-sibling::*;
+preceding-sibling::*[2]/following-sibling::*[4];
+preceding-sibling::*[2]/following-sibling::*[4]/preceding-sibling::*[5]/following-sibling::*[4]/following-sibling::*[2];
+preceding-sibling::*|following-sibling::*;
+preceding-sibling::child1|//child3;
+preceding-sibling::child1|following-sibling::child3;
+preceding-sibling::foo[1]/@att1;
+preceding-sibling::west;
+preceding::*;
+preceding::*[2]/../descendant::*[10]/following-sibling::east;
+preceding::*[2]/../following::*;
+preceding::*[4];
+preceding::foo[1]/@att1;
+preceding::out-yonder-west;
+preceding::text();
+preceding::text()[$this];
+primary/name/first;
+primary/name/last;
+processing-instruction();
+r;
+revenue;
+root/x;
+round(-1.1)=-1;
+round(-1.5);
+round(-1.9)=-2;
+round(-2.5)=-2;
+round(0.0);
+round(1.1)=1;
+round(1.24);
+round(1.5)=2;
+round(1.9)=2;
+round(2.5);
+round(2.999999);
+round(n0);
+round(n1);
+round(n2);
+round(number('xxx'));
+row;
+sales/division;
+self::*;
+self::*[1];
+self::*[@center-attr-2];
+self::*[near-south];
+self::center;
+self::comment();
+self::foo;
+self::node();
+self::node()|child::*;
+self::processing-instruction();
+self::text();
+side;
+Spr/State[. = 'Open'];
+sss//i;
+sss/sss;
+starts-with('','');
+starts-with('ab', 'abc');
+starts-with('abc', '');
+starts-with('abc', 'bc');
+starts-with('ENCYCLOPEDIA', 'EN');
+starts-with('ENCYCLOPEDIA', 'EN');
+starts-with('ENCYCLOPEDIA', 'en');
+starts-with('ENCYCLOPEDIA', 'en');
+starts-with('ENCYCLOPEDIA', 'ENCY');
+starts-with('true()', 'tr');
+starts-with(doc, 'ENCY');
+starts-with(doc, 'test');
+starts-with(doc/@attr, 'slam');
+starts-with(doc/@attr, 'wich');
+string('!From m!');
+string('!From n!');
+string('!From o!');
+string('!From p!');
+string('!From ss2!');
+string('!From ss3!');
+string('!From ss4!');
+string('!From ss5!');
+string('');
+string('test');
+string();
+string(-1 * number(.));
+string(0);
+string(2);
+string(av//*);
+string(doc);
+string(foo);
+string(number(.));
+string-length ();
+string-length('This is a test');
+string-length();
+string-length(.);
+string-length(doc);
+string-length(doc/a);
+string-length(normalize-space(.));
+subj;
+substring('1999/04/01', 1, 0);
+substring('1999/04/01', 1, 4);
+substring('abcdefghi',2,4);
+substring('abcdefghijk',0 div 0, 5);
+substring('abcdefghijk',4, 6);
+substring('ENCYCLOPEDIA', 8);
+substring('ENCYCLOPEDIA', 8, 3);
+substring('x',2,1);
+substring(@key,2,1);
+substring(doc, 1, 4);
+substring(doc/@attr, 1, 3);
+substring(doc/@attr, 2.5, 3.6);
+substring(doc/@attr, 4);
+substring(foo, 2, 2);
+substring-after('1999/04/01', '/');
+substring-after('1999/04/01', '1');
+substring-after('abcdefghijk','l');
+substring-after('ENCYCLOPEDIA', '/');
+substring-after('ENCYCLOPEDIA', 'C');
+substring-after(.,'-');
+substring-after(doc, '/');
+substring-after(doc/@attr, 'D');
+substring-after(doc/@attr, 'D');
+substring-after(doc/@attr, 'd');
+substring-after(doc/@attr, 'd');
+substring-after(doc/@attr, 'z');
+substring-after(foo, '/');
+substring-before('1999/04/01', '/');
+substring-before('a','z');
+substring-before('ENCYCLOPEDIA', '/');
+substring-before('ENCYCLOPEDIA', 'C');
+substring-before('ENCYCLOPEDIA', 'C');
+substring-before('ENCYCLOPEDIA', 'c');
+substring-before('ENCYCLOPEDIA', 'c');
+substring-before(doc, '/');
+substring-before(doc/@attr, 'D');
+substring-before(doc/@attr, 'D');
+substring-before(doc/@attr, 'd');
+substring-before(doc/@attr, 'd');
+substring-before(doc/@attr, 'z');
+substring-before(foo, '/');
+sum(a-set/a);
+sum(e);
+sum(n);
+sum(n/@attrib);
+sum(x);
+t;
+td;
+team[1];
+team[2];
+tee/s;
+testfile.html;
+text();
+text()[1];
+text()[3];
+time;
+title;
+town[generate-id() = generate-id(key('places',@state)[1])];
+translate("BAR","abc","ABC");
+translate("BAR","Rab","TxX");
+translate("bar","RAB","xyz");
+translate("ddaaadddd","abcd","ABCxy");
+translate("zzaaazzz","abcz","ABC");
+translate(.,'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+translate(a,"abc","ABC");
+translate(a/@attrib,"lo","IT");
+translate(b,"ABC","abc");
+translate(b/@attrib,"LO","it");
+translate(b/@attrib,"LO","it");
+translate(b/@attrib,"lo","it");
+translate(b/@attrib,"lo","it");
+true();
+true() and false();
+true() and true();
+true() or 1 div 0;
+true() or false();
+true() or true();
+true()!=false();
+true()='0';
+true()=2;
+width * depth;
+z[1];
+zoneone;
+("2000-01-01" cast as xs:date?);
+xs:date("2000-01-01");
+(($floatvalue * 0.2E-5) cast as xs:decimal?);
+xs:decimal($floatvalue * 0.2E-5);
+("P21D" cast as xs:dayTimeDuration?);
+xs:dayTimeDuration("P21D");
+17 cast as Q{}apple;
+Q{}apple(17);
+17 cast as apple;
+apple(17);
+$myaddress treat as element(*, USAddress);
+child::div1 / child::para / string() ! concat("id-", .);
+$emp ! (@first, @middle, @last);
+$docs ! ( //employee);
+avg( //employee / salary ! translate(., '$', '') ! number(.));
+fn:string-join((1 to $n)!"*");
+$values!(.*.) => fn:sum();
+string-join(ancestor::*!name(), '/');
+tokenize((normalize-unicode(upper-case($string))),"\s+");
+$string => upper-case() => normalize-unicode() => tokenize("\s+");
+some $x in $expr1 satisfies $x = 47;
+//product[id = 47];
+if (doc-available('abc.xml')) then doc('abc.xml') else ();
+$N[@x castable as xs:date][xs:date(@x) gt xs:date("2000-01-01")];
+$N[if (@x castable as xs:date) then xs:date(@x) gt xs:date("2000-01-01") else false()];
+$myaddress treat as function(node()) as xs:string*;
+$myaddress treat as (function(node()) as xs:string)*;
+//label[normalize-space(.)='Phone']/parent::lightning-input/parent::slot/parent::slot/parent::span/parent::div/parent::force-record-layout-item/parent::slot/parent::force-record-layout-row/parent::slot/parent::div/parent::div/parent::div/parent::force-record-layout-section/parent::slot/parent::force-record-layout-block/parent::forcegenerated-detailpanel_contact___012b0000000jhhvia4___full___view___recordlayout2/parent::records-lwc-record-layout/parent::slot/parent::records-record-layout-event-broker/parent::div/parent::div/following-sibling::force-form-footer//button;


### PR DESCRIPTION
This is a fix for [XPath31 grammar missing CR/LF as whitespace contrary to spec. #1804](https://github.com/antlr/grammars-v4/issues/1804). It turns out that it's very handy to use CR/LF's in large expressions. An example, one expression that I'm working on is this one for finding lexer string literals that participate in rules of the form "FOOBAR : 'foobar' ;":

    //ruleSpec
        /lexerRuleSpec
            /lexerRuleBlock
                /lexerAltList[not(@ChildCount > 1)]
                    /lexerAlt
                        /lexerElements[not(@ChildCount > 1)]
                            /lexerElement[not(@ChildCount > 1)]
                                /lexerAtom
                                    /terminal[not(@ChildCount > 1)]
                                        /STRING_LITERAL

It's used to replace string literals with the corresponding lexer symbol in parse rules, since a partitioned lexer/parser grammar cannot define string literals in parser rules. Admittedly, even this is rather unruly to read, but it's a little better than trying to read the expression without the returns and indents. Anyway, what was there before was not per spec. Instead, I used a semi-colon to delimit XPath expressions for testing.

"mvn clean test" works on Ubuntu and Windows.

--Ken