### PR TITLE
[scss] Add media query support up to level 3.

### DIFF
--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -99,10 +99,14 @@ AT_EACH         : '@each';
 INCLUDE         : '@include';
 IMPORT          : '@import';
 RETURN          : '@return';
+MEDIA           : '@media';
 
 FROM            : 'from';
 THROUGH         : 'through';
 POUND_DEFAULT   : '!default';
+ONLY            : 'only';
+NOT             : 'not';
+AND_WORD        : 'and';
 
 
 Identifier

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -36,7 +36,7 @@ stylesheet
 
 statement
   : importDeclaration
-  | nested
+  | mediaDeclaration
   | ruleset
   | mixinDeclaration
   | functionDeclaration
@@ -189,8 +189,8 @@ identifierValue
 
 //Imports
 importDeclaration
-	: '@import' referenceUrl mediaTypes? ';'
-	;
+  : '@import' referenceUrl ';'
+  ;
 
 referenceUrl
     : StringLiteral
@@ -198,24 +198,34 @@ referenceUrl
     ;
 
 
-mediaTypes
-  : (Identifier (COMMA Identifier)*)
+// Media
+mediaDeclaration
+  : '@media' mediaQueryList block
   ;
 
+mediaQueryList
+  : (mediaQuery (COMMA mediaQuery)* )?
+  ;
 
+mediaQuery
+  : ('only' | 'not')? mediaType ('and' mediaExpression)*
+  | mediaExpression ('and' mediaExpression)*
+  ;
 
+// Typically only 'all', 'print', 'screen', and 'speech', but there are some
+// deprecated values too.
+mediaType
+  : Identifier
+  ;
 
-//Nested (stylesheets, etc)
-nested
- 	: '@' nest selectors BlockStart stylesheet BlockEnd
-	;
+mediaExpression
+  : '(' mediaFeature (':' commandStatement)? ')'
+  ;
 
-nest
-	: (Identifier | '&') Identifier* pseudo*
-	;
-
-
-
+// Typically 'max-width', 'hover', 'orientation', etc. Many possible values.
+mediaFeature
+  : Identifier
+  ;
 
 
 //Rules
@@ -251,9 +261,9 @@ combinator
   ;
 
 pseudo
-	: COLON COLON? Identifier
-	| COLON COLON? Identifier LPAREN (selector | values) RPAREN
-	;
+  : COLON COLON? identifier
+  | COLON COLON? identifier LPAREN (selector | values) RPAREN
+  ;
 
 attrib
 	: LBRACK Identifier (attribRelate (StringLiteral | Identifier))? RBRACK
@@ -268,6 +278,12 @@ attribRelate
 identifier
   : Identifier identifierPart*
   | InterpolationStart identifierVariableName BlockEnd identifierPart*
+  // These are keywords in some contexts, but can be used as identifiers too.
+  | FROM
+  | THROUGH
+  | ONLY
+  | NOT
+  | AND_WORD
   ;
 
 identifierPart

--- a/scss/testsrc/test/java/TestBasicCss.java
+++ b/scss/testsrc/test/java/TestBasicCss.java
@@ -119,25 +119,6 @@ public class TestBasicCss extends TestBase {
   }
 
   @Test
-  public void testNesting() {
-    String[] lines = {
-      "@media hello,world {", "  body, head {}", "}",
-    };
-    ScssParser.StylesheetContext context = parse(lines);
-    assertThat(context.statement(0).nested().nest().Identifier(0).getText()).isEqualTo("media");
-    assertThat(context.statement(0).nested().selectors().selector(0).element(0).getText())
-        .isEqualTo("hello");
-    assertThat(context.statement(0).nested().selectors().selector(1).element(0).getText())
-        .isEqualTo("world");
-
-    ScssParser.StylesheetContext innerSheet = context.statement(0).nested().stylesheet();
-    assertThat(innerSheet.statement(0).ruleset().selectors().selector(0).getText())
-        .isEqualTo("body");
-    assertThat(innerSheet.statement(0).ruleset().selectors().selector(1).getText())
-        .isEqualTo("head");
-  }
-
-  @Test
   public void testNestingWithCombinatorAtStartOfLine() {
     String[] lines = {
       "p {", "  > p {}", "}",

--- a/scss/testsrc/test/java/TestMedia.java
+++ b/scss/testsrc/test/java/TestMedia.java
@@ -1,0 +1,231 @@
+/*
+ [The "BSD licence"]
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestMedia extends TestBase {
+  @Test
+  public void oneMediaType() {
+    String[] lines = {
+      "@media print {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaType().getText()).isEqualTo("print");
+  }
+
+  @Test
+  public void twoMediaTypes() {
+    String[] lines = {
+      "@media screen, print {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaType().getText()).isEqualTo("screen");
+    assertThat(context.mediaQuery(1).mediaType().getText()).isEqualTo("print");
+  }
+
+  @Test
+  public void mediaFeature() {
+    String[] lines = {
+      "@media (hover: hover) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("hover");
+    assertThat(context.mediaQuery(0).mediaExpression(0).commandStatement().getText())
+        .isEqualTo("hover");
+  }
+
+  @Test
+  public void rangeMediaFeature() {
+    String[] lines = {
+      "@media (max-width: 12450px) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("max-width");
+    assertThat(context.mediaQuery(0).mediaExpression(0).commandStatement().getText())
+        .isEqualTo("12450px");
+  }
+
+  @Test
+  public void mediaFeatureWithoutValue() {
+    String[] lines = {
+      "@media (color) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("color");
+  }
+
+  @Test
+  public void combiningMediaFeatures() {
+    String[] lines = {
+      "@media (min-width: 30em) and (orientation: landscape) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("min-width");
+    assertThat(context.mediaQuery(0).mediaExpression(1).mediaFeature().getText())
+        .isEqualTo("orientation");
+  }
+
+  @Test
+  public void mediaTypeWithMediaFeatures() {
+    String[] lines = {
+      "@media screen and (min-width: 30em) and (orientation: landscape) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaType().getText()).isEqualTo("screen");
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("min-width");
+    assertThat(context.mediaQuery(0).mediaExpression(1).mediaFeature().getText())
+        .isEqualTo("orientation");
+  }
+
+  @Test
+  public void multipleMediaQueries() {
+    String[] lines = {
+      "@media (min-height: 680px), screen and (orientation: portrait) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("min-height");
+    assertThat(context.mediaQuery(1).mediaType().getText()).isEqualTo("screen");
+    assertThat(context.mediaQuery(1).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("orientation");
+  }
+
+  @Test
+  public void invertingMediaQuery() {
+    String[] lines = {
+      "@media not all and (monochrome) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).NOT()).isNotNull();
+    assertThat(context.mediaQuery(0).mediaType().getText()).isEqualTo("all");
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("monochrome");
+  }
+
+  @Test
+  public void invertingOneOfManyMediaQueries() {
+    String[] lines = {
+      "@media not screen and (color), print and (color) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).NOT()).isNotNull();
+    assertThat(context.mediaQuery(0).mediaType().getText()).isEqualTo("screen");
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("color");
+    assertThat(context.mediaQuery(1).NOT()).isNull();
+    assertThat(context.mediaQuery(1).mediaType().getText()).isEqualTo("print");
+    assertThat(context.mediaQuery(1).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("color");
+  }
+
+  @Test
+  public void onlyKeyword() {
+    String[] lines = {
+      "@media only screen and (color) {}",
+    };
+
+    ScssParser.MediaQueryListContext context = getMedia(lines);
+    assertThat(context.mediaQuery(0).ONLY()).isNotNull();
+    assertThat(context.mediaQuery(0).mediaType().getText()).isEqualTo("screen");
+    assertThat(context.mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("color");
+  }
+
+  @Test
+  public void nestedMediaQueries() {
+    String[] lines = {
+      "@media (hover: hover) {",
+      "  .button:hover {",
+      "    border: 2px solid black;",
+      "    @media (color) {",
+      "      border-color: #036;",
+      "    }",
+      "  }",
+      "}",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    assertThat(
+            context
+                .statement(0)
+                .mediaDeclaration()
+                .block()
+                .statement(0)
+                .ruleset()
+                .selectors()
+                .selector(0)
+                .getText())
+        .isEqualTo(".button:hover");
+    ScssParser.MediaDeclarationContext innerMedia =
+        context
+            .statement(0)
+            .mediaDeclaration()
+            .block()
+            .statement(0)
+            .ruleset()
+            .block()
+            .statement(0)
+            .mediaDeclaration();
+    assertThat(
+            innerMedia.mediaQueryList().mediaQuery(0).mediaExpression(0).mediaFeature().getText())
+        .isEqualTo("color");
+    assertThat(
+            innerMedia
+                .block()
+                .property(0)
+                .values()
+                .commandStatement(0)
+                .expression(0)
+                .Color()
+                .getText())
+        .isEqualTo("#036");
+  }
+
+  private ScssParser.MediaQueryListContext getMedia(String... lines) {
+    ScssParser.StylesheetContext context = parse(lines);
+    return context.statement(0).mediaDeclaration().mediaQueryList();
+  }
+}

--- a/scss/testsrc/test/java/TestMixins.java
+++ b/scss/testsrc/test/java/TestMixins.java
@@ -215,7 +215,7 @@ public class TestMixins extends TestBase {
                 .selector(0)
                 .element(1)
                 .pseudo()
-                .Identifier()
+                .identifier()
                 .getText())
         .isEqualTo("after");
 


### PR DESCRIPTION
This goes up to Media Queries Level 3, so doesn't include Level 4 sytnax such as range context.
Previously, only media types worked.