### PR TITLE
expand Label to support Capital and all UPPER

### DIFF
--- a/php/PhpLexer.g4
+++ b/php/PhpLexer.g4
@@ -302,7 +302,7 @@ Quote:              '\'';
 BackQuote:          '`';
 
 VarName:            '$' NameString;
-Label:              [a-z_][a-z_0-9]*;
+Label:              [a-zA-Z_][a-zA-Z_0-9]*;
 Octal:              '0' [0-7]+;
 Decimal:            '0' | NonZeroDigit Digit*;
 Real:               (Digit+ '.' Digit* | '.' Digit+) ExponentPart?

--- a/php/examples/classWithUpperCase.php
+++ b/php/examples/classWithUpperCase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace foobar\baz;
+
+class MyClass extends BasicClass{
+    public function __construct(int $meta = 0){
+        parent::__construct(self::BASIC, $meta, "Basic");
+    }
+    public function getLevel() : int{
+        return 123456;
+    }
+}


### PR DESCRIPTION
Before the A-Z addition, this file tokenized as 

```
  Class                'class'
  Whitespace           ' '
  ErrorPhp             'M'
  Label                'y'
  ErrorPhp             'C'
  Label                'lass'
  Whitespace           ' '
  Extends              'extends'
  Whitespace           ' '
  ErrorPhp             'B'
  Label                'asic'
  ErrorPhp             'C'
  Label                'lass'
  OpenCurlyBracket     '{'
  ```
  
  after the minor label change, the tokenization becomes 

```
  Class                'class'
  Whitespace           ' '
  Label                'MyClass'
  Whitespace           ' '
  Extends              'extends'
  Whitespace           ' '
  Label                'BasicClass'
  OpenCurlyBracket     '{'
```