### PR TITLE
[scss] Add explicit parser rules for maps and lists.

### DIFF
--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -70,6 +70,13 @@ DIV             : '/';
 MINUS           : '-';
 PERC            : '%';
 
+// When a variable or parenthesized statement is negated, there cannot be a
+// space after the - or +.
+MINUS_DOLLAR    : MINUS DOLLAR;
+PLUS_DOLLAR     : PLUS DOLLAR;
+MINUS_LPAREN    : MINUS LPAREN;
+PLUS_LPAREN     : PLUS LPAREN;
+
 
 UrlStart
   : 'url' LPAREN -> pushMode(URL_STARTED)

--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -123,6 +123,10 @@ PseudoIdentifier
   : COLON COLON? Identifier -> pushMode(IDENTIFY)
   ;
 
+FunctionIdentifier
+    : Identifier LPAREN
+    ;
+
 fragment STRING
   	:	'"' (~('"'|'\n'|'\r'))* '"'
   	|	'\'' (~('\''|'\n'|'\r'))* '\''

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -60,7 +60,7 @@ declaredParam
   ;
 
 variableName
-  : DOLLAR Identifier
+  : (DOLLAR | MINUS_DOLLAR | PLUS_DOLLAR) Identifier
   ;
 
 paramOptionalValue
@@ -73,7 +73,7 @@ passedParams
   ;
 
 passedParam
-  : (variableName COLON)? (commandStatement | bracketedList | map)
+  : (variableName COLON)? (commandStatement | listSpaceSeparated | listBracketed | map)
   ;
 
 // MIXINS and related rules
@@ -112,7 +112,9 @@ functionStatement
 
 
 commandStatement
-  : (PLUS | MINUS)? (expression | '(' commandStatement ')') mathStatement?
+  : (expression
+      | (LPAREN | MINUS_LPAREN | PLUS_LPAREN) commandStatement RPAREN
+    ) mathStatement?
   ;
 
 mathCharacter
@@ -161,7 +163,7 @@ condition
 
 
 variableDeclaration
-  : variableName COLON (commandStatement | list | map) '!default'? ';'
+  : variableName COLON (propertyValue | listBracketed | map) '!default'? ';'
   ;
 
 
@@ -338,15 +340,22 @@ functionNamespace
   ;
 
 
-// Lists can be space or comma separated as long as it's consistent.
-// Lists can be optionally wrapped in brackets.
 list
-  : listElement (listElement+ | (COMMA listElement)+ COMMA?)
-  | bracketedList
+  : listCommaSeparated
+  | listSpaceSeparated
+  | listBracketed
   ;
 
-bracketedList
-  : LBRACK listElement (listElement+ | (COMMA listElement)+) RBRACK
+listCommaSeparated
+  : listElement (COMMA listElement)+ COMMA?
+  ;
+
+listSpaceSeparated
+  : listElement listElement+
+  ;
+
+listBracketed
+  : LBRACK (listCommaSeparated | listSpaceSeparated) RBRACK
   ;
 
 listElement

--- a/scss/testsrc/test/java/TestBase.java
+++ b/scss/testsrc/test/java/TestBase.java
@@ -69,8 +69,9 @@ public class TestBase {
         int charPositionInLine,
         String msg,
         RecognitionException e) {
-      // We don't care about this particular error.
-      if (msg.startsWith("reportAttemptingFullContext")) {
+      // These two messages don't indicate problems.
+      if (msg.startsWith("reportAttemptingFullContext")
+          || msg.startsWith("reportContextSensitivity")) {
         return;
       }
 

--- a/scss/testsrc/test/java/TestBasicCss.java
+++ b/scss/testsrc/test/java/TestBasicCss.java
@@ -187,7 +187,8 @@ public class TestBasicCss extends TestBase {
     assertThat(context.lastProperty().identifier().getText()).isEqualTo("font-family");
 
     ScssParser.PropertyValueContext val = context.lastProperty().propertyValue();
-    assertThat(val.commandStatement(0).expression().StringLiteral().getText()).isEqualTo("'Roboto'");
+    assertThat(val.commandStatement(0).expression().StringLiteral().getText())
+        .isEqualTo("'Roboto'");
     assertThat(val.commandStatement(1).expression().identifier().getText()).isEqualTo("Arial");
     assertThat(val.commandStatement(2).expression().identifier().getText()).isEqualTo("sans-serif");
   }
@@ -440,12 +441,11 @@ public class TestBasicCss extends TestBase {
 
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
     assertThat(context.property(0).identifier().getText()).isEqualTo("p1");
-    assertThat(context.property(0).propertyValue().commandStatement(0).getText())
-        .isEqualTo("-$my-var");
-    assertThat(context.property(0).propertyValue().commandStatement(0).MINUS().getText())
-        .isEqualTo("-");
-    assertThat(context.property(0).propertyValue().commandStatement(0).expression().getText())
-        .isEqualTo("$my-var");
+    ScssParser.ExpressionContext expression =
+        context.property(0).propertyValue().commandStatement(0).expression();
+    assertThat(expression.getText()).isEqualTo("-$my-var");
+    assertThat(expression.variableName().MINUS_DOLLAR()).isNotNull();
+    assertThat(expression.variableName().Identifier().getText()).isEqualTo("my-var");
   }
 
   @Test
@@ -456,8 +456,7 @@ public class TestBasicCss extends TestBase {
     assertThat(context.property(0).identifier().getText()).isEqualTo("p1");
     assertThat(context.property(0).propertyValue().commandStatement(0).getText())
         .isEqualTo("+(400px-200px)");
-    assertThat(context.property(0).propertyValue().commandStatement(0).PLUS().getText())
-        .isEqualTo("+");
+    assertThat(context.property(0).propertyValue().commandStatement(0).PLUS_LPAREN()).isNotNull();
     assertThat(
             context
                 .property(0)

--- a/scss/testsrc/test/java/TestConditionals.java
+++ b/scss/testsrc/test/java/TestConditionals.java
@@ -156,14 +156,11 @@ public class TestConditionals extends TestBase {
 
     ScssParser.EachDeclarationContext context = parse(lines).statement(0).eachDeclaration();
     assertThat(context.variableName(0).getText()).isEqualTo("$animal");
-    assertThat(context.eachValueList().list().listElement(0).commandStatement().getText())
-        .isEqualTo("puma");
-    assertThat(context.eachValueList().list().listElement(1).commandStatement().getText())
-        .isEqualTo("sea-slug");
-    assertThat(context.eachValueList().list().listElement(2).commandStatement().getText())
-        .isEqualTo("egret");
-    assertThat(context.eachValueList().list().listElement(3).commandStatement().getText())
-        .isEqualTo("salamander");
+    ScssParser.ListCommaSeparatedContext list = context.eachValueList().list().listCommaSeparated();
+    assertThat(list.listElement(0).commandStatement().getText()).isEqualTo("puma");
+    assertThat(list.listElement(1).commandStatement().getText()).isEqualTo("sea-slug");
+    assertThat(list.listElement(2).commandStatement().getText()).isEqualTo("egret");
+    assertThat(list.listElement(3).commandStatement().getText()).isEqualTo("salamander");
   }
 
   @Test
@@ -176,12 +173,26 @@ public class TestConditionals extends TestBase {
     assertThat(context.variableName(1).getText()).isEqualTo("$color");
     assertThat(context.variableName(2).getText()).isEqualTo("$cursor");
 
-    ScssParser.ListContext list1 = context.eachValueList().list().listElement(0).list();
+    ScssParser.ListCommaSeparatedContext list1 =
+        context
+            .eachValueList()
+            .list()
+            .listCommaSeparated()
+            .listElement(0)
+            .list()
+            .listCommaSeparated();
     assertThat(list1.listElement(0).commandStatement().getText()).isEqualTo("puma");
     assertThat(list1.listElement(1).commandStatement().getText()).isEqualTo("black");
     assertThat(list1.listElement(2).commandStatement().getText()).isEqualTo("default");
 
-    ScssParser.ListContext list2 = context.eachValueList().list().listElement(1).list();
+    ScssParser.ListCommaSeparatedContext list2 =
+        context
+            .eachValueList()
+            .list()
+            .listCommaSeparated()
+            .listElement(1)
+            .list()
+            .listCommaSeparated();
     assertThat(list2.listElement(0).commandStatement().getText()).isEqualTo("sea-slug");
     assertThat(list2.listElement(1).commandStatement().getText()).isEqualTo("blue");
     assertThat(list2.listElement(2).commandStatement().getText()).isEqualTo("pointer");

--- a/scss/testsrc/test/java/TestConditionals.java
+++ b/scss/testsrc/test/java/TestConditionals.java
@@ -38,7 +38,7 @@ public class TestConditionals extends TestBase {
   public void testIf() {
     String[] lines = {"@if 1 + 1 == 2 {}"};
     ScssParser.IfDeclarationContext context = parse(lines).statement(0).ifDeclaration();
-    assertThat(context.conditions().condition().commandStatement().expression(0).getText())
+    assertThat(context.conditions().condition().commandStatement().expression().getText())
         .isEqualTo("1");
     assertThat(
             context
@@ -56,7 +56,7 @@ public class TestConditionals extends TestBase {
                 .commandStatement()
                 .mathStatement()
                 .commandStatement()
-                .expression(0)
+                .expression()
                 .getText())
         .isEqualTo("1");
 
@@ -67,7 +67,7 @@ public class TestConditionals extends TestBase {
                 .conditions()
                 .condition()
                 .commandStatement()
-                .expression(0)
+                .expression()
                 .getText())
         .isEqualTo("2");
   }
@@ -77,7 +77,7 @@ public class TestConditionals extends TestBase {
     String[] lines = {"@if 1 + 1 == 2 {}", "@else if 1 + 1 == 3 {}"};
     ScssParser.ElseIfStatementContext context =
         parse(lines).statement(0).ifDeclaration().elseIfStatement(0);
-    assertThat(context.conditions().condition().commandStatement().expression(0).getText())
+    assertThat(context.conditions().condition().commandStatement().expression().getText())
         .isEqualTo("1");
     assertThat(
             context
@@ -95,7 +95,7 @@ public class TestConditionals extends TestBase {
                 .commandStatement()
                 .mathStatement()
                 .commandStatement()
-                .expression(0)
+                .expression()
                 .getText())
         .isEqualTo("1");
 
@@ -106,7 +106,7 @@ public class TestConditionals extends TestBase {
                 .conditions()
                 .condition()
                 .commandStatement()
-                .expression(0)
+                .expression()
                 .getText())
         .isEqualTo("3");
   }
@@ -118,7 +118,7 @@ public class TestConditionals extends TestBase {
     ScssParser.ElseStatementContext context =
         parse(lines).statement(0).ifDeclaration().elseStatement();
     assertThat(context.block().lastProperty().identifier().getText()).isEqualTo("color");
-    assertThat(context.block().lastProperty().values().getText()).isEqualTo("red");
+    assertThat(context.block().lastProperty().propertyValue().getText()).isEqualTo("red");
   }
 
   @Test
@@ -141,7 +141,7 @@ public class TestConditionals extends TestBase {
                 .conditions()
                 .condition()
                 .commandStatement()
-                .expression(0)
+                .expression()
                 .variableName()
                 .getText())
         .isEqualTo("$i");
@@ -156,14 +156,18 @@ public class TestConditionals extends TestBase {
 
     ScssParser.EachDeclarationContext context = parse(lines).statement(0).eachDeclaration();
     assertThat(context.variableName(0).getText()).isEqualTo("$animal");
-    assertThat(context.eachValueList().Identifier(0).getText()).isEqualTo("puma");
-    assertThat(context.eachValueList().Identifier(1).getText()).isEqualTo("sea-slug");
-    assertThat(context.eachValueList().Identifier(2).getText()).isEqualTo("egret");
-    assertThat(context.eachValueList().Identifier(3).getText()).isEqualTo("salamander");
+    assertThat(context.eachValueList().list().listElement(0).commandStatement().getText())
+        .isEqualTo("puma");
+    assertThat(context.eachValueList().list().listElement(1).commandStatement().getText())
+        .isEqualTo("sea-slug");
+    assertThat(context.eachValueList().list().listElement(2).commandStatement().getText())
+        .isEqualTo("egret");
+    assertThat(context.eachValueList().list().listElement(3).commandStatement().getText())
+        .isEqualTo("salamander");
   }
 
   @Test
-  public void testBasicEachMultiAssign() {
+  public void eachDestructuringWithListOfLists() {
     String[] lines = {
       "@each $animal, $color, $cursor in (puma, black, default), (sea-slug, blue, pointer) {}"
     };
@@ -172,23 +176,19 @@ public class TestConditionals extends TestBase {
     assertThat(context.variableName(1).getText()).isEqualTo("$color");
     assertThat(context.variableName(2).getText()).isEqualTo("$cursor");
 
-    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(0).getText())
-        .isEqualTo("puma");
-    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(1).getText())
-        .isEqualTo("black");
-    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(2).getText())
-        .isEqualTo("default");
+    ScssParser.ListContext list1 = context.eachValueList().list().listElement(0).list();
+    assertThat(list1.listElement(0).commandStatement().getText()).isEqualTo("puma");
+    assertThat(list1.listElement(1).commandStatement().getText()).isEqualTo("black");
+    assertThat(list1.listElement(2).commandStatement().getText()).isEqualTo("default");
 
-    assertThat(context.eachValueList().identifierListOrMap(1).identifierValue(0).getText())
-        .isEqualTo("sea-slug");
-    assertThat(context.eachValueList().identifierListOrMap(1).identifierValue(1).getText())
-        .isEqualTo("blue");
-    assertThat(context.eachValueList().identifierListOrMap(1).identifierValue(2).getText())
-        .isEqualTo("pointer");
+    ScssParser.ListContext list2 = context.eachValueList().list().listElement(1).list();
+    assertThat(list2.listElement(0).commandStatement().getText()).isEqualTo("sea-slug");
+    assertThat(list2.listElement(1).commandStatement().getText()).isEqualTo("blue");
+    assertThat(list2.listElement(2).commandStatement().getText()).isEqualTo("pointer");
   }
 
   @Test
-  public void testBasicEachMultiAssignWithvalues() {
+  public void eachDestructuringWithMap() {
     String[] lines = {"@each $header, $size in (h1: 2em, h2: 1.5em, h3: 1.2em) {}"};
 
     ScssParser.EachDeclarationContext context = parse(lines).statement(0).eachDeclaration();
@@ -198,34 +198,30 @@ public class TestConditionals extends TestBase {
     assertThat(
             context
                 .eachValueList()
-                .identifierListOrMap(0)
-                .identifierValue(0)
+                .map()
+                .mapEntry(0)
+                .mapKey()
+                .commandStatement()
+                .expression()
                 .identifier()
                 .getText())
         .isEqualTo("h1");
-    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(0).values().getText())
+    assertThat(
+            context
+                .eachValueList()
+                .map()
+                .mapEntry(0)
+                .mapValue()
+                .commandStatement()
+                .expression()
+                .measurement()
+                .getText())
         .isEqualTo("2em");
 
-    assertThat(
-            context
-                .eachValueList()
-                .identifierListOrMap(0)
-                .identifierValue(1)
-                .identifier()
-                .getText())
-        .isEqualTo("h2");
-    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(1).values().getText())
-        .isEqualTo("1.5em");
+    assertThat(context.eachValueList().map().mapEntry(1).mapKey().getText()).isEqualTo("h2");
+    assertThat(context.eachValueList().map().mapEntry(1).mapValue().getText()).isEqualTo("1.5em");
 
-    assertThat(
-            context
-                .eachValueList()
-                .identifierListOrMap(0)
-                .identifierValue(2)
-                .identifier()
-                .getText())
-        .isEqualTo("h3");
-    assertThat(context.eachValueList().identifierListOrMap(0).identifierValue(2).values().getText())
-        .isEqualTo("1.2em");
+    assertThat(context.eachValueList().map().mapEntry(2).mapKey().getText()).isEqualTo("h3");
+    assertThat(context.eachValueList().map().mapEntry(2).mapValue().getText()).isEqualTo("1.2em");
   }
 }

--- a/scss/testsrc/test/java/TestFunctions.java
+++ b/scss/testsrc/test/java/TestFunctions.java
@@ -67,7 +67,13 @@ public class TestFunctions extends TestBase {
     ScssParser.FunctionStatementContext funcContext = context.functionBody().functionStatement(0);
     assertThat(funcContext.statement().variableDeclaration().variableName().getText())
         .isEqualTo("$color");
-    assertThat(funcContext.statement().variableDeclaration().commandStatement().getText())
+    assertThat(
+            funcContext
+                .statement()
+                .variableDeclaration()
+                .propertyValue()
+                .commandStatement(0)
+                .getText())
         .isEqualTo("red");
 
     ScssParser.FunctionReturnContext returnContext = context.functionBody().functionReturn();
@@ -125,7 +131,13 @@ public class TestFunctions extends TestBase {
 
     ScssParser.StylesheetContext context = parse(lines);
     ScssParser.FunctionCallContext function =
-        context.statement(0).variableDeclaration().commandStatement().expression().functionCall();
+        context
+            .statement(0)
+            .variableDeclaration()
+            .propertyValue()
+            .commandStatement(0)
+            .expression()
+            .functionCall();
     assertThat(function.functionNamespace().getText()).isEqualTo("map.");
     assertThat(function.functionNamespace().Identifier(0).getText()).isEqualTo("map");
     assertThat(function.FunctionIdentifier().getText()).isEqualTo("deep-merge(");

--- a/scss/testsrc/test/java/TestFunctions.java
+++ b/scss/testsrc/test/java/TestFunctions.java
@@ -36,15 +36,13 @@ import org.junit.runners.JUnit4;
 public class TestFunctions extends TestBase {
   @Test
   public void testFunction() {
-    // TODO: make it work with parans in the math.
-    // ($n - 1) * $gutter-width;
     String[] lines = {"@function grid-width($n) {", "  @return ($n - 1) * $gutter-width;", "}"};
     ScssParser.FunctionDeclarationContext context = parse(lines).statement(0).functionDeclaration();
-    assertThat(context.Identifier().getText()).isEqualTo("grid-width");
+    assertThat(context.FunctionIdentifier().getText()).isEqualTo("grid-width(");
     assertThat(context.declaredParams().declaredParam(0).variableName().getText()).isEqualTo("$n");
 
     ScssParser.FunctionReturnContext funcContext = context.functionBody().functionReturn();
-    assertThat(funcContext.commandStatement().commandStatement().expression(0).getText())
+    assertThat(funcContext.commandStatement().commandStatement().expression().getText())
         .isEqualTo("$n");
     assertThat(
             funcContext
@@ -63,18 +61,17 @@ public class TestFunctions extends TestBase {
 
   @Test
   public void testFunctionMultiLine() {
-    // TODO: make it work with parans in the math.
-    // ($n - 1) * $gutter-width;
     String[] lines = {"@function grid-width () {", "  $color: red;", "  @return $color;", "}"};
     ScssParser.FunctionDeclarationContext context = parse(lines).statement(0).functionDeclaration();
 
     ScssParser.FunctionStatementContext funcContext = context.functionBody().functionStatement(0);
     assertThat(funcContext.statement().variableDeclaration().variableName().getText())
         .isEqualTo("$color");
-    assertThat(funcContext.statement().variableDeclaration().values().getText()).isEqualTo("red");
+    assertThat(funcContext.statement().variableDeclaration().commandStatement().getText())
+        .isEqualTo("red");
 
     ScssParser.FunctionReturnContext returnContext = context.functionBody().functionReturn();
-    assertThat(returnContext.commandStatement().expression(0).getText()).isEqualTo("$color");
+    assertThat(returnContext.commandStatement().expression().getText()).isEqualTo("$color");
   }
 
   @Test
@@ -88,12 +85,14 @@ public class TestFunctions extends TestBase {
       "}"
     };
     ScssParser.FunctionDeclarationContext context = parse(lines).statement(0).functionDeclaration();
+    // With space before the paren
     assertThat(context.Identifier().getText()).isEqualTo("grid-width");
     assertThat(context.declaredParams().declaredParam(0).variableName().getText()).isEqualTo("$a");
 
     ScssParser.FunctionStatementContext funcContext = context.functionBody().functionStatement(0);
-    assertThat(funcContext.statement().functionDeclaration().Identifier().getText())
-        .isEqualTo("grid-height");
+    // Without space before the paren
+    assertThat(funcContext.statement().functionDeclaration().FunctionIdentifier().getText())
+        .isEqualTo("grid-height(");
     assertThat(
             funcContext
                 .statement()
@@ -111,12 +110,24 @@ public class TestFunctions extends TestBase {
                 .functionBody()
                 .functionReturn()
                 .commandStatement()
-                .expression(0)
+                .expression()
                 .variableName()
                 .getText())
         .isEqualTo("$color");
 
     ScssParser.FunctionReturnContext returnContext = context.functionBody().functionReturn();
-    assertThat(returnContext.commandStatement().expression(0).getText()).isEqualTo("$world");
+    assertThat(returnContext.commandStatement().expression().getText()).isEqualTo("$world");
+  }
+
+  @Test
+  public void namespacedFunctionCall() {
+    String[] lines = {"$helvetica: map.deep-merge($helvetica-light, $helvetica-heavy);"};
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.FunctionCallContext function =
+        context.statement(0).variableDeclaration().commandStatement().expression().functionCall();
+    assertThat(function.functionNamespace().getText()).isEqualTo("map.");
+    assertThat(function.functionNamespace().Identifier(0).getText()).isEqualTo("map");
+    assertThat(function.FunctionIdentifier().getText()).isEqualTo("deep-merge(");
   }
 }

--- a/scss/testsrc/test/java/TestListAndMap.java
+++ b/scss/testsrc/test/java/TestListAndMap.java
@@ -1,0 +1,176 @@
+/*
+ [The "BSD licence"]
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class TestListAndMap extends TestBase {
+  @Test
+  public void listSpaceSeparated() {
+    String[] lines = {
+      "$var: 10px 1em 0 -5px;",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.ListContext list = context.statement(0).variableDeclaration().list();
+    assertThat(list.listElement()).hasSize(4);
+    assertThat(list.listElement(0).commandStatement().getText()).isEqualTo("10px");
+    assertThat(list.listElement(1).commandStatement().getText()).isEqualTo("1em");
+    assertThat(list.listElement(2).commandStatement().getText()).isEqualTo("0");
+    assertThat(list.listElement(3).commandStatement().getText()).isEqualTo("-5px");
+  }
+
+  @Test
+  public void listCommaSeparated() {
+    String[] lines = {
+      "$var: red, blue, yellow;",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.ListContext list = context.statement(0).variableDeclaration().list();
+    assertThat(list.listElement()).hasSize(3);
+    assertThat(list.listElement(0).commandStatement().getText()).isEqualTo("red");
+    assertThat(list.listElement(1).commandStatement().getText()).isEqualTo("blue");
+    assertThat(list.listElement(2).commandStatement().getText()).isEqualTo("yellow");
+  }
+
+  @Test
+  public void bracketedListSpaceSeparated() {
+    String[] lines = {
+      "$var: [$a $b];",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.BracketedListContext list =
+        context.statement(0).variableDeclaration().list().bracketedList();
+    assertThat(list.listElement()).hasSize(2);
+    assertThat(list.listElement(0).commandStatement().getText()).isEqualTo("$a");
+    assertThat(list.listElement(1).commandStatement().getText()).isEqualTo("$b");
+  }
+
+  @Test
+  public void bracketedListCommaSeparated() {
+    String[] lines = {
+      "$var: [1 + 2, 3 / 4];",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.BracketedListContext list =
+        context.statement(0).variableDeclaration().list().bracketedList();
+    assertThat(list.listElement()).hasSize(2);
+    assertThat(list.listElement(0).commandStatement().getText()).isEqualTo("1+2");
+    assertThat(list.listElement(1).commandStatement().getText()).isEqualTo("3/4");
+  }
+
+  @Test
+  public void nestedList() {
+    String[] lines = {
+      "$var: (a b) (c, (d e f), g, h);",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.ListContext outerList = context.statement(0).variableDeclaration().list();
+    assertThat(outerList.listElement(0).list().listElement()).hasSize(2);
+    assertThat(outerList.listElement(1).list().listElement()).hasSize(4);
+    assertThat(outerList.listElement(1).list().listElement(1).list().listElement()).hasSize(3);
+  }
+
+  @Test
+  public void map() {
+    String[] lines = {"$font-weights: (\"regular\": 400, \"medium\": 500, \"bold\": 700);"};
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.MapContext map = context.statement(0).variableDeclaration().map();
+    assertThat(map.mapEntry()).hasSize(3);
+    assertThat(map.mapEntry(0).mapKey().commandStatement().getText()).isEqualTo("\"regular\"");
+    assertThat(map.mapEntry(0).mapValue().commandStatement().getText()).isEqualTo("400");
+  }
+
+  @Test
+  public void mapUnquotedKeys() {
+    String[] lines = {"$var: (1: 2, a: b, red: blue);"};
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.MapContext map = context.statement(0).variableDeclaration().map();
+    assertThat(map.mapEntry()).hasSize(3);
+    assertThat(map.mapEntry(2).mapKey().commandStatement().getText()).isEqualTo("red");
+    assertThat(map.mapEntry(2).mapValue().commandStatement().getText()).isEqualTo("blue");
+  }
+
+  @Test
+  public void mapListValue() {
+    String[] lines = {
+      "$new-theme: map-merge(",
+      "  base-theme(),",
+      "  (",
+      "    background-color: $backgroundColor,",
+      "    border: 1px solid $borderColor,",
+      "  )",
+      ");",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.MapContext map =
+        context
+            .statement(0)
+            .variableDeclaration()
+            .commandStatement()
+            .expression()
+            .functionCall()
+            .passedParams()
+            .passedParam(1)
+            .map();
+    assertThat(map.mapEntry()).hasSize(2);
+    assertThat(map.mapEntry(1).mapValue().list().listElement()).hasSize(3);
+    assertThat(map.mapEntry(1).mapValue().list().listElement(0).getText()).isEqualTo("1px");
+    assertThat(map.mapEntry(1).mapValue().list().listElement(1).getText()).isEqualTo("solid");
+    assertThat(map.mapEntry(1).mapValue().list().listElement(2).getText())
+        .isEqualTo("$borderColor");
+  }
+
+  @Test
+  public void nestedMap() {
+    String[] lines = {"$config: (a: (b: (c: d)));"};
+
+    ScssParser.StylesheetContext context = parse(lines);
+    ScssParser.MapContext map = context.statement(0).variableDeclaration().map();
+    assertThat(
+            map.mapEntry(0)
+                .mapValue()
+                .map()
+                .mapEntry(0)
+                .mapValue()
+                .map()
+                .mapEntry(0)
+                .mapValue()
+                .getText())
+        .isEqualTo("d");
+  }
+}

--- a/scss/testsrc/test/java/TestMedia.java
+++ b/scss/testsrc/test/java/TestMedia.java
@@ -220,9 +220,9 @@ public class TestMedia extends TestBase {
             innerMedia
                 .block()
                 .property(0)
-                .values()
+                .propertyValue()
                 .commandStatement(0)
-                .expression(0)
+                .expression()
                 .Color()
                 .getText())
         .isEqualTo("#036");

--- a/scss/testsrc/test/java/TestMixinAndInclude.java
+++ b/scss/testsrc/test/java/TestMixinAndInclude.java
@@ -268,7 +268,8 @@ public final class TestMixinAndInclude extends TestBase {
     ScssParser.StylesheetContext context = parse(lines);
     assertThat(context.statement(0).variableDeclaration().variableName().getText())
         .isEqualTo("$form-selectors");
-    assertThat(context.statement(0).variableDeclaration().list().listElement()).hasSize(3);
+    assertThat(context.statement(0).variableDeclaration().propertyValue().commandStatement())
+        .hasSize(3);
     assertThat(
             context.statement(1).includeDeclaration().functionCall().passedParams().passedParam())
         .hasSize(2);

--- a/scss/testsrc/test/java/TestMixinAndInclude.java
+++ b/scss/testsrc/test/java/TestMixinAndInclude.java
@@ -24,8 +24,6 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-package com.google.thirdparty.antlr4grammars.scss;
-
 import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
@@ -73,12 +71,12 @@ public final class TestMixinAndInclude extends TestBase {
     ScssParser.IncludeDeclarationContext include1 =
         context.statement(1).mixinDeclaration().block().statement(0).includeDeclaration();
     assertThat(include1.Identifier().getText()).isEqualTo("reset-list");
-    assertThat(include1.passedParams()).isNull();
+    assertThat(include1.functionCall()).isNull();
 
     ScssParser.IncludeDeclarationContext include2 =
         context.statement(2).ruleset().block().statement(0).includeDeclaration();
     assertThat(include2.Identifier().getText()).isEqualTo("horizontal-list");
-    assertThat(include2.passedParams()).isNull();
+    assertThat(include2.functionCall()).isNull();
   }
 
   @Test
@@ -107,9 +105,9 @@ public final class TestMixinAndInclude extends TestBase {
 
     ScssParser.IncludeDeclarationContext include =
         context.statement(1).ruleset().block().statement(0).includeDeclaration();
-    assertThat(include.passedParams().passedParam(0).getText()).isEqualTo("float");
-    assertThat(include.passedParams().passedParam(1).getText()).isEqualTo("left");
-    assertThat(include.passedParams().passedParam(2).getText()).isEqualTo("right");
+    assertThat(include.functionCall().passedParams().passedParam(0).getText()).isEqualTo("float");
+    assertThat(include.functionCall().passedParams().passedParam(1).getText()).isEqualTo("left");
+    assertThat(include.functionCall().passedParams().passedParam(2).getText()).isEqualTo("right");
   }
 
   @Test
@@ -147,11 +145,11 @@ public final class TestMixinAndInclude extends TestBase {
 
     ScssParser.IncludeDeclarationContext include =
         context.statement(1).ruleset().block().statement(0).includeDeclaration();
-    assertThat(include.passedParams().Ellipsis()).isNull();
-    assertThat(include.passedParams().passedParam()).hasSize(2);
-    assertThat(include.passedParams().passedParam(0).getText())
+    assertThat(include.functionCall().passedParams().Ellipsis()).isNull();
+    assertThat(include.functionCall().passedParams().passedParam()).hasSize(2);
+    assertThat(include.functionCall().passedParams().passedParam(0).getText())
         .isEqualTo("url(\"/images/mail.svg\")");
-    assertThat(include.passedParams().passedParam(1).getText()).isEqualTo("0");
+    assertThat(include.functionCall().passedParams().passedParam(1).getText()).isEqualTo("0");
   }
 
   @Test
@@ -174,11 +172,13 @@ public final class TestMixinAndInclude extends TestBase {
     ScssParser.StylesheetContext context = parse(lines);
     ScssParser.IncludeDeclarationContext include =
         context.statement(1).ruleset().block().statement(0).includeDeclaration();
-    assertThat(include.passedParams().passedParam(0).variableName()).isNull();
-    assertThat(include.passedParams().passedParam(0).commandStatement().getText())
+    assertThat(include.functionCall().passedParams().passedParam(0).variableName()).isNull();
+    assertThat(include.functionCall().passedParams().passedParam(0).commandStatement().getText())
         .isEqualTo("100px");
-    assertThat(include.passedParams().passedParam(1).variableName().getText()).isEqualTo("$radius");
-    assertThat(include.passedParams().passedParam(1).commandStatement().getText()).isEqualTo("4px");
+    assertThat(include.functionCall().passedParams().passedParam(1).variableName().getText())
+        .isEqualTo("$radius");
+    assertThat(include.functionCall().passedParams().passedParam(1).commandStatement().getText())
+        .isEqualTo("4px");
   }
 
   @Test
@@ -201,7 +201,9 @@ public final class TestMixinAndInclude extends TestBase {
     ScssParser.StylesheetContext context = parse(lines);
     assertThat(context.statement(0).mixinDeclaration().declaredParams().declaredParam()).hasSize(2);
     assertThat(context.statement(0).mixinDeclaration().declaredParams().Ellipsis()).isNotNull();
-    assertThat(context.statement(1).includeDeclaration().passedParams().passedParam()).hasSize(4);
+    assertThat(
+            context.statement(1).includeDeclaration().functionCall().passedParams().passedParam())
+        .hasSize(4);
   }
 
   @Test
@@ -226,11 +228,32 @@ public final class TestMixinAndInclude extends TestBase {
     assertThat(context.statement(0).mixinDeclaration().declaredParams().declaredParam(0).getText())
         .isEqualTo("$args");
     assertThat(context.statement(0).mixinDeclaration().declaredParams().Ellipsis()).isNotNull();
-    assertThat(context.statement(1).includeDeclaration().passedParams().passedParam(0).getText())
+    assertThat(
+            context
+                .statement(1)
+                .includeDeclaration()
+                .functionCall()
+                .passedParams()
+                .passedParam(0)
+                .getText())
         .isEqualTo("$string:#080");
-    assertThat(context.statement(1).includeDeclaration().passedParams().passedParam(1).getText())
+    assertThat(
+            context
+                .statement(1)
+                .includeDeclaration()
+                .functionCall()
+                .passedParams()
+                .passedParam(1)
+                .getText())
         .isEqualTo("$comment:#800");
-    assertThat(context.statement(1).includeDeclaration().passedParams().passedParam(2).getText())
+    assertThat(
+            context
+                .statement(1)
+                .includeDeclaration()
+                .functionCall()
+                .passedParams()
+                .passedParam(2)
+                .getText())
         .isEqualTo("$variable:#60b");
   }
 
@@ -245,9 +268,12 @@ public final class TestMixinAndInclude extends TestBase {
     ScssParser.StylesheetContext context = parse(lines);
     assertThat(context.statement(0).variableDeclaration().variableName().getText())
         .isEqualTo("$form-selectors");
-    assertThat(context.statement(0).variableDeclaration().values().commandStatement()).hasSize(3);
-    assertThat(context.statement(1).includeDeclaration().passedParams().passedParam()).hasSize(2);
-    assertThat(context.statement(1).includeDeclaration().passedParams().Ellipsis()).isNotNull();
+    assertThat(context.statement(0).variableDeclaration().list().listElement()).hasSize(3);
+    assertThat(
+            context.statement(1).includeDeclaration().functionCall().passedParams().passedParam())
+        .hasSize(2);
+    assertThat(context.statement(1).includeDeclaration().functionCall().passedParams().Ellipsis())
+        .isNotNull();
   }
 
   @Test
@@ -283,7 +309,7 @@ public final class TestMixinAndInclude extends TestBase {
     ScssParser.IncludeDeclarationContext include =
         context.statement(1).ruleset().block().statement(0).includeDeclaration();
     assertThat(include.Identifier().getText()).isEqualTo("hover");
-    assertThat(include.passedParams()).isNull();
+    assertThat(include.functionCall()).isNull();
     assertThat(include.block().property(0).getText()).isEqualTo("border-width:2px;");
   }
 
@@ -326,4 +352,3 @@ public final class TestMixinAndInclude extends TestBase {
     assertThat(include.declaredParams().declaredParam(0).getText()).isEqualTo("$type");
   }
 }
-


### PR DESCRIPTION
- Able to use maps outside of @each
- Nested lists and nested maps
- Function identifier namespaces
- Spaces between an identifier and lparen will always be parsed as a
function
- Move prefixed '-' and '+' to lexer rules to avoid ambiguity with list
- Explicit rules for list, entry, key, value, etc. for cleaner visitor/listeners