### PR TITLE
Fix for parsing function prototypes correctly

### DIFF
--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -377,10 +377,10 @@ simpleTypeSpecifier:
 	| nestedNameSpecifier Template simpleTemplateId
 	| simpleTypeSignednessModifier
 	| simpleTypeSignednessModifier? simpleTypeLengthModifier+
-	| Char
-	| Char16
-	| Char32
-	| Wchar
+	| simpleTypeSignednessModifier? Char
+	| simpleTypeSignednessModifier? Char16
+	| simpleTypeSignednessModifier? Char32
+	| simpleTypeSignednessModifier? Wchar
 	| Bool
 	| simpleTypeSignednessModifier? simpleTypeLengthModifier* Int
 	| Float

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -330,12 +330,7 @@ declSpecifier:
 	| Typedef
 	| Constexpr;
 	
-paramDeclSpecifier:
-	typeSpecifier;
-	
-declSpecifierSeq: declSpecifier+ attributeSpecifierSeq?;
-
-paramDeclSpecifierSeq: cvqualifierseq? paramDeclSpecifier attributeSpecifierSeq?;
+declSpecifierSeq: declSpecifier+? attributeSpecifierSeq?;
 
 storageClassSpecifier:
 	Register
@@ -567,7 +562,7 @@ parameterDeclarationList:
 	parameterDeclaration (Comma parameterDeclaration)*;
 
 parameterDeclaration:
-	attributeSpecifierSeq? paramDeclSpecifierSeq (
+	attributeSpecifierSeq? declSpecifierSeq (
 		(declarator | abstractDeclarator?) (
 			Assign initializerClause
 		)?

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -329,8 +329,13 @@ declSpecifier:
 	| Friend
 	| Typedef
 	| Constexpr;
-
+	
+paramDeclSpecifier:
+	typeSpecifier;
+	
 declSpecifierSeq: declSpecifier+ attributeSpecifierSeq?;
+
+paramDeclSpecifierSeq: cvqualifierseq? paramDeclSpecifier attributeSpecifierSeq?;
 
 storageClassSpecifier:
 	Register
@@ -556,7 +561,7 @@ parameterDeclarationList:
 	parameterDeclaration (Comma parameterDeclaration)*;
 
 parameterDeclaration:
-	attributeSpecifierSeq? declSpecifierSeq (
+	attributeSpecifierSeq? paramDeclSpecifierSeq (
 		(declarator | abstractDeclarator?) (
 			Assign initializerClause
 		)?
@@ -816,3 +821,4 @@ literal:
 	| BooleanLiteral
 	| PointerLiteral
 	| UserDefinedLiteral;
+	

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -364,21 +364,27 @@ typeSpecifierSeq: typeSpecifier+ attributeSpecifierSeq?;
 trailingTypeSpecifierSeq:
 	trailingTypeSpecifier+ attributeSpecifierSeq?;
 
+simpleTypeLengthModifier:
+	Short
+	| Long;
+	
+simpleTypeSignednessModifier:
+	Unsigned
+	| Signed;
+
 simpleTypeSpecifier:
 	nestedNameSpecifier? theTypeName
 	| nestedNameSpecifier Template simpleTemplateId
+	| simpleTypeSignednessModifier
+	| simpleTypeSignednessModifier? simpleTypeLengthModifier+
 	| Char
 	| Char16
 	| Char32
 	| Wchar
 	| Bool
-	| Short
-	| Int
-	| Long
-	| Signed
-	| Unsigned
+	| simpleTypeSignednessModifier? simpleTypeLengthModifier* Int
 	| Float
-	| Double
+	| simpleTypeLengthModifier? Double
 	| Void
 	| Auto
 	| decltypeSpecifier;


### PR DESCRIPTION
The parse tree was classifying variables as types.  CPP14Parser was using an overly broad rule that was intended for non-function prototype variable declarations.  Made a more limited rule for function/method prototypes.

I'm not 100% sure this covers all cases, but is an improvement from what it was doing previously.  There are some CPP parsing requirements I have on a project I am working on so it will be tested more.  But I think this at least gets us going down the right road.

I also noticed that some simple types are not being parsed correctly, for example, unsigned short, unsigned int, unsigned long long, for example.  I think I also have a fix for that, but it needs more testing and will do that as a separate commit.