### PR TITLE
Update C# and Java Antlr4 parsers to work out of the box

### DIFF
--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -37,7 +37,7 @@
 lexer grammar ANTLRv4Lexer;
 
 
-options { superClass = GrammarGrammar.LexerAdaptor; }
+options { superClass = LexerAdaptor; }
 import LexBasic;
 // Standard set of fragments
 tokens { TOKEN_REF , RULE_REF , LEXER_CHAR_SET }

--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -37,7 +37,7 @@
 lexer grammar ANTLRv4Lexer;
 
 
-options { superClass = Antlr2BGF.AntlrParser.LexerAdaptor; }
+options { superClass = GrammarGrammar.LexerAdaptor; }
 import LexBasic;
 // Standard set of fragments
 tokens { TOKEN_REF , RULE_REF , LEXER_CHAR_SET }

--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -37,7 +37,7 @@
 lexer grammar ANTLRv4Lexer;
 
 
-options { superClass = LexerAdaptor; }
+options { superClass = Antlr2BGF.AntlrParser.LexerAdaptor; }
 import LexBasic;
 // Standard set of fragments
 tokens { TOKEN_REF , RULE_REF , LEXER_CHAR_SET }
@@ -92,10 +92,10 @@ BEGIN_ARGUMENT
    { handleBeginArgument(); }
    ;
    // -------------------------
-   // Actions
+   // Target Language Actions
 
 BEGIN_ACTION
-   : LBrace -> pushMode (Action)
+   : LBrace -> pushMode (TargetLanguageAction)
    ;
    // -------------------------
    // Keywords
@@ -330,7 +330,7 @@ ARGUMENT_CONTENT
    : .
    ;
    // -------------------------
-   // Actions
+   // Target Language Actions
    //
    // Many language targets use {} as block delimiters and so we
    // must recursively match {} delimited blocks to balance the
@@ -339,9 +339,9 @@ ARGUMENT_CONTENT
    // that they are delimited by ' or " and so consume these
    // in their own alts so as not to inadvertantly match {}.
 
-mode Action;
+mode TargetLanguageAction;
 NESTED_ACTION
-   : LBrace -> type (ACTION_CONTENT) , pushMode (Action)
+   : LBrace -> type (ACTION_CONTENT) , pushMode (TargetLanguageAction)
    ;
 
 ACTION_ESCAPE

--- a/antlr/antlr4/LexerAdaptor.cs
+++ b/antlr/antlr4/LexerAdaptor.cs
@@ -26,7 +26,7 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-namespace Antlr2BGF.AntlrParser
+namespace LexerAdaptor
 {
     using System;
     using System.IO;

--- a/antlr/antlr4/LexerAdaptor.cs
+++ b/antlr/antlr4/LexerAdaptor.cs
@@ -103,7 +103,7 @@ namespace Antlr2BGF.AntlrParser
             if (InsideOptionsBlock)
             {
                 CurrentRuleType = ANTLRv4Lexer.BEGIN_ACTION;
-                PushMode(ANTLRv4Lexer.CodeAction);
+                PushMode(ANTLRv4Lexer.TargetLanguageAction);
             }
             else
             {

--- a/antlr/antlr4/LexerAdaptor.cs
+++ b/antlr/antlr4/LexerAdaptor.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  [The "BSD licence"]
  Copyright (c) 2005-2007 Terence Parr
  All rights reserved.
@@ -25,17 +25,16 @@
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-using System;
-using System.Reflection;
-namespace GrammarGrammar
+
+namespace Antlr2BGF.AntlrParser
 {
+    using System;
     using System.IO;
+    using System.Reflection;
     using Antlr4.Runtime;
     using Antlr4.Runtime.Misc;
 
-#pragma warning disable CA1012 // Abstract types should not have constructors
     public abstract class LexerAdaptor : Lexer
-#pragma warning restore CA1012 // But Lexer demands it - old 
     {
         // I copy a reference to the stream, so It can be used as a Char Stream, not as a IISStream
         readonly ICharStream stream;
@@ -66,6 +65,8 @@ namespace GrammarGrammar
          */
         private int CurrentRuleType { get; set; } = TokenConstants.InvalidType;
 
+        private bool InsideOptionsBlock { get; set; } = false;
+
         protected void handleBeginArgument()
         {
             if (InLexerRule)
@@ -94,6 +95,20 @@ namespace GrammarGrammar
             if (ModeStack.Count > 0)
             {
                 CurrentRuleType = (ANTLRv4Lexer.ACTION_CONTENT);
+            }
+        }
+
+        protected void handleOptionsLBrace()
+        {
+            if (InsideOptionsBlock)
+            {
+                CurrentRuleType = ANTLRv4Lexer.BEGIN_ACTION;
+                PushMode(ANTLRv4Lexer.CodeAction);
+            }
+            else
+            {
+                CurrentRuleType = ANTLRv4Lexer.LBRACE;
+                InsideOptionsBlock = true;
             }
         }
 
@@ -133,6 +148,6 @@ namespace GrammarGrammar
 
 
         private bool InParserRule => CurrentRuleType == ANTLRv4Lexer.RULE_REF;
-
+        
     }
 }

--- a/antlr/antlr4/src/main/java/org/antlr/parser/antlr4/LexerAdaptor.java
+++ b/antlr/antlr4/src/main/java/org/antlr/parser/antlr4/LexerAdaptor.java
@@ -87,7 +87,7 @@ public abstract class LexerAdaptor extends Lexer {
 	    int oldMode = _mode;
         int newMode = popMode();
         boolean isActionWithinAction = _modeStack.size() > 0
-            && newMode == ANTLRv4Lexer.Action
+            && newMode == ANTLRv4Lexer.TargetLanguageAction
             && oldMode == newMode;
 
 		if (isActionWithinAction) {
@@ -98,7 +98,7 @@ public abstract class LexerAdaptor extends Lexer {
 	protected void handleOptionsLBrace() {
 		if (insideOptionsBlock) {
 			setType(ANTLRv4Lexer.BEGIN_ACTION);
-			pushMode(ANTLRv4Lexer.Action);
+			pushMode(ANTLRv4Lexer.TargetLanguageAction);
 		} else {
 			setType(ANTLRv4Lexer.LBRACE);
 			insideOptionsBlock = true;


### PR DESCRIPTION
The Antlr4 lexer grammar had a mode called 'Action' which collided with the function of the same name in the Lexer class. It has been renamed to TargetLanguageAction in the lexer grammar.

The C# lexer adaptor was still missing the handleOptionsLBrace method, this has been implemented as a replication of the Java reference.