### PR TITLE
Bring ANTLR4 grammar closer to spec

### DIFF
--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -291,11 +291,11 @@ WS
 // parser. This means that the parser to deal with the gramamr file anyway
 // but we will not try to analyse or code generate from a file with lexical
 // errors.
-//
+
 // Comment this rule out to allow the error to be propagated to the parser
-// ERRCHAR
-//    : . -> channel (HIDDEN)
-//    ;
+ERRCHAR
+   : . -> channel (HIDDEN)
+   ;
 
 // ======================================================
 // Lexer modes
@@ -324,7 +324,7 @@ END_ARGUMENT
    { handleEndArgument(); }
    ;
 
-   // added this to return non-EOF token type here. EOF does something weird
+// added this to return non-EOF token type here. EOF does something weird
 UNTERMINATED_ARGUMENT
    : EOF -> popMode
    ;
@@ -383,8 +383,8 @@ UNTERMINATED_ACTION
 ACTION_CONTENT
    : .
    ;
-   // -------------------------
 
+// -------------------------
 mode Options;
 OPT_DOC_COMMENT
    : DocComment -> type (DOC_COMMENT) , channel (COMMENT)
@@ -438,8 +438,8 @@ OPT_SEMI
 OPT_WS
    : Ws+ -> type (WS) , channel (OFF_CHANNEL)
    ;
-   // -------------------------
 
+// -------------------------
 mode Tokens;
 TOK_DOC_COMMENT
    : DocComment -> type (DOC_COMMENT) , channel (COMMENT)
@@ -476,8 +476,8 @@ TOK_COMMA
 TOK_WS
    : Ws+ -> type (WS) , channel (OFF_CHANNEL)
    ;
-   // -------------------------
 
+// -------------------------
 mode Channels;
 // currently same as Tokens mode; distinguished by keyword
 CHN_DOC_COMMENT
@@ -515,8 +515,8 @@ CHN_COMMA
 CHN_WS
    : Ws+ -> type (WS) , channel (OFF_CHANNEL)
    ;
-   // -------------------------
 
+// -------------------------
 mode LexerCharSet;
 LEXER_CHAR_SET_BODY
    : (~ [\]\\] | EscAny)+ -> more
@@ -529,9 +529,9 @@ LEXER_CHAR_SET
 UNTERMINATED_CHAR_SET
    : EOF -> popMode
    ;
-   // ------------------------------------------------------------------------------
-   // Grammar specific Keywords, Punctuation, etc.
 
+// ------------------------------------------------------------------------------
+// Grammar specific Keywords, Punctuation, etc.
 fragment Id
    : NameStartChar NameChar*
    ;

--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -41,7 +41,7 @@
 
 lexer grammar ANTLRv4Lexer;
 
-options { superClass = Antlr2BGF.AntlrParser.LexerAdaptor; }
+options { superClass = LexerAdaptor; }
 import LexBasic;
 
 // Standard set of fragments

--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -34,21 +34,24 @@
  *	Modified 2015.06.16 gbr
  *	-- update for compatibility with Antlr v4.5
  */
+
+// ======================================================
+// Lexer specification
+// ======================================================
+
 lexer grammar ANTLRv4Lexer;
 
-
-options { superClass = LexerAdaptor; }
+options { superClass = Antlr2BGF.AntlrParser.LexerAdaptor; }
 import LexBasic;
+
 // Standard set of fragments
 tokens { TOKEN_REF , RULE_REF , LEXER_CHAR_SET }
 channels { OFF_CHANNEL , COMMENT }
-// ======================================================
-// Lexer specification
-//
+
 // -------------------------
 // Comments
 DOC_COMMENT
-   : DocComment
+   : DocComment -> channel (COMMENT)
    ;
 
 BLOCK_COMMENT
@@ -58,21 +61,21 @@ BLOCK_COMMENT
 LINE_COMMENT
    : LineComment -> channel (COMMENT)
    ;
-   // -------------------------
-   // Integer
-   //
+
+// -------------------------
+// Integer
 
 INT
    : DecimalNumeral
    ;
-   // -------------------------
-   // Literal string
-   //
-   // ANTLR makes no distinction between a single character literal and a
-   // multi-character string. All literals are single quote delimited and
-   // may contain unicode escape sequences of the form \uxxxx, where x
-   // is a valid hexadecimal number (per Unicode standard).
 
+// -------------------------
+// Literal string
+//
+// ANTLR makes no distinction between a single character literal and a
+// multi-character string. All literals are single quote delimited and
+// may contain unicode escape sequences of the form \uxxxx, where x
+// is a valid hexadecimal number (per Unicode standard).
 STRING_LITERAL
    : SQuoteLiteral
    ;
@@ -80,30 +83,30 @@ STRING_LITERAL
 UNTERMINATED_STRING_LITERAL
    : USQuoteLiteral
    ;
-   // -------------------------
-   // Arguments
-   //
-   // Certain argument lists, such as those specifying call parameters
-   // to a rule invocation, or input parameters to a rule specification
-   // are contained within square brackets.
 
+// -------------------------
+// Arguments
+//
+// Certain argument lists, such as those specifying call parameters
+// to a rule invocation, or input parameters to a rule specification
+// are contained within square brackets.
 BEGIN_ARGUMENT
    : LBrack
    { handleBeginArgument(); }
    ;
-   // -------------------------
-   // Target Language Actions
 
+// -------------------------
+// Target Language Actions
 BEGIN_ACTION
    : LBrace -> pushMode (TargetLanguageAction)
    ;
-   // -------------------------
-   // Keywords
-   //
-   // Keywords may not be used as labels for rules or in any other context where
-   // they would be ambiguous with the keyword vs some other identifier.  OPTIONS,
-   // TOKENS, & CHANNELS blocks are handled idiomatically in dedicated lexical modes.
 
+// -------------------------
+// Keywords
+//
+// Keywords may not be used as labels for rules or in any other context where
+// they would be ambiguous with the keyword vs some other identifier.  OPTIONS,
+// TOKENS, & CHANNELS blocks are handled idiomatically in dedicated lexical modes.
 OPTIONS
    : 'options' -> pushMode (Options)
    ;
@@ -277,27 +280,27 @@ ID
 WS
    : Ws+ -> channel (OFF_CHANNEL)
    ;
-   // -------------------------
-   // Illegal Characters
-   //
-   // This is an illegal character trap which is always the last rule in the
-   // lexer specification. It matches a single character of any value and being
-   // the last rule in the file will match when no other rule knows what to do
-   // about the character. It is reported as an error but is not passed on to the
-   // parser. This means that the parser to deal with the gramamr file anyway
-   // but we will not try to analyse or code generate from a file with lexical
-   // errors.
-   //
-   // Comment this rule out to allow the error to be propagated to the parser
 
-ERRCHAR
-   : . -> channel (HIDDEN)
-   ;
-   // ======================================================
-   // Lexer modes
-   // -------------------------
-   // Arguments
+// -------------------------
+// Illegal Characters
+//
+// This is an illegal character trap which is always the last rule in the
+// lexer specification. It matches a single character of any value and being
+// the last rule in the file will match when no other rule knows what to do
+// about the character. It is reported as an error but is not passed on to the
+// parser. This means that the parser to deal with the gramamr file anyway
+// but we will not try to analyse or code generate from a file with lexical
+// errors.
+//
+// Comment this rule out to allow the error to be propagated to the parser
+// ERRCHAR
+//    : . -> channel (HIDDEN)
+//    ;
 
+// ======================================================
+// Lexer modes
+// -------------------------
+// Arguments
 mode Argument;
 // E.g., [int x, List<String> a[]]
 NESTED_ARGUMENT
@@ -320,8 +323,8 @@ END_ARGUMENT
    : RBrack
    { handleEndArgument(); }
    ;
-   // added this to return non-EOF token type here. EOF does something weird
 
+   // added this to return non-EOF token type here. EOF does something weird
 UNTERMINATED_ARGUMENT
    : EOF -> popMode
    ;
@@ -329,16 +332,16 @@ UNTERMINATED_ARGUMENT
 ARGUMENT_CONTENT
    : .
    ;
-   // -------------------------
-   // Target Language Actions
-   //
-   // Many language targets use {} as block delimiters and so we
-   // must recursively match {} delimited blocks to balance the
-   // braces. Additionally, we must make some assumptions about
-   // literal string representation in the target language. We assume
-   // that they are delimited by ' or " and so consume these
-   // in their own alts so as not to inadvertantly match {}.
 
+// -------------------------
+// Target Language Actions
+//
+// Many language targets use {} as block delimiters and so we
+// must recursively match {} delimited blocks to balance the
+// braces. Additionally, we must make some assumptions about
+// literal string representation in the target language. We assume
+// that they are delimited by ' or " and so consume these
+// in their own alts so as not to inadvertantly match {}.
 mode TargetLanguageAction;
 NESTED_ACTION
    : LBrace -> type (ACTION_CONTENT) , pushMode (TargetLanguageAction)
@@ -532,4 +535,3 @@ UNTERMINATED_CHAR_SET
 fragment Id
    : NameStartChar NameChar*
    ;
-

--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -535,3 +535,4 @@ UNTERMINATED_CHAR_SET
 fragment Id
    : NameStartChar NameChar*
    ;
+   

--- a/antlr/antlr4/ANTLRv4Parser.g4
+++ b/antlr/antlr4/ANTLRv4Parser.g4
@@ -43,7 +43,7 @@ parser grammar ANTLRv4Parser;
 options { tokenVocab = ANTLRv4Lexer; }
 // The main entry point for parsing a v4 grammar.
 grammarSpec
-   : DOC_COMMENT* grammarDecl prequelConstruct* rules modeSpec* EOF
+   : grammarDecl prequelConstruct* rules modeSpec* EOF
    ;
 
 grammarDecl
@@ -53,10 +53,9 @@ grammarDecl
 grammarType
    : (LEXER GRAMMAR | PARSER GRAMMAR | GRAMMAR)
    ;
-
-// This is the list of all constructs that can be declared before
-// the set of rules that compose the grammar, and is invoked 0..n
-// times by the grammarPrequel rule.
+   // This is the list of all constructs that can be declared before
+   // the set of rules that compose the grammar, and is invoked 0..n
+   // times by the grammarPrequel rule.
 
 prequelConstruct
    : optionsSpec
@@ -65,9 +64,8 @@ prequelConstruct
    | channelsSpec
    | action_
    ;
-
-// ------------
-// Options - things that affect analysis and/or code generation
+   // ------------
+   // Options - things that affect analysis and/or code generation
 
 optionsSpec
    : OPTIONS LBRACE (option SEMI)* RBRACE
@@ -83,9 +81,8 @@ optionValue
    | actionBlock
    | INT
    ;
-
-// ------------
-// Delegates
+   // ------------
+   // Delegates
 
 delegateGrammars
    : IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
@@ -95,9 +92,8 @@ delegateGrammar
    : identifier ASSIGN identifier
    | identifier
    ;
-
-// ------------
-// Tokens & Channels
+   // ------------
+   // Tokens & Channels
 
 tokensSpec
    : TOKENS LBRACE idList? RBRACE
@@ -110,14 +106,12 @@ channelsSpec
 idList
    : identifier (COMMA identifier)* COMMA?
    ;
-
-// Match stuff like @parser::members {int i;}
+   // Match stuff like @parser::members {int i;}
 
 action_
    : AT (actionScopeName COLONCOLON)? identifier actionBlock
    ;
-
-// Scope names could collide with keywords; allow them as ids for action scopes
+   // Scope names could collide with keywords; allow them as ids for action scopes
 
 actionScopeName
    : identifier
@@ -147,7 +141,7 @@ ruleSpec
    ;
 
 parserRuleSpec
-   : DOC_COMMENT* ruleModifiers? RULE_REF argActionBlock? ruleReturns? throwsSpec? localsSpec? rulePrequel* COLON ruleBlock SEMI exceptionGroup
+   : ruleModifiers? RULE_REF argActionBlock? ruleReturns? throwsSpec? localsSpec? rulePrequel* COLON ruleBlock SEMI exceptionGroup
    ;
 
 exceptionGroup
@@ -173,7 +167,6 @@ ruleReturns
 
 // --------------
 // Exception spec
-
 throwsSpec
    : THROWS identifier (COMMA identifier)*
    ;
@@ -182,20 +175,20 @@ localsSpec
    : LOCALS argActionBlock
    ;
 
-/** Match stuff like @init {int i;} */ ruleAction
+/** Match stuff like @init {int i;} */
+ruleAction
    : AT identifier actionBlock
    ;
 
 ruleModifiers
    : ruleModifier+
    ;
-
-// An individual access modifier for a rule. The 'fragment' modifier
-// is an internal indication for lexer rules that they do not match
-// from the input but are like subroutines for other lexer rules to
-// reuse for certain lexical patterns. The other modifiers are passed
-// to the code generation templates and may be ignored by the template
-// if they are of no use in that language.
+   // An individual access modifier for a rule. The 'fragment' modifier
+   // is an internal indication for lexer rules that they do not match
+   // from the input but are like subroutines for other lexer rules to
+   // reuse for certain lexical patterns. The other modifiers are passed
+   // to the code generation templates and may be ignored by the template
+   // if they are of no use in that language.
 
 ruleModifier
    : PUBLIC
@@ -215,12 +208,11 @@ ruleAltList
 labeledAlt
    : alternative (POUND identifier)?
    ;
-
-// --------------------
-// Lexer rules
+   // --------------------
+   // Lexer rules
 
 lexerRuleSpec
-   : DOC_COMMENT* FRAGMENT? TOKEN_REF COLON lexerRuleBlock SEMI
+   : FRAGMENT? TOKEN_REF COLON lexerRuleBlock SEMI
    ;
 
 lexerRuleBlock
@@ -233,12 +225,13 @@ lexerAltList
 
 lexerAlt
    : lexerElements lexerCommands?
-   | // empty alt
+   |
+   // explicitly allow empty alts
    ;
 
 lexerElements
    : lexerElement+
-   | // empty alt
+   |
    ;
 
 lexerElement
@@ -247,8 +240,7 @@ lexerElement
    | lexerBlock ebnfSuffix?
    | actionBlock QUESTION?
    ;
-
-// but preds can be anywhere
+   // but preds can be anywhere
 
 labeledLexerElement
    : identifier (ASSIGN | PLUS_ASSIGN) (lexerAtom | lexerBlock)
@@ -257,8 +249,7 @@ labeledLexerElement
 lexerBlock
    : LPAREN lexerAltList RPAREN
    ;
-
-// E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop
+   // E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop
 
 lexerCommands
    : RARROW lexerCommand (COMMA lexerCommand)*
@@ -278,9 +269,8 @@ lexerCommandExpr
    : identifier
    | INT
    ;
-
-// --------------------
-// Rule Alts
+   // --------------------
+   // Rule Alts
 
 altList
    : alternative (OR alternative)*
@@ -302,9 +292,8 @@ element
 labeledElement
    : identifier (ASSIGN | PLUS_ASSIGN) (atom | block)
    ;
-
-// --------------------
-// EBNF and blocks
+   // --------------------
+   // EBNF and blocks
 
 ebnf
    : block blockSuffix?
@@ -337,7 +326,6 @@ atom
 
 // --------------------
 // Inverted element set
-
 notSet
    : NOT setElement
    | NOT blockSet
@@ -356,21 +344,18 @@ setElement
 
 // -------------
 // Grammar Block
-
 block
    : LPAREN (optionsSpec? ruleAction* COLON)? altList RPAREN
    ;
 
 // ----------------
 // Parser rule ref
-
 ruleref
    : RULE_REF argActionBlock? elementOptions?
    ;
 
 // ---------------
 // Character Range
-
 characterRange
    : STRING_LITERAL RANGE STRING_LITERAL
    ;
@@ -382,7 +367,6 @@ terminal
 
 // Terminals may be adorned with certain options when
 // reference in the grammar: TOK<,,,>
-
 elementOptions
    : LT elementOption (COMMA elementOption)* GT
    ;
@@ -396,4 +380,4 @@ identifier
    : RULE_REF
    | TOKEN_REF
    ;
-
+   

--- a/antlr/antlr4/LexBasic.g4
+++ b/antlr/antlr4/LexBasic.g4
@@ -271,4 +271,4 @@ fragment Pound
 fragment Tilde
    : '~'
    ;
-
+   

--- a/antlr/antlr4/LexerAdaptor.cs
+++ b/antlr/antlr4/LexerAdaptor.cs
@@ -26,7 +26,7 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-namespace Antlr2BGF.AntlrParser
+namespace LexerAdaptor
 {
     using System;
     using System.IO;

--- a/antlr/antlr4/LexerAdaptor.cs
+++ b/antlr/antlr4/LexerAdaptor.cs
@@ -26,7 +26,7 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-namespace LexerAdaptor
+namespace Antlr2BGF.AntlrParser
 {
     using System;
     using System.IO;
@@ -36,10 +36,14 @@ namespace LexerAdaptor
 
     public abstract class LexerAdaptor : Lexer
     {
+        private static readonly int PREQUEL_CONSTRUCT = -10;
+
         // I copy a reference to the stream, so It can be used as a Char Stream, not as a IISStream
         readonly ICharStream stream;
+
         // Tokens are read only so I hack my way
         readonly FieldInfo tokenInput = typeof(CommonToken).GetField("_type", BindingFlags.NonPublic | BindingFlags.Instance);
+
         protected LexerAdaptor(ICharStream input)
              : base(input, Console.Out, Console.Error)
         {
@@ -65,7 +69,7 @@ namespace LexerAdaptor
          */
         private int CurrentRuleType { get; set; } = TokenConstants.InvalidType;
 
-        private bool InsideOptionsBlock { get; set; } = false;
+        private bool _insideOptionsBlock;
 
         protected void handleBeginArgument()
         {
@@ -85,59 +89,81 @@ namespace LexerAdaptor
             PopMode();
             if (ModeStack.Count > 0)
             {
-                CurrentRuleType = (ANTLRv4Lexer.ARGUMENT_CONTENT);
+                Type = ANTLRv4Lexer.ARGUMENT_CONTENT;
             }
         }
 
         protected void handleEndAction()
         {
-            PopMode();
-            if (ModeStack.Count > 0)
+            var oldMode = CurrentMode;
+            var newMode = PopMode();
+
+            if (ModeStack.Count > 0 && newMode == ANTLRv4Lexer.TargetLanguageAction && oldMode == newMode)
             {
-                CurrentRuleType = (ANTLRv4Lexer.ACTION_CONTENT);
+                Type = ANTLRv4Lexer.ACTION_CONTENT;
             }
         }
 
         protected void handleOptionsLBrace()
         {
-            if (InsideOptionsBlock)
+            if (_insideOptionsBlock)
             {
-                CurrentRuleType = ANTLRv4Lexer.BEGIN_ACTION;
+                Type = ANTLRv4Lexer.BEGIN_ACTION;
                 PushMode(ANTLRv4Lexer.TargetLanguageAction);
             }
             else
             {
-                CurrentRuleType = ANTLRv4Lexer.LBRACE;
-                InsideOptionsBlock = true;
+                Type = ANTLRv4Lexer.LBRACE;
+                _insideOptionsBlock = true;
             }
         }
-
 
         public override IToken NextToken()
         {
             var token = base.NextToken();
-            if (Type == ANTLRv4Lexer.ID)
+            if ((Type == ANTLRv4Lexer.OPTIONS || Type == ANTLRv4Lexer.TOKENS || Type == ANTLRv4Lexer.CHANNELS) && CurrentRuleType == TokenConstants.InvalidType)
             {
-                char firstChar = stream.GetText(Interval.Of(TokenStartCharIndex, TokenStartCharIndex))[0];
+                // enter prequel construct ending with an RBRACE
+                CurrentRuleType = PREQUEL_CONSTRUCT;
+            }
+            else if (Type == ANTLRv4Lexer.RBRACE && CurrentRuleType == PREQUEL_CONSTRUCT)
+            {
+                // exit prequel construct
+                CurrentRuleType = TokenConstants.InvalidType;
+            }
+            else if (Type == ANTLRv4Lexer.AT && CurrentRuleType == TokenConstants.InvalidType)
+            {
+                // enter action
+                CurrentRuleType = ANTLRv4Lexer.AT;
+            }
+            else if (Type == ANTLRv4Lexer.END_ACTION && CurrentRuleType == ANTLRv4Lexer.AT)
+            {
+                // exit action
+                CurrentRuleType = TokenConstants.InvalidType;
+            }
+            else if (Type == ANTLRv4Lexer.ID)
+            {
+                var firstChar = stream.GetText(Interval.Of(TokenStartCharIndex, TokenStartCharIndex))[0];
                 if (char.IsUpper(firstChar))
                 {
                     Type = ANTLRv4Lexer.TOKEN_REF;
                     tokenInput.SetValue(token, ANTLRv4Lexer.TOKEN_REF);
                 }
+
                 if (char.IsLower(firstChar))
                 {
-
                     Type = ANTLRv4Lexer.RULE_REF;
                     tokenInput.SetValue(token, ANTLRv4Lexer.RULE_REF);
                 }
 
                 if (CurrentRuleType == TokenConstants.InvalidType)
-                { // if outside of rule def
+                {
+                    // if outside of rule def
                     CurrentRuleType = Type; // set to inside lexer or parser rule
                 }
             }
             else if (Type == ANTLRv4Lexer.SEMI)
-            { // exit rule def
+            {
                 CurrentRuleType = TokenConstants.InvalidType;
             }
 
@@ -145,9 +171,5 @@ namespace LexerAdaptor
         }
 
         private bool InLexerRule => CurrentRuleType == ANTLRv4Lexer.TOKEN_REF;
-
-
-        private bool InParserRule => CurrentRuleType == ANTLRv4Lexer.RULE_REF;
-        
     }
 }

--- a/antlr/antlr4/examples/three.g4.errors
+++ b/antlr/antlr4/examples/three.g4.errors
@@ -1,2 +1,2 @@
-line 4:0 extraneous input '<EOF>' expecting {DOC_COMMENT, 'lexer', 'parser', 'grammar'}
+line 4:0 extraneous input '<EOF>' expecting {'lexer', 'parser', 'grammar'}
 

--- a/antlr/antlr4/examples/three.g4.errors
+++ b/antlr/antlr4/examples/three.g4.errors
@@ -1,2 +1,2 @@
-line 4:0 extraneous input '<EOF>' expecting {'lexer', 'parser', 'grammar'}
+line 4:0 mismatched input '<EOF>' expecting {'lexer', 'parser', 'grammar'}
 


### PR DESCRIPTION
There are two main differences: moving where doc comments are processed to the lexer (in the same way any other comment is handled), and updating the LexerAdaptor.cs implementation to match the Java reference exactly.

There is one prevailing issue, when a rule has the same name as one of the reserved keywords (and the parser thinks that it has left the preamble) where ANTLR 4.9.1 accepts the input, but this grammar does not. At least, that is the case on the C# implementation now.