### PR TITLE
Fix link to Kotlin specification

### DIFF
--- a/kotlin/kotlin/README.md
+++ b/kotlin/kotlin/README.md
@@ -4,7 +4,7 @@ ANTLR4 grammar for Kotlin written only in ANTLR's special syntax.
 
 ## Links
 * [EBNF Kotlin grammar](http://kotlinlang.org/docs/reference/grammar.html)
-* [Kotlin specification](http://jetbrains.github.io/kotlin-spec/)
+* [Kotlin specification](https://kotlinlang.org/spec)
 
 ## License
 Licensed under the Apache 2.0


### PR DESCRIPTION
The link in the README for the Kotlin grammar was broken.