### PR TITLE
Fix for 2171

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        language: [CSharp, Java, JavaScript, Go, Python3, Dart]
+        language: [CSharp, Java, Go, Python3, Dart]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
This is a fix for #2171. The Antlr 4.9.2 JavaScript runtime is unstable and should be disabled until the next release of the runtime. For a full explanation, see #2171.