### PR TITLE
Fix Erlang check error caused by TestRig package name change

### DIFF
--- a/erlang/Makefile
+++ b/erlang/Makefile
@@ -5,7 +5,7 @@ compile:
 	javac Erlang*.java
 
 debug: compile
-	java org.antlr.v4.runtime.misc.TestRig  Erlang forms -gui -encoding utf8
+	java org.antlr.v4.gui.TestRig  Erlang forms -gui -encoding utf8
 
 check: compile
 	./check.sh test/

--- a/erlang/check.sh
+++ b/erlang/check.sh
@@ -41,7 +41,7 @@ for file in `find $SRC -name '*.erl'`; do
     if [ $? -eq 0 ]; then
 
         ## Syntax
-        java org.antlr.v4.runtime.misc.TestRig Erlang forms -encoding utf8 $pped 1>$O 2>>$O
+        java org.antlr.v4.gui.TestRig Erlang forms -encoding utf8 $pped 1>$O 2>>$O
 
         if [ -s $O ]; then # $O is not empty
             printf "%s \033[0;33m%s\033[00m\033[0;31m%$(($COLUMNS - ${#file} -${#j} -1))s\033[00m\n" $j $pped ERROR

--- a/html/examples/antlr.html
+++ b/html/examples/antlr.html
@@ -105,7 +105,7 @@ OS X
 <span class="dollar">$</span> <span class="cmd">sudo curl</span> -O http://www.antlr.org/download/antlr-4.2.2-complete.jar
 <span class="dollar">$</span> <span class="cmd">export</span> <span class="equals">CLASSPATH=</span><span class="path">".:/usr/local/lib/antlr-4.2.2-complete.jar:$CLASSPATH"</span>
 <span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">antlr4=</span><span class="path">'java -jar /usr/local/lib/antlr-4.2.2-complete.jar'</span>
-<span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">grun=</span><span class="path">'java org.antlr.v4.runtime.misc.TestRig'</span>
+<span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">grun=</span><span class="path">'java org.antlr.v4.gui.TestRig'</span>
 </pre>
 	</div>
 	
@@ -116,7 +116,7 @@ LINUX
 <span class="dollar">$</span> <span class="cmd">wget</span> http://antlr.org/download/antlr-4.2.2-complete.jar
 <span class="dollar">$</span> <span class="cmd">export</span> <span class="equals">CLASSPATH=</span><span class="path">".:/usr/local/lib/antlr-4.2.2-complete.jar:$CLASSPATH"</span>
 <span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">antlr4=</span><span class="path">'java -jar /usr/local/lib/antlr-4.2.2-complete.jar'</span>
-<span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">grun=</span><span class="path">'java org.antlr.v4.runtime.misc.TestRig'</span>
+<span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">grun=</span><span class="path">'java org.antlr.v4.gui.TestRig'</span>
 </pre>
 </div>
 
@@ -137,7 +137,7 @@ SET CLASSPATH=.;C:\Javalib\antlr4-complete.jar;%CLASSPATH%
 <li>Create batch commands for ANTLR Tool, TestRig in dir in PATH
 <pre>
  antlr4.bat: java org.antlr.v4.Tool %*
- grun.bat:   java org.antlr.v4.runtime.misc.TestRig %*
+ grun.bat:   java org.antlr.v4.gui.TestRig %*
 </pre>
 </ol>
 </div>

--- a/tnsnames/examplesdoc/README.html
+++ b/tnsnames/examplesdoc/README.html
@@ -8,7 +8,7 @@
 <pre><code>export ANTLR4=&quot;/where/downloaded/to/antlr-4.x.x-complete.jar&quot;
 export CLASSPATH=&quot;.:${CLASSPATH}:${ANTLR4}&quot;
 alias antlr4=&#39;java org.antlr.v4.Tool&#39;
-alias grun=&#39;java org.antlr.v4.runtime.misc.TestRig&#39;
+alias grun=&#39;java org.antlr.v4.gui.TestRig&#39;
 alias jar=&#39;${JAVA_HOME}/bin/jar&#39;
 alias java=&#39;${JAVA_HOME}/bin/java&#39;
 alias javac=&#39;${JAVA_HOME}/bin/javac&#39;

--- a/tnsnames/examplesdoc/README.md
+++ b/tnsnames/examplesdoc/README.md
@@ -24,7 +24,7 @@ Follow the instructions on the [Getting Started page](https://github.com/antlr/a
 export ANTLR4="/where/downloaded/to/antlr-4.x.x-complete.jar"
 export CLASSPATH=".:${CLASSPATH}:${ANTLR4}"
 alias antlr4='java org.antlr.v4.Tool'
-alias grun='java org.antlr.v4.runtime.misc.TestRig'
+alias grun='java org.antlr.v4.gui.TestRig'
 alias jar='${JAVA_HOME}/bin/jar'
 alias java='${JAVA_HOME}/bin/java'
 alias javac='${JAVA_HOME}/bin/javac'


### PR DESCRIPTION
When I tried the Erlang grammar, [check.sh](https://github.com/antlr/grammars-v4/blob/master/erlang/check.sh) reported errors. It seems that the captured message "Warning: TestRig moved to org.antlr.v4.gui.TestRig; calling automatically"  was recognized as an error output.

Since the package name change updated in docs as https://github.com/antlr/antlr4/commit/978851f7034bb882ac546d85bf925293cd3643ac, I just simply replace them in Erlang and other directories. Hope it does not break compatibility.