### PR TITLE
Allow arbitrary table alias in column name

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -1924,6 +1924,7 @@ tableName
 
 fullColumnName
     : uid (dottedId dottedId? )?
+    | . dottedId dottedId?
     ;
 
 indexColumnName

--- a/sql/mysql/Positive-Technologies/examples/dml_select.sql
+++ b/sql/mysql/Positive-Technologies/examples/dml_select.sql
@@ -130,3 +130,4 @@ select CONVERT( LEFT( CONVERT( '自動下書き' USING binary ), 100 ) USING utf
 select CONVERT( LEFT( CONVERT( '自動' USING binary ), 6 ) USING utf8 ) AS x_0;
 select  t.*, tt.* FROM wptests_terms AS t  INNER JOIN wptests_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND t.name IN ('远征手记') ORDER BY t.name ASC;
 #end
+SELECT trigger.num FROM test `trigger`;


### PR DESCRIPTION
This is supported

```sql
create table test (num int primary key);
create view test_v as select * from test;
create view `trigger` as select * from test;
create view `test_view_2` as select trigger.num from test `trigger`;
```

as you can see the `SELECT` refers to a column by table alias that can be an arbitrary string - e.g. any keyword etc.

This rule should capture any token/keyword defined in lexer. IMHO alternative would be another `keywordsCanBeId` rule that will contain *all* keywords so it would refer to `keywordsCanBeId` and then contain the rest of the keywords.

Originally reported as https://issues.redhat.com/browse/DBZ-2639