### PR TITLE
Allow non-mandatory parentheses in function calls

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -2196,7 +2196,7 @@ specificFunction
     : (
       CURRENT_DATE | CURRENT_TIME | CURRENT_TIMESTAMP
       | CURRENT_USER | LOCALTIME
-      )                                                             #simpleFunctionCall
+      ) ('(' ')')?                                                  #simpleFunctionCall
     | CONVERT '(' expression separator=',' convertedDataType ')'    #dataTypeFunctionCall
     | CONVERT '(' expression USING charsetName ')'                  #dataTypeFunctionCall
     | CAST '(' expression AS convertedDataType ')'                  #dataTypeFunctionCall

--- a/sql/mysql/Positive-Technologies/examples/dml_insert.sql
+++ b/sql/mysql/Positive-Technologies/examples/dml_insert.sql
@@ -42,4 +42,5 @@ SELECT 'Aleem' UNION ALL SELECT 'Latif' UNION ALL SELECT 'Mughal';
 insert into t values ('кириллица', 2, 3);
 insert INTO `wptests_posts` (`post_author`, `post_date`, `post_date_gmt`, `post_content`, `post_content_filtered`, `post_title`, `post_excerpt`, `post_status`, `post_type`, `comment_status`, `ping_status`, `post_password`, `post_name`, `to_ping`, `pinged`, `post_modified`, `post_modified_gmt`, `post_parent`, `menu_order`, `post_mime_type`, `guid`) VALUES (7, '2016-09-06 16:49:51', '2016-09-06 16:49:51', '', '', 'صورة', '', 'inherit', 'attachment', 'open', 'closed', '', '%d8%b5%d9%88%d8%b1%d8%a9', '', '', '2016-09-06 16:49:51', '2016-09-06 16:49:51', 0, 0, 'image/jpeg', '');
 #end
-
+insert into sql_log values(retGUID,log_type,log_text,0,0,current_user,now());
+insert into sql_log values(retGUID,log_type,log_text,0,0,current_user(),now());


### PR DESCRIPTION
Few functions like current_user does not require parenthesses while they
are called. Still the parentheses could be used.