### PR TITLE
Fixes for Issue #2003.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Test C# target
       run: |
         sudo apt-get install xml2
-        bash csharp-regression-tests.sh
+        bash _scripts/csharp-regression-tests.sh

--- a/_scripts/csharp-regression-tests.sh
+++ b/_scripts/csharp-regression-tests.sh
@@ -176,14 +176,15 @@ recurse()
 }
 
 # Main
-dotnet tool install -g dotnet-antlr --version 1.1.0
+dotnet tool install -g dotnet-antlr --version 1.4.0
 echo "These grammars will not be tested for the CSharp target:"
 echo $do_not_do_list | fmt
 recurse "$prefix"
 echo "Grammars that succeeded: $succeeded" | fmt
-echo "Grammars that failed: $failed" | fmt
 echo "Grammars skipped: $skipped" | fmt
-
+echo "================"
+echo "Grammars that failed: $failed" | fmt
+echo "================"
 date
 
 if [[ "$failed" == "" ]]

--- a/_scripts/js-regression-tests.sh
+++ b/_scripts/js-regression-tests.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/bash
+
+# This script tests Antlr grammars for the C# target. It searches
+# pom.xml files for grammars, generates a driver, builds, and tests the
+# parser on input files. The code only runs on Linux-type boxes.
+# It requires Bash, rm, pwd, echo, cat, xml2, grep, sed, awk, find, and
+# the NET SDK.
+#
+# Most grammars in this directory are target independent. However,
+# there is a large number that, currently, are for a specific target.
+# These grammars are skipped from testing by inclusion of the name of
+# the grammar (path from the top-level directory of the repository) in
+# the "do_not_do_list". If you add a new grammar with a pom.xml file
+# that includes testing, then the grammar will be tested for the C#
+# target. If your grammar is target specific, adjust the list
+# below.
+
+# List<string> do_not_do_list = ...;
+# idl iri molecule rfc1035 rfc1960 tcpheader unicode/graphemes abb 
+
+do_not_do_list=" \
+idl molecule tcpheader unicode/graphemes \
+======== \
+antlr/antlr2 antlr/antlr3 antlr/antlr4 apex asm/masm asn/asn_3gpp \
+cobol85 cpp cql3 csharp cto dice fortran77 fusion-tables \
+graphstream-dgs haskell html java/java java/java8 java/java9 \
+javadoc javascript/ecmascript kirikiri-tjs kotlin/kotlin kotlin/kotlin-formal \
+less logo/ucb-logo lpc mckeeman-form muparser oncrpc pgn php \
+powerbuilder promql prov-n python/python3 python/python3alt \
+r rego rexx rfc822/rfc822-datetime rfc822/rfc822-emailaddress \
+scss sharc sql/hive sql/mysql sql/plsql sql/sqlite sql/tsql \
+stringtemplate swift/swift2 swift/swift3 swift-fin thrift tnsnames \
+turtle-doc v vb6 wat xml xpath/xpath31 xsd-regex z \
+"
+
+# Sanity checks for required environment.
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     machine=Linux;;
+    Darwin*)    machine=Mac;;
+    CYGWIN*)    machine=Cygwin;;
+    MINGW*)     machine=MinGw;;
+    *)          machine="UNKNOWN:${unameOut}"
+esac
+echo ${machine}
+if [[ "$machine" != "Linux" && "$machine" != "Mac" ]]
+then
+    echo "This script runs only in a Linux environment. Skipping."
+    exit 0
+fi
+
+date
+
+# List<string> failed = new List<string>();
+failed=""
+
+# List<string> succeeded = new List<string>();
+succeeded=""
+
+# List<string> skipped = new List<string>();
+skipped=""
+
+# string prefix = current working directory.
+prefix=`pwd`
+
+# string contains(List<string> list, string item)
+# If "list" contains the "item", return "yes" else return "no".
+contains() {
+    if [[ " $1 " =~ " $2 " ]]
+    then
+        echo yes
+    else
+        echo no
+    fi
+}
+
+# List<string> add(List<string> list, string name), without duplicates.
+# This function returns a new list by adding "name" to "list".
+add() {
+    if [[ `contains "$1" "$2"` == "no" ]]
+    then
+        echo "$1 $2"
+    else
+        echo "$1"
+    fi
+}
+
+# Uncomment this line to remove the temporary directories.
+# rm -rf `find . -name Generated`
+
+# void recurse(string cwd)
+recurse()
+{
+    local x="$1"
+    local d
+    local examples
+    local files
+    local filtered
+    local i
+    local newd
+    local pass
+    local s
+    local testname
+    cd "$x"
+    # Assert(cwd is valid)
+    if [[ $? != "0" ]]
+    then
+        exit 1
+    fi
+    testname=${x#"$prefix/"}
+    # In the current working directory, extract sub-modules from the pom.xml.
+    d=`cat pom.xml | xml2 | grep modules/module= | sed 's/=/ /' | awk '{print $2}'`
+    if [[ "$d" == "" ]]
+    then
+        echo "===================================================="
+        echo Testing JS parsing for $testname
+        echo ""
+        filtered=`contains "$do_not_do_list" "$testname"`
+        s=`cat pom.xml | xml2 | grep configuration/entryPoint= | sed 's/=/ /' | awk '{print $2}'`
+        if [[ "$filtered" == "yes" ]]
+        then
+            echo "On do_not_do_list -- skipping."
+            skipped=`add "$skipped" "$testname"`
+        elif [[ "$s" == "" ]]
+        then
+            echo "No entry point for grammar specified in pom.xml -- skipping."
+            skipped=`add "$skipped" "$testname"`
+        else
+            rm -rf Generated
+            dotnet-antlr -s $s -t JavaScript
+            pushd Generated
+	    stop="0"
+	    bash build.sh
+            if [[ "$?" != "0" ]]
+            then
+	        stop="1"
+                failed=`add "$failed" "$testname"`
+            fi
+            examples=`cat ../pom.xml | xml2 | grep configuration/exampleFiles= | sed 's/=/ /' | awk '{print $2}'`
+            if [[ "$stop" == "1" ]]
+	    then
+	        echo "Generation failed."
+	    elif [[ "$examples" == "" ]]
+            then
+                echo "No examples to parse -- skipping."
+            else
+                files=`find "../$examples" -type f | grep -v '\.tree$' | grep -v '\.errors'`
+                for i in $files
+                do
+                    echo Parsing $i
+                    node program.js -file "$i"
+                    pass=$?
+                    if [[ -f "${i%*}.errors" ]]
+                    then
+                        if [[ "$pass" -eq "1" ]]
+                        then
+                            echo "(Expected failed parse => OK)"
+                        else
+                            failed=`add "$failed" "$testname"`
+                        fi
+                    else
+                        if [[ "$pass" -ne "0" ]]
+                        then
+                            failed=`add "$failed" "$testname"`
+                        fi
+                    fi
+                done
+            fi
+            popd
+	    if [[ `contains "$failed" "$testname"` == "no" ]]
+            then
+                succeeded=`add "$succeeded" "$testname"`
+            fi
+            rm -rf Generated
+        fi
+    else
+        for i in $d
+        do
+            newd="$x/$i"
+            recurse "$newd"
+        done
+    fi
+}
+
+# Main
+dotnet tool install -g dotnet-antlr --version 1.4.0
+echo "These grammars will not be tested for the JS target:"
+echo $do_not_do_list | fmt
+recurse "$prefix"
+echo "Grammars that succeeded: $succeeded" | fmt
+echo "Grammars skipped: $skipped" | fmt
+echo "================"
+echo "Grammars that failed: $failed" | fmt
+echo "================"
+date
+
+if [[ "$failed" == "" ]]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/basic/jvmBasic.g4
+++ b/basic/jvmBasic.g4
@@ -103,7 +103,7 @@ statement
    ;
 
 vardecl
-   : var (LPAREN exprlist RPAREN)*
+   : var_ (LPAREN exprlist RPAREN)*
    ;
 
 printstmt1
@@ -247,7 +247,7 @@ drawstmt
    ;
 
 defstmt
-   : DEF FN? var LPAREN var RPAREN EQ expression
+   : DEF FN? var_ LPAREN var_ RPAREN EQ expression
    ;
 
 tabstmt
@@ -396,7 +396,7 @@ expression
    ;
 
 // lists
-var
+var_
    : varname varsuffix?
    ;
 
@@ -478,7 +478,7 @@ strfunc
    ;
 
 fnfunc
-   : FN var LPAREN expression RPAREN
+   : FN var_ LPAREN expression RPAREN
    ;
 
 valfunc

--- a/css3/css3.g4
+++ b/css3/css3.g4
@@ -193,16 +193,16 @@ term
     | String ws              # knownTerm
     | UnicodeRange ws        # knownTerm
     | ident ws               # knownTerm
-    | var                    # knownTerm
+    | var_                   # knownTerm
     | Uri ws                 # knownTerm
     | hexcolor               # knownTerm
     | calc                   # knownTerm
-    | function               # knownTerm
+    | function_              # knownTerm
     | unknownDimension ws    # unknownTerm
     | dxImageTransform       # badTerm
     ;
 
-function
+function_
     : Function ws expr ')' ws
     ;
 
@@ -328,7 +328,7 @@ generalEnclosed
 
 // Variable
 // https://www.w3.org/TR/css-variables-1
-var
+var_
     : Var ws Variable ws ')' ws
     ;
 

--- a/erlang/Erlang.g4
+++ b/erlang/Erlang.g4
@@ -26,7 +26,7 @@ grammar Erlang;
 
 forms : form+ EOF ;
 
-form : (attribute | function | ruleClauses) '.' ;
+form : (attribute | function_ | ruleClauses) '.' ;
 
 /// Tokens
 
@@ -164,7 +164,7 @@ attrVal :     expr
         |     expr ',' exprs
         | '(' expr ',' exprs ')' ;
 
-function : functionClause (';' functionClause)* ;
+function_ : functionClause (';' functionClause)* ;
 
 functionClause : tokAtom clauseArgs clauseGuard clauseBody ;
 

--- a/hypertalk/HyperTalk.g4
+++ b/hypertalk/HyperTalk.g4
@@ -29,7 +29,7 @@ grammar HyperTalk;
 // expressions that are not inside of a handler or function block.
 script
     : handler script
-    | function script
+    | function_ script
     | NEWLINE script
     | EOF
     ;
@@ -53,7 +53,7 @@ handler
     | 'on' handlerName parameterList NEWLINE+ statementList? 'end' handlerName
     ;
 
-function
+function_
     : 'function' ID NEWLINE+ statementList? 'end' ID
     | 'function' ID parameterList NEWLINE+ statementList? 'end' ID
     ;

--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -155,7 +155,7 @@ iterationStatement
 
 varModifier  // let, const - ECMAScript 6
     : Var
-    | let
+    | let_
     | Const
     ;
 
@@ -484,7 +484,7 @@ keyword
     | Export
     | Import
     | Implements
-    | let
+    | let_
     | Private
     | Public
     | Interface
@@ -498,7 +498,7 @@ keyword
     | As
     ;
 
-let
+let_
     : NonStrictLet
     | StrictLet
     ;

--- a/joss/joss.g4
+++ b/joss/joss.g4
@@ -313,10 +313,10 @@ assignment
 value
    : NUMBER
    | variable
-   | function
+   | function_
    ;
 
-function
+function_
    : funcSqrt
    | funcLog
    | funcExp

--- a/lambda/lambda.g4
+++ b/lambda/lambda.g4
@@ -33,10 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar lambda;
 
 expression
-    : VARIABLE | function | application
+    : VARIABLE | function_ | application
     ;
 
-function
+function_
     : 'λ' VARIABLE '.' scope
     ;
 

--- a/loop/loop.g4
+++ b/loop/loop.g4
@@ -46,18 +46,18 @@ statement
    ;
 
 assignstmt
-   : var ':=' number ';'
+   : var_ ':=' number ';'
    ;
 
 incrementstmt
-   : var ':=' var ('+' | '-') number
+   : var_ ':=' var_ ('+' | '-') number
    ;
 
 loopstmt
-   : 'LOOP' var 'DO' statementlist 'END'
+   : 'LOOP' var_ 'DO' statementlist 'END'
    ;
 
-var
+var_
    : ID
    ;
 

--- a/lua/Lua.g4
+++ b/lua/Lua.g4
@@ -95,7 +95,7 @@ funcname
     ;
 
 varlist
-    : var (',' var)*
+    : var_ (',' var_)*
     ;
 
 namelist
@@ -134,10 +134,10 @@ functioncall
     ;
 
 varOrExp
-    : var | '(' exp ')'
+    : var_ | '(' exp ')'
     ;
 
-var
+var_
     : (NAME | '(' exp ')' varSuffix) varSuffix*
     ;
 
@@ -150,12 +150,12 @@ nameAndArgs
     ;
 
 /*
-var
+var_
     : NAME | prefixexp '[' exp ']' | prefixexp '.' NAME
     ;
 
 prefixexp
-    : var | functioncall | '(' exp ')'
+    : var_ | functioncall | '(' exp ')'
     ;
 
 functioncall

--- a/mdx/mdx.g4
+++ b/mdx/mdx.g4
@@ -148,16 +148,16 @@ factor
    | value_expression_primary
    ;
 
-function
+function_
    : identifier LPAREN (exp_list)? RPAREN
    ;
 
 value_expression_primary
-   : value_expression_primary0 (DOT (unquoted_identifier | quoted_identifier | amp_quoted_identifier | function))*
+   : value_expression_primary0 (DOT (unquoted_identifier | quoted_identifier | amp_quoted_identifier | function_))*
    ;
 
 value_expression_primary0
-   : function
+   : function_
    | (LPAREN exp_list RPAREN)
    | (LBRACE (exp_list)? RBRACE)
    | case_expression

--- a/mumps/mumps.g4
+++ b/mumps/mumps.g4
@@ -105,7 +105,7 @@ expression
 
 term
    : variable
-   | function
+   | function_
    | NUMBER
    | LPAREN expression RPAREN
    ;
@@ -123,7 +123,7 @@ variable
    : (CARAT | AMPERSAND)* identifier
    ;
 
-function
+function_
     : DOLLAR identifier (LPAREN arglist RPAREN)?
     ;
 

--- a/sparql/Sparql.g4
+++ b/sparql/Sparql.g4
@@ -54,7 +54,7 @@ prefixDecl
     ;
 
 selectQuery
-    : 'SELECT' ( 'DISTINCT' | 'REDUCED' )? ( var+ | '*' ) datasetClause* whereClause solutionModifier
+    : 'SELECT' ( 'DISTINCT' | 'REDUCED' )? ( var_+ | '*' ) datasetClause* whereClause solutionModifier
     ;
 
 constructQuery
@@ -103,7 +103,7 @@ orderClause
 
 orderCondition
     : ( ( 'ASC' | 'DESC' ) brackettedExpression )
-    | ( constraint | var )
+    | ( constraint | var_ )
     ;
 
 limitClause
@@ -205,15 +205,15 @@ graphNode
     ;
 
 varOrTerm
-    : var
+    : var_
     | graphTerm
     ;
 
 varOrIRIref
-    : var | iriRef
+    : var_ | iriRef
     ;
 
-var
+var_
     : VAR1
     | VAR2
     ;
@@ -267,7 +267,7 @@ unaryExpression
     ;
 
 primaryExpression
-    : brackettedExpression | builtInCall | iriRefOrFunction | rdfLiteral | numericLiteral | booleanLiteral | var
+    : brackettedExpression | builtInCall | iriRefOrFunction | rdfLiteral | numericLiteral | booleanLiteral | var_
     ;
 
 brackettedExpression
@@ -279,7 +279,7 @@ builtInCall
     | 'LANG' '(' expression ')'
     | 'LANGMATCHES' '(' expression ',' expression ')'
     | 'DATATYPE' '(' expression ')'
-    | 'BOUND' '(' var ')'
+    | 'BOUND' '(' var_ ')'
     | 'sameTerm' '(' expression ',' expression ')'
     | 'isIRI' '(' expression ')'
     | 'isURI' '(' expression ')'

--- a/ttm/ttm.g4
+++ b/ttm/ttm.g4
@@ -32,10 +32,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar ttm;
 
 program
-   : function* EOF?
+   : function_* EOF?
    ;
 
-function
+function_
    : active
    | neutral
    ;
@@ -53,8 +53,8 @@ arglist
    ;
 
 arg
-   : function
-   | ('<' function '>')
+   : function_
+   | ('<' function_ '>')
    | string
    ;
 


### PR DESCRIPTION
This change renames conflicting parser symbols in grammars for JavaScript, i.e., var, function, let. I have also included a script to test the grammars against the JavaScript target, and moved the C# target tests to _scripts/. All tests not skipped in the js-regression-tests.sh pass, but the script has not been added to CI because the JS tests take about an hour to run. https://github.com/antlr/grammars-v4/issues/2003