### PR TITLE
add abb parser files

### DIFF
--- a/abb/abbLexer.g4
+++ b/abb/abbLexer.g4
@@ -1,0 +1,260 @@
+lexer grammar abbLexer;
+
+MODULE : 'module' ;
+PROC : P R O C ;
+ENDPROC : E N D P R O C;
+LOCAL : L O C A L ;
+CONST : C O N S T ;
+PERS : P E R S ;
+VAR : V A R ;
+TOOLDATA : T O O L D A T A ;
+WOBJDATA : W O B J D A T A ;
+SPEEDDATA : S P E E D D A T A ;
+ZONEDATA : Z O N E D A T A ;
+CLOCK : C L O C K ;
+BOOL : B O O L ;
+ON_CALL : '\\' O N ;
+OFF_CALL : '\\' O F F ;
+
+SLASH               : '/' ;
+EQUALS              : ':=' ;
+COMMA               : ',';
+CURLY_OPEN          : '{';
+CURLY_CLOSE         : '}';
+COLON               : ':';
+SEMICOLON           : ';';
+BRACKET_OPEN        : '(';
+BRACKET_CLOSE       : ')';
+SQUARE_OPEN         : '[';
+SQUARE_CLOSE        : ']';
+DOT                 : '.';
+DOUBLEDOT           : '..';
+REL_BIGGER          : '>';
+REL_BIGGER_OR_EQUAL : '>=';
+REL_SMALLER         : '<';
+REL_SMALLER_OR_EQUAL: '<=';
+REL_EQUAL           : '==';
+REL_NOTEQUAL        : '<>';
+PLUS                : '+';
+MINUS               : '-';
+MULTIPLY            : '*';
+PERCENT             : '%';
+HASH                : '#';
+
+fragment A
+   : ('a' | 'A')
+   ;
+
+
+fragment B
+   : ('b' | 'B')
+   ;
+
+
+fragment C
+   : ('c' | 'C')
+   ;
+
+
+fragment D
+   : ('d' | 'D')
+   ;
+
+
+fragment E
+   : ('e' | 'E')
+   ;
+
+
+fragment F
+   : ('f' | 'F')
+   ;
+
+
+fragment G
+   : ('g' | 'G')
+   ;
+
+
+fragment H
+   : ('h' | 'H')
+   ;
+
+
+fragment I
+   : ('i' | 'I')
+   ;
+
+
+fragment J
+   : ('j' | 'J')
+   ;
+
+
+fragment K
+   : ('k' | 'K')
+   ;
+
+
+fragment L
+   : ('l' | 'L')
+   ;
+
+
+fragment M
+   : ('m' | 'M')
+   ;
+
+
+fragment N
+   : ('n' | 'N')
+   ;
+
+
+fragment O
+   : ('o' | 'O')
+   ;
+
+
+fragment P
+   : ('p' | 'P')
+   ;
+
+
+fragment Q
+   : ('q' | 'Q')
+   ;
+
+
+fragment R
+   : ('r' | 'R')
+   ;
+
+
+fragment S
+   : ('s' | 'S')
+   ;
+
+
+fragment T
+   : ('t' | 'T')
+   ;
+
+
+fragment U
+   : ('u' | 'U')
+   ;
+
+
+fragment V
+   : ('v' | 'V')
+   ;
+
+
+fragment W
+   : ('w' | 'W')
+   ;
+
+
+fragment X
+   : ('x' | 'X')
+   ;
+
+
+fragment Y
+   : ('y' | 'Y')
+   ;
+
+
+fragment Z
+   : ('z' | 'Z')
+   ;
+
+
+WS
+   : (' ' | '\t' | '\u000C') -> skip
+   ;
+
+NEWLINE
+   : '\r'? '\n'
+   ;
+
+
+LINE_COMMENT
+   : '!' ~ ('\n' | '\r')* -> skip
+   ;
+
+BOOLLITERAL
+   : (F A L S E | T R U E)
+   ;
+
+CHARLITERAL
+   : '\'' (EscapeSequence | ~ ('\'' | '\\' | '\r' | '\n')) '\''
+   ;
+
+
+STRINGLITERAL
+   : '"' (EscapeSequence | ~ ('\\' | '"' | '\r' | '\n'))* '"'
+   ;
+
+fragment EscapeSequence
+   : '\\' ('b' | 't' | 'n' | 'f' | 'r' | '"' | '\'' | '\\' | ('0' .. '3') ('0' .. '7') ('0' .. '7') | ('0' .. '7') ('0' .. '7') | ('0' .. '7'))
+   ;
+
+FLOATLITERAL
+   : ('0' .. '9') + '.' ('0' .. '9')* Exponent? | '.' ('0' .. '9') + Exponent? | ('0' .. '9') + Exponent
+   ;
+
+
+fragment Exponent
+   : E ('+' | '-')? ('0' .. '9') +
+   ;
+
+
+INTLITERAL
+   : ('0' .. '9') + | HexPrefix HexDigit + HexSuffix | BinPrefix BinDigit + BinSuffix
+   ;
+
+
+fragment HexPrefix
+   : '\'' H
+   ;
+
+
+fragment HexDigit
+   : ('0' .. '9' | 'a' .. 'f' | 'A' .. 'F')
+   ;
+
+
+fragment HexSuffix
+   : '\''
+   ;
+
+
+fragment BinPrefix
+   : '\'' B
+   ;
+
+
+fragment BinDigit
+   : ('0' | '1')
+   ;
+
+
+fragment BinSuffix
+   : '\''
+   ;
+
+IDENTIFIER
+   : IdentifierStart IdentifierPart*
+   ;
+
+
+fragment IdentifierStart
+   : 'a' .. 'z' | 'A' .. 'Z' | '_'
+   ;
+
+
+fragment IdentifierPart
+   : (IdentifierStart | '0' .. '9')
+   ;

--- a/abb/abbParser.g4
+++ b/abb/abbParser.g4
@@ -1,0 +1,105 @@
+parser grammar abbParser;
+
+options { tokenVocab = abbLexer; }
+
+/*
+    This grammar is still in development. 
+    In the current state, it is only able to parse .sys-files and read the given declarations. 
+*/
+/*
+    This file is the grammar for the ABB RAPID Robot Language.
+    
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+Antlr4 port by Tom Everett, 2016
+
+Question mark stands for: zero or one
+Plus stands for: one or more
+Star stands for: zero or more
+
+*/
+
+module
+    : moduleData EOF
+    ;
+
+moduleData
+    : MODULE moduleName NEWLINE
+      dataList 
+      NEWLINE*
+    ;
+
+moduleName
+    : IDENTIFIER 
+    | procCall
+    ;
+
+dataList
+    : (NEWLINE
+    | declaration NEWLINE
+    | procedure NEWLINE)*
+    ;
+
+procedure
+    : PROC procCall NEWLINE
+      (functionCall NEWLINE)*
+    ENDPROC
+    ;
+
+procCall
+    : procName procParameter?
+    ;
+
+procName
+    : IDENTIFIER
+    ;
+
+procParameter
+    : BRACKET_OPEN IDENTIFIER? BRACKET_CLOSE
+    ;
+
+functionCall
+    : IDENTIFIER (functionParameter COMMA)* functionParameter SEMICOLON
+    ;
+
+functionParameter
+    : ON_CALL
+    | OFF_CALL
+    | primitive
+    | IDENTIFIER
+    ;
+
+declaration
+    : init type IDENTIFIER (EQUALS expression)? SEMICOLON
+    ;
+
+type
+    : ( TOOLDATA | WOBJDATA | SPEEDDATA | ZONEDATA | CLOCK | BOOL )
+    ;
+
+init
+    : LOCAL? ( CONST | PERS | VAR )
+    ;
+
+expression
+    : array | primitive
+    ;
+
+array
+    : SQUARE_OPEN (expression COMMA)* expression SQUARE_CLOSE
+    ;
+
+primitive
+    : BOOLLITERAL
+    | CHARLITERAL
+    | STRINGLITERAL
+    | (PLUS | MINUS)? FLOATLITERAL
+    | (PLUS | MINUS)? INTLITERAL
+    ;

--- a/abb/example/robdata.sys
+++ b/abb/example/robdata.sys
@@ -1,0 +1,12 @@
+module robdata(sysmodule)
+
+	PERS tooldata tMain:=[TRUE,[[0.0,0.0,700.0],[1.0,0.0,0.0,0.0]],[0.0,[5.0,0,95.5],[1,0,0,0],0.228,0.094,0]];
+	PERS wobjdata wobjMain:= [FALSE, TRUE, "", [[0, 0, 0],[1, 0, 0, 0]],[[0, 0, 0],[1, 0, 0, 0]]];
+	CONST speeddata v200:=[200,500,5000,1000];
+	
+	PROC ConfigOn()
+		ConfJ\On;
+		ConfL\On;
+	ENDPROC
+  
+endmodule

--- a/abb/readme.txt
+++ b/abb/readme.txt
@@ -1,0 +1,4 @@
+Maximilian Segelken Thu Jan 7, 2021 11:21
+The grammar of the industrial robots of ABB. This grammar has been reverse engineered based on a set of ABB Rapid sys-files and the existing kuka-krl antlr file '../kuka/krl.g4'
+
+Antlr4 port by Tom Everett, 2016


### PR DESCRIPTION
Added ANTLR parser files for abb rapid language.
Reverse Engineered from abb-sys (machine-data) files to parse variable definitions.

Added a short example of a robdata.sys file

References #1526 