### PR TITLE
[scss] Support pseudo-classes appearing anywhere in the selector.

### DIFF
--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -64,7 +64,6 @@ DOLLAR          : '$';
 AT              : '@';
 AND             : '&';
 HASH            : '#';
-COLONCOLON      : '::';
 PLUS            : '+';
 TIMES           : '*';
 DIV             : '/';

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -232,7 +232,7 @@ selectors
 	;
 
 selector
-	: element+ (selectorPrefix element)* attrib* pseudo?
+	: element+ (selectorPrefix element)* attrib*
 	;
 
 selectorPrefix
@@ -245,11 +245,12 @@ element
   | '.' identifier
   | '&'
   | '*'
+  | pseudo
 	;
 
 pseudo
-	: (COLON|COLONCOLON) Identifier
-	| (COLON|COLONCOLON) functionCall
+  : COLON COLON? Identifier
+  | COLON COLON? functionCall
 	;
 
 attrib

--- a/scss/testsrc/test/java/TestBasicCss.java
+++ b/scss/testsrc/test/java/TestBasicCss.java
@@ -349,6 +349,47 @@ public class TestBasicCss extends TestBase
 
   }
 
+  @Test
+  public void testPseudoClassAtEndOfSelector()
+  {
+    String [] lines = {
+        "h1:hover { color: blue; }"
+    };
+
+    ScssParser.SelectorsContext context = getSelector(lines);
+    Assert.assertEquals(context.selector(0).element(0).getText(), "h1");
+    Assert.assertEquals(context.selector(0).element(1).pseudo().getText(), ":hover");
+  }
+
+  @Test
+  public void testPseudoElementAndPseudoClass()
+  {
+    // After is a pseudo-element and hover is a pseduo-class.
+    // After is supported with 1 or 2 colons.
+    String [] lines = {
+        "h1:after:hover, h2:hover::after { color: blue; }"
+    };
+
+    ScssParser.SelectorsContext context = getSelector(lines);
+    Assert.assertEquals(context.selector(0).element(0).getText(), "h1");
+    Assert.assertEquals(context.selector(0).element(1).pseudo().getText(), ":after");
+    Assert.assertEquals(context.selector(0).element(2).pseudo().getText(), ":hover");
+    Assert.assertEquals(context.selector(1).element(0).getText(), "h2");
+    Assert.assertEquals(context.selector(1).element(1).pseudo().getText(), ":hover");
+    Assert.assertEquals(context.selector(1).element(2).pseudo().getText(), "::after");
+  }
+
+  @Test
+  public void testStandAlonePseudoElement()
+  {
+    String [] lines = {
+        "::placeholder { color: blue; }"
+    };
+
+    ScssParser.SelectorsContext context = getSelector(lines);
+    Assert.assertEquals(context.selector(0).element(0).pseudo().getText(), "::placeholder");
+  }
+
   private ScssParser.SelectorsContext getSelector( String ... lines)
   {
     ScssParser.StylesheetContext context = parse(lines);


### PR DESCRIPTION
Pseudo-classes are allowed anywhere in selectors while pseudo-elements may only be appended after the last simple selector of the selector.
Double colons were added to the spec to distinguish pseudo-elements from
single colon pseudo-classes, however for backwards compatibilty many
pseudo-elements work with single colons. So our parser wont distinguish
the pseudo type or restrict the positioning.

Spec: https://www.w3.org/TR/CSS21/selector.html#pseudo-elements