### PR TITLE
Remove duplicate 'on' from fragment definition

### DIFF
--- a/graphql/GraphQL.g4
+++ b/graphql/GraphQL.g4
@@ -73,7 +73,7 @@ alias: name ':';
 //https://spec.graphql.org/June2018/#sec-Language.Fragments
 fragmentSpread: '...' fragmentName directives?;
 fragmentDefinition:
-	'fragment' fragmentName 'on' typeCondition directives? selectionSet;
+	'fragment' fragmentName typeCondition directives? selectionSet;
 fragmentName: name; // except on
 
 //https://spec.graphql.org/June2018/#sec-Type-Conditions


### PR DESCRIPTION
The 'on' work is defined on the typeCondition and isn't repeated on the fragment definition.

https://spec.graphql.org/June2018/#sec-Language.Fragments