### PR TITLE
adapted to be able to parse BLAS-3.8.0

### DIFF
--- a/fortran77/Fortran77Lexer.g4
+++ b/fortran77/Fortran77Lexer.g4
@@ -264,9 +264,9 @@ SEQUENTIAL
    ;
 
 
-ICON
-   : 'ICON' | 'icon'
-   ;
+// ICON
+//    : 'ICON' | 'icon'
+//    ;
 
 
 LABEL
@@ -413,10 +413,10 @@ DIV
    : '/'
    ;
 
-
-STAR
+fragment STARCHAR
    : '*'
    ;
+
 
 
 POWER
@@ -620,7 +620,7 @@ fragment FDESC
 
 
 fragment EXPON
-   : ('e' | 'd') (SIGN)? (NUM) +
+   : ('e' | 'E' | 'd' | 'D') (SIGN)? (NUM) +
    ;
 
 
@@ -641,11 +641,14 @@ SCON
    : '\'' ('\'' '\'' | ~ ('\'' | '\n' | '\r') | (('\n' | '\r' ('\n')?) '     ' CONTINUATION) ('\n' | '\r' ('\n')?) '     ' CONTINUATION)* '\''
    ;
 
-
+// real constant
 RCON
-   : '.' (NUM)* (EXPON)?
+   : (NUM)+ '.' (NUM)* (EXPON)?
    ;
 
+ICON
+   : (NUM)+
+   ;
 
 NAME
    : (('i' | 'f' | 'd' | 'g' | 'e') (NUM) + '.') FDESC | (ALNUM +) (ALNUM)*
@@ -653,18 +656,27 @@ NAME
 
 
 COMMENT
-   : 'c' (~ [\r\n])*
+   : {getCharPositionInLine() == 0}?
+     ('c' | STARCHAR) (~ [\n])* EOL
+   ;
+
+STAR
+   : STARCHAR
    ;
 
 
 STRINGLITERAL
-   : '"' ~ ["\r\n]* '"'
+   : '"' ~ ["\n]* '"'
    ;
 
 EOL
-   : [\r\n] + 
+   : [\n] + 
    ;
-    
+
+LINECONT
+   : ((EOL '     $') | (EOL '     +')) -> skip
+   ;
+   
 WS
    : [\t ] + -> skip
    ;

--- a/fortran77/Fortran77Parser.g4
+++ b/fortran77/Fortran77Parser.g4
@@ -31,8 +31,13 @@ parser grammar Fortran77Parser;
 options
    { tokenVocab = Fortran77Lexer; }
 
+// multi-line comments?
+commentStatement
+    : COMMENT+
+    ;
+    
 program
-   : executableUnit + EOL*
+   : commentStatement* (executableUnit commentStatement*)+ EOL*
    ;
 
 executableUnit
@@ -78,7 +83,7 @@ entryStatement
    ;
 
 functionStatement
-   : (type)? FUNCTION NAME LPAREN (namelist)? RPAREN
+   : (type)? FUNCTION NAME LPAREN (namelist)? RPAREN EOL?
    ;
 
 blockdataStatement
@@ -86,7 +91,7 @@ blockdataStatement
    ;
 
 subroutineStatement
-   : SUBROUTINE NAME (LPAREN (namelist)? RPAREN)?
+   : SUBROUTINE NAME (LPAREN (namelist)? RPAREN)? EOL?
    ;
 
 namelist
@@ -105,17 +110,16 @@ statement
    | dataStatement
    | (statementFunctionStatement) statementFunctionStatement
    | executableStatement
-   | commentStatement
    ;
 
 subprogramBody
-   : wholeStatement + endStatement
+   : commentStatement* (wholeStatement commentStatement*)+ endStatement
    ;
 
 wholeStatement
    : LABEL? statement EOL
    ;
-
+   
 endStatement
    : LABEL? END
    ;
@@ -174,10 +178,6 @@ commonBlock
    : commonName commonItems
    ;
 
-commentStatement
-    : COMMENT
-    ;
-
 typeStatement
    : typename typeStatementNameList
    | characterWithLen typeStatementNameCharList
@@ -205,7 +205,7 @@ typeStatementLenSpec
    ;
 
 typename
-   : (REAL | COMPLEX (STAR ICON?)? | DOUBLE COMPLEX | DOUBLE PRECISION | INTEGER | LOGICAL)
+   : (REAL | COMPLEX (STAR ICON?)? | DOUBLE COMPLEX | DOUBLE PRECISION | INTEGER | LOGICAL | CHARACTER)
    ;
 
 type
@@ -374,19 +374,19 @@ logicalIfStatement
    ;
 
 blockIfStatement
-   : firstIfBlock (: elseIfStatement)* (elseStatement)? endIfStatement
+   : firstIfBlock (elseIfStatement)* (elseStatement)? endIfStatement
    ;
 
 firstIfBlock
-   : THEN wholeStatement +
+   : THEN EOL? commentStatement* (wholeStatement commentStatement*)+
    ;
 
 elseIfStatement
-   : (ELSEIF | (ELSE IF)) LPAREN logicalExpression RPAREN THEN wholeStatement +
+   : (ELSEIF | (ELSE IF)) LPAREN logicalExpression RPAREN THEN EOL? wholeStatement+
    ;
 
 elseStatement
-   : ELSE wholeStatement +
+   : ELSE EOL? commentStatement* (wholeStatement commentStatement*)+
    ;
 
 endIfStatement
@@ -402,7 +402,7 @@ doVarArgs
    ;
 
 doWithLabel
-   : lblRef (COMMA)? doVarArgs
+   : lblRef (COMMA)? doVarArgs EOL? doBody EOL? continueStatement
    ;
 
 doBody
@@ -410,7 +410,7 @@ doBody
    ;
 
 doWithEndDo
-   : doVarArgs doBody enddoStatement
+   : doVarArgs EOL? doBody EOL? enddoStatement
    ;
 
 enddoStatement
@@ -418,7 +418,7 @@ enddoStatement
    ;
 
 continueStatement
-   : CONTINUE
+   : lblRef* CONTINUE
    ;
 
 stopStatement
@@ -747,7 +747,7 @@ aexpr3
    ;
 
 aexpr4
-   : (unsignedArithmeticConstant) unsignedArithmeticConstant
+   : unsignedArithmeticConstant
    | (HOLLERITH | SCON)
    | logicalConstant
    | varRef


### PR DESCRIPTION
Hi there,

I adapted the Fortran 77 grammar to be able to parse BLAS-3.8.0.
It it tested on the d* and s* routines, except *rotmg, which fails since the "do while" used there is not available in F77.

Is there more code than the few examples in this repo to test the grammar on?

Best,
 Jonathan