### PR TITLE
[scss] "Modernize" scss test suite

### DIFF
--- a/scss/build.gradle
+++ b/scss/build.gradle
@@ -44,29 +44,16 @@ repositories {
 }
 
 dependencies {
-  compile group:'org.mockito', name:'mockito-all', version:'1.9.5'
-  compile group:'org.testng', name:'testng', version:'6.1.1'
-  compile group:'antlr', name:'antlr-complete', version:'4.2.2'
+  compile group:'antlr', name:'antlr-complete', version:'4.9.1'
 
-
+  testCompile 'junit:junit:4.12'
+  testImplementation "com.google.truth:truth:1.1.2"
 }
 
-sourceSets {
-  main {
-    java {
-      srcDir file(relativePath('src'))
-    }
-
-  }
-}
-
-test {
-  useTestNG {
-  }
-}
+sourceSets.main.java.srcDirs = ['src']
+sourceSets.test.java.srcDirs = ['testsrc']
 
 task createClasses() {
-
   def jarFile = project.configurations.compile.find { it.name.contains("antlr-complete") }
   def dir = project.file("./src/main/java")
   if (dir.exists())
@@ -84,7 +71,4 @@ task createClasses() {
   if (result.exitValue != 0) {
     throw new GradleScriptException("Couldn't compile ANTLR", new GradleScriptException(err.toString(), null));
   }
-
-
 }
-

--- a/scss/testsrc/test/java/TestBase.java
+++ b/scss/testsrc/test/java/TestBase.java
@@ -26,142 +26,82 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.List;
-import org.antlr.v4.runtime.ANTLRErrorListener;
-import org.antlr.v4.runtime.ANTLRInputStream;
+import static org.junit.Assert.fail;
+
+import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.BufferedTokenStream;
-import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.DiagnosticErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.TokenStream;
-import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.atn.PredictionMode;
-import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.testng.Assert;
 
-public class TestBase
-{
-  protected void assertEqualsNoOrder(List actual, List expected)
-  {
-    Assert.assertEqualsNoOrder(actual.toArray(), expected.toArray(), "Not Equal Expected: " +  Arrays.toString(expected.toArray()) + " Actual: " + Arrays.toString(
-        actual.toArray()));
+public class TestBase {
+
+  protected ScssParser.StylesheetContext parse(String... lines) {
+    StringBuilder fileLines = new StringBuilder();
+    for (String line : lines) {
+      fileLines.append(line);
+    }
+
+    CharStream inputStream = CharStreams.fromString(fileLines.toString());
+
+    ScssLexer lexer = new ScssLexer(inputStream);
+    TokenStream stream = new BufferedTokenStream(lexer);
+    ScssParser par = new ScssParser(stream);
+    par.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
+
+    par.addErrorListener(new DiagnosticErrorListener());
+    par.addErrorListener(new FailOnErrorListener());
+    return par.stylesheet();
   }
 
-  protected ScssParser.StylesheetContext parse(String ... lines)
-  {
-    try
-    {
-      StringBuilder fileLines = new StringBuilder();
-      for (String line : lines)
-      {
-        fileLines.append(line);
+  private static class FailOnErrorListener extends BaseErrorListener {
+    @Override
+    public void syntaxError(
+        Recognizer<?, ?> recognizer,
+        Object offendingSymbol,
+        int line,
+        int charPositionInLine,
+        String msg,
+        RecognitionException e) {
+      // We don't care about this particular error.
+      if (msg.startsWith("reportAttemptingFullContext")) {
+        return;
       }
 
-      ANTLRInputStream source = new ANTLRInputStream(new ByteArrayInputStream(fileLines.toString().getBytes()));
-
-      ScssLexer lexer = new ScssLexer(source);
-      TokenStream stream = new BufferedTokenStream(lexer);
-      ScssParser par = new ScssParser(stream);
-      par.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
-
-      par.addErrorListener(new FailOnErrorListener());
-      return par.stylesheet();
-    }
-    catch (IOException e)
-    {
-      Assert.fail("Exception should not happen here", e);
-    }
-    return null;
-  }
-
-  private class FailOnErrorListener implements ANTLRErrorListener
-  {
-    @Override
-    public void syntaxError(Recognizer<?, ?> recognizer,
-                            Object o,
-                            int i,
-                            int i2,
-                            String s,
-                            RecognitionException e)
-    {
-      Assert.fail("Syntax error in detection.");
-    }
-
-    @Override
-    public void reportAmbiguity(Parser parser,
-                                DFA dfa,
-                                int i,
-                                int i2,
-                                boolean b,
-                                BitSet bitSet,
-                                ATNConfigSet atnConfigs)
-    {
-      Assert.fail("Ambiguity error in detection.");
-
-    }
-
-    @Override
-    public void reportAttemptingFullContext(Parser parser,
-                                            DFA dfa,
-                                            int i,
-                                            int i2,
-                                            BitSet bitSet,
-                                            ATNConfigSet atnConfigs)
-    {
-      Assert.fail("Attempting full context error in detection.");
-
-    }
-
-    @Override
-    public void reportContextSensitivity(Parser parser,
-                                         DFA dfa,
-                                         int i,
-                                         int i2,
-                                         int i3,
-                                         ATNConfigSet atnConfigs)
-    {
-      Assert.fail("Context sensitivity error in detection.");
-
+      fail("Syntax error in detection. line " + line + ":" + charPositionInLine + ". " + msg);
     }
   }
 
-
-  private String getExpressionMap(ParseTree start, int tabs)
-  {
-    if (start == null)
-    {
+  private String getExpressionMap(ParseTree start, int tabs) {
+    if (start == null) {
       return "";
     }
 
     StringBuilder bld = new StringBuilder();
-    if (TerminalNode.class.isAssignableFrom(start.getClass()))
-    {
-      for (int t = 0; t < tabs; t++)
-      {
+    if (start instanceof TerminalNode) {
+      for (int t = 0; t < tabs; t++) {
         bld.append("  ");
       }
       bld.append(start.getText());
       bld.append("\n");
-
     }
     int count = start.getChildCount();
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
       ParseTree child = start.getChild(i);
-      for (int t = 0; t < tabs; t++)
-      {
+      for (int t = 0; t < tabs; t++) {
         bld.append("  ");
       }
 
-      bld.append(child.getClass().getSimpleName() + ":\n" + getExpressionMap(child, tabs + 1));
+      bld.append(child.getClass().getSimpleName())
+          .append(":\n")
+          .append(getExpressionMap(child, tabs + 1));
     }
     return bld.toString();
   }
-
 }

--- a/scss/testsrc/test/java/TestBasicCss.java
+++ b/scss/testsrc/test/java/TestBasicCss.java
@@ -26,365 +26,463 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static com.google.common.truth.Truth.assertThat;
 
-public class TestBasicCss extends TestBase
-{
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
+public class TestBasicCss extends TestBase {
   @Test
-  public void testSimple()
-  {
-    String [] lines = {
-        "body {}",
+  public void testSimple() {
+    String[] lines = {
+      "body {}",
     };
-    Assert.assertEquals(getSelector(lines).selector(0).element(0).identifier().getText(), "body");
+    assertThat(getSelector(lines).selector(0).element(0).identifier().getText()).isEqualTo("body");
   }
 
   @Test
-  public void testIds()
-  {
-    String [] lines = {
-        "#id1 {}",
+  public void testIds() {
+    String[] lines = {
+      "#id1 {}",
     };
-    Assert.assertEquals(getSelector(lines).selector(0).element(0).identifier().getText(), "id1");
+    assertThat(getSelector(lines).selector(0).element(0).identifier().getText()).isEqualTo("id1");
   }
 
   @Test
-  public void testBlockWithNoSpacing()
-  {
-    String [] lines = {
-            "#id1{}",
+  public void testBlockWithNoSpacing() {
+    String[] lines = {
+      "#id1{}",
     };
-    Assert.assertEquals(getSelector(lines).selector(0).element(0).identifier().getText(), "id1");
+    assertThat(getSelector(lines).selector(0).element(0).identifier().getText()).isEqualTo("id1");
   }
 
   @Test
-  public void testClass()
-  {
-    String [] lines = {
-        ".cls {}",
+  public void testClass() {
+    String[] lines = {
+      ".cls {}",
     };
-    Assert.assertEquals(getSelector(lines).selector(0).element(0).identifier().getText(), "cls");
+    assertThat(getSelector(lines).selector(0).element(0).identifier().getText()).isEqualTo("cls");
   }
 
   @Test
-  public void testOneSelectorMultipleParts()
-  {
-    String [] lines = {
-        "body .cls {}",
+  public void testOneSelectorMultipleParts() {
+    String[] lines = {
+      "body .cls {}",
     };
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).getText(), "body");
-    Assert.assertEquals(context.selector(0).element(1).getText(), ".cls");
+    assertThat(context.selector(0).element(0).getText()).isEqualTo("body");
+    assertThat(context.selector(0).element(1).getText()).isEqualTo(".cls");
   }
 
   @Test
-  public void testMultipleSelectorsDifferentSelectors()
-  {
-    String [] lines = {
-        "body .cls, h1 {}",
+  public void testMultipleSelectorsDifferentSelectors() {
+    String[] lines = {
+      "body .cls, h1 {}",
     };
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).identifier().getText(), "body");
-    Assert.assertEquals(context.selector(0).element(1).getText(), ".cls");
+    assertThat(context.selector(0).element(0).identifier().getText()).isEqualTo("body");
+    assertThat(context.selector(0).element(1).getText()).isEqualTo(".cls");
 
-    Assert.assertEquals(context.selector(1).element(0).getText(), "h1");
+    assertThat(context.selector(1).element(0).getText()).isEqualTo("h1");
   }
 
   @Test
-  public void testMultipleSelectorsSameElement()
-  {
-    String [] lines = {
-        "body .cls, h1.cls1 {}",
+  public void testMultipleSelectorsSameElement() {
+    String[] lines = {
+      "body .cls, h1.cls1 {}",
     };
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).identifier().getText(), "body");
-    Assert.assertEquals(context.selector(0).element(1).getText(), ".cls");
+    assertThat(context.selector(0).element(0).identifier().getText()).isEqualTo("body");
+    assertThat(context.selector(0).element(1).getText()).isEqualTo(".cls");
 
-    Assert.assertEquals(context.selector(1).element(0).getText(), "h1");
-    Assert.assertEquals(context.selector(1).element(1).getText(), ".cls1");
-
+    assertThat(context.selector(1).element(0).getText()).isEqualTo("h1");
+    assertThat(context.selector(1).element(1).getText()).isEqualTo(".cls1");
   }
 
   @Test
-  public void testMultipleSelectorsMix()
-  {
-    String [] lines = {
-        ".cls1 .cls2, .cls3, .cls4 > .cls5 {}",
+  public void testMultipleSelectorsMix() {
+    String[] lines = {
+      ".cls1 .cls2, .cls3, .cls4 > .cls5 {}",
     };
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).getText(), ".cls1");
-    Assert.assertEquals(context.selector(0).element(1).getText(), ".cls2");
+    assertThat(context.selector(0).element(0).getText()).isEqualTo(".cls1");
+    assertThat(context.selector(0).element(1).getText()).isEqualTo(".cls2");
 
-    Assert.assertEquals(context.selector(1).element(0).getText(), ".cls3");
+    assertThat(context.selector(1).element(0).getText()).isEqualTo(".cls3");
 
-    Assert.assertEquals(context.selector(2).element(0).getText(), ".cls4");
+    assertThat(context.selector(2).element(0).getText()).isEqualTo(".cls4");
 
-    Assert.assertEquals(context.selector(2).element(1).combinator().getText(), ">");
-    Assert.assertEquals(context.selector(2).element(2).getText(), ".cls5");
-
+    assertThat(context.selector(2).element(1).combinator().getText()).isEqualTo(">");
+    assertThat(context.selector(2).element(2).getText()).isEqualTo(".cls5");
   }
 
   @Test
-  public void testNesting()
-  {
-    String [] lines = {
-        "@media hello,world {",
-        "  body, head {}",
-        "}",
+  public void testNesting() {
+    String[] lines = {
+      "@media hello,world {", "  body, head {}", "}",
     };
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).nested().nest().Identifier(0).getText(), "media");
-    Assert.assertEquals(context.statement(0).nested().selectors().selector(0).element(0).getText(), "hello");
-    Assert.assertEquals(context.statement(0).nested().selectors().selector(1).element(0).getText(), "world");
+    assertThat(context.statement(0).nested().nest().Identifier(0).getText()).isEqualTo("media");
+    assertThat(context.statement(0).nested().selectors().selector(0).element(0).getText())
+        .isEqualTo("hello");
+    assertThat(context.statement(0).nested().selectors().selector(1).element(0).getText())
+        .isEqualTo("world");
 
     ScssParser.StylesheetContext innerSheet = context.statement(0).nested().stylesheet();
-    Assert.assertEquals(innerSheet.statement(0).ruleset().selectors().selector(0).getText(), "body");
-    Assert.assertEquals(innerSheet.statement(0).ruleset().selectors().selector(1).getText(), "head");
+    assertThat(innerSheet.statement(0).ruleset().selectors().selector(0).getText())
+        .isEqualTo("body");
+    assertThat(innerSheet.statement(0).ruleset().selectors().selector(1).getText())
+        .isEqualTo("head");
   }
 
   @Test
-  public void testNestingWithCombinatorAtStartOfLine()
-  {
-    String [] lines = {
-      "p {",
-      "  > p {}",
-      "}",
+  public void testNestingWithCombinatorAtStartOfLine() {
+    String[] lines = {
+      "p {", "  > p {}", "}",
     };
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).ruleset().selectors().selector(0).element(0).getText(), "p");
-    Assert.assertEquals(context.statement(0).ruleset().block().statement(0).ruleset().selectors().selector(0).element(0).combinator().getText(), ">");
-    Assert.assertEquals(context.statement(0).ruleset().block().statement(0).ruleset().selectors().selector(0).element(1).getText(), "p");
+    assertThat(context.statement(0).ruleset().selectors().selector(0).element(0).getText())
+        .isEqualTo("p");
+    assertThat(
+            context
+                .statement(0)
+                .ruleset()
+                .block()
+                .statement(0)
+                .ruleset()
+                .selectors()
+                .selector(0)
+                .element(0)
+                .combinator()
+                .getText())
+        .isEqualTo(">");
+    assertThat(
+            context
+                .statement(0)
+                .ruleset()
+                .block()
+                .statement(0)
+                .ruleset()
+                .selectors()
+                .selector(0)
+                .element(1)
+                .getText())
+        .isEqualTo("p");
   }
 
   @Test
-  public void testProperties()
-  {
-    String [] lines = {
-        "h1 {",
-        "  display: block",
-        "}",
+  public void testProperties() {
+    String[] lines = {
+      "h1 {", "  display: block", "}",
     };
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
-    Assert.assertEquals(context.property(0).identifier().getText(), "display");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).getText(), "block");
+    assertThat(context.property(0).identifier().getText()).isEqualTo("display");
+    assertThat(context.property(0).values().commandStatement(0).getText()).isEqualTo("block");
   }
 
   @Test
-  public void testPropertiesMultivalues()
-  {
-    String [] lines = {
-        "h1 {",
-        "  background: url('a'), 1px 2px",
-        "}",
+  public void testPropertiesMultivalues() {
+    String[] lines = {
+      "h1 {", "  background: url('a'), 1px 2px", "}",
     };
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
-    Assert.assertEquals(context.property(0).identifier().getText(), "background");
+    assertThat(context.property(0).identifier().getText()).isEqualTo("background");
 
     ScssParser.ValuesContext val = context.property(0).values();
-    Assert.assertEquals(val.commandStatement(0).expression(0).url().Url().getText(), "'a'");
-    Assert.assertEquals(val.commandStatement(1).expression(0).measurement().Number().getText(), "1");
-    Assert.assertEquals(val.commandStatement(1).expression(0).measurement().Unit().getText(), "px");
+    assertThat(val.commandStatement(0).expression(0).url().Url().getText()).isEqualTo("'a'");
+    assertThat(val.commandStatement(1).expression(0).measurement().Number().getText())
+        .isEqualTo("1");
+    assertThat(val.commandStatement(1).expression(0).measurement().Unit().getText())
+        .isEqualTo("px");
 
-    Assert.assertEquals(val.commandStatement(1).expression(1).measurement().Number().getText(), "2");
-    Assert.assertEquals(val.commandStatement(1).expression(1).measurement().Unit().getText(), "px");
-
+    assertThat(val.commandStatement(1).expression(1).measurement().Number().getText())
+        .isEqualTo("2");
+    assertThat(val.commandStatement(1).expression(1).measurement().Unit().getText())
+        .isEqualTo("px");
   }
 
   @Test
-  public void testPropertiesMultiLines()
-  {
-    String [] lines = {
-        "h1 {",
-        "  color: 1px;",
-        "  font-size: #fff",
-        "}",
+  public void testPropertiesMultiLines() {
+    String[] lines = {
+      "h1 {", "  color: 1px;", "  font-size: #fff", "}",
     };
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
 
-    Assert.assertEquals(context.property(0).identifier().getText(), "color");
+    assertThat(context.property(0).identifier().getText()).isEqualTo("color");
     ScssParser.ValuesContext val = context.property(0).values();
-    Assert.assertEquals(val.commandStatement(0).expression(0).measurement().Number().getText(), "1");
-    Assert.assertEquals(val.commandStatement(0).expression(0).measurement().Unit().getText(), "px");
+    assertThat(val.commandStatement(0).expression(0).measurement().Number().getText())
+        .isEqualTo("1");
+    assertThat(val.commandStatement(0).expression(0).measurement().Unit().getText())
+        .isEqualTo("px");
 
-    Assert.assertEquals(context.property(1).identifier().getText(), "font-size");
+    assertThat(context.property(1).identifier().getText()).isEqualTo("font-size");
     val = context.property(1).values();
-    Assert.assertEquals(val.commandStatement(0).expression(0).Color().getText(), "#fff");
-
+    assertThat(val.commandStatement(0).expression(0).Color().getText()).isEqualTo("#fff");
   }
 
   @Test
-  public void testPropertyMeasurement()
-  {
+  public void testPropertyMeasurement() {
     ScssParser.ExpressionContext exp = createProperty("p1: 1;");
-    Assert.assertEquals(exp.measurement().Number().getText(), "1");
-    Assert.assertNull(exp.measurement().Unit());
+    assertThat(exp.measurement().Number().getText()).isEqualTo("1");
+    assertThat(exp.measurement().Unit()).isNull();
   }
 
   @Test
-  public void testPropertyMeasurementAndUnit()
-  {
+  public void testPropertyMeasurementAndUnit() {
     ScssParser.ExpressionContext exp = createProperty("p1: 1px;");
-    Assert.assertEquals(exp.measurement().Number().getText(), "1");
-    Assert.assertEquals(exp.measurement().Unit().getText(), "px");
+    assertThat(exp.measurement().Number().getText()).isEqualTo("1");
+    assertThat(exp.measurement().Unit().getText()).isEqualTo("px");
   }
 
   @Test
-  public void testPropertyShortColor()
-  {
+  public void testPropertyShortColor() {
     ScssParser.ExpressionContext exp = createProperty("p1: #fff;");
-    Assert.assertEquals(exp.Color().getText(), "#fff");
+    assertThat(exp.Color().getText()).isEqualTo("#fff");
   }
 
   @Test
-  public void testPropertyLongColor()
-  {
+  public void testPropertyLongColor() {
     ScssParser.ExpressionContext exp = createProperty("p1: #ababab;");
-    Assert.assertEquals(exp.Color().getText(), "#ababab");
+    assertThat(exp.Color().getText()).isEqualTo("#ababab");
   }
 
   @Test
-  public void testPropertyIdentifier()
-  {
+  public void testPropertyIdentifier() {
     ScssParser.ExpressionContext exp = createProperty("p1: solid;");
-    Assert.assertEquals(exp.identifier().getText(), "solid");
+    assertThat(exp.identifier().getText()).isEqualTo("solid");
   }
 
   @Test
-  public void testPropertyUrlString()
-  {
+  public void testPropertyUrlString() {
     ScssParser.ExpressionContext exp = createProperty("p1: url(\"hello\");");
-    Assert.assertEquals(exp.url().Url().getText(), "\"hello\"");
+    assertThat(exp.url().Url().getText()).isEqualTo("\"hello\"");
   }
 
   @Test
-  public void testPropertyUrl()
-  {
+  public void testPropertyUrl() {
     ScssParser.ExpressionContext exp = createProperty("p1: url(hello);");
-    Assert.assertEquals(exp.url().Url().getText(), "hello");
+    assertThat(exp.url().Url().getText()).isEqualTo("hello");
   }
 
   @Test
-  public void testPropertyString()
-  {
+  public void testPropertyString() {
     ScssParser.ExpressionContext exp = createProperty("p1: \"hello\";");
-    Assert.assertEquals(exp.StringLiteral().getText(), "\"hello\"");
+    assertThat(exp.StringLiteral().getText()).isEqualTo("\"hello\"");
   }
 
   @Test
-  public void testPropertyVariable()
-  {
+  public void testPropertyVariable() {
     ScssParser.ExpressionContext exp = createProperty("p1: $hello;");
-    Assert.assertEquals(exp.variableName().getText(), "$hello");
+    assertThat(exp.variableName().getText()).isEqualTo("$hello");
   }
 
   @Test
-  public void testPropertyFunctionMath()
-  {
+  public void testPropertyFunctionMath() {
     ScssParser.ExpressionContext exp = createProperty("p1: calc(100% / 3);");
-    Assert.assertEquals(exp.functionCall().Identifier().getText(), "calc");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).expression(0).getText(), "100%");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).mathStatement().mathCharacter().getText(), "/");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).mathStatement().commandStatement().expression(0)
-                            .measurement().Number().getText(), "3");
+    assertThat(exp.functionCall().Identifier().getText()).isEqualTo("calc");
+    assertThat(exp.functionCall().values().commandStatement(0).expression(0).getText())
+        .isEqualTo("100%");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .mathStatement()
+                .mathCharacter()
+                .getText())
+        .isEqualTo("/");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .mathStatement()
+                .commandStatement()
+                .expression(0)
+                .measurement()
+                .Number()
+                .getText())
+        .isEqualTo("3");
   }
 
   @Test
-  public void testPropertyFunctionMathMinus()
-  {
+  public void testPropertyFunctionMathMinus() {
     ScssParser.ExpressionContext exp = createProperty("p1: calc(100% - 80px);");
-    Assert.assertEquals(exp.functionCall().Identifier().getText(), "calc");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).expression(0).measurement().Number().getText(), "100");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).expression(0).measurement().Unit().getText(), "%");
+    assertThat(exp.functionCall().Identifier().getText()).isEqualTo("calc");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .measurement()
+                .Number()
+                .getText())
+        .isEqualTo("100");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .measurement()
+                .Unit()
+                .getText())
+        .isEqualTo("%");
 
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).mathStatement().mathCharacter().getText(), "-");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .mathStatement()
+                .mathCharacter()
+                .getText())
+        .isEqualTo("-");
 
-    ScssParser.MeasurementContext measure = exp.functionCall().values().commandStatement(0)
-        .mathStatement().commandStatement().expression(0).measurement();
-    Assert.assertEquals(measure.Number().getText(), "80");
-    Assert.assertEquals(measure.Unit().getText(), "px");
+    ScssParser.MeasurementContext measure =
+        exp.functionCall()
+            .values()
+            .commandStatement(0)
+            .mathStatement()
+            .commandStatement()
+            .expression(0)
+            .measurement();
+    assertThat(measure.Number().getText()).isEqualTo("80");
+    assertThat(measure.Unit().getText()).isEqualTo("px");
   }
 
-
   @Test
-  public void testPropertyFunctionMathVar()
-  {
+  public void testPropertyFunctionMathVar() {
     ScssParser.ExpressionContext exp = createProperty("p1: calc(100% - $var);");
-    Assert.assertEquals(exp.functionCall().Identifier().getText(), "calc");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).expression(0).measurement().Number().getText(), "100");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).expression(0).measurement().Unit().getText(), "%");
+    assertThat(exp.functionCall().Identifier().getText()).isEqualTo("calc");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .measurement()
+                .Number()
+                .getText())
+        .isEqualTo("100");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .measurement()
+                .Unit()
+                .getText())
+        .isEqualTo("%");
 
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).mathStatement().mathCharacter().getText(), "-");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .mathStatement()
+                .mathCharacter()
+                .getText())
+        .isEqualTo("-");
 
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).mathStatement().commandStatement().expression(0).variableName().getText(), "$var");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .mathStatement()
+                .commandStatement()
+                .expression(0)
+                .variableName()
+                .getText())
+        .isEqualTo("$var");
   }
 
   @Test
-  public void testPropertyFunctionMathParen()
-  {
+  public void testPropertyFunctionMathParen() {
     ScssParser.ExpressionContext exp = createProperty("p1: calc(((100%)));");
-    Assert.assertEquals(exp.functionCall().Identifier().getText(), "calc");
-    Assert.assertEquals(exp.functionCall().values().commandStatement(0).commandStatement().commandStatement()
-                            .expression(0).measurement().Number().getText(), "100");
+    assertThat(exp.functionCall().Identifier().getText()).isEqualTo("calc");
+    assertThat(
+            exp.functionCall()
+                .values()
+                .commandStatement(0)
+                .commandStatement()
+                .commandStatement()
+                .expression(0)
+                .measurement()
+                .Number()
+                .getText())
+        .isEqualTo("100");
   }
 
   @Test
-  public void testPropertyWithNegatedMathValue()
-  {
-    String [] lines = {
-        "h1 { p1: -$my-var; }"
-    };
+  public void testPropertyWithNegatedMathValue() {
+    String[] lines = {"h1 { p1: -$my-var; }"};
 
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
-    Assert.assertEquals(context.property(0).identifier().getText(), "p1");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).getText(), "-$my-var");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).MINUS().getText(), "-");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).expression(0).getText(), "$my-var");
+    assertThat(context.property(0).identifier().getText()).isEqualTo("p1");
+    assertThat(context.property(0).values().commandStatement(0).getText()).isEqualTo("-$my-var");
+    assertThat(context.property(0).values().commandStatement(0).MINUS().getText()).isEqualTo("-");
+    assertThat(context.property(0).values().commandStatement(0).expression(0).getText())
+        .isEqualTo("$my-var");
   }
 
   @Test
-  public void testPropertyWithPlusPrefix()
-  {
-    String [] lines = {
-        "h1 { p1: +(400px - 200px); }"
-    };
+  public void testPropertyWithPlusPrefix() {
+    String[] lines = {"h1 { p1: +(400px - 200px); }"};
 
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
-    Assert.assertEquals(context.property(0).identifier().getText(), "p1");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).getText(), "+(400px-200px)");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).PLUS().getText(), "+");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).commandStatement().expression(0).getText(), "400px");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).commandStatement().mathStatement().mathCharacter().MINUS().getText(), "-");
-    Assert.assertEquals(context.property(0).values().commandStatement(0).commandStatement().mathStatement().commandStatement().expression(0).getText(), "200px");
+    assertThat(context.property(0).identifier().getText()).isEqualTo("p1");
+    assertThat(context.property(0).values().commandStatement(0).getText())
+        .isEqualTo("+(400px-200px)");
+    assertThat(context.property(0).values().commandStatement(0).PLUS().getText()).isEqualTo("+");
+    assertThat(
+            context
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .commandStatement()
+                .expression(0)
+                .getText())
+        .isEqualTo("400px");
+    assertThat(
+            context
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .commandStatement()
+                .mathStatement()
+                .mathCharacter()
+                .MINUS()
+                .getText())
+        .isEqualTo("-");
+    assertThat(
+            context
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .commandStatement()
+                .mathStatement()
+                .commandStatement()
+                .expression(0)
+                .getText())
+        .isEqualTo("200px");
   }
 
   @Test
-  public void testInterpolation()
-  {
-    String [] lines = {
-        "p.#{$name} > select2 {}"
-    };
+  public void testInterpolation() {
+    String[] lines = {"p.#{$name} > select2 {}"};
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).identifier().getText(), "p");
-    Assert.assertEquals(
-        context.selector(0).element(1).identifier().identifierVariableName().getText(), "$name");
+    assertThat(context.selector(0).element(0).identifier().getText()).isEqualTo("p");
+    assertThat(context.selector(0).element(1).identifier().identifierVariableName().getText())
+        .isEqualTo("$name");
 
-    Assert.assertEquals(context.selector(0).element(2).getText(), ">");
-    Assert.assertEquals(context.selector(0).element(3).getText(), "select2");
+    assertThat(context.selector(0).element(2).getText()).isEqualTo(">");
+    assertThat(context.selector(0).element(3).getText()).isEqualTo("select2");
   }
 
   @Test
-  public void testInterpolationSpace()
-  {
-    String [] lines = {
-        "p #{$name} {}"
-    };
+  public void testInterpolationSpace() {
+    String[] lines = {"p #{$name} {}"};
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).identifier().getText(), "p");
-    Assert.assertEquals(
-        context.selector(0).element(1).identifier().identifierVariableName().getText(), "$name");
-
+    assertThat(context.selector(0).element(0).identifier().getText()).isEqualTo("p");
+    assertThat(context.selector(0).element(1).identifier().identifierVariableName().getText())
+        .isEqualTo("$name");
   }
 
   @Test
@@ -392,9 +490,9 @@ public class TestBasicCss extends TestBase
     String[] lines = {":host(.fullscreen) {}"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).pseudo().getText(), ":host(.fullscreen)");
-    Assert.assertEquals(
-        context.selector(0).element(0).pseudo().selector().getText(), ".fullscreen");
+    assertThat(context.selector(0).element(0).pseudo().getText()).isEqualTo(":host(.fullscreen)");
+    assertThat(context.selector(0).element(0).pseudo().selector().getText())
+        .isEqualTo(".fullscreen");
   }
 
   @Test
@@ -402,9 +500,10 @@ public class TestBasicCss extends TestBase
     String[] lines = {"button:not([disabled]) {}"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).identifier().getText(), "button");
-    Assert.assertEquals(context.selector(0).element(1).pseudo().getText(), ":not([disabled])");
-    Assert.assertEquals(context.selector(0).element(1).pseudo().selector().getText(), "[disabled]");
+    assertThat(context.selector(0).element(0).identifier().getText()).isEqualTo("button");
+    assertThat(context.selector(0).element(1).pseudo().getText()).isEqualTo(":not([disabled])");
+    assertThat(context.selector(0).element(1).pseudo().selector().getText())
+        .isEqualTo("[disabled]");
   }
 
   @Test
@@ -412,89 +511,72 @@ public class TestBasicCss extends TestBase
     String[] lines = {"button:nth-child(4) {}"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).identifier().getText(), "button");
-    Assert.assertEquals(context.selector(0).element(1).pseudo().getText(), ":nth-child(4)");
-    Assert.assertEquals(context.selector(0).element(1).pseudo().values().getText(), "4");
+    assertThat(context.selector(0).element(0).identifier().getText()).isEqualTo("button");
+    assertThat(context.selector(0).element(1).pseudo().getText()).isEqualTo(":nth-child(4)");
+    assertThat(context.selector(0).element(1).pseudo().values().getText()).isEqualTo("4");
   }
 
   @Test
-  public void testAttributeSelector()
-  {
-    String [] lines = {
-        "input[type=number] {}"
-    };
+  public void testAttributeSelector() {
+    String[] lines = {"input[type=number] {}"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).getText(), "input");
-    Assert.assertEquals(context.selector(0).element(1).attrib().getText(), "[type=number]");
-    Assert.assertEquals(context.selector(0).element(1).attrib().Identifier(0).getText(), "type");
-    Assert.assertEquals(context.selector(0).element(1).attrib().attribRelate().getText(), "=");
-    Assert.assertEquals(context.selector(0).element(1).attrib().Identifier(1).getText(), "number");
+    assertThat(context.selector(0).element(0).getText()).isEqualTo("input");
+    assertThat(context.selector(0).element(1).attrib().getText()).isEqualTo("[type=number]");
+    assertThat(context.selector(0).element(1).attrib().Identifier(0).getText()).isEqualTo("type");
+    assertThat(context.selector(0).element(1).attrib().attribRelate().getText()).isEqualTo("=");
+    assertThat(context.selector(0).element(1).attrib().Identifier(1).getText()).isEqualTo("number");
   }
 
   @Test
-  public void testStandAloneAttributeSelector()
-  {
-    String [] lines = {
-        "[disabled] {}"
-    };
+  public void testStandAloneAttributeSelector() {
+    String[] lines = {"[disabled] {}"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).attrib().getText(), "[disabled]");
-    Assert.assertEquals(context.selector(0).element(0).attrib().Identifier(0).getText(), "disabled");
+    assertThat(context.selector(0).element(0).attrib().getText()).isEqualTo("[disabled]");
+    assertThat(context.selector(0).element(0).attrib().Identifier(0).getText())
+        .isEqualTo("disabled");
   }
 
   @Test
-  public void testPseudoClassAtEndOfSelector()
-  {
-    String [] lines = {
-        "h1:hover { color: blue; }"
-    };
+  public void testPseudoClassAtEndOfSelector() {
+    String[] lines = {"h1:hover { color: blue; }"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).getText(), "h1");
-    Assert.assertEquals(context.selector(0).element(1).pseudo().getText(), ":hover");
+    assertThat(context.selector(0).element(0).getText()).isEqualTo("h1");
+    assertThat(context.selector(0).element(1).pseudo().getText()).isEqualTo(":hover");
   }
 
   @Test
-  public void testPseudoElementAndPseudoClass()
-  {
+  public void testPseudoElementAndPseudoClass() {
     // After is a pseudo-element and hover is a pseduo-class.
     // After is supported with 1 or 2 colons.
-    String [] lines = {
-        "h1:after:hover, h2:hover::after { color: blue; }"
-    };
+    String[] lines = {"h1:after:hover, h2:hover::after { color: blue; }"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).getText(), "h1");
-    Assert.assertEquals(context.selector(0).element(1).pseudo().getText(), ":after");
-    Assert.assertEquals(context.selector(0).element(2).pseudo().getText(), ":hover");
-    Assert.assertEquals(context.selector(1).element(0).getText(), "h2");
-    Assert.assertEquals(context.selector(1).element(1).pseudo().getText(), ":hover");
-    Assert.assertEquals(context.selector(1).element(2).pseudo().getText(), "::after");
+    assertThat(context.selector(0).element(0).getText()).isEqualTo("h1");
+    assertThat(context.selector(0).element(1).pseudo().getText()).isEqualTo(":after");
+    assertThat(context.selector(0).element(2).pseudo().getText()).isEqualTo(":hover");
+    assertThat(context.selector(1).element(0).getText()).isEqualTo("h2");
+    assertThat(context.selector(1).element(1).pseudo().getText()).isEqualTo(":hover");
+    assertThat(context.selector(1).element(2).pseudo().getText()).isEqualTo("::after");
   }
 
   @Test
-  public void testStandAlonePseudoElement()
-  {
-    String [] lines = {
-        "::placeholder { color: blue; }"
-    };
+  public void testStandAlonePseudoElement() {
+    String[] lines = {"::placeholder { color: blue; }"};
 
     ScssParser.SelectorsContext context = getSelector(lines);
-    Assert.assertEquals(context.selector(0).element(0).pseudo().getText(), "::placeholder");
+    assertThat(context.selector(0).element(0).pseudo().getText()).isEqualTo("::placeholder");
   }
 
-  private ScssParser.SelectorsContext getSelector( String ... lines)
-  {
+  private ScssParser.SelectorsContext getSelector(String... lines) {
     ScssParser.StylesheetContext context = parse(lines);
     return context.statement(0).ruleset().selectors();
   }
 
-
-  private ScssParser.ExpressionContext createProperty(String ... lines)
-  {
-    String [] all = new String[lines.length + 2];
+  private ScssParser.ExpressionContext createProperty(String... lines) {
+    String[] all = new String[lines.length + 2];
     all[0] = "h1 {";
     System.arraycopy(lines, 0, all, 1, lines.length);
     all[all.length - 1] = "}";

--- a/scss/testsrc/test/java/TestConditionals.java
+++ b/scss/testsrc/test/java/TestConditionals.java
@@ -26,146 +26,206 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-public class TestConditionals extends TestBase
-{
+@RunWith(JUnit4.class)
+public class TestConditionals extends TestBase {
   @Test
-  public void testIf()
-  {
-    String [] lines = {
-        "@if 1 + 1 == 2 {}"
-    };
+  public void testIf() {
+    String[] lines = {"@if 1 + 1 == 2 {}"};
     ScssParser.IfDeclarationContext context = parse(lines).statement(0).ifDeclaration();
-    Assert.assertEquals(context.conditions().condition().commandStatement().expression(0).getText(), "1");
-    Assert.assertEquals(context.conditions().condition().commandStatement().mathStatement().mathCharacter().getText(), "+");
-    Assert.assertEquals(context.conditions().condition().commandStatement().mathStatement().commandStatement().expression(0).getText(), "1");
+    assertThat(context.conditions().condition().commandStatement().expression(0).getText())
+        .isEqualTo("1");
+    assertThat(
+            context
+                .conditions()
+                .condition()
+                .commandStatement()
+                .mathStatement()
+                .mathCharacter()
+                .getText())
+        .isEqualTo("+");
+    assertThat(
+            context
+                .conditions()
+                .condition()
+                .commandStatement()
+                .mathStatement()
+                .commandStatement()
+                .expression(0)
+                .getText())
+        .isEqualTo("1");
 
-    Assert.assertEquals(context.conditions().condition().conditions().condition()
-                            .commandStatement().expression(0).getText(), "2");
+    assertThat(
+            context
+                .conditions()
+                .condition()
+                .conditions()
+                .condition()
+                .commandStatement()
+                .expression(0)
+                .getText())
+        .isEqualTo("2");
   }
 
   @Test
-  public void testElseIf()
-  {
-    String [] lines = {
-        "@if 1 + 1 == 2 {}",
-        "@else if 1 + 1 == 3 {}"
-    };
-    ScssParser.ElseIfStatementContext context = parse(lines).statement(0).ifDeclaration().elseIfStatement(0);
-    Assert.assertEquals(context.conditions().condition().commandStatement().expression(0).getText(), "1");
-    Assert.assertEquals(context.conditions().condition().commandStatement().mathStatement().mathCharacter().getText(), "+");
-    Assert.assertEquals(context.conditions().condition().commandStatement()
-                            .mathStatement().commandStatement().expression(0).getText(), "1");
+  public void testElseIf() {
+    String[] lines = {"@if 1 + 1 == 2 {}", "@else if 1 + 1 == 3 {}"};
+    ScssParser.ElseIfStatementContext context =
+        parse(lines).statement(0).ifDeclaration().elseIfStatement(0);
+    assertThat(context.conditions().condition().commandStatement().expression(0).getText())
+        .isEqualTo("1");
+    assertThat(
+            context
+                .conditions()
+                .condition()
+                .commandStatement()
+                .mathStatement()
+                .mathCharacter()
+                .getText())
+        .isEqualTo("+");
+    assertThat(
+            context
+                .conditions()
+                .condition()
+                .commandStatement()
+                .mathStatement()
+                .commandStatement()
+                .expression(0)
+                .getText())
+        .isEqualTo("1");
 
-    Assert.assertEquals(context.conditions().condition().conditions().condition().commandStatement().expression(0).getText()
-        , "3");
+    assertThat(
+            context
+                .conditions()
+                .condition()
+                .conditions()
+                .condition()
+                .commandStatement()
+                .expression(0)
+                .getText())
+        .isEqualTo("3");
   }
 
-
   @Test
-  public void testElseIfElse()
-  {
-    String [] lines = {
-        "@if 1 + 1 == 2 {}",
-        "@else if 1 + 1 == 3 {}",
-        "@else { color: red }"
+  public void testElseIfElse() {
+    String[] lines = {"@if 1 + 1 == 2 {}", "@else if 1 + 1 == 3 {}", "@else { color: red }"};
 
-    };
-    ScssParser.ElseStatementContext context = parse(lines).statement(0).ifDeclaration().elseStatement();
-    Assert.assertEquals(context.block().property(0).identifier().getText(), "color");
-    Assert.assertEquals(context.block().property(0).values().getText(), "red");
-
+    ScssParser.ElseStatementContext context =
+        parse(lines).statement(0).ifDeclaration().elseStatement();
+    assertThat(context.block().property(0).identifier().getText()).isEqualTo("color");
+    assertThat(context.block().property(0).values().getText()).isEqualTo("red");
   }
 
-
-
   @Test
-  public void testForLoop()
-  {
-    String [] lines = {
-        "@for $i from 1 through 3 {}"
+  public void testForLoop() {
+    String[] lines = {"@for $i from 1 through 3 {}"};
 
-    };
     ScssParser.ForDeclarationContext context = parse(lines).statement(0).forDeclaration();
-    Assert.assertEquals(context.variableName().getText(), "$i");
-    Assert.assertEquals(context.fromNumber().getText(), "1");
-    Assert.assertEquals(context.throughNumber().getText(), "3");
-
-
-
+    assertThat(context.variableName().getText()).isEqualTo("$i");
+    assertThat(context.fromNumber().getText()).isEqualTo("1");
+    assertThat(context.throughNumber().getText()).isEqualTo("3");
   }
 
   @Test
-  public void testWhileLoop()
-  {
-    String [] lines = {
-        "@while $i > 0 {}"
+  public void testWhileLoop() {
+    String[] lines = {"@while $i > 0 {}"};
 
-    };
     ScssParser.WhileDeclarationContext context = parse(lines).statement(0).whileDeclaration();
-    Assert.assertEquals(context.conditions().condition().commandStatement().expression(0).variableName().getText(), "$i");
-    Assert.assertEquals(context.conditions().condition().conditions().condition().commandStatement().getText(), "0");
+    assertThat(
+            context
+                .conditions()
+                .condition()
+                .commandStatement()
+                .expression(0)
+                .variableName()
+                .getText())
+        .isEqualTo("$i");
+    assertThat(
+            context.conditions().condition().conditions().condition().commandStatement().getText())
+        .isEqualTo("0");
   }
 
   @Test
-  public void testBasicEach()
-  {
-    String [] lines = {
-        "@each $animal in puma, sea-slug, egret, salamander {}"
+  public void testBasicEach() {
+    String[] lines = {"@each $animal in puma, sea-slug, egret, salamander {}"};
 
-    };
     ScssParser.EachDeclarationContext context = parse(lines).statement(0).eachDeclaration();
-    Assert.assertEquals(context.variableName(0).getText(), "$animal");
-    Assert.assertEquals(context.eachValueList().Identifier(0).getText(), "puma");
-    Assert.assertEquals(context.eachValueList().Identifier(1).getText(), "sea-slug");
-    Assert.assertEquals(context.eachValueList().Identifier(2).getText(), "egret");
-    Assert.assertEquals(context.eachValueList().Identifier(3).getText(), "salamander");
+    assertThat(context.variableName(0).getText()).isEqualTo("$animal");
+    assertThat(context.eachValueList().Identifier(0).getText()).isEqualTo("puma");
+    assertThat(context.eachValueList().Identifier(1).getText()).isEqualTo("sea-slug");
+    assertThat(context.eachValueList().Identifier(2).getText()).isEqualTo("egret");
+    assertThat(context.eachValueList().Identifier(3).getText()).isEqualTo("salamander");
   }
 
   @Test
-  public void testBasicEachMultiAssign()
-  {
-    String [] lines = {
-        "@each $animal, $color, $cursor in (puma, black, default), (sea-slug, blue, pointer) {}"
-
+  public void testBasicEachMultiAssign() {
+    String[] lines = {
+      "@each $animal, $color, $cursor in (puma, black, default), (sea-slug, blue, pointer) {}"
     };
     ScssParser.EachDeclarationContext context = parse(lines).statement(0).eachDeclaration();
-    Assert.assertEquals(context.variableName(0).getText(), "$animal");
-    Assert.assertEquals(context.variableName(1).getText(), "$color");
-    Assert.assertEquals(context.variableName(2).getText(), "$cursor");
+    assertThat(context.variableName(0).getText()).isEqualTo("$animal");
+    assertThat(context.variableName(1).getText()).isEqualTo("$color");
+    assertThat(context.variableName(2).getText()).isEqualTo("$cursor");
 
+    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(0).getText())
+        .isEqualTo("puma");
+    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(1).getText())
+        .isEqualTo("black");
+    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(2).getText())
+        .isEqualTo("default");
 
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(0).getText(), "puma");
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(1).getText(), "black");
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(2).getText(), "default");
-
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(1).identifierValue(0).getText(), "sea-slug");
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(1).identifierValue(1).getText(), "blue");
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(1).identifierValue(2).getText(), "pointer");
+    assertThat(context.eachValueList().identifierListOrMap(1).identifierValue(0).getText())
+        .isEqualTo("sea-slug");
+    assertThat(context.eachValueList().identifierListOrMap(1).identifierValue(1).getText())
+        .isEqualTo("blue");
+    assertThat(context.eachValueList().identifierListOrMap(1).identifierValue(2).getText())
+        .isEqualTo("pointer");
   }
 
   @Test
-  public void testBasicEachMultiAssignWithvalues()
-  {
-    String [] lines = {
-        "@each $header, $size in (h1: 2em, h2: 1.5em, h3: 1.2em) {}"
+  public void testBasicEachMultiAssignWithvalues() {
+    String[] lines = {"@each $header, $size in (h1: 2em, h2: 1.5em, h3: 1.2em) {}"};
 
-    };
     ScssParser.EachDeclarationContext context = parse(lines).statement(0).eachDeclaration();
-    Assert.assertEquals(context.variableName(0).getText(), "$header");
-    Assert.assertEquals(context.variableName(1).getText(), "$size");
+    assertThat(context.variableName(0).getText()).isEqualTo("$header");
+    assertThat(context.variableName(1).getText()).isEqualTo("$size");
 
+    assertThat(
+            context
+                .eachValueList()
+                .identifierListOrMap(0)
+                .identifierValue(0)
+                .identifier()
+                .getText())
+        .isEqualTo("h1");
+    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(0).values().getText())
+        .isEqualTo("2em");
 
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(0).identifier().getText(), "h1");
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(0).values().getText(), "2em");
+    assertThat(
+            context
+                .eachValueList()
+                .identifierListOrMap(0)
+                .identifierValue(1)
+                .identifier()
+                .getText())
+        .isEqualTo("h2");
+    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(1).values().getText())
+        .isEqualTo("1.5em");
 
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(1).identifier().getText(), "h2");
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(1).values().getText(), "1.5em");
-
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(2).identifier().getText(), "h3");
-    Assert.assertEquals(context.eachValueList().identifierListOrMap(0).identifierValue(2).values().getText(), "1.2em");
+    assertThat(
+            context
+                .eachValueList()
+                .identifierListOrMap(0)
+                .identifierValue(2)
+                .identifier()
+                .getText())
+        .isEqualTo("h3");
+    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(2).values().getText())
+        .isEqualTo("1.2em");
   }
 }

--- a/scss/testsrc/test/java/TestFunctions.java
+++ b/scss/testsrc/test/java/TestFunctions.java
@@ -26,86 +26,97 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-public class TestFunctions extends TestBase
-{
+@RunWith(JUnit4.class)
+public class TestFunctions extends TestBase {
   @Test
-  public void testFunction()
-  {
-    //TODO: make it work with parans in the math.
-    //($n - 1) * $gutter-width;
-    String [] lines = {
-        "@function grid-width($n) {",
-        "  @return ($n - 1) * $gutter-width;",
-        "}"
-    };
+  public void testFunction() {
+    // TODO: make it work with parans in the math.
+    // ($n - 1) * $gutter-width;
+    String[] lines = {"@function grid-width($n) {", "  @return ($n - 1) * $gutter-width;", "}"};
     ScssParser.FunctionDeclarationContext context = parse(lines).statement(0).functionDeclaration();
-    Assert.assertEquals(context.Identifier().getText(), "grid-width");
-    Assert.assertEquals(context.params().param(0).variableName().getText(), "$n");
+    assertThat(context.Identifier().getText()).isEqualTo("grid-width");
+    assertThat(context.params().param(0).variableName().getText()).isEqualTo("$n");
 
     ScssParser.FunctionReturnContext funcContext = context.functionBody().functionReturn();
-    Assert.assertEquals(funcContext.commandStatement().commandStatement().expression(0).getText(), "$n");
-    Assert.assertEquals(funcContext.commandStatement().commandStatement().mathStatement().commandStatement().getText(), "1");
+    assertThat(funcContext.commandStatement().commandStatement().expression(0).getText())
+        .isEqualTo("$n");
+    assertThat(
+            funcContext
+                .commandStatement()
+                .commandStatement()
+                .mathStatement()
+                .commandStatement()
+                .getText())
+        .isEqualTo("1");
 
-
-    Assert.assertEquals(funcContext.commandStatement().mathStatement().mathCharacter().getText(), "*");
-    Assert.assertEquals(funcContext.commandStatement().mathStatement().commandStatement().getText(), "$gutter-width");
-
-
+    assertThat(funcContext.commandStatement().mathStatement().mathCharacter().getText())
+        .isEqualTo("*");
+    assertThat(funcContext.commandStatement().mathStatement().commandStatement().getText())
+        .isEqualTo("$gutter-width");
   }
 
- @Test
- public void testFunctionMultiLine()
- {
-   //TODO: make it work with parans in the math.
-   //($n - 1) * $gutter-width;
-   String [] lines = {
-       "@function grid-width () {",
-       "  $color: red;",
-       "  @return $color;",
-       "}"
-   };
-   ScssParser.FunctionDeclarationContext context = parse(lines).statement(0).functionDeclaration();
-
-   ScssParser.FunctionStatementContext funcContext = context.functionBody().functionStatement(0);
-   Assert.assertEquals(funcContext.statement().variableDeclaration().variableName().getText(), "$color");
-   Assert.assertEquals(funcContext.statement().variableDeclaration().values().getText(), "red");
-
-
-
-   ScssParser.FunctionReturnContext returnContext = context.functionBody().functionReturn();
-   Assert.assertEquals(returnContext.commandStatement().expression(0).getText(), "$color");
- }
-
   @Test
-  public void testNestedFunctions()
-  {
-    String [] lines = {
-        "@function grid-width ($a) {",
-        "  @function grid-height($b) {",
-        "    @return $color;",
-        "  }",
-        "  @return $world;",
-        "}"
-    };
+  public void testFunctionMultiLine() {
+    // TODO: make it work with parans in the math.
+    // ($n - 1) * $gutter-width;
+    String[] lines = {"@function grid-width () {", "  $color: red;", "  @return $color;", "}"};
     ScssParser.FunctionDeclarationContext context = parse(lines).statement(0).functionDeclaration();
-    Assert.assertEquals(context.Identifier().getText(), "grid-width");
-    Assert.assertEquals(context.params().param(0).variableName().getText(), "$a");
 
     ScssParser.FunctionStatementContext funcContext = context.functionBody().functionStatement(0);
-    Assert.assertEquals(funcContext.statement().functionDeclaration().Identifier().getText(), "grid-height");
-    Assert.assertEquals(funcContext.statement().functionDeclaration().params().param(0).variableName().getText(), "$b");
-
-    Assert.assertEquals(funcContext.statement().functionDeclaration().functionBody().functionReturn()
-                            .commandStatement().expression(0).variableName().getText(), "$color");
-
+    assertThat(funcContext.statement().variableDeclaration().variableName().getText())
+        .isEqualTo("$color");
+    assertThat(funcContext.statement().variableDeclaration().values().getText()).isEqualTo("red");
 
     ScssParser.FunctionReturnContext returnContext = context.functionBody().functionReturn();
-    Assert.assertEquals(returnContext.commandStatement().expression(0).getText(), "$world");
+    assertThat(returnContext.commandStatement().expression(0).getText()).isEqualTo("$color");
+  }
 
+  @Test
+  public void testNestedFunctions() {
+    String[] lines = {
+      "@function grid-width ($a) {",
+      "  @function grid-height($b) {",
+      "    @return $color;",
+      "  }",
+      "  @return $world;",
+      "}"
+    };
+    ScssParser.FunctionDeclarationContext context = parse(lines).statement(0).functionDeclaration();
+    assertThat(context.Identifier().getText()).isEqualTo("grid-width");
+    assertThat(context.params().param(0).variableName().getText()).isEqualTo("$a");
 
+    ScssParser.FunctionStatementContext funcContext = context.functionBody().functionStatement(0);
+    assertThat(funcContext.statement().functionDeclaration().Identifier().getText())
+        .isEqualTo("grid-height");
+    assertThat(
+            funcContext
+                .statement()
+                .functionDeclaration()
+                .params()
+                .param(0)
+                .variableName()
+                .getText())
+        .isEqualTo("$b");
+
+    assertThat(
+            funcContext
+                .statement()
+                .functionDeclaration()
+                .functionBody()
+                .functionReturn()
+                .commandStatement()
+                .expression(0)
+                .variableName()
+                .getText())
+        .isEqualTo("$color");
+
+    ScssParser.FunctionReturnContext returnContext = context.functionBody().functionReturn();
+    assertThat(returnContext.commandStatement().expression(0).getText()).isEqualTo("$world");
   }
 }

--- a/scss/testsrc/test/java/TestImports.java
+++ b/scss/testsrc/test/java/TestImports.java
@@ -26,61 +26,52 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-public class TestImports extends TestBase
-{
+@RunWith(JUnit4.class)
+public class TestImports extends TestBase {
   @Test
-  public void testImport()
-  {
+  public void testImport() {
     ScssParser.ReferenceUrlContext context = parseImport("@import \"hello\";");
-    Assert.assertEquals(context.StringLiteral().getText(), "\"hello\"");
+    assertThat(context.StringLiteral().getText()).isEqualTo("\"hello\"");
   }
 
   @Test
-  public void testImportUrlString()
-  {
+  public void testImportUrlString() {
     ScssParser.ReferenceUrlContext context = parseImport("@import url(\"hello\");");
-    Assert.assertEquals(context.Url().getText(), "\"hello\"");
+    assertThat(context.Url().getText()).isEqualTo("\"hello\"");
   }
 
   @Test
-  public void testImportUrlNonStrings()
-  {
+  public void testImportUrlNonStrings() {
     ScssParser.ReferenceUrlContext context = parseImport("@import url(hello);");
-    Assert.assertEquals(context.Url().getText(), "hello");
+    assertThat(context.Url().getText()).isEqualTo("hello");
   }
 
   @Test
-  public void testImportUrlNonStringsSpace()
-  {
+  public void testImportUrlNonStringsSpace() {
     ScssParser.ReferenceUrlContext context = parseImport("@import url(hello world);");
-    Assert.assertEquals(context.Url().getText(), "hello world");
+    assertThat(context.Url().getText()).isEqualTo("hello world");
   }
 
   @Test
-  public void testMultipleImports()
-  {
-    String [] lines = {
-        "@import url(hello world);",
-        "@import url(\"foobar\");",
-        "@import \"hi\";"
+  public void testMultipleImports() {
+    String[] lines = {"@import url(hello world);", "@import url(\"foobar\");", "@import \"hi\";"};
 
-    };
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).importDeclaration()
-                            .referenceUrl().Url().getText(), "hello world");
-    Assert.assertEquals(context.statement(1).importDeclaration()
-                            .referenceUrl().Url().getText(), "\"foobar\"");
-    Assert.assertEquals(context.statement(2).importDeclaration()
-                            .referenceUrl().StringLiteral().getText(), "\"hi\"");
+    assertThat(context.statement(0).importDeclaration().referenceUrl().Url().getText())
+        .isEqualTo("hello world");
+    assertThat(context.statement(1).importDeclaration().referenceUrl().Url().getText())
+        .isEqualTo("\"foobar\"");
+    assertThat(context.statement(2).importDeclaration().referenceUrl().StringLiteral().getText())
+        .isEqualTo("\"hi\"");
   }
 
-
-  private ScssParser.ReferenceUrlContext parseImport(String ... lines)
-  {
+  private ScssParser.ReferenceUrlContext parseImport(String... lines) {
     ScssParser.StylesheetContext context = parse(lines);
     return context.statement(0).importDeclaration().referenceUrl();
   }

--- a/scss/testsrc/test/java/TestInclude.java
+++ b/scss/testsrc/test/java/TestInclude.java
@@ -26,114 +26,145 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-public class TestInclude extends TestBase
-{
+@RunWith(JUnit4.class)
+public class TestInclude extends TestBase {
   @Test
-  public void testInclude()
-  {
-    String [] lines = {
-        "@include large-text;"
-    };
+  public void testInclude() {
+    String[] lines = {"@include large-text;"};
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).includeDeclaration().Identifier().getText(), "large-text");
+    assertThat(context.statement(0).includeDeclaration().Identifier().getText())
+        .isEqualTo("large-text");
   }
 
   @Test
-  public void testIncludeInBlock()
-  {
-    String [] lines = {
-        ".test {",
-        "  @include large-text;",
-        "}"
-    };
+  public void testIncludeInBlock() {
+    String[] lines = {".test {", "  @include large-text;", "}"};
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).ruleset().block().statement(0).includeDeclaration().Identifier().getText(), "large-text");
+    assertThat(
+            context
+                .statement(0)
+                .ruleset()
+                .block()
+                .statement(0)
+                .includeDeclaration()
+                .Identifier()
+                .getText())
+        .isEqualTo("large-text");
   }
 
   @Test
-  public void testMultipleIncludes()
-  {
-    String [] lines = {
-        "@include large-text;",
-        "@include large-button;",
-
+  public void testMultipleIncludes() {
+    String[] lines = {
+      "@include large-text;", "@include large-button;",
     };
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).includeDeclaration().Identifier().getText(), "large-text");
-    Assert.assertEquals(context.statement(1).includeDeclaration().Identifier().getText(), "large-button");
-
+    assertThat(context.statement(0).includeDeclaration().Identifier().getText())
+        .isEqualTo("large-text");
+    assertThat(context.statement(1).includeDeclaration().Identifier().getText())
+        .isEqualTo("large-button");
   }
 
   @Test
-  public void testIncludesInMixin()
-  {
-    String [] lines = {
-        "@mixin large-text {",
-        "   @include large-button;",
-        "}"
+  public void testIncludesInMixin() {
+    String[] lines = {"@mixin large-text {", "   @include large-button;", "}"};
 
-    };
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).mixinDeclaration().Identifier().getText(), "large-text");
-    Assert.assertEquals(context.statement(0).mixinDeclaration().block().statement(0)
-                            .includeDeclaration().Identifier().getText(), "large-button");
-
-  }
-
-
-  @Test
-  public void testIncludesWithParams()
-  {
-    String [] lines = {
-        "@include large-button(blue, $var);"
-
-    };
-    ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).includeDeclaration().Identifier().getText(), "large-button");
-    Assert.assertEquals(context.statement(0).includeDeclaration().values()
-                            .commandStatement(0).expression(0).identifier().getText(), "blue");
-    Assert.assertEquals(context.statement(0).includeDeclaration().values()
-                            .commandStatement(1).expression(0).variableName().getText(), "$var");
-
+    assertThat(context.statement(0).mixinDeclaration().Identifier().getText())
+        .isEqualTo("large-text");
+    assertThat(
+            context
+                .statement(0)
+                .mixinDeclaration()
+                .block()
+                .statement(0)
+                .includeDeclaration()
+                .Identifier()
+                .getText())
+        .isEqualTo("large-button");
   }
 
   @Test
-  public void testIncludesWithBody()
-  {
-    String [] lines = {
-        "@include large-button {",
-        "  color: black",
-        "}"
+  public void testIncludesWithParams() {
+    String[] lines = {"@include large-button(blue, $var);"};
 
-    };
     ScssParser.StylesheetContext context = parse(lines);
-    Assert.assertEquals(context.statement(0).includeDeclaration().Identifier().getText(), "large-button");
-    Assert.assertEquals(context.statement(0).includeDeclaration().block().property(0).identifier().getText(), "color");
-    Assert.assertEquals(context.statement(0).includeDeclaration().block().property(0)
-                            .values().commandStatement(0).expression(0).identifier().getText(), "black");
-
-
+    assertThat(context.statement(0).includeDeclaration().Identifier().getText())
+        .isEqualTo("large-button");
+    assertThat(
+            context
+                .statement(0)
+                .includeDeclaration()
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .identifier()
+                .getText())
+        .isEqualTo("blue");
+    assertThat(
+            context
+                .statement(0)
+                .includeDeclaration()
+                .values()
+                .commandStatement(1)
+                .expression(0)
+                .variableName()
+                .getText())
+        .isEqualTo("$var");
   }
 
   @Test
-  public void testIncludesWithInterpolation()
-  {
-    String [] lines = {
-        "@include large-button (#{$var1}) {",
-        "  color-#{$var2}: black",
-        "}"
+  public void testIncludesWithBody() {
+    String[] lines = {"@include large-button {", "  color: black", "}"};
 
-    };
+    ScssParser.StylesheetContext context = parse(lines);
+    assertThat(context.statement(0).includeDeclaration().Identifier().getText())
+        .isEqualTo("large-button");
+    assertThat(context.statement(0).includeDeclaration().block().property(0).identifier().getText())
+        .isEqualTo("color");
+    assertThat(
+            context
+                .statement(0)
+                .includeDeclaration()
+                .block()
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .identifier()
+                .getText())
+        .isEqualTo("black");
+  }
+
+  @Test
+  public void testIncludesWithInterpolation() {
+    String[] lines = {"@include large-button (#{$var1}) {", "  color-#{$var2}: black", "}"};
+
     ScssParser.IncludeDeclarationContext context = parse(lines).statement(0).includeDeclaration();
 
-    Assert.assertEquals(context.values().commandStatement(0).expression(0).identifier().identifierVariableName().getText(), "$var1");
-    Assert.assertEquals(context.block().property(0).identifier().Identifier().getText(), "color-");
-    Assert.assertEquals(context.block().property(0).identifier().identifierPart(0).identifierVariableName().getText(), "$var2");
-
+    assertThat(
+            context
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .identifier()
+                .identifierVariableName()
+                .getText())
+        .isEqualTo("$var1");
+    assertThat(context.block().property(0).identifier().Identifier().getText()).isEqualTo("color-");
+    assertThat(
+            context
+                .block()
+                .property(0)
+                .identifier()
+                .identifierPart(0)
+                .identifierVariableName()
+                .getText())
+        .isEqualTo("$var2");
   }
-
 }

--- a/scss/testsrc/test/java/TestMixins.java
+++ b/scss/testsrc/test/java/TestMixins.java
@@ -26,236 +26,286 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+import static com.google.common.truth.Truth.assertThat;
 
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-
-public class TestMixins extends TestBase
-{
+@RunWith(JUnit4.class)
+public class TestMixins extends TestBase {
   @Test
-   public void testMixin()
-  {
-    String [] lines = {
-        "@mixin something-awesome {}"
+  public void testMixin() {
+    String[] lines = {"@mixin something-awesome {}"};
+    ScssParser.MixinDeclarationContext context = parseImport(lines);
+    assertThat(context.Identifier().getText()).isEqualTo("something-awesome");
+  }
+
+  @Test
+  public void testMixinProperties() {
+    String[] lines = {"@mixin test {", "  display: $hello;", "}"};
+    ScssParser.MixinDeclarationContext context = parseImport(lines);
+    assertThat(context.Identifier().getText()).isEqualTo("test");
+    assertThat(context.block().property(0).identifier().getText()).isEqualTo("display");
+    assertThat(
+            context
+                .block()
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .variableName()
+                .Identifier()
+                .getText())
+        .isEqualTo("hello");
+  }
+
+  @Test
+  public void testMixinNesting() {
+    String[] lines = {"@mixin test {", "  @mixin hello {}", "}"};
+    ScssParser.MixinDeclarationContext context = parseImport(lines);
+    assertThat(context.Identifier().getText()).isEqualTo("test");
+
+    ScssParser.MixinDeclarationContext innerContext =
+        context.block().statement(0).mixinDeclaration();
+    assertThat(innerContext.Identifier().getText()).isEqualTo("hello");
+  }
+
+  @Test
+  public void testMixinParams() {
+    String[] lines = {"@mixin test ($val1, $val2) {}"};
+    ScssParser.MixinDeclarationContext context = parseImport(lines);
+    assertThat(context.Identifier().getText()).isEqualTo("test");
+    assertThat(context.params().param(0).variableName().getText()).isEqualTo("$val1");
+    assertThat(context.params().param(1).variableName().getText()).isEqualTo("$val2");
+  }
+
+  @Test
+  public void testMixinParamWithValues() {
+    String[] lines = {"@mixin test ($val1 : 3px, $val2) {}"};
+    ScssParser.MixinDeclarationContext context = parseImport(lines);
+    assertThat(context.Identifier().getText()).isEqualTo("test");
+    assertThat(context.params().param(0).variableName().getText()).isEqualTo("$val1");
+    assertThat(
+            context
+                .params()
+                .param(0)
+                .paramOptionalValue()
+                .expression(0)
+                .measurement()
+                .Number()
+                .getText())
+        .isEqualTo("3");
+    assertThat(
+            context
+                .params()
+                .param(0)
+                .paramOptionalValue()
+                .expression(0)
+                .measurement()
+                .Unit()
+                .getText())
+        .isEqualTo("px");
+
+    assertThat(context.params().param(1).variableName().getText()).isEqualTo("$val2");
+  }
+
+  @Test
+  public void testMixinParamWithElipses() {
+    String[] lines = {"@mixin test ($val1, $val2...) {}"};
+    ScssParser.MixinDeclarationContext context = parseImport(lines);
+    assertThat(context.Identifier().getText()).isEqualTo("test");
+    assertThat(context.params().param(0).variableName().getText()).isEqualTo("$val1");
+    assertThat(context.params().param(1).variableName().getText()).isEqualTo("$val2");
+    assertThat(context.params().Ellipsis().getText()).isEqualTo("...");
+  }
+
+  @Test
+  public void testMixinParamAndBody() {
+    String[] lines = {
+      "@mixin box-shadow ($shadows...) {",
+      "  -moz-box-shadow: $shadows;",
+      "  -webkit-box-shadow: $shadows;",
+      "  box-shadow: $shadows;",
+      "}"
     };
     ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "something-awesome");
+    assertThat(context.Identifier().getText()).isEqualTo("box-shadow");
+    assertThat(context.params().param(0).variableName().getText()).isEqualTo("$shadows");
+    assertThat(context.params().Ellipsis()).isNotNull();
+
+    assertThat(context.block().property(0).identifier().getText()).isEqualTo("-moz-box-shadow");
+    assertThat(
+            context
+                .block()
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .variableName()
+                .Identifier()
+                .getText())
+        .isEqualTo("shadows");
+
+    assertThat(context.block().property(1).identifier().getText()).isEqualTo("-webkit-box-shadow");
+    assertThat(
+            context
+                .block()
+                .property(1)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .variableName()
+                .Identifier()
+                .getText())
+        .isEqualTo("shadows");
+
+    assertThat(context.block().property(2).identifier().getText()).isEqualTo("box-shadow");
+    assertThat(
+            context
+                .block()
+                .property(2)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .variableName()
+                .Identifier()
+                .getText())
+        .isEqualTo("shadows");
   }
 
   @Test
-  public void testMixinProperties()
-  {
-    String [] lines = {
-        "@mixin test {",
-        "  display: $hello;",
-        "}"
+  public void testMixinPropertyAndRule() {
+    String[] lines = {
+      "@mixin clearfix {",
+      "  display: inline-block;",
+      "  &:after {",
+      "    content: \".\";",
+      "    display: block;",
+      "    height: 0;",
+      "    clear: both;",
+      "    visibility: hidden;",
+      "  }",
+      "  * html & { height: 1px }",
+      "}"
     };
     ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "test");
-    Assert.assertEquals(context.block().property(0).identifier().getText(), "display");
-    Assert.assertEquals(context.block().property(0).values().commandStatement(0).expression(0)
-                            .variableName().Identifier().getText(), "hello");
+    assertThat(context.Identifier().getText()).isEqualTo("clearfix");
+
+    assertThat(context.block().property(0).identifier().getText()).isEqualTo("display");
+    assertThat(
+            context
+                .block()
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .identifier()
+                .getText())
+        .isEqualTo("inline-block");
+
+    assertThat(context.block().statement(0).ruleset().selectors().selector(0).element(0).getText())
+        .isEqualTo("&");
+    assertThat(
+            context
+                .block()
+                .statement(0)
+                .ruleset()
+                .selectors()
+                .selector(0)
+                .element(1)
+                .pseudo()
+                .Identifier()
+                .getText())
+        .isEqualTo("after");
+
+    assertThat(context.block().statement(1).ruleset().selectors().selector(0).element(0).getText())
+        .isEqualTo("*");
+    assertThat(
+            context
+                .block()
+                .statement(1)
+                .ruleset()
+                .selectors()
+                .selector(0)
+                .element(1)
+                .identifier()
+                .getText())
+        .isEqualTo("html");
+    assertThat(context.block().statement(1).ruleset().selectors().selector(0).element(2).getText())
+        .isEqualTo("&");
+
+    assertThat(context.block().statement(1).ruleset().block().property(0).identifier().getText())
+        .isEqualTo("height");
+    assertThat(
+            context
+                .block()
+                .statement(1)
+                .ruleset()
+                .block()
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .measurement()
+                .getText())
+        .isEqualTo("1px");
   }
 
   @Test
-  public void testMixinNesting()
-  {
-    String [] lines = {
-        "@mixin test {",
-        "  @mixin hello {}",
-        "}"
-    };
+  public void testMixinBlockInterpolation() {
+    String[] lines = {"@mixin test () {", "  #{$attr}-color: blue;", "}"};
     ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "test");
-
-    ScssParser.MixinDeclarationContext innerContext = context.block().statement(0).mixinDeclaration();
-    Assert.assertEquals(innerContext.Identifier().getText(), "hello");
+    assertThat(context.Identifier().getText()).isEqualTo("test");
+    assertThat(context.block().property(0).identifier().identifierVariableName().getText())
+        .isEqualTo("$attr");
+    assertThat(
+            context.block().property(0).identifier().identifierPart(0).IdentifierAfter().getText())
+        .isEqualTo("-color");
   }
 
   @Test
-  public void testMixinParams()
-  {
-    String [] lines = {
-        "@mixin test ($val1, $val2) {}"
-    };
-    ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "test");
-    Assert.assertEquals(context.params().param(0).variableName().getText(), "$val1");
-    Assert.assertEquals(context.params().param(1).variableName().getText(), "$val2");
+  public void testNoErrors() {
+    String lines =
+        "@mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null,"
+            + " $retina-suffix: _2x, $asset-pipeline: false) {\n"
+            + "  @if $asset-pipeline {\n"
+            + "    background-image: image-url(\"#{$filename}.#{$extension}\");\n"
+            + "  }\n"
+            + "  @else {\n"
+            + "    background-image:       url(\"#{$filename}.#{$extension}\");\n"
+            + "  }\n"
+            + "\n"
+            + "  @include hidpi {\n"
+            + "    @if $asset-pipeline {\n"
+            + "      @if $retina-filename {\n"
+            + "        background-image: image-url(\"#{$retina-filename}.#{$extension}\");\n"
+            + "      }\n"
+            + "      @else {\n"
+            + "        background-image:"
+            + " image-url(\"#{$filename}#{$retina-suffix}.#{$extension}\");\n"
+            + "      }\n"
+            + "    }\n"
+            + "\n"
+            + "    @else {\n"
+            + "      @if $retina-filename {\n"
+            + "        background-image: url(\"#{$retina-filename}.#{$extension}\");\n"
+            + "      }\n"
+            + "      @else {\n"
+            + "        background-image: url(\"#{$filename}#{$retina-suffix}.#{$extension}\");\n"
+            + "      }\n"
+            + "    }\n"
+            + "\n"
+            + "    background-size: $background-size;\n"
+            + "\n"
+            + "  }\n"
+            + "}";
 
+    // Just expect no syntax errors.
+    parse(lines);
   }
 
-  @Test
-  public void testMixinParamWithValues()
-  {
-    String [] lines = {
-        "@mixin test ($val1 : 3px, $val2) {}"
-    };
-    ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "test");
-    Assert.assertEquals(context.params().param(0).variableName().getText(), "$val1");
-    Assert.assertEquals(context.params().param(0).paramOptionalValue().expression(0)
-                            .measurement().Number().getText(), "3");
-    Assert.assertEquals(context.params().param(0).paramOptionalValue().expression(0)
-                            .measurement().Unit().getText(), "px");
-
-
-    Assert.assertEquals(context.params().param(1).variableName().getText(), "$val2");
-
-  }
-
-  @Test
-  public void testMixinParamWithElipses()
-  {
-    String [] lines = {
-        "@mixin test ($val1, $val2...) {}"
-    };
-    ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "test");
-    Assert.assertEquals(context.params().param(0).variableName().getText(), "$val1");
-    Assert.assertEquals(context.params().param(1).variableName().getText(), "$val2");
-    Assert.assertEquals(context.params().Ellipsis().getText(), "...");
-  }
-
-  @Test
-  public void testMixinParamAndBody()
-  {
-    String [] lines = {
-        "@mixin box-shadow ($shadows...) {",
-        "  -moz-box-shadow: $shadows;",
-        "  -webkit-box-shadow: $shadows;",
-        "  box-shadow: $shadows;",
-        "}"
-    };
-    ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "box-shadow");
-    Assert.assertEquals(context.params().param(0).variableName().getText(), "$shadows");
-    Assert.assertNotNull(context.params().Ellipsis());
-
-    Assert.assertEquals(context.block().property(0).identifier().getText(), "-moz-box-shadow");
-    Assert.assertEquals(context.block().property(0).values().commandStatement(0)
-                            .expression(0).variableName().Identifier().getText(), "shadows");
-
-    Assert.assertEquals(context.block().property(1).identifier().getText(), "-webkit-box-shadow");
-    Assert.assertEquals(context.block().property(1).values().commandStatement(0)
-                            .expression(0).variableName().Identifier().getText(), "shadows");
-
-    Assert.assertEquals(context.block().property(2).identifier().getText(), "box-shadow");
-    Assert.assertEquals(context.block().property(2).values().commandStatement(0)
-                            .expression(0).variableName().Identifier().getText(), "shadows");
-
-  }
-
-  @Test
-  public void testMixinPropertyAndRule()
-  {
-    String [] lines = {
-        "@mixin clearfix {",
-        "  display: inline-block;",
-        "  &:after {",
-        "    content: \".\";",
-        "    display: block;",
-        "    height: 0;",
-        "    clear: both;",
-        "    visibility: hidden;",
-        "  }",
-        "  * html & { height: 1px }",
-        "}"
-    };
-    ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "clearfix");
-
-    Assert.assertEquals(context.block().property(0).identifier().getText(), "display");
-    Assert.assertEquals(context.block().property(0).values().commandStatement(0)
-                            .expression(0).identifier().getText(), "inline-block");
-
-    Assert.assertEquals(context.block().statement(0).ruleset().selectors()
-                            .selector(0).element(0).getText(), "&");
-    Assert.assertEquals(context.block().statement(0).ruleset().selectors()
-                            .selector(0).element(1).pseudo().Identifier().getText(), "after");
-
-
-    Assert.assertEquals(context.block().statement(1).ruleset().selectors()
-                            .selector(0).element(0).getText(), "*");
-    Assert.assertEquals(context.block().statement(1).ruleset().selectors()
-                            .selector(0).element(1).identifier().getText(), "html");
-    Assert.assertEquals(context.block().statement(1).ruleset().selectors()
-                            .selector(0).element(2).getText(), "&");
-
-    Assert.assertEquals(context.block().statement(1).ruleset().block().property(0).identifier().getText(), "height");
-    Assert.assertEquals(context.block().statement(1).ruleset().block().property(0).values()
-                            .commandStatement(0).expression(0).measurement().getText(), "1px");
-
-
-  }
-
-  @Test
-  public void testMixinBlockInterpolation()
-  {
-    String [] lines = {
-        "@mixin test () {",
-        "  #{$attr}-color: blue;"
-        ,"}"
-    };
-    ScssParser.MixinDeclarationContext context = parseImport(lines);
-    Assert.assertEquals(context.Identifier().getText(), "test");
-    Assert.assertEquals(context.block().property(0).identifier().identifierVariableName().getText(), "$attr");
-    Assert.assertEquals(context.block().property(0).identifier().identifierPart(0).IdentifierAfter().getText(), "-color");
-  }
-
-  @Test
-  public void testNoErrors()
-  {
-    String lines = "@mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $retina-suffix: _2x, $asset-pipeline: false) {\n" +
-        "  @if $asset-pipeline {\n" +
-        "    background-image: image-url(\"#{$filename}.#{$extension}\");\n" +
-        "  }\n" +
-        "  @else {\n" +
-        "    background-image:       url(\"#{$filename}.#{$extension}\");\n" +
-        "  }\n" +
-        "\n" +
-        "  @include hidpi {\n" +
-        "    @if $asset-pipeline {\n" +
-        "      @if $retina-filename {\n" +
-        "        background-image: image-url(\"#{$retina-filename}.#{$extension}\");\n" +
-        "      }\n" +
-        "      @else {\n" +
-        "        background-image: image-url(\"#{$filename}#{$retina-suffix}.#{$extension}\");\n" +
-        "      }\n" +
-        "    }\n" +
-        "\n" +
-        "    @else {\n" +
-        "      @if $retina-filename {\n" +
-        "        background-image: url(\"#{$retina-filename}.#{$extension}\");\n" +
-        "      }\n" +
-        "      @else {\n" +
-        "        background-image: url(\"#{$filename}#{$retina-suffix}.#{$extension}\");\n" +
-        "      }\n" +
-        "    }\n" +
-        "\n" +
-        "    background-size: $background-size;\n" +
-        "\n" +
-        "  }\n" +
-        "}";
-
-    ScssParser.StylesheetContext context = parse(lines);
-    for (ParserRuleContext child : context.getRuleContexts(ParserRuleContext.class))
-    {
-
-    }
-
-  }
-
-  private void assertNoErrors(ParserRuleContext context)
-  {
-
-  }
-
-
-  private ScssParser.MixinDeclarationContext parseImport(String ... lines)
-  {
+  private ScssParser.MixinDeclarationContext parseImport(String... lines) {
     ScssParser.StylesheetContext context = parse(lines);
     return context.statement(0).mixinDeclaration();
   }


### PR DESCRIPTION
- Bump antlr version
- Remove deprecated stream creation method
- Add DiagnosticErrorListener for easier debugging
- Alll assertEquals calls had their arguments backwards. Instead of flipping everything, replace with assertThat().is...
- Fix 2 tests that were broken
- Remove dead code
- Fix lint errors
- and a little auto-formatting xD