### PR TITLE
Fix escape sequences in string constants

### DIFF
--- a/terraform/examples/array.tf
+++ b/terraform/examples/array.tf
@@ -1,4 +1,7 @@
 locals {
   empty     = []
   not_emtpy = [1, 2, 3]
+
+  string_array = ["abc", "def"]
+  string_array_escape = ["\"test\"", "abc"]
 }

--- a/terraform/terraform.g4
+++ b/terraform/terraform.g4
@@ -188,7 +188,7 @@ VARIABLE
 PROVIDER
    : 'provider'
    ;
-   
+
 IN
    : 'in'
    ;
@@ -263,7 +263,7 @@ MULTILINESTRING
    ;
 
 STRING
-   : '"' (~ [\r\n"] | '""' | '\\"')* '"'
+   : '"' ( '\\"' | ~["\r\n] )* '"'
    ;
 
 IDENTIFIER


### PR DESCRIPTION
'""' is not a valid terraform escape sequence