### PR TITLE
Fix for Issue #2016

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 # Visual Studio Generated
 .antlr
 .fetch_time_cache
-/.vs
+.vs/
 .vscode/
 .gradle/
 


### PR DESCRIPTION
VS2019 creates and stores editor configurations in .vs/. The .gitignore file is not correct because after running VS2019 from a sub-directory in the repo, git indicates unstaged files in the .vs/ directory. Further, there are no '.vs' files within the repo--only .vs/ directories created by VS2019. Since the .gitignore comments indicate to ignore VS2019 temps, as well as other IDEs, the fix is to change "/.vs" to ".vs/". https://github.com/antlr/grammars-v4/issues/2016