### PR TITLE
[scss] Support nested property declarations.

### DIFF
--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -109,7 +109,6 @@ ONLY            : 'only';
 NOT             : 'not';
 AND_WORD        : 'and';
 
-
 Identifier
 	:	(('_' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' )
 		('_' | '-' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' | '0'..'9')*
@@ -117,7 +116,9 @@ Identifier
 		('_' | '-' | 'a'..'z'| 'A'..'Z' | '\u0100'..'\ufffe' | '0'..'9')*) -> pushMode(IDENTIFY)
 	;
 
-
+PseudoIdentifier
+  : COLON COLON? Identifier -> pushMode(IDENTIFY)
+  ;
 
 fragment STRING
   	:	'"' (~('"'|'\n'|'\r'))* '"'
@@ -184,3 +185,4 @@ SEMI_ID                   : SEMI -> popMode, type(SEMI);
 EQ_ID                     : EQ -> popMode, type(EQ);
 PIPE_EQ_ID                : PIPE_EQ -> popMode, type(PIPE_EQ);
 TILD_EQ_ID                : TILD_EQ -> popMode, type(TILD_EQ);
+PseudoIdentifier_ID       : PseudoIdentifier -> popMode, type(PseudoIdentifier);

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -31,8 +31,8 @@ parser grammar ScssParser;
 options { tokenVocab=ScssLexer; }
 
 stylesheet
-	: statement*
-	;
+  : statement*
+  ;
 
 statement
   : importDeclaration
@@ -116,9 +116,9 @@ expression
   | StringLiteral
   | NULL
   | url
-	| variableName
-	| functionCall
-	;
+  | variableName
+  | functionCall
+  ;
 
 
 
@@ -198,7 +198,6 @@ referenceUrl
     ;
 
 
-// Media
 mediaDeclaration
   : '@media' mediaQueryList block
   ;
@@ -230,23 +229,23 @@ mediaFeature
 
 //Rules
 ruleset
- 	: selectors block
-	;
+  : selectors block
+  ;
 
 block
-  : BlockStart (property ';' | statement)* property? BlockEnd
+  : BlockStart (property | statement)* lastProperty? BlockEnd
   ;
 
 selectors
-	: selector (COMMA selector)*
-	;
+  : selector (COMMA selector)*
+  ;
 
 selector
-	: element+
-	;
+  : element+
+  ;
 
 element
-	: identifier
+  : identifier
   | '#' identifier
   | '.' identifier
   | '&'
@@ -254,26 +253,26 @@ element
   | combinator
   | attrib
   | pseudo
-	;
+  ;
 
 combinator
   : (GT | PLUS | TIL)
   ;
 
 pseudo
-  : COLON COLON? identifier
-  | COLON COLON? identifier LPAREN (selector | values) RPAREN
+  : pseudoIdentifier
+  | pseudoIdentifier LPAREN (selector | values) RPAREN
   ;
 
 attrib
-	: LBRACK Identifier (attribRelate (StringLiteral | Identifier))? RBRACK
-	;
+  : LBRACK Identifier (attribRelate (StringLiteral | Identifier))? RBRACK
+  ;
 
 attribRelate
   : EQ
   | PIPE_EQ
   | TILD_EQ
-	;
+  ;
 
 identifier
   : Identifier identifierPart*
@@ -286,6 +285,10 @@ identifier
   | AND_WORD
   ;
 
+pseudoIdentifier
+  : PseudoIdentifier identifierPart*
+  ;
+
 identifierPart
   : InterpolationStartAfter identifierVariableName BlockEnd
   | IdentifierAfter
@@ -295,12 +298,18 @@ identifierVariableName
   ;
 
 property
-  : identifier COLON values '!important'?
+  : identifier COLON values IMPORTANT? SEMI
+  | identifier COLON block IMPORTANT?
+  | identifier COLON values block IMPORTANT?
+  ;
+
+lastProperty
+  : identifier COLON values IMPORTANT?
   ;
 
 values
-	: commandStatement (COMMA commandStatement)*
-	;
+  : commandStatement (COMMA commandStatement)*
+  ;
 
 url
   : UrlStart Url UrlEnd
@@ -312,5 +321,5 @@ measurement
 
 
 functionCall
-	: Identifier LPAREN values? RPAREN
-	;
+  : Identifier LPAREN values? RPAREN
+  ;

--- a/scss/testsrc/test/java/TestConditionals.java
+++ b/scss/testsrc/test/java/TestConditionals.java
@@ -117,8 +117,8 @@ public class TestConditionals extends TestBase {
 
     ScssParser.ElseStatementContext context =
         parse(lines).statement(0).ifDeclaration().elseStatement();
-    assertThat(context.block().property(0).identifier().getText()).isEqualTo("color");
-    assertThat(context.block().property(0).values().getText()).isEqualTo("red");
+    assertThat(context.block().lastProperty().identifier().getText()).isEqualTo("color");
+    assertThat(context.block().lastProperty().values().getText()).isEqualTo("red");
   }
 
   @Test

--- a/scss/testsrc/test/java/TestInclude.java
+++ b/scss/testsrc/test/java/TestInclude.java
@@ -125,14 +125,15 @@ public class TestInclude extends TestBase {
     ScssParser.StylesheetContext context = parse(lines);
     assertThat(context.statement(0).includeDeclaration().Identifier().getText())
         .isEqualTo("large-button");
-    assertThat(context.statement(0).includeDeclaration().block().property(0).identifier().getText())
+    assertThat(
+            context.statement(0).includeDeclaration().block().lastProperty().identifier().getText())
         .isEqualTo("color");
     assertThat(
             context
                 .statement(0)
                 .includeDeclaration()
                 .block()
-                .property(0)
+                .lastProperty()
                 .values()
                 .commandStatement(0)
                 .expression(0)
@@ -156,11 +157,12 @@ public class TestInclude extends TestBase {
                 .identifierVariableName()
                 .getText())
         .isEqualTo("$var1");
-    assertThat(context.block().property(0).identifier().Identifier().getText()).isEqualTo("color-");
+    assertThat(context.block().lastProperty().identifier().Identifier().getText())
+        .isEqualTo("color-");
     assertThat(
             context
                 .block()
-                .property(0)
+                .lastProperty()
                 .identifier()
                 .identifierPart(0)
                 .identifierVariableName()

--- a/scss/testsrc/test/java/TestMixins.java
+++ b/scss/testsrc/test/java/TestMixins.java
@@ -215,9 +215,9 @@ public class TestMixins extends TestBase {
                 .selector(0)
                 .element(1)
                 .pseudo()
-                .identifier()
+                .pseudoIdentifier()
                 .getText())
-        .isEqualTo("after");
+        .isEqualTo(":after");
 
     assertThat(context.block().statement(1).ruleset().selectors().selector(0).element(0).getText())
         .isEqualTo("*");
@@ -235,7 +235,7 @@ public class TestMixins extends TestBase {
     assertThat(context.block().statement(1).ruleset().selectors().selector(0).element(2).getText())
         .isEqualTo("&");
 
-    assertThat(context.block().statement(1).ruleset().block().property(0).identifier().getText())
+    assertThat(context.block().statement(1).ruleset().block().lastProperty().identifier().getText())
         .isEqualTo("height");
     assertThat(
             context
@@ -243,7 +243,7 @@ public class TestMixins extends TestBase {
                 .statement(1)
                 .ruleset()
                 .block()
-                .property(0)
+                .lastProperty()
                 .values()
                 .commandStatement(0)
                 .expression(0)


### PR DESCRIPTION
e.g.
```
.info-page {
  margin: auto {
    bottom: 10px;
    top: 2px;
  }
}
```
Also make sure that pseudo-classes/elements don't parse with spaces between the colon and the name.