### PR TITLE
Allow keywords as identifiers

### DIFF
--- a/terraform/examples/keywords.tf
+++ b/terraform/examples/keywords.tf
@@ -1,0 +1,19 @@
+data "aws_iam_policy_document" "datadog_aws_integration_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::123456:root"]
+    }
+
+    condition {
+      test = "StringEquals"
+      variable = "sts:ExternalId"  //variable is a keyword
+
+      values = [
+        "123456"
+      ]
+    }
+  }
+}

--- a/terraform/terraform.g4
+++ b/terraform/terraform.g4
@@ -95,10 +95,6 @@ argument
    : identifier '=' expression
    ;
 
-identifier
-   : IDENTIFIER
-   ;
-
 expression
    : RESOURCEREFERENCE index?
    | section
@@ -170,6 +166,11 @@ map
 string
    : STRING
    | MULTILINESTRING
+   ;
+
+identifier
+   : IDENTIFIER
+   | 'variable'
    ;
 
 fragment DIGIT


### PR DESCRIPTION
Sometimes keywords are used as identifiers in the HCL. Make sure that the parser doesn't fail.

data "aws_iam_policy_document" "datadog_aws_integration_assume_role" {
...
    condition {
      test = "StringEquals"
      variable = "sts:ExternalId"  //variable is a keyword

      values = [
        "123456"
      ]
    }
  }
}
