### PR TITLE
Add missing Rust parser to top-level pom.xml

### DIFF
--- a/csharp-regression-tests.sh
+++ b/csharp-regression-tests.sh
@@ -27,7 +27,7 @@ graphstream-dgs haskell html java/java java/java8 java/java9 \
 javadoc javascript/ecmascript kirikiri-tjs kotlin/kotlin kotlin/kotlin-formal \
 less logo/ucb-logo lpc mckeeman-form muparser oncrpc pgn php \
 powerbuilder promql prov-n python/python3 python/python3alt \
-r rego rexx rfc822/rfc822-datetime rfc822/rfc822-emailaddress \
+r rego rexx rfc822/rfc822-datetime rfc822/rfc822-emailaddress rust \
 scss sharc sql/hive sql/mysql sql/plsql sql/sqlite sql/tsql \
 stringtemplate swift/swift2 swift/swift3 swift-fin thrift tnsnames \
 turtle-doc v vb6 wat xml xpath/xpath31 xsd-regex z \

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
 				<module>romannumerals</module>
 				<module>rpn</module>
 				<module>ruby</module>
+				<module>rust</module>
 				<module>scala</module>
 				<module>scotty</module>
 				<module>scss</module>


### PR DESCRIPTION
This PR also fixes individual (Java) parser installation with the `--pl` option in Maven.