### PR TITLE
Fix for #2032

### DIFF
--- a/abb/pom.xml
+++ b/abb/pom.xml
@@ -18,7 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>abbParser.g4</grammars>
+					<includes>
+					   <include>abbParser.g4</include>
+					   <include>abbLexer.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/abnf/pom.xml
+++ b/abnf/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Abnf.g4</grammars>
+					<includes>
+					   <include>Abnf.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/acme/pom.xml
+++ b/acme/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>acme.g4</grammars>
+					<includes>
+					   <include>acme.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/agc/pom.xml
+++ b/agc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>agc.g4</grammars>
+					<includes>
+					   <include>agc.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/algol60/pom.xml
+++ b/algol60/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>algol60.g4</grammars>
+					<includes>
+					   <include>algol60.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/alpaca/pom.xml
+++ b/alpaca/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>alpaca.g4</grammars>
+					<includes>
+					   <include>alpaca.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/antlr/antlr2/pom.xml
+++ b/antlr/antlr2/pom.xml
@@ -17,7 +17,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ANTLRv2Parser.g4</grammars>
 					<includes>
 						<include>ANTLRv2Lexer.g4</include>
 						<include>ANTLRv2Parser.g4</include>

--- a/antlr/antlr3/pom.xml
+++ b/antlr/antlr3/pom.xml
@@ -17,7 +17,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ANTLRv3Parser.g4</grammars>
 					<includes>
 						<include>ANTLRv3Lexer.g4</include>
 						<include>ANTLRv3Parser.g4</include>

--- a/antlr/antlr4/pom.xml
+++ b/antlr/antlr4/pom.xml
@@ -17,7 +17,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ANTLRv4Parser.g4</grammars>
 					<includes>
 						<include>ANTLRv4Lexer.g4</include>
 						<include>ANTLRv4Parser.g4</include>

--- a/apex/pom.xml
+++ b/apex/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>apex.g4</grammars>
+					<includes>
+					   <include>apex.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/apt/pom.xml
+++ b/apt/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>apt.g4</grammars>
+					<includes>
+					   <include>apt.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/arithmetic/pom.xml
+++ b/arithmetic/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>arithmetic.g4</grammars>
+					<includes>
+					   <include>arithmetic.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asm/asm6502/pom.xml
+++ b/asm/asm6502/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>asm6502.g4</grammars>
+					<includes>
+					   <include>asm6502.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asm/asm8080/pom.xml
+++ b/asm/asm8080/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>asm8080.g4</grammars>
+					<includes>
+					   <include>asm8080.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asm/asm8086/pom.xml
+++ b/asm/asm8086/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>asm8086.g4</grammars>
+					<includes>
+					   <include>asm8086.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asm/asmMASM/pom.xml
+++ b/asm/asmMASM/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>asmMASM.g4</grammars>
+					<includes>
+					   <include>asmMASM.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asm/asmZ80/pom.xml
+++ b/asm/asmZ80/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>asmZ80.g4</grammars>
+					<includes>
+					   <include>asmZ80.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asm/masm/pom.xml
+++ b/asm/masm/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>MASM.g4</grammars>
+					<includes>
+					   <include>MASM.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asn/asn/pom.xml
+++ b/asn/asn/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ASN.g4</grammars>
+					<includes>
+					   <include>ASN.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/asn/asn_3gpp/pom.xml
+++ b/asn/asn_3gpp/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ASN_3gpp.g4</grammars>
+					<includes>
+					   <include>ASN_3gpp.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/atl/pom.xml
+++ b/atl/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ATL.g4</grammars>
+					<includes>
+					   <include>ATL.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/b/pom.xml
+++ b/b/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>b.g4</grammars>
+					<includes>
+					   <include>b.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>jvmBasic.g4</grammars>
+					<includes>
+					   <include>jvmBasic.g4</include>
+				        </includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/bcpl/pom.xml
+++ b/bcpl/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>bcpl.g4</grammars>
+					<includes>
+					   <include>bcpl.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/bibcode/pom.xml
+++ b/bibcode/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>bibcode.g4</grammars>
+					<includes>
+					   <include>bibcode.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/bnf/pom.xml
+++ b/bnf/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>bnf.g4</grammars>
+					<includes>
+					   <include>bnf.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/brainflak/pom.xml
+++ b/brainflak/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>brainflak.g4</grammars>
+					<includes>
+					   <include>brainflak.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/brainfuck/pom.xml
+++ b/brainfuck/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>brainfuck.g4</grammars>
+					<includes>
+					   <include>brainfuck.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/c/pom.xml
+++ b/c/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>C.g4</grammars>
+					<includes>
+					   <include>C.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/calculator/pom.xml
+++ b/calculator/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>calculator.g4</grammars>
+					<includes>
+					   <include>calculator.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/capnproto/pom.xml
+++ b/capnproto/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>CapnProto.g4</grammars>
+					<includes>
+					   <include>CapnProto.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/clf/pom.xml
+++ b/clf/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>clf.g4</grammars>
+					<includes>
+					   <include>clf.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/clif/pom.xml
+++ b/clif/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>CLIF.g4</grammars>
+					<includes>
+					   <include>CLIF.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/clojure/pom.xml
+++ b/clojure/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Clojure.g4</grammars>
+					<includes>
+					   <include>Clojure.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/clu/pom.xml
+++ b/clu/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>clu.g4</grammars>
+					<includes>
+					   <include>clu.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/cmake/pom.xml
+++ b/cmake/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>CMake.g4</grammars>
+					<includes>
+					   <include>CMake.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/cobol85/pom.xml
+++ b/cobol85/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Cobol85.g4</grammars>
 					<includes>
 						<include>Cobol85.g4</include>
 						<include>Cobol85Preprocessor.g4</include>

--- a/cookie/pom.xml
+++ b/cookie/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>cookie.g4</grammars>
+					<includes>
+					   <include>cookie.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/cool/pom.xml
+++ b/cool/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>COOL.g4</grammars>
+					<includes>
+					   <include>COOL.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>cql.g4</grammars>
+					<includes>
+					   <include>cql.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/creole/pom.xml
+++ b/creole/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>creole.g4</grammars>
+					<includes>
+					   <include>creole.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/css3/pom.xml
+++ b/css3/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>css3.g4</grammars>
+					<includes>
+					   <include>css3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/csv/pom.xml
+++ b/csv/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>CSV.g4</grammars>
+					<includes>
+					   <include>CSV.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/dart2/pom.xml
+++ b/dart2/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Dart2.g4</grammars>
+					<includes>
+					   <include>Dart2.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/databank/pom.xml
+++ b/databank/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>databank.g4</grammars>
+					<includes>
+					   <include>databank.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/dcm/pom.xml
+++ b/dcm/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>DCM_2_0_grammar.g4</grammars>
+					<includes>
+					   <include>DCM_2_0_grammar.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/dgol/pom.xml
+++ b/dgol/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>dgol.g4</grammars>
+					<includes>
+					   <include>dgol.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/dice/pom.xml
+++ b/dice/pom.xml
@@ -18,11 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>DiceNotation.g4</grammars>
-               <includes>
-                  <include>DiceNotationLexer.g4</include>
-                  <include>DiceNotation.g4</include>
-               </includes>
+					<includes>
+					   <include>DiceNotationLexer.g4</include>
+					   <include>DiceNotation.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/doiurl/pom.xml
+++ b/doiurl/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>doiurl.g4</grammars>
+					<includes>
+					   <include>doiurl.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/dot/pom.xml
+++ b/dot/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>DOT.g4</grammars>
+					<includes>
+					   <include>DOT.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/edn/pom.xml
+++ b/edn/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>edn.g4</grammars>
+					<includes>
+					   <include>edn.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/erlang/pom.xml
+++ b/erlang/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Erlang.g4</grammars>
+					<includes>
+					   <include>Erlang.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/fasta/pom.xml
+++ b/fasta/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>fasta.g4</grammars>
+					<includes>
+					   <include>fasta.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/fen/pom.xml
+++ b/fen/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>fen.g4</grammars>
+					<includes>
+					   <include>fen.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/flatbuffers/pom.xml
+++ b/flatbuffers/pom.xml
@@ -19,7 +19,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>FlatBuffers.g4</grammars>
+					<includes>
+					   <include>FlatBuffers.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/focal/pom.xml
+++ b/focal/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>focal.g4</grammars>
+					<includes>
+					   <include>focal.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/fol/pom.xml
+++ b/fol/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>fol.g4</grammars>
+					<includes>
+					   <include>fol.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/fortran77/pom.xml
+++ b/fortran77/pom.xml
@@ -18,7 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>fortran77.g4</grammars>
+					<includes>
+					   <include>Fortran77Lexer.g4</include>
+					   <include>Fortran77Parser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/fusion-tables/pom.xml
+++ b/fusion-tables/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>FusionTablesSql.g4</grammars>
+					<includes>
+					   <include>FusionTablesSql.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/gedcom/pom.xml
+++ b/gedcom/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>gedcom.g4</grammars>
+					<includes>
+					   <include>gedcom.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/gff3/pom.xml
+++ b/gff3/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>gff3.g4</grammars>
+					<includes>
+					   <include>gff3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/gml/pom.xml
+++ b/gml/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>gml.g4</grammars>
+					<includes>
+					   <include>gml.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/golang/pom.xml
+++ b/golang/pom.xml
@@ -18,7 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Golang.g4</grammars>
+					<includes>
+					   <include>GoLexer.g4</include>
+					   <include>GoParser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>GraphQL.g4</grammars>
+					<includes>
+					   <include>GraphQL.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/graphstream-dgs/pom.xml
+++ b/graphstream-dgs/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>DGSParser.g4</grammars>
 					<includes>
 						<include>DGSLexer.g4</include>
 						<include>DGSParser.g4</include>

--- a/gtin/pom.xml
+++ b/gtin/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>gtin.g4</grammars>
+					<includes>
+					   <include>gtin.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/guido/pom.xml
+++ b/guido/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>guido.g4</grammars>
+					<includes>
+					   <include>guido.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/guitartab/pom.xml
+++ b/guitartab/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>guitartab.g4</grammars>
+					<includes>
+					   <include>guitartab.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>http.g4</grammars>
+					<includes>
+					   <include>http.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/hypertalk/pom.xml
+++ b/hypertalk/pom.xml
@@ -18,7 +18,9 @@
                 <version>${antlr.version}</version>
                 <configuration>
                     <sourceDirectory>${basedir}</sourceDirectory>
-                    <grammars>HyperTalk.g4</grammars>
+                    <includes>
+                       <include>HyperTalk.g4</include>
+                    </includes>
                     <visitor>true</visitor>
                     <listener>true</listener>
                 </configuration>

--- a/icalendar/pom.xml
+++ b/icalendar/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ICalendar.g4</grammars>
+					<includes>
+					   <include>ICalendar.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/icon/pom.xml
+++ b/icon/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>icon.g4</grammars>
+					<includes>
+					   <include>icon.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/idl/pom.xml
+++ b/idl/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>IDL.g4</grammars>
+					<includes>
+					   <include>IDL.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/inf/pom.xml
+++ b/inf/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>inf.g4</grammars>
+					<includes>
+					   <include>inf.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/informix/pom.xml
+++ b/informix/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>informix.g4</grammars>
+					<includes>
+					   <include>informix.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/infosapient/pom.xml
+++ b/infosapient/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>infosapient.g4</grammars>
+					<includes>
+					   <include>infosapient.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/iri/pom.xml
+++ b/iri/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>IRI.g4</grammars>
+					<includes>
+					   <include>IRI.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>v
 				</configuration>

--- a/iso8601/pom.xml
+++ b/iso8601/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>iso8601.g4</grammars>
+					<includes>
+					   <include>iso8601.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/istc/pom.xml
+++ b/istc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>istc.g4</grammars>
+					<includes>
+					   <include>istc.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/janus/pom.xml
+++ b/janus/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>janus.g4</grammars>
+					<includes>
+					   <include>janus.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/java/java8/pom.xml
+++ b/java/java8/pom.xml
@@ -18,7 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Java8.g4</grammars>
+					<includes>
+					   <include>Java8Lexer.g4</include>
+					   <include>Java8Parser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/java/java9/pom.xml
+++ b/java/java9/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Java9.g4</grammars>
+					<includes>
+					   <include>Java9.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>JavadocParser.g4</grammars>
 					<includes>
 						<include>JavadocLexer.g4</include>
 						<include>JavadocParser.g4</include>

--- a/javascript/ecmascript/pom.xml
+++ b/javascript/ecmascript/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ECMAScript.g4</grammars>
 					<includes>
 						<include>ECMAScript.g4</include>
 					</includes>	

--- a/joss/pom.xml
+++ b/joss/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>joss.g4</grammars>
+					<includes>
+					   <include>joss.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>JPA.g4</grammars>
+					<includes>
+					   <include>JPA.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>JSON.g4</grammars>
+					<includes>
+					   <include>JSON.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/json5/pom.xml
+++ b/json5/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>JSON5.g4</grammars>
+					<includes>
+					   <include>JSON5.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/kuka/pom.xml
+++ b/kuka/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>krl.g4</grammars>
+					<includes>
+					   <include>krl.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>lambda.g4</grammars>
+					<includes>
+					   <include>lambda.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/lcc/pom.xml
+++ b/lcc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>lcc.g4</grammars>
+					<includes>
+					   <include>lcc.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/less/pom.xml
+++ b/less/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>LessParser.g4</grammars>
 					<includes>
 						<include>LessLexer.g4</include>
 						<include>LessParser.g4</include>

--- a/logo/logo/pom.xml
+++ b/logo/logo/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>logo.g4</grammars>
+					<includes>
+					   <include>logo.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/logo/ucb-logo/pom.xml
+++ b/logo/ucb-logo/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>UCBLogo.g4</grammars>
+					<includes>
+					   <include>UCBLogo.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/lolcode/pom.xml
+++ b/lolcode/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>lolcode.g4</grammars>
+					<includes>
+					   <include>lolcode.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/loop/pom.xml
+++ b/loop/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>loop.g4</grammars>
+					<includes>
+					   <include>loop.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/lpc/pom.xml
+++ b/lpc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>LPC.g4</grammars>
+					<includes>
+					   <include>LPC.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/lua/pom.xml
+++ b/lua/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Lua.g4</grammars>
+					<includes>
+					   <include>Lua.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/matlab/pom.xml
+++ b/matlab/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>matlab.g4</grammars>
+					<includes>
+					   <include>matlab.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/mckeeman-form/pom.xml
+++ b/mckeeman-form/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>McKeemanForm.g4</grammars>
+					<includes>
+					   <include>McKeemanForm.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/mdx/pom.xml
+++ b/mdx/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>mdx.g4</grammars>
+					<includes>
+					   <include>mdx.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/memcached_protocol/pom.xml
+++ b/memcached_protocol/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>memcached_protocol.g4</grammars>
+					<includes>
+					   <include>memcached_protocol.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/metamath/pom.xml
+++ b/metamath/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>metamath.g4</grammars>
+					<includes>
+					   <include>metamath.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/metric/pom.xml
+++ b/metric/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>metric.g4</grammars>
+					<includes>
+					   <include>metric.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/microc/pom.xml
+++ b/microc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>microc.g4</grammars>
+					<includes>
+					   <include>microc.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/modelica/pom.xml
+++ b/modelica/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>modelica.g4</grammars>
+					<includes>
+					   <include>modelica.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/modula2pim4/pom.xml
+++ b/modula2pim4/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>m2pim4.g4</grammars>
+					<includes>
+					   <include>m2pim4.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/molecule/pom.xml
+++ b/molecule/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>molecule.g4</grammars>
+					<includes>
+					   <include>molecule.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/moo/pom.xml
+++ b/moo/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>moo.g4</grammars>
+					<includes>
+					   <include>moo.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/morsecode/pom.xml
+++ b/morsecode/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>morsecode.g4</grammars>
+					<includes>
+					   <include>morsecode.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/mps/pom.xml
+++ b/mps/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>mps.g4</grammars>
+					<includes>
+					   <include>mps.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/muddb/pom.xml
+++ b/muddb/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>muddb.g4</grammars>
+					<includes>
+					   <include>muddb.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/mumath/pom.xml
+++ b/mumath/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>mumath.g4</grammars>
+					<includes>
+					   <include>mumath.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/mumps/pom.xml
+++ b/mumps/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>mumps.g4</grammars>
+					<includes>
+					   <include>mumps.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/muparser/pom.xml
+++ b/muparser/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>MuParser.g4</grammars>
+					<includes>
+					   <include>MuParser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/nanofuck/pom.xml
+++ b/nanofuck/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>nanofuck.g4</grammars>
+					<includes>
+					   <include>nanofuck.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/newick/pom.xml
+++ b/newick/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>newick.g4</grammars>
+					<includes>
+					   <include>newick.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/oberon/pom.xml
+++ b/oberon/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>oberon.g4</grammars>
+					<includes>
+					   <include>oberon.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/objc/pom.xml
+++ b/objc/pom.xml
@@ -18,9 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ObjectiveCParser.g4</grammars>
 					<includes>
-						<include>ObjectiveCLexer.g4</include>
+						<include>one-step-processing/ObjectiveCLexer.g4</include>
+						<include>one-step-processing/ObjectiveCPreprocessorParser.g4</include>
 						<include>ObjectiveCParser.g4</include>
 					</includes>
 					<visitor>true</visitor>

--- a/oncrpc/pom.xml
+++ b/oncrpc/pom.xml
@@ -19,7 +19,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>oncrpcv2.g4</grammars>
 					<includes>
 						<include>oncrpcv2.g4</include>
 						<include>xdr.g4</include>

--- a/p/pom.xml
+++ b/p/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>p.g4</grammars>
+					<includes>
+					   <include>p.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/parkingsign/pom.xml
+++ b/parkingsign/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>parkingsign.g4</grammars>
+					<includes>
+					   <include>parkingsign.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pascal/pom.xml
+++ b/pascal/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>pascal.g4</grammars>
+					<includes>
+					   <include>pascal.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pcre/pom.xml
+++ b/pcre/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>PCRE.g4</grammars>
+					<includes>
+					   <include>PCRE.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pddl/pom.xml
+++ b/pddl/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Pddl.g4</grammars>
+					<includes>
+					   <include>Pddl.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pdn/pom.xml
+++ b/pdn/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>pdn.g4</grammars>
+					<includes>
+					   <include>pdn.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pdp7/pom.xml
+++ b/pdp7/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>pdp7.g4</grammars>
+					<includes>
+					   <include>pdp7.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/peoplecode/pom.xml
+++ b/peoplecode/pom.xml
@@ -19,7 +19,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>PeopleCode.g4</grammars>
+					<includes>
+					   <include>PeopleCode.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pgn/pom.xml
+++ b/pgn/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>PGN.g4</grammars>
+					<includes>
+					   <include>PGN.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pii/pom.xml
+++ b/pii/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>pii.g4</grammars>
+					<includes>
+					   <include>pii.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pike/pom.xml
+++ b/pike/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>pike.g4</grammars>
+					<includes>
+					   <include>pike.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pl0/pom.xml
+++ b/pl0/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>pl0.g4</grammars>
+					<includes>
+					   <include>pl0.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/ply/pom.xml
+++ b/ply/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ply.g4</grammars>
+					<includes>
+					   <include>ply.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/pmmn/pom.xml
+++ b/pmmn/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>PMMN.g4</grammars>
+					<includes>
+					   <include>PMMN.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/postalcode/pom.xml
+++ b/postalcode/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>postalcode.g4</grammars>
+					<includes>
+					   <include>postalcode.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/prolog/pom.xml
+++ b/prolog/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>prolog.g4</grammars>
+					<includes>
+					   <include>prolog.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/promql/pom.xml
+++ b/promql/pom.xml
@@ -18,7 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>PromQL.g4</grammars>
+					<includes>
+					   <include>PromQLLexer.g4</include>
+					   <include>PromQLParser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/propcalc/pom.xml
+++ b/propcalc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>propcalc.g4</grammars>
+					<includes>
+					   <include>propcalc.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/properties/pom.xml
+++ b/properties/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>properties.g4</grammars>
+					<includes>
+					   <include>properties.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/protobuf3/pom.xml
+++ b/protobuf3/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Protobuf3.g4</grammars>
+					<includes>
+					   <include>Protobuf3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/prov-n/pom.xml
+++ b/prov-n/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>PROV_N.g4</grammars>
+					<includes>
+					   <include>PROV_N.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python2-js/pom.xml
+++ b/python/python2-js/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python2.g4</grammars>
+					<includes>
+					   <include>Python2.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python2/pom.xml
+++ b/python/python2/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python2.g4</grammars>
+					<includes>
+					   <include>Python2.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python3-js/pom.xml
+++ b/python/python3-js/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python3.g4</grammars>
+					<includes>
+					   <include>Python3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python3-py/pom.xml
+++ b/python/python3-py/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python3.g4</grammars>
+					<includes>
+					   <include>Python3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python3-ts/pom.xml
+++ b/python/python3-ts/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python3.g4</grammars>
+					<includes>
+					   <include>Python3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python3-without-actions/pom.xml
+++ b/python/python3-without-actions/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python3.g4</grammars>
+					<includes>
+					   <include>Python3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python3/pom.xml
+++ b/python/python3/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python3.g4</grammars>
+					<includes>
+					   <include>Python3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/python3alt/pom.xml
+++ b/python/python3alt/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>AltPython3.g4</grammars>
+					<includes>
+					   <include>AltPython3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/python/tiny-python/pom.xml
+++ b/python/tiny-python/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Python3.g4</grammars>
+					<includes>
+					   <include>Python3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/quakemap/pom.xml
+++ b/quakemap/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>quakemap.g4</grammars>
+					<includes>
+					   <include>quakemap.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>R.g4</grammars>
 					<includes>
 						<include>R.g4</include>
 						<include>RFilter.g4</include>

--- a/rcs/pom.xml
+++ b/rcs/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>RCS.g4</grammars>
+					<includes>
+					   <include>RCS.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/redcode/pom.xml
+++ b/redcode/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>redcode.g4</grammars>
+					<includes>
+					   <include>redcode.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/restructuredtext/pom.xml
+++ b/restructuredtext/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ReStructuredText.g4</grammars>
+					<includes>
+					   <include>ReStructuredText.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/rfc1035/pom.xml
+++ b/rfc1035/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>domain.g4</grammars>
+					<includes>
+					   <include>domain.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/rfc1960/pom.xml
+++ b/rfc1960/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>filter.g4</grammars>
+					<includes>
+					   <include>filter.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/rfc3080/pom.xml
+++ b/rfc3080/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>beep.g4</grammars>
+					<includes>
+					   <include>beep.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/rfc822/rfc822-datetime/pom.xml
+++ b/rfc822/rfc822-datetime/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>datetime.g4</grammars>
+					<includes>
+					   <include>datetime.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/rfc822/rfc822-emailaddress/pom.xml
+++ b/rfc822/rfc822-emailaddress/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>emailaddress.g4</grammars>
+					<includes>
+					   <include>emailaddress.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/robotwars/pom.xml
+++ b/robotwars/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>robotwar.g4</grammars>
+					<includes>
+					   <include>robotwar.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/romannumerals/pom.xml
+++ b/romannumerals/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>romannumerals.g4</grammars>
+					<includes>
+					   <include>romannumerals.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/rpn/pom.xml
+++ b/rpn/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>rpn.g4</grammars>
+					<includes>
+					   <include>rpn.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/ruby/pom.xml
+++ b/ruby/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Corundum.g4</grammars>
+					<includes>
+					   <include>Corundum.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/rust/pom.xml
+++ b/rust/pom.xml
@@ -37,7 +37,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>RustParser.g4</grammars>
+					<includes>
+					   <include>RustLexer.g4</include>
+					   <include>RustParser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Scala.g4</grammars>
+					<includes>
+					   <include>Scala.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/scotty/pom.xml
+++ b/scotty/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>scotty.g4</grammars>
+					<includes>
+					   <include>scotty.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/sexpression/pom.xml
+++ b/sexpression/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>sexpression.g4</grammars>
+					<includes>
+					   <include>sexpression.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/sgf/pom.xml
+++ b/sgf/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>sgf.g4</grammars>
+					<includes>
+					   <include>sgf.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/sharc/pom.xml
+++ b/sharc/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>SHARCParser.g4</grammars>
 					<includes>
 						<include>SHARCLexer.g4</include>
 						<include>SHARCParser.g4</include>

--- a/sici/pom.xml
+++ b/sici/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>sici.g4</grammars>
+					<includes>
+					   <include>sici.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/sickbay/pom.xml
+++ b/sickbay/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>sickbay.g4</grammars>
+					<includes>
+					   <include>sickbay.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/sieve/pom.xml
+++ b/sieve/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>sieve.g4</grammars>
+					<includes>
+					   <include>sieve.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/smalltalk/pom.xml
+++ b/smalltalk/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Smalltalk.g4</grammars>
+					<includes>
+					   <include>Smalltalk.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/smiles/pom.xml
+++ b/smiles/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>smiles.g4</grammars>
+					<includes>
+					   <include>smiles.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/smtlibv2/pom.xml
+++ b/smtlibv2/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>SMTLIBv2.g4</grammars>
+					<includes>
+					   <include>SMTLIBv2.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/snobol/pom.xml
+++ b/snobol/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>snobol.g4</grammars>
+					<includes>
+					   <include>snobol.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/solidity/pom.xml
+++ b/solidity/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Solidity.g4</grammars>
+					<includes>
+					   <include>Solidity.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/sparql/pom.xml
+++ b/sparql/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Sparql.g4</grammars>
+					<includes>
+					   <include>Sparql.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/stacktrace/pom.xml
+++ b/stacktrace/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>StackTrace.g4</grammars>
+					<includes>
+					   <include>StackTrace.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/stellaris/pom.xml
+++ b/stellaris/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>stellaris.g4</grammars>
+					<includes>
+					   <include>stellaris.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/stringtemplate/pom.xml
+++ b/stringtemplate/pom.xml
@@ -17,7 +17,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>STParser.g4</grammars>
 					<includes>
 						<include>STGLexer.g4</include>
 						<include>STGParser.g4</include>

--- a/suokif/pom.xml
+++ b/suokif/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>SUOKIF.g4</grammars>
+					<includes>
+					   <include>SUOKIF.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/swift/swift2/pom.xml
+++ b/swift/swift2/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Swift2.g4</grammars>
+					<includes>
+					   <include>Swift2.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/swift/swift3/pom.xml
+++ b/swift/swift3/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Swift3.g4</grammars>
+					<includes>
+					   <include>Swift3.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/tcpheader/pom.xml
+++ b/tcpheader/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tcp.g4</grammars>
+					<includes>
+					   <include>tcp.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/teal/pom.xml
+++ b/teal/pom.xml
@@ -21,7 +21,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Teal.g4</grammars>
+					<includes>
+					   <include>Teal.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/telephone/pom.xml
+++ b/telephone/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>telephone.g4</grammars>
+					<includes>
+					   <include>telephone.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/terraform/pom.xml
+++ b/terraform/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>terraform.g4</grammars>
+					<includes>
+					   <include>terraform.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/thrift/pom.xml
+++ b/thrift/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Thrift.g4</grammars>
+					<includes>
+					   <include>Thrift.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/tiny/pom.xml
+++ b/tiny/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tiny.g4</grammars>
+					<includes>
+					   <include>tiny.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/tinybasic/pom.xml
+++ b/tinybasic/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tinybasic.g4</grammars>
+					<includes>
+					   <include>tinybasic.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/tinyc/pom.xml
+++ b/tinyc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tinyc.g4</grammars>
+					<includes>
+					   <include>tinyc.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/tinymud/pom.xml
+++ b/tinymud/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tinymud.g4</grammars>
+					<includes>
+					   <include>tinymud.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/tnsnames/pom.xml
+++ b/tnsnames/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tnsnamesParser.g4</grammars>
 					<includes>
 						<include>tnsnamesLexer.g4</include>
 						<include>tnsnamesParser.g4</include>

--- a/tnt/pom.xml
+++ b/tnt/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tnt.g4</grammars>
+					<includes>
+					   <include>tnt.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/toml/pom.xml
+++ b/toml/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>toml.g4</grammars>
+					<includes>
+					   <include>toml.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/trac/pom.xml
+++ b/trac/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>trac.g4</grammars>
+					<includes>
+					   <include>trac.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/tsv/pom.xml
+++ b/tsv/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>tsv.g4</grammars>
+					<includes>
+					   <include>tsv.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/ttm/pom.xml
+++ b/ttm/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ttm.g4</grammars>
+					<includes>
+					   <include>ttm.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/turing/pom.xml
+++ b/turing/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>turing.g4</grammars>
+					<includes>
+					   <include>turing.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/turtle-doc/pom.xml
+++ b/turtle-doc/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>turtle.g4</grammars>
+					<includes>
+					   <include>turtle.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/turtle/pom.xml
+++ b/turtle/pom.xml
@@ -25,7 +25,9 @@
 				<artifactId>antlr4-maven-plugin</artifactId>
 				<version>${antlr.version}</version>
 				<configuration>
-					<grammars>TURTLE.g4</grammars>
+					<includes>
+					   <include>TURTLE.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 					<sourceDirectory>${basedir}</sourceDirectory>

--- a/unicode/graphemes/pom.xml
+++ b/unicode/graphemes/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Graphemes.g4</grammars>
+					<includes>
+					   <include>Graphemes.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/unicode/unicode16/pom.xml
+++ b/unicode/unicode16/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>classify.g4</grammars>
+					<includes>
+					   <include>classify.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/upnp/pom.xml
+++ b/upnp/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>upnp.g4</grammars>
+					<includes>
+					   <include>Upnp.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/url/pom.xml
+++ b/url/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>url.g4</grammars>
+					<includes>
+					   <include>url.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/useragent/pom.xml
+++ b/useragent/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>useragent.g4</grammars>
+					<includes>
+					   <include>useragent.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/v/pom.xml
+++ b/v/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>V.g4</grammars>
+					<includes>
+					   <include>V.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/vba/pom.xml
+++ b/vba/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>vba.g4</grammars>
+					<includes>
+					   <include>vba.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/verilog/verilog/pom.xml
+++ b/verilog/verilog/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>Verilog2001.g4</grammars>
+					<includes>
+					   <include>Verilog2001.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/vhdl/pom.xml
+++ b/vhdl/pom.xml
@@ -19,7 +19,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>vhdl.g4</grammars>
+					<includes>
+					   <include>vhdl.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/vmf/pom.xml
+++ b/vmf/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>vmf.g4</grammars>
+					<includes>
+					   <include>vmf.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/wat/pom.xml
+++ b/wat/pom.xml
@@ -18,7 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>WatParser.g4</grammars>
+					<includes>
+					   <include>WatLexer.g4</include>
+					   <include>WatParser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/wavefront/pom.xml
+++ b/wavefront/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>WavefrontOBJ.g4</grammars>
+					<includes>
+					   <include>WavefrontOBJ.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/webidl/pom.xml
+++ b/webidl/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>WebIDL.g4</grammars>
+					<includes>
+					   <include>WebIDL.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/wkt/pom.xml
+++ b/wkt/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>wkt.g4</grammars>
+					<includes>
+					   <include>wkt.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/wln/pom.xml
+++ b/wln/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>wln.g4</grammars>
+					<includes>
+					   <include>wln.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>XMLParser.g4</grammars>
 					<includes>
 						<include>XMLLexer.g4</include>
 						<include>XMLParser.g4</include>

--- a/xpath/xpath1/pom.xml
+++ b/xpath/xpath1/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>xpath.g4</grammars>
+					<includes>
+					   <include>xpath.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/xpath/xpath31/pom.xml
+++ b/xpath/xpath31/pom.xml
@@ -18,7 +18,9 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>XPath31.g4</grammars>
+					<includes>
+					   <include>XPath31.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/xsd-regex/pom.xml
+++ b/xsd-regex/pom.xml
@@ -18,7 +18,10 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>regexLexer.g4 regexParser.g4</grammars>
+					<includes>
+					   <include>regexLexer.g4</include>
+					   <include>regexParser.g4</include>
+					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>

--- a/z/pom.xml
+++ b/z/pom.xml
@@ -18,7 +18,6 @@
 				<version>${antlr.version}</version>
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
-					<grammars>ZParser.g4</grammars>
 					<includes>
 						<include>ZLexer.g4</include>
 						<include>ZParser.g4</include>


### PR DESCRIPTION
This is a collection of changes to pom.xml files. Replaced are the "grammars" elements with "includes" elements, because "grammars" elements are ignored by the Antlr4 tool plugin. I did not change the Mysql pom--it's not in the CI tests, and that will be a separate fix. Believe it or not, "python/tiny-python" was never pushed through the Antlr Tool--"No grammars to process". That's because the sourceDirectory was not set correctly. Geezus folks!

One could actually remove the "includes" elements from most of the grammars. But, since the pom's already list the grammar files, and since it helps to remove any ambiguity of what is actually processed by the Antlr tool, I left them in.
