### PR TITLE
Fixed several C++ things

### DIFF
--- a/cpp/CPP14Lexer.g4
+++ b/cpp/CPP14Lexer.g4
@@ -7,10 +7,7 @@ IntegerLiteral:
 	| BinaryLiteral Integersuffix?;
 
 CharacterLiteral:
-	'\'' Cchar+ '\''
-	| 'u' '\'' Cchar+ '\''
-	| 'U' '\'' Cchar+ '\''
-	| 'L' '\'' Cchar+ '\'';
+	('u' | 'U' | 'L')? '\'' Cchar+ '\'';
 
 FloatingLiteral:
 	Fractionalconstant Exponentpart? Floatingsuffix?

--- a/cpp/CPP14Lexer.g4
+++ b/cpp/CPP14Lexer.g4
@@ -381,7 +381,7 @@ fragment Schar:
 	| Escapesequence
 	| Universalcharactername;
 
-fragment Rawstring: '"' (~[\r\n])*? '(' (~[\r\n])*? ')' (~[\r\n])*? '"';
+fragment Rawstring: '"' ~[\r\n(]* '(' ~[\r\n)]* ')' ~[\r\n"]* '"';
 
 UserDefinedIntegerLiteral:
 	DecimalLiteral Udsuffix

--- a/cpp/CPP14Lexer.g4
+++ b/cpp/CPP14Lexer.g4
@@ -1,13 +1,34 @@
 lexer grammar CPP14Lexer;
 
-Literal:
-	IntegerLiteral
-	| CharacterLiteral
-	| FloatingLiteral
-	| StringLiteral
-	| BooleanLiteral
-	| PointerLiteral
-	| UserDefinedLiteral;
+IntegerLiteral:
+	DecimalLiteral Integersuffix?
+	| OctalLiteral Integersuffix?
+	| HexadecimalLiteral Integersuffix?
+	| BinaryLiteral Integersuffix?;
+
+CharacterLiteral:
+	'\'' Cchar+ '\''
+	| 'u' '\'' Cchar+ '\''
+	| 'U' '\'' Cchar+ '\''
+	| 'L' '\'' Cchar+ '\'';
+
+FloatingLiteral:
+	Fractionalconstant Exponentpart? Floatingsuffix?
+	| Digitsequence Exponentpart Floatingsuffix?;
+
+StringLiteral:
+	Encodingprefix? '"' Schar* '"'
+	| Encodingprefix? 'R' Rawstring;
+
+BooleanLiteral: False_ | True_;
+
+PointerLiteral: Nullptr;
+
+UserDefinedLiteral:
+	UserDefinedIntegerLiteral
+	| UserDefinedFloatingLiteral
+	| UserDefinedStringLiteral
+	| UserDefinedCharacterLiteral;
 
 MultiLineMacro:
 	'#' (~[\n]*? '\\' '\r'? '\n')+ ~ [\n]+ -> channel (HIDDEN);
@@ -222,10 +243,6 @@ AndAssign: '&=';
 
 OrAssign: '|=';
 
-LeftShift: '<<';
-
-RightShift: '>>';
-
 LeftShiftAssign: '<<=';
 
 RightShiftAssign: '>>=';
@@ -285,12 +302,6 @@ fragment NONDIGIT: [a-zA-Z_];
 
 fragment DIGIT: [0-9];
 
-IntegerLiteral:
-	DecimalLiteral Integersuffix?
-	| OctalLiteral Integersuffix?
-	| HexadecimalLiteral Integersuffix?
-	| BinaryLiteral Integersuffix?;
-
 DecimalLiteral: NONZERODIGIT ('\''? DIGIT)*;
 
 OctalLiteral: '0' ('\''? OCTALDIGIT)*;
@@ -321,12 +332,6 @@ fragment Longsuffix: [lL];
 
 fragment Longlongsuffix: 'll' | 'LL';
 
-CharacterLiteral:
-	'\'' Cchar+ '\''
-	| 'u' '\'' Cchar+ '\''
-	| 'U' '\'' Cchar+ '\''
-	| 'L' '\'' Cchar+ '\'';
-
 fragment Cchar:
 	~ ['\\\r\n]
 	| Escapesequence
@@ -347,6 +352,7 @@ fragment Simpleescapesequence:
 	| '\\f'
 	| '\\n'
 	| '\\r'
+    | ('\\' ('\r' '\n'? | '\n'))
 	| '\\t'
 	| '\\v';
 
@@ -356,10 +362,6 @@ fragment Octalescapesequence:
 	| '\\' OCTALDIGIT OCTALDIGIT OCTALDIGIT;
 
 fragment Hexadecimalescapesequence: '\\x' HEXADECIMALDIGIT+;
-
-FloatingLiteral:
-	Fractionalconstant Exponentpart? Floatingsuffix?
-	| Digitsequence Exponentpart Floatingsuffix?;
 
 fragment Fractionalconstant:
 	Digitsequence? '.' Digitsequence
@@ -375,9 +377,6 @@ fragment Digitsequence: DIGIT ('\''? DIGIT)*;
 
 fragment Floatingsuffix: [flFL];
 
-StringLiteral:
-	Encodingprefix? '"' Schar* '"'
-	| Encodingprefix? 'R' Rawstring;
 fragment Encodingprefix: 'u8' | 'u' | 'U' | 'L';
 
 fragment Schar:
@@ -385,17 +384,7 @@ fragment Schar:
 	| Escapesequence
 	| Universalcharactername;
 
-fragment Rawstring: '"' .*? '(' .*? ')' .*? '"';
-
-BooleanLiteral: False_ | True_;
-
-PointerLiteral: Nullptr;
-
-UserDefinedLiteral:
-	UserDefinedIntegerLiteral
-	| UserDefinedFloatingLiteral
-	| UserDefinedStringLiteral
-	| UserDefinedCharacterLiteral;
+fragment Rawstring: '"' (~[\r\n])*? '(' (~[\r\n])*? ')' (~[\r\n])*? '"';
 
 UserDefinedIntegerLiteral:
 	DecimalLiteral Udsuffix

--- a/cpp/CPP14Lexer.g4
+++ b/cpp/CPP14Lexer.g4
@@ -349,7 +349,7 @@ fragment Simpleescapesequence:
 	| '\\f'
 	| '\\n'
 	| '\\r'
-    | ('\\' ('\r' '\n'? | '\n'))
+	| ('\\' ('\r' '\n'? | '\n'))
 	| '\\t'
 	| '\\v';
 

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -170,7 +170,7 @@ additiveExpression:
 shiftExpression:
 	additiveExpression (shiftOperator additiveExpression)*;
 
-shiftOperator: (Greater Greater) | (Less Less);
+shiftOperator: Greater Greater | Less Less;
 
 relationalExpression:
 	shiftExpression (

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -779,7 +779,7 @@ theOperator:
 	| Tilde
 	| Not
 	| Assign
-    | Greater
+	| Greater
 	| Less
 	| GreaterEqual
 	| PlusAssign

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -790,8 +790,8 @@ theOperator:
 	| XorAssign
 	| AndAssign
 	| OrAssign
-	| (Less Less)
-	| (Greater Greater)
+	| Less Less
+	| Greater Greater
 	| RightShiftAssign
 	| LeftShiftAssign
 	| Equal

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -29,7 +29,7 @@ translationUnit: declarationseq? EOF;
 /*Expressions*/
 
 primaryExpression:
-	Literal+
+	literal+
 	| This
 	| LeftParen expression RightParen
 	| idExpression
@@ -62,7 +62,7 @@ lambdaCapture:
 	captureList
 	| captureDefault (Comma captureList)?;
 
-captureDefault: And | Equal;
+captureDefault: And | Assign;
 
 captureList: capture (Comma capture)* Ellipsis?;
 
@@ -73,7 +73,7 @@ simpleCapture: And? Identifier | This;
 initcapture: And? Identifier initializer;
 
 lambdaDeclarator:
-	LeftParen parameterDeclarationClause RightParen Mutable? exceptionSpecification?
+	LeftParen parameterDeclarationClause? RightParen Mutable? exceptionSpecification?
 		attributeSpecifierSeq? trailingReturnType?;
 
 postfixExpression:
@@ -170,7 +170,7 @@ additiveExpression:
 shiftExpression:
 	additiveExpression (shiftOperator additiveExpression)*;
 
-shiftOperator: RightShift | LeftShift;
+shiftOperator: (Greater Greater) | (Less Less);
 
 relationalExpression:
 	shiftExpression (
@@ -779,6 +779,7 @@ theOperator:
 	| Tilde
 	| Not
 	| Assign
+    | Greater
 	| Less
 	| GreaterEqual
 	| PlusAssign
@@ -789,8 +790,8 @@ theOperator:
 	| XorAssign
 	| AndAssign
 	| OrAssign
-	| LeftShift
-	| RightShift
+	| (Less Less)
+	| (Greater Greater)
 	| RightShiftAssign
 	| LeftShiftAssign
 	| Equal
@@ -806,3 +807,12 @@ theOperator:
 	| Arrow
 	| LeftParen RightParen
 	| LeftBracket RightBracket;
+
+literal:
+	IntegerLiteral
+	| CharacterLiteral
+	| FloatingLiteral
+	| StringLiteral
+	| BooleanLiteral
+	| PointerLiteral
+	| UserDefinedLiteral;

--- a/cpp/examples/test2.cpp
+++ b/cpp/examples/test2.cpp
@@ -1,0 +1,12 @@
+operator>() {}
+
+A<B<C>> not_right_shift;
+
+auto zero_parameter_lambda_with_assign = [=] () -> A <B> {};
+
+std::string rawstring_one_line = R"a(b)c";
+
+extern "C" {
+	std::string literal_newline = "new\
+	line";
+}


### PR DESCRIPTION
1. Moved Literal to parser: antlr#1862
2. Removed LeftShift and RightShift: antlr#1702
3. Added escaped literal newlines to Simpleescapesequence: antlr#1940
4. Rawstring no longer spans over newlines: antlr#1940
5. Changed Equal to Assign in captureDefault: antlr#1940
6. Made parameterDeclarationClause optional in lambdaDeclarator: antlr#1940
7. Added missing Greater in theOperator: antlr#1940
8. Added example