### PR TITLE
chore: re-integrate the PL/SQL grammar into the build

### DIFF
--- a/sql/plsql/Java/PlSqlLexerBase.java
+++ b/sql/plsql/Java/PlSqlLexerBase.java
@@ -1,5 +1,3 @@
-package PlSqlParseTree;
-
 import org.antlr.v4.runtime.*;
 
 public abstract class PlSqlLexerBase extends Lexer

--- a/sql/plsql/Java/PlSqlParserBase.java
+++ b/sql/plsql/Java/PlSqlParserBase.java
@@ -1,5 +1,3 @@
-package PlSqlParseTree;
-
 import org.antlr.v4.runtime.*;
 
 public abstract class PlSqlParserBase extends Parser

--- a/sql/plsql/pom.xml
+++ b/sql/plsql/pom.xml
@@ -11,6 +11,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>
+		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -15,7 +15,7 @@
 	<modules>
 		<module>hive</module>
 		<module>mysql</module>
-	<!--	<module>plsql</module>-->
+		<module>plsql</module>
 		<module>sqlite</module>
 		<module>tsql</module>
 	</modules>


### PR DESCRIPTION
The grammar was there already but unreachable by the build (it was
commented out without any explanation).
This commit re-integrates the grammar into the Maven build.