### PR TITLE
Allow to check colmun

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -994,14 +994,14 @@ queryExpressionNointo
 
 querySpecification
     : SELECT selectSpec* selectElements selectIntoExpression?
-      fromClause? orderByClause? limitClause?
+      fromClause? groupByClause? havingClause? orderByClause? limitClause?
     | SELECT selectSpec* selectElements
-    fromClause? orderByClause? limitClause? selectIntoExpression?
+    fromClause? groupByClause? havingClause? orderByClause? limitClause? selectIntoExpression?
     ;
 
 querySpecificationNointo
     : SELECT selectSpec* selectElements
-      fromClause? orderByClause? limitClause?
+      fromClause? groupByClause? havingClause? orderByClause? limitClause?
     ;
 
 unionParenthesis
@@ -1064,12 +1064,16 @@ selectLinesInto
 fromClause
     : FROM tableSources
       (WHERE whereExpr=expression)?
-      (
-        GROUP BY
+    ;
+
+groupByClause
+    :  GROUP BY
         groupByItem (',' groupByItem)*
         (WITH ROLLUP)?
-      )?
-      (HAVING havingExpr=expression)?
+    ;
+
+havingClause
+    :  HAVING havingExpr=expression
     ;
 
 groupByItem

--- a/sql/mysql/Positive-Technologies/examples/dml_select.sql
+++ b/sql/mysql/Positive-Technologies/examples/dml_select.sql
@@ -137,3 +137,5 @@ SELECT * FROM test LIMIT LIMIT1,LIMIT2;
 SELECT SCHEMA();
 -- Functions
 SELECT mod(3,2);SELECT * FROM TEST WHERE TB_SCHEMA = SCHEMA();
+-- Group By with computed column
+SELECT 1 AS col1, t1.Id FROM t1 GROUP BY col1;


### PR DESCRIPTION
In this case:

```sql
SELECT 1 AS toto, table.Id
FROM table
GROUP BY toto
```

To check the column in select, we must parse the first FROM clause. But then parse FromClause, in the previous g4, group by clause is included in from clause and we cannot know the alias in select. Thus, we must separate from clause and group by clause to simply the SQL parsing.