### PR TITLE
IBM TSO/E REXX Standardization P1

### DIFF
--- a/rexx/RexxLexer.g4
+++ b/rexx/RexxLexer.g4
@@ -254,7 +254,7 @@ fragment Extra_letter           :   Hash_
                                 |   Dollar_
                                 ;
 // Const
-fragment Const_symbol_          :   Digit_ Var_symbol_char* ;
+fragment Const_symbol_          :   ( Digit_ | Stop_ ) Var_symbol_char* ;
 fragment Digit_                 :   [0-9] ;
 // Number
 fragment Number_                :   Plain_number Exponent_? ;

--- a/rexx/RexxParser.g4
+++ b/rexx/RexxParser.g4
@@ -26,7 +26,7 @@ single_instruction          :   assignment
                             |   keyword_instruction
                             |   command_
                             ;
-  assignment                :   ( VAR_SYMBOL | SPECIAL_VAR | CONST_SYMBOL ) EQ expression ;
+  assignment                :   ( VAR_SYMBOL | SPECIAL_VAR | CONST_SYMBOL ) EQ expression? ;
   keyword_instruction       :   address_
                             |   arg_
                             |   call_


### PR DESCRIPTION
# Summary of Changes

We are incrementally updating the ANTLR grammar for REXX to fully conform to the IBM z/OS TSO/E REXX standard. There are several other changes still in development, but here's what we've changed so far. We love the grammar and appreciate your participation in the Open Source Software (OSS) community!

## Empty Assignment

On the [assignments and symbols](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.ikja300/tso/ikja300/assinmt.htm) page of the documentation, it states "On TSO/E, if you omit expression, the variable is set to the null string".

## Constant Symbols

On the [constant symbols](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.ikja300/tso/ikja300/constnt.htm) page of the documentation, it states "A constant symbol starts with a digit (0–9) or a period".
