### PR TITLE
Add TypeScript base classes for PL/SQL

### DIFF
--- a/sql/plsql/TypeScript/PlSqlLexerBase.ts
+++ b/sql/plsql/TypeScript/PlSqlLexerBase.ts
@@ -1,0 +1,10 @@
+import { Lexer } from "antlr4ts";
+
+export abstract class PlSqlLexerBase extends Lexer {
+  
+  IsNewlineAtPos(pos: number): boolean {
+    const la = this._input.LA(pos);
+    return la == -1 || String.fromCharCode(la) == '\n';
+  }
+
+}

--- a/sql/plsql/TypeScript/PlSqlParserBase.ts
+++ b/sql/plsql/TypeScript/PlSqlParserBase.ts
@@ -1,0 +1,30 @@
+import { Parser, TokenStream } from "antlr4ts"
+
+export abstract class PlSqlParserBase extends Parser {
+
+  _isVersion10: boolean;
+  _isVersion12: boolean;
+
+  constructor(input: TokenStream) {
+    super(input);
+    this._isVersion10 = false;
+    this._isVersion12 = true;
+  }
+
+  isVersion10(): boolean {
+    return this._isVersion10;
+  }
+
+  isVersion12(): boolean {
+    return this._isVersion12;
+  }
+
+  setVersion10(value: boolean): void {
+    this._isVersion10 = value;
+  }
+
+  setVersion12(value: boolean): void {
+    this._isVersion12 = value;
+  }
+
+}


### PR DESCRIPTION
Effectively this is just a copy of the JavaScript base classes, but rewritten natively for TypeScript users.