### PR TITLE
Fix Kotlin parser packaging that would break C# builds.

### DIFF
--- a/kotlin/kotlin-formal/KotlinParser.g4
+++ b/kotlin/kotlin-formal/KotlinParser.g4
@@ -12,10 +12,6 @@
 
 parser grammar KotlinParser;
 
-@ header {
-    package org.antlr.grammars;
-}
-
 options { tokenVocab = KotlinLexer; }
 
 kotlinFile

--- a/kotlin/kotlin-formal/UnicodeClasses.g4
+++ b/kotlin/kotlin-formal/UnicodeClasses.g4
@@ -4,10 +4,6 @@
 
 lexer grammar UnicodeClasses;
 
-@ header {
-    package org.antlr.grammars;
-}
-
 UNICODE_CLASS_LL:
 	'\u0061'..'\u007A' |
 	'\u00B5' |

--- a/kotlin/kotlin-formal/pom.xml
+++ b/kotlin/kotlin-formal/pom.xml
@@ -25,6 +25,10 @@
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
+					<arguments>
+					  <argument>-package</argument>
+					  <argument>org.antlr.grammars</argument>
+					</arguments>
 				</configuration>
 				<executions>
 					<execution>

--- a/kotlin/kotlin/KotlinParser.g4
+++ b/kotlin/kotlin/KotlinParser.g4
@@ -12,10 +12,6 @@
 
 parser grammar KotlinParser;
 
-@ header {
-    package org.antlr.grammars;
-}
-
 options { tokenVocab = KotlinLexer; }
 
 kotlinFile

--- a/kotlin/kotlin/UnicodeClasses.g4
+++ b/kotlin/kotlin/UnicodeClasses.g4
@@ -4,10 +4,6 @@
 
 lexer grammar UnicodeClasses;
 
-@ header {
-    package org.antlr.grammars;
-}
-
 UNICODE_CLASS_LL:
 	'\u0061'..'\u007A' |
 	'\u00B5' |

--- a/kotlin/kotlin/pom.xml
+++ b/kotlin/kotlin/pom.xml
@@ -25,6 +25,10 @@
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
+					<arguments>
+					  <argument>-package</argument>
+					  <argument>org.antlr.grammars</argument>
+					</arguments>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
This PR fixes PR #1997 which would break C# builds for Kotlin (#1989). Now, Kotlin parsers use the "-package" option in pom.xml, as suggested by @kaby76.

On the C# front, the two Kotlin grammars seem to behave differently when running `bash ../../csharp-regression-tests.sh` in their respective subdirectories but the issues seem unrelated to this PR:
* **kotlin-formal** fails because of the dash in the generated code (`namespace kotlin-formal` in three .cs files). Replacing it with `namespace kotlinFormal` makes the tests pass.
* **kotlin** fails with a message possibly related to the way csharp-regression-tests.sh parses multiple tests in a pom.xml (`find: ‘examples/kotlinFile\nexamples/script’: No such file or directory`).
