### PR TITLE
Do not terminate a string with an escaped double quote

### DIFF
--- a/terraform/examples/strings.tf
+++ b/terraform/examples/strings.tf
@@ -1,0 +1,4 @@
+locals {
+  a = "test"
+  b = "\"test\""
+}

--- a/terraform/terraform.g4
+++ b/terraform/terraform.g4
@@ -227,7 +227,7 @@ MULTILINESTRING
    ;
 
 STRING
-   : '"' (~ [\r\n"] | '""')* '"'
+   : '"' (~ [\r\n"] | '""' | '\\"')* '"'
    ;
 
 IDENTIFIER


### PR DESCRIPTION
"This is a valid string\""