### PR TITLE
Use expression as default for variable declaration.

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -1410,7 +1410,7 @@ cursorStatement
 // details
 
 declareVariable
-    : DECLARE uidList dataType (DEFAULT defaultValue)?
+    : DECLARE uidList dataType (DEFAULT expression)?
     ;
 
 declareCondition

--- a/sql/mysql/Positive-Technologies/examples/ddl_create.sql
+++ b/sql/mysql/Positive-Technologies/examples/ddl_create.sql
@@ -246,3 +246,15 @@ CREATE TABLE `tab1` (
   mi MIDDLEINT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 #end
+#begin
+-- Create procedure
+-- The default value for local variables in a DECLARE statement should be an expression
+-- src: https://dev.mysql.com/doc/refman/5.7/en/declare-local-variable.html
+-- delimiter //
+CREATE PROCEDURE procedure1()
+BEGIN
+  DECLARE var1 INT unsigned default 1;
+  DECLARE var2 TIMESTAMP default CURRENT_TIMESTAMP;
+  DECLARE var3 INT unsigned default 2 + var1;
+END -- //-- delimiter ;
+#end


### PR DESCRIPTION
MySql procedure variable declaration's default value can be specified as an expression; it need not be a constant.
Source: https://dev.mysql.com/doc/refman/5.7/en/declare-local-variable.html

Link to issue: https://github.com/antlr/grammars-v4/issues/1866