### PR TITLE
Fix for #2035

### DIFF
--- a/golang/Antlr4cs/GoParserBase.cs
+++ b/golang/Antlr4cs/GoParserBase.cs
@@ -10,11 +10,6 @@ using Antlr4.Runtime;
         {
         }
 
-        protected GoParserBase(ITokenStream input, TextWriter output, TextWriter errorOutput)
-            : base(input, output, errorOutput)
-        {
-        }
-
         /// <summary>
         /// Returns `true` if on the current index of the parser's
         /// token stream a token exists on the `HIDDEN` channel which
@@ -38,13 +33,13 @@ using Antlr4.Runtime;
                 return false;
             }
 
-            if (ahead.Type == GoLexer.TERMINATOR)
+            if (ahead.Type == TERMINATOR)
             {
                 // There is definitely a line terminator ahead.
                 return true;
             }
 
-            if (ahead.Type == GoLexer.WS)
+            if (ahead.Type == WS)
             {
                 // Get the token ahead of the current whitespaces.
                 possibleIndexEosToken = CurrentToken.TokenIndex - 2;
@@ -62,8 +57,8 @@ using Antlr4.Runtime;
             int type = ahead.Type;
 
             // Check if the token is, or contains a line terminator.
-            return type == GoLexer.COMMENT && (text.Contains("\r") || text.Contains("\n")) ||
-                   type == GoLexer.TERMINATOR;
+            return type == COMMENT && (text.Contains("\r") || text.Contains("\n")) ||
+                   type == TERMINATOR;
         }
 
         /// <summary>
@@ -100,7 +95,7 @@ using Antlr4.Runtime;
             int leftParams = 1;
             int rightParams = 0;
 
-            if (LT(stream, tokenOffset).Type == GoLexer.L_PAREN)
+            if (LT(stream, tokenOffset).Type == L_PAREN)
             {
                 // Scan past parameters
                 while (leftParams != rightParams)
@@ -108,11 +103,11 @@ using Antlr4.Runtime;
                     tokenOffset++;
                     int tokenType = LT(stream, tokenOffset).Type;
 
-                    if (tokenType == GoLexer.L_PAREN)
+                    if (tokenType == L_PAREN)
                     {
                         leftParams++;
                     }
-                    else if (tokenType == GoLexer.R_PAREN)
+                    else if (tokenType == R_PAREN)
                     {
                         rightParams++;
                     }
@@ -132,14 +127,14 @@ using Antlr4.Runtime;
 
         private IToken LT(ITokenStream stream, int k)
         {
-            return stream.LT(k);
+            return stream.Lt(k);
         }
 
         private ITokenStream tokenStream
         {
             get
             {
-                return TokenStream;
+                return _input;
             }
         }
     }

--- a/golang/Go/go_parser_base.go
+++ b/golang/Go/go_parser_base.go
@@ -1,4 +1,3 @@
-package GoParseTree
 
 import (
 	"strings"

--- a/golang/Java/GoParserBase.java
+++ b/golang/Java/GoParserBase.java
@@ -1,5 +1,3 @@
-package GoParseTree;
-
 import java.util.List;
 import org.antlr.v4.runtime.*;
 

--- a/golang/pom.xml
+++ b/golang/pom.xml
@@ -13,6 +13,25 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>Java</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>
 				<version>${antlr.version}</version>
@@ -24,6 +43,7 @@
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
+					<outputDirectory>${project.build.directory}/generated-sources/antlr4</outputDirectory>
 				</configuration>
 				<executions>
 					<execution>
@@ -41,7 +61,7 @@
 					<verbose>false</verbose>
 					<showTree>false</showTree>
 					<entryPoint>sourceFile</entryPoint>
-					<grammarName>Golang</grammarName>
+					<grammarName>Go</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
 				<module>gedcom</module>
 				<module>gff3</module>
 				<module>gml</module>
+				<module>golang</module>
 				<module>graphql</module>
 				<module>graphstream-dgs</module>
 				<module>gtin</module>


### PR DESCRIPTION
This fixes the CI testing of the Go grammar, adding Java and C# testing. Changes in this commit:

* removed package declarations;
* fixed pom.xml to copy sources from Java/ for "maven test";
* fixed grammar name ("Golang" => "Go" since the grammars were changed long ago);
* split Antlr4cs and CSharp target source code so they can be independent;
* add golang back to top-level pom.

All `examples/*.go` parse.

--Ken