### PR TITLE
Solution for: CPP14-grammar error when generated for Python antlr#1778

### DIFF
--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -1245,7 +1245,7 @@ Extern
    : 'extern'
    ;
 
-BoolFalse
+False_
    : 'false'
    ;
 
@@ -1385,7 +1385,7 @@ Throw
    : 'throw'
    ;
 
-BoolTrue
+True_
    : 'true'
    ;
 
@@ -1883,8 +1883,8 @@ fragment Rawstring
    ;
 
 booleanliteral
-   : BoolFalse
-   | BoolTrue
+   : False_
+   | True_
    ;
 
 pointerliteral

--- a/cpp/CPP14.g4
+++ b/cpp/CPP14.g4
@@ -1245,7 +1245,7 @@ Extern
    : 'extern'
    ;
 
-False
+BoolFalse
    : 'false'
    ;
 
@@ -1385,7 +1385,7 @@ Throw
    : 'throw'
    ;
 
-True
+BoolTrue
    : 'true'
    ;
 
@@ -1883,8 +1883,8 @@ fragment Rawstring
    ;
 
 booleanliteral
-   : False
-   | True
+   : BoolFalse
+   | BoolTrue
    ;
 
 pointerliteral


### PR DESCRIPTION
Solved namecollision for "True" and "False"-rulenames in some programminglanguages. See antlr#1778 .