### PR TITLE
fix Hive Transform/Map-Reduce grammar

### DIFF
--- a/sql/hive/examples/transform_1.sql
+++ b/sql/hive/examples/transform_1.sql
@@ -1,0 +1,8 @@
+FROM (
+  FROM src
+  SELECT TRANSFORM(src.key, src.value) ROW FORMAT SERDE 'org.apache.hadoop.hive.contrib.serde2.TypedBytesSerDe'
+  USING '/bin/cat'
+  AS (tkey, tvalue) ROW FORMAT SERDE 'org.apache.hadoop.hive.contrib.serde2.TypedBytesSerDe'
+  RECORDREADER 'org.apache.hadoop.hive.contrib.util.typedbytes.TypedBytesRecordReader'
+) tmap
+INSERT OVERWRITE TABLE dest1 SELECT tkey, tvalue

--- a/sql/hive/examples/transform_2.sql
+++ b/sql/hive/examples/transform_2.sql
@@ -1,0 +1,10 @@
+FROM (
+  FROM pv_users
+  MAP pv_users.userid, pv_users.date
+  USING 'map_script'
+  AS dt, uid
+  CLUSTER BY dt) map_output
+INSERT OVERWRITE TABLE pv_users_reduced
+  REDUCE map_output.dt, map_output.uid
+  USING 'reduce_script'
+  AS date, count

--- a/sql/hive/examples/transform_2.sql
+++ b/sql/hive/examples/transform_2.sql
@@ -1,10 +1,10 @@
 FROM (
   FROM pv_users
-  MAP pv_users.userid, pv_users.date
+  MAP pv_users.userid, pv_users.date1
   USING 'map_script'
   AS dt, uid
   CLUSTER BY dt) map_output
 INSERT OVERWRITE TABLE pv_users_reduced
   REDUCE map_output.dt, map_output.uid
   USING 'reduce_script'
-  AS date, count
+  AS date1, count

--- a/sql/hive/examples/transform_3.sql
+++ b/sql/hive/examples/transform_3.sql
@@ -1,10 +1,10 @@
 FROM (
   FROM pv_users
-  SELECT TRANSFORM(pv_users.userid, pv_users.date)
+  SELECT TRANSFORM(pv_users.userid, pv_users.date1)
   USING 'map_script'
   AS dt, uid
   CLUSTER BY dt) map_output
 INSERT OVERWRITE TABLE pv_users_reduced
   SELECT TRANSFORM(map_output.dt, map_output.uid)
   USING 'reduce_script'
-  AS date, count
+  AS date1, count

--- a/sql/hive/examples/transform_3.sql
+++ b/sql/hive/examples/transform_3.sql
@@ -1,0 +1,10 @@
+FROM (
+  FROM pv_users
+  SELECT TRANSFORM(pv_users.userid, pv_users.date)
+  USING 'map_script'
+  AS dt, uid
+  CLUSTER BY dt) map_output
+INSERT OVERWRITE TABLE pv_users_reduced
+  SELECT TRANSFORM(map_output.dt, map_output.uid)
+  USING 'reduce_script'
+  AS date, count

--- a/sql/hive/examples/transform_4.sql
+++ b/sql/hive/examples/transform_4.sql
@@ -1,9 +1,9 @@
 FROM (
   FROM pv_users
-  MAP pv_users.userid, pv_users.date
+  MAP pv_users.userid, pv_users.date1
   USING 'map_script'
   CLUSTER BY key) map_output
 INSERT OVERWRITE TABLE pv_users_reduced
   REDUCE map_output.key, map_output.value
   USING 'reduce_script'
-  AS date, count
+  AS date1, count

--- a/sql/hive/examples/transform_4.sql
+++ b/sql/hive/examples/transform_4.sql
@@ -1,0 +1,9 @@
+FROM (
+  FROM pv_users
+  MAP pv_users.userid, pv_users.date
+  USING 'map_script'
+  CLUSTER BY key) map_output
+INSERT OVERWRITE TABLE pv_users_reduced
+  REDUCE map_output.key, map_output.value
+  USING 'reduce_script'
+  AS date, count

--- a/sql/hive/examples/transform_5.sql
+++ b/sql/hive/examples/transform_5.sql
@@ -1,0 +1,10 @@
+FROM (
+  FROM pv_users
+  SELECT TRANSFORM(pv_users.userid, pv_users.date)
+  USING 'map_script'
+  AS dt, uid
+  CLUSTER BY dt) map_output
+INSERT OVERWRITE TABLE pv_users_reduced
+  SELECT TRANSFORM(map_output.dt, map_output.uid)
+  USING 'reduce_script'
+  AS (date INT, count INT)

--- a/sql/hive/examples/transform_5.sql
+++ b/sql/hive/examples/transform_5.sql
@@ -1,10 +1,10 @@
 FROM (
   FROM pv_users
-  SELECT TRANSFORM(pv_users.userid, pv_users.date)
+  SELECT TRANSFORM(pv_users.userid, pv_users.date1)
   USING 'map_script'
   AS dt, uid
   CLUSTER BY dt) map_output
 INSERT OVERWRITE TABLE pv_users_reduced
   SELECT TRANSFORM(map_output.dt, map_output.uid)
   USING 'reduce_script'
-  AS (date INT, count INT)
+  AS (date1 INT, count INT)

--- a/sql/hive/examples/transform_6.sql
+++ b/sql/hive/examples/transform_6.sql
@@ -1,0 +1,1 @@
+SELECT TRANSFORM(*) USING 'cat' AS (col ARRAY<BIGINT>) FROM transform1_t1

--- a/sql/hive/grammar/SelectClauseParser.g4
+++ b/sql/hive/grammar/SelectClauseParser.g4
@@ -32,10 +32,10 @@ selectList
 
 selectTrfmClause
     : LPAREN selectExpressionList RPAREN
-    rowFormat recordWriter
+    rowFormat? recordWriter?
     KW_USING StringLiteral
     ( KW_AS ((LPAREN (aliasList | columnNameTypeList) RPAREN) | (aliasList | columnNameTypeList)))?
-    rowFormat recordReader
+    rowFormat? recordReader?
     ;
 
 selectItem
@@ -48,10 +48,10 @@ selectItem
 trfmClause
     : (   KW_MAP    selectExpressionList
       | KW_REDUCE selectExpressionList )
-    rowFormat recordWriter
+    rowFormat? recordWriter?
     KW_USING StringLiteral
     ( KW_AS ((LPAREN (aliasList | columnNameTypeList) RPAREN) | (aliasList | columnNameTypeList)))?
-    rowFormat recordReader
+    rowFormat? recordReader?
     ;
 
 selectExpression


### PR DESCRIPTION
`rowFormat`, `recordReader` and `recordWriter` in Transform statements are all optional, they should have '?' suffix in selectTrfmClause and trfmClause rules.

Some Hive transform statement test files added.

The syntax of Hive transform/map-reduce grammar:
[https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Transform#LanguageManualTransform-TRANSFORMExamples](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Transform#LanguageManualTransform-TRANSFORMExamples)
