### PR TITLE
Changes for #2069

### DIFF
--- a/abb/abbParser.g4
+++ b/abb/abbParser.g4
@@ -78,10 +78,10 @@ functionParameter
     ;
 
 declaration
-    : init type IDENTIFIER (EQUALS expression)? SEMICOLON
+    : init type_ IDENTIFIER (EQUALS expression)? SEMICOLON
     ;
 
-type
+type_
     : ( TOOLDATA | WOBJDATA | SPEEDDATA | ZONEDATA | CLOCK | BOOL )
     ;
 

--- a/algol60/algol60.g4
+++ b/algol60/algol60.g4
@@ -230,9 +230,9 @@ declaration : type_declaration | array_declaration | switch_declaration | proced
 
 // 5.1.1
 type_list : simple_variable | simple_variable Comma_ type_list ;
-type : Real_ | Integer_ | Boolean_ ;
+type_ : Real_ | Integer_ | Boolean_ ;
 local_or_own : empty | Own_ ;
-type_declaration : local_or_own type type_list ;
+type_declaration : local_or_own type_ type_list ;
 
 // 5.2.1
 lower_bound : arithmetic_expression ;
@@ -241,7 +241,7 @@ bound_pair : lower_bound Colon_ upper_bound ;
 bound_pair_list : bound_pair | bound_pair_list Comma_ bound_pair ;
 array_segment : array_identifier Lb_ bound_pair_list Rb_ | array_identifier Comma_ array_segment ;
 array_list : array_segment | array_list Comma_ array_segment ;
-array_declarer : type Array_ | Array_ ;
+array_declarer : type_ Array_ | Array_ ;
 array_declaration : local_or_own array_declarer array_list ;
 
 // 5.3.1
@@ -254,11 +254,11 @@ formal_parameter_list : formal_parameter | formal_parameter_list parameter_delim
 formal_parameter_part : empty | LP_ formal_parameter_list Rp_ ;
 identifier_list : Identifier | identifier_list Comma_ Identifier ;
 value_part : Value_ identifier_list Semi_ | empty ;
-specifier : String_ | type | Array_ | type Array_ | Label_ | Switch_ | Procedure_ | type Procedure_ ;
+specifier : String_ | type_ | Array_ | type_ Array_ | Label_ | Switch_ | Procedure_ | type_ Procedure_ ;
 specification_part : empty | specifier identifier_list Semi_ | specification_part specifier identifier_list ;
 procedure_heading : procedure_identifier formal_parameter_part Semi_ value_part specification_part ;
 procedure_body : statement | code ;
-procedure_declaration : Procedure_ procedure_heading procedure_body | type Procedure_ procedure_heading procedure_body ;
+procedure_declaration : Procedure_ procedure_heading procedure_body | type_ Procedure_ procedure_heading procedure_body ;
 
 WS : Ws -> channel(HIDDEN) ;
 fragment Ws : [ \r\n\t]+ ;

--- a/arithmetic/arithmetic.g4
+++ b/arithmetic/arithmetic.g4
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 grammar arithmetic;
 
-file : equation* EOF;
+file_ : equation* EOF;
 
 equation
    : expression relop expression

--- a/asm/asm6502/asm6502.g4
+++ b/asm/asm6502/asm6502.g4
@@ -68,7 +68,7 @@ label
    ;
 
 argument
-   : prefix? (number | name | string | '*') (('+' | '-') number)?
+   : prefix? (number | name | string_ | '*') (('+' | '-') number)?
    | '(' argument ')'
    ;
 
@@ -76,7 +76,7 @@ prefix
    : '#'
    ;
 
-string
+string_
    : STRING
    ;
 

--- a/asm/asm8080/asm8080.g4
+++ b/asm/asm8080/asm8080.g4
@@ -88,7 +88,7 @@ argument
    | register_
    | dollar
    | name
-   | string
+   | string_
    | ('(' expression ')')
    ;
 
@@ -96,7 +96,7 @@ dollar
    : '$'
    ;
 
-string
+string_
    : STRING
    ;
 

--- a/asm/asm8086/asm8086.g4
+++ b/asm/asm8086/asm8086.g4
@@ -136,7 +136,7 @@ org
    ;
 
 title
-   : TITLE string
+   : TITLE string_
    ;
 
 include
@@ -164,7 +164,7 @@ argument
    | dollar
    | register_
    | name
-   | string
+   | string_
    | ('(' expression ')')
    | ((number | name)? '[' expression ']')
    | ptr expression
@@ -186,7 +186,7 @@ register_
    : REGISTER
    ;
 
-string
+string_
    : STRING
    ;
 

--- a/asm/asmZ80/asmZ80.g4
+++ b/asm/asmZ80/asmZ80.g4
@@ -88,7 +88,7 @@ argument
    | register_
    | dollar
    | name
-   | string
+   | string_
    | ('(' expression ')')
    ;
 
@@ -96,7 +96,7 @@ dollar
    : '$'
    ;
 
-string
+string_
    : STRING
    ;
 

--- a/asn/asn/ASN.g4
+++ b/asn/asn/ASN.g4
@@ -171,7 +171,7 @@ parameterizedAssignment :
 	)
 )
 |( definedObjectClass ASSIGN_OP
-	( object
+	( object_
 		|	objectClass
 		|	objectSet
 	)
@@ -242,7 +242,7 @@ fieldSpec :
 	  typeOptionalitySpec?
   	| asnType (valueSetOptionalitySpec?  | UNIQUE_LITERAL? valueOptionalitySpec? )
 	| fieldName (OPTIONAL_LITERAL | (DEFAULT_LITERAL (valueSet | value)))?
-	| definedObjectClass (OPTIONAL_LITERAL | (DEFAULT_LITERAL (objectSet | object)))?
+	| definedObjectClass (OPTIONAL_LITERAL | (DEFAULT_LITERAL (objectSet | object_)))?
 
 	)
 
@@ -273,7 +273,7 @@ fixedTypeValueSetFieldSpec : AMPERSAND IDENTIFIER   asnType valueSetOptionalityS
 valueSetOptionalitySpec : OPTIONAL_LITERAL | DEFAULT_LITERAL valueSet
 ;
 
-object : definedObject /*| objectDefn | objectFromObject */|  parameterizedObject
+object_ : definedObject /*| objectDefn | objectFromObject */|  parameterizedObject
 ;
 parameterizedObject : definedObject actualParameterList
 ;
@@ -320,7 +320,7 @@ elements  : subtypeElements
 // |  L_PARAN elementSetSpec R_PARAN
 ;
 objectSetElements :
-    object | definedObject /*| objectSetFromObjects | parameterizedObjectSet      */
+    object_ | definedObject /*| objectSetFromObjects | parameterizedObjectSet      */
 ;
 
 
@@ -338,7 +338,7 @@ variableTypeValueSetFieldSpec : AMPERSAND IDENTIFIER    fieldName valueSetOption
 ;
 objectFieldSpec : AMPERSAND IDENTIFIER definedObjectClass objectOptionalitySpec?
 ;
-objectOptionalitySpec : OPTIONAL_LITERAL | DEFAULT_LITERAL object
+objectOptionalitySpec : OPTIONAL_LITERAL | DEFAULT_LITERAL object_
 ;
 objectSetFieldSpec : AMPERSAND IDENTIFIER definedObjectClass objectSetOptionalitySpec ?
 ;
@@ -410,7 +410,7 @@ userDefinedConstraintParameter :
 	governor (COLON
  		value
  		| valueSet
- 		| object
+ 		| object_
  		| objectSet
  		)?
 ;
@@ -524,7 +524,7 @@ simpleDefinedValue : IDENTIFIER (DOT IDENTIFIER)?
 
 actualParameterList : L_BRACE actualParameter (COMMA actualParameter)* R_BRACE
 ;
-actualParameter : asnType | value /*| valueSet | definedObjectClass | object | objectSet*/
+actualParameter : asnType | value /*| valueSet | definedObjectClass | object_ | objectSet*/
 ;
 exceptionSpec : EXCLAM  exceptionIdentification
 ;

--- a/atl/ATL.g4
+++ b/atl/ATL.g4
@@ -23,7 +23,7 @@ grammar ATL;
  */
 unit
    : module
-   | library
+   | library_
    | query
    ;
 
@@ -45,7 +45,7 @@ transformationMode
    | 'from'
    ;
 
-library
+library_
    : 'library' (STRING | IDENTIFIER) ';' libraryRef* helper*
    ;
 


### PR DESCRIPTION
This PR fixes only a few parser symbol conflicts in grammars to not conflict with various targets (Python3, Dart, Go). This PR deals with just the grammars starting with the letter "a". I only fixed the symbol conflicts, and haven't rewritten the grammar for multiple targets. Folks can address this by creating a new issue to carve out what they want to work on, or comment on an old issue.

I am now working on the CI tool dotnet-antlr so that it works as much as possible with StringTemplates.