### PR TITLE
[scss] Support stand-alone attribute selectors

### DIFF
--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -165,19 +165,18 @@ DOLLAR_ID              : DOLLAR -> type(DOLLAR);
 
 InterpolationStartAfter  : InterpolationStart;
 InterpolationEnd_ID    : BlockEnd -> type(BlockEnd);
-
 IdentifierAfter        : Identifier;
-Ellipsis_ID            : Ellipsis -> popMode, type(Ellipsis);
-DOT_ID                 : DOT -> popMode, type(DOT);
 
+// All tokens that can signal the end of identifiers
+Ellipsis_ID               : Ellipsis -> popMode, type(Ellipsis);
+DOT_ID                    : DOT -> popMode, type(DOT);
+LBRACK_ID                 : LBRACK -> popMode, type(LBRACK);
+RBRACK_ID                 : RBRACK -> popMode, type(RBRACK);
 LPAREN_ID                 : LPAREN -> popMode, type(LPAREN);
 RPAREN_ID                 : RPAREN -> popMode, type(RPAREN);
-
 COLON_ID                  : COLON -> popMode, type(COLON);
 COMMA_ID                  : COMMA -> popMode, type(COMMA);
-SEMI_ID                  : SEMI -> popMode, type(SEMI);
-
-
-
-
-
+SEMI_ID                   : SEMI -> popMode, type(SEMI);
+EQ_ID                     : EQ -> popMode, type(EQ);
+PIPE_EQ_ID                : PIPE_EQ -> popMode, type(PIPE_EQ);
+TILD_EQ_ID                : TILD_EQ -> popMode, type(TILD_EQ);

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -232,7 +232,7 @@ selectors
 	;
 
 selector
-	: element+ (selectorPrefix element)* attrib* pseudo?
+	: element+ (selectorPrefix element)* pseudo?
 	;
 
 selectorPrefix
@@ -245,6 +245,7 @@ element
   | '.' identifier
   | '&'
   | '*'
+  | attrib
 	;
 
 pseudo
@@ -253,13 +254,13 @@ pseudo
 	;
 
 attrib
-	: '[' Identifier (attribRelate (StringLiteral | Identifier))? ']'
+	: LBRACK Identifier (attribRelate (StringLiteral | Identifier))? RBRACK
 	;
 
 attribRelate
-	: '='
-	| '~='
-	| '|='
+  : EQ
+  | PIPE_EQ
+  | TILD_EQ
 	;
 
 identifier

--- a/scss/testsrc/test/java/TestBasicCss.java
+++ b/scss/testsrc/test/java/TestBasicCss.java
@@ -349,6 +349,33 @@ public class TestBasicCss extends TestBase
 
   }
 
+  @Test
+  public void testAttributeSelector()
+  {
+    String [] lines = {
+        "input[type=number] {}"
+    };
+
+    ScssParser.SelectorsContext context = getSelector(lines);
+    Assert.assertEquals(context.selector(0).element(0).getText(), "input");
+    Assert.assertEquals(context.selector(0).element(1).attrib().getText(), "[type=number]");
+    Assert.assertEquals(context.selector(0).element(1).attrib().Identifier(0).getText(), "type");
+    Assert.assertEquals(context.selector(0).element(1).attrib().attribRelate().getText(), "=");
+    Assert.assertEquals(context.selector(0).element(1).attrib().Identifier(1).getText(), "number");
+  }
+
+  @Test
+  public void testStandAloneAttributeSelector()
+  {
+    String [] lines = {
+        "[disabled] {}"
+    };
+
+    ScssParser.SelectorsContext context = getSelector(lines);
+    Assert.assertEquals(context.selector(0).element(0).attrib().getText(), "[disabled]");
+    Assert.assertEquals(context.selector(0).element(0).attrib().Identifier(0).getText(), "disabled");
+  }
+
   private ScssParser.SelectorsContext getSelector( String ... lines)
   {
     ScssParser.StylesheetContext context = parse(lines);


### PR DESCRIPTION
`[disabled]` is interpreted as `*[disabled]`, the * isn't required.