### PR TITLE
Allow ',' to separate map entries

### DIFF
--- a/terraform/examples/map.tf
+++ b/terraform/examples/map.tf
@@ -1,0 +1,4 @@
+locals {
+  a = {b = "C", d = 1}
+  tags = merge(local.a, {v = "test"})
+}

--- a/terraform/examples/map.tf
+++ b/terraform/examples/map.tf
@@ -1,4 +1,5 @@
 locals {
-  a = {b = "C", d = 1}
+  a    = {b = "C"
+          d = 1}
   tags = merge(local.a, {v = "test"})
 }

--- a/terraform/terraform.g4
+++ b/terraform/terraform.g4
@@ -105,7 +105,6 @@ expression
    | expression OPERATOR expression
    | LPAREN expression RPAREN
    | expression '?' expression ':' expression
-   | map
    ;
 
 RESOURCEREFERENCE
@@ -160,7 +159,7 @@ list
    ;
 
 map
-   : LCURL argument* (',' argument)* LCURL
+   : LCURL (argument ','?)* RCURL
    ;
 
 string

--- a/terraform/terraform.g4
+++ b/terraform/terraform.g4
@@ -105,10 +105,11 @@ expression
    | expression OPERATOR expression
    | LPAREN expression RPAREN
    | expression '?' expression ':' expression
+   | map
    ;
 
 RESOURCEREFERENCE
-   : [a-zA-Z] [a-zA-Z0-9_-]* RESOURCEINDEX? '.' ([a-zA-Z0-9_.-] RESOURCEINDEX?)+ 
+   : [a-zA-Z] [a-zA-Z0-9_-]* RESOURCEINDEX? '.' ([a-zA-Z0-9_.-] RESOURCEINDEX?)+
    ;
 
 RESOURCEINDEX
@@ -159,7 +160,7 @@ list
    ;
 
 map
-   : '{' argument* '}'
+   : '{' argument* (',' argument)* '}'
    ;
 
 string
@@ -191,6 +192,14 @@ OPERATOR
    | '!='
    | '&&'
    | '||'
+   ;
+
+LCURL
+   : '{'
+   ;
+
+RCURL
+   : '}'
    ;
 
 LPAREN

--- a/terraform/terraform.g4
+++ b/terraform/terraform.g4
@@ -88,7 +88,7 @@ label
    ;
 
 blockbody
-   : '{' (argument | block)* '}'
+   : LCURL (argument | block)* RCURL
    ;
 
 argument
@@ -160,7 +160,7 @@ list
    ;
 
 map
-   : '{' argument* (',' argument)* '}'
+   : LCURL argument* (',' argument)* LCURL
    ;
 
 string


### PR DESCRIPTION
{ a=1
 b=2} is a valid map.