### PR TITLE
T-SQL - Restore Built-in Function Handling

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3277,8 +3277,8 @@ function_call
     : ranking_windowed_function                         #RANKING_WINDOWED_FUNC
     | aggregate_windowed_function                       #AGGREGATE_WINDOWED_FUNC
     | analytic_windowed_function                        #ANALYTIC_WINDOWED_FUNC
+    | built_in_functions                                #BUILT_IN_FUNC
     | scalar_function_name '(' expression_list? ')'     #SCALAR_FUNCTION
-    | build_in_functions                                #BUILT_IN_FUNC
     | freetext_function                                 #FREE_TEXT
     | partition_function                                #PARTITION_FUNC
     ;
@@ -3297,7 +3297,7 @@ freetext_predicate
     : CONTAINS '(' (full_column_name | '(' full_column_name (',' full_column_name)* ')' | '*' | PROPERTY '(' full_column_name ',' expression ')') ',' expression ')'
     | FREETEXT '(' table_name ',' (full_column_name | '(' full_column_name (',' full_column_name)* ')' | '*' ) ',' expression  (',' LANGUAGE expression)? ')'
     ;
-build_in_functions
+built_in_functions
     // https://msdn.microsoft.com/en-us/library/ms173784.aspx
     : BINARY_CHECKSUM '(' '*' ')'                       #BINARY_CHECKSUM
     // https://msdn.microsoft.com/en-us/library/hh231076.aspx


### PR DESCRIPTION
This pr restores the behavior of built-in functions before the regression introduced in 67d66f1e24474d4531f7bb1c4c29b57b93d9280b (and corrects the rule's name).

Given the example:

```sql
SELECT DATEADD(YEAR, 2, '2020/1/1')
```

The old grammar would produce this tree:

![image](https://user-images.githubusercontent.com/2753330/114738227-6637ca00-9d0d-11eb-88b8-fd907e554264.png)

After the order change, the following is produced:

![image](https://user-images.githubusercontent.com/2753330/114738017-2f61b400-9d0d-11eb-9171-bd194bc0d605.png)

Which corrects the handling of discriminators being parsed as database objects. 