### PR TITLE
Update mdx.g4

### DIFF
--- a/mdx/mdx.g4
+++ b/mdx/mdx.g4
@@ -87,7 +87,7 @@ cell_props
    ;
 
 cell_property_list
-   : cell_property COMMA cell_property*
+   : cell_property (COMMA cell_property)*
    ;
 
 cell_property


### PR DESCRIPTION
The comma is not mandatory, and you cannot have multiple properties after the comma.  Rather, the statement can have multiple pairs of a comma and cell_property after the first cell_property