### PR TITLE
Lexer fix for DoubleLiteral

### DIFF
--- a/kotlin/kotlin/KotlinLexer.g4
+++ b/kotlin/kotlin/KotlinLexer.g4
@@ -184,7 +184,7 @@ FloatLiteral
     ;
 
 DoubleLiteral
-    : ( (DecDigitNoZero DecDigit*)? '.'
+    : ( (DecDigitNoZero DecDigit* | '0')? '.'
       | (DecDigitNoZero (DecDigit | '_')* DecDigit)? '.')
      ( DecDigit+
       | DecDigit (DecDigit | '_')+ DecDigit


### PR DESCRIPTION
Came across this in the following stackoverflow Q&A: https://stackoverflow.com/questions/63746942/correct-antlr-grammar-error-for-nested-functions

Tokenising the input `.6f 0.6f 1.6f` results in these tokens:

```antlr
RealLiteral               `.6f`
IntegerLiteral            `0`
RealLiteral               `.6f`
RealLiteral               `1.6f`
```

I.e. `0.6f` is not properly recognized as a `DoubleLiteral`.