### PR TITLE
T-SQL - Improves Parentheses Handling in table_source's

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3143,14 +3143,15 @@ table_sources
     : source+=table_source (',' source+=table_source)*
     ;
 
-// https://msdn.microsoft.com/en-us/library/ms177634.aspx
+// https://docs.microsoft.com/en-us/sql/t-sql/queries/from-transact-sql
 table_source
     : table_source_item_joined
-    | '(' table_source_item_joined ')'
+    | '(' table_source ')'
     ;
 
 table_source_item_joined
     : table_source_item joins+=join_part*
+    | '(' table_source_item_joined ')' joins+=join_part*
     ;
 
 table_source_item

--- a/sql/tsql/examples/dml_select.sql
+++ b/sql/tsql/examples/dml_select.sql
@@ -65,6 +65,12 @@ SELECT
 FROM [Production].[Product]
 GO
 
+-- Superfluous parentheses.
+-- Not 100% this matches Microsoft's grammar, but SQL Server 2019 parses it /shrug.
+SELECT * FROM ((A INNER JOIN B ON 1 = 1))
+SELECT * FROM (A INNER JOIN B ON 1 = 1) LEFT JOIN C ON 1 = 1
+SELECT * FROM ((A INNER JOIN B ON 1 = 1) LEFT JOIN C ON 1 = 1)
+
 --+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 -- Using SELECT with column headings and calculations
 


### PR DESCRIPTION
This pr improves handling of parentheses in table_source parsing.

The [grammar](https://docs.microsoft.com/en-us/sql/t-sql/queries/from-transact-sql) suggests these parentheses aren't valid (or that I'm blind). That said, SQL Server does parse these queries just fine, and Microsoft's Entity Framework generates these types of queries via Linq to SQL.