### PR TITLE
TSQL: $action has been moved to expression for output_dml_list_elem.

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -1824,12 +1824,7 @@ output_clause
     ;
 
 output_dml_list_elem
-    : (output_column_name | expression) as_column_alias?  // TODO: scalar_expression
-    ;
-
-output_column_name
-    : (DELETED | INSERTED | table_name) '.' ('*' | id_)
-    | DOLLAR_ACTION
+    : (expression | asterisk) as_column_alias?
     ;
 
 // DDL
@@ -2895,6 +2890,7 @@ expression
     | expression op=('+' | '-' | '&' | '^' | '|' | '||') expression
     | expression time_zone
     | over_clause
+    | DOLLAR_ACTION
     ;
 
 time_zone
@@ -3091,6 +3087,7 @@ udt_method_arguments
 // https://docs.microsoft.com/ru-ru/sql/t-sql/queries/select-clause-transact-sql
 asterisk
     : (table_name '.')? '*'
+    | (INSERTED | DELETED) '.' '*'
     ;
 
 column_elem
@@ -3589,7 +3586,8 @@ ddl_object
     ;
 
 full_column_name
-    : server=id_? '.' schema=id_? '.' tablename=id_? '.' column_name=id_
+    : (DELETED | INSERTED) '.' column_name=id_
+    | server=id_? '.' schema=id_? '.' tablename=id_? '.' column_name=id_
     | schema=id_? '.' tablename=id_? '.' column_name=id_
     | tablename=id_? '.' column_name=id_
     | column_name=id_

--- a/sql/tsql/examples/dml_merge.sql
+++ b/sql/tsql/examples/dml_merge.sql
@@ -9,4 +9,10 @@ WHEN MATCHED THEN
 WHEN NOT MATCHED THEN
 INSERT (UnitMeasureCode, Name)
 VALUES (src.UnitMeasureCode, src.Name)
-OUTPUT deleted.*, $action, inserted.* INTO #MyTempTable;
+OUTPUT deleted.*,
+       $action,
+       inserted.*,
+       CASE WHEN $action = 'INSERT' THEN 1 ELSE 0 END,
+       IIF($action = 'DELETE', 1, 0),
+       inserted.UnitMeasureCode
+INTO #MyTempTable;


### PR DESCRIPTION
`$action` has been moved to `expression`:
```sql
MERGE Production.UnitMeasure AS target
USING (SELECT @UnitMeasureCode, @Name) AS src (UnitMeasureCode, Name)
ON (target.UnitMeasureCode = src.UnitMeasureCode)
WHEN MATCHED THEN
    UPDATE SET Name = src.Name
WHEN NOT MATCHED THEN
INSERT (UnitMeasureCode, Name)
VALUES (src.UnitMeasureCode, src.Name)
OUTPUT deleted.*,
       $action,
       inserted.*,
       CASE WHEN $action = 'INSERT' THEN 1 ELSE 0 END,
       IIF($action = 'DELETE', 1, 0),
       inserted.UnitMeasureCode
INTO #MyTempTable;
```