### PR TITLE
Moves variableStatement down the function statement rules

### DIFF
--- a/typescript/TypeScriptParser.g4
+++ b/typescript/TypeScriptParser.g4
@@ -334,7 +334,6 @@ sourceElement
 
 statement
     : block
-    | variableStatement
     | importStatement
     | exportStatement
     | emptyStatement
@@ -358,6 +357,7 @@ statement
     | functionDeclaration
     | arrowFunctionDeclaration
     | generatorFunctionDeclaration
+    | variableStatement
     | typeAliasDeclaration //ADDED
     | enumDeclaration      //ADDED
     | expressionStatement


### PR DESCRIPTION
Moving `variableStatement` to the bottom in the `statement`  list.