### PR TITLE
Swift 5 grammar

### DIFF
--- a/_scripts/skip-cpp.txt
+++ b/_scripts/skip-cpp.txt
@@ -1,2 +1,3 @@
 kirikiri-tjs
 clif
+swift/swift5

--- a/_scripts/skip-csharp.txt
+++ b/_scripts/skip-csharp.txt
@@ -36,6 +36,7 @@ stringtemplate
 swift-fin
 swift/swift2
 swift/swift3
+swift/swift5
 tcpheader
 thrift
 v

--- a/_scripts/skip-dart.txt
+++ b/_scripts/skip-dart.txt
@@ -51,6 +51,7 @@ stringtemplate
 swift-fin
 swift/swift2
 swift/swift3
+swift/swift5
 tcpheader
 thrift
 tinymud

--- a/_scripts/skip-go.txt
+++ b/_scripts/skip-go.txt
@@ -73,6 +73,7 @@ stringtemplate
 swift-fin
 swift/swift2
 swift/swift3
+swift/swift5
 tcpheader
 terraform
 tinymud

--- a/_scripts/skip-javascript.txt
+++ b/_scripts/skip-javascript.txt
@@ -56,6 +56,7 @@ stringtemplate
 swift-fin
 swift/swift2
 swift/swift3
+swift/swift5
 tcpheader
 thrift
 v

--- a/_scripts/skip-python3.txt
+++ b/_scripts/skip-python3.txt
@@ -95,6 +95,7 @@ stringtemplate
 swift-fin
 swift/swift2
 swift/swift3
+swift/swift5
 tcpheader
 terraform
 tinyc

--- a/swift/pom.xml
+++ b/swift/pom.xml
@@ -14,5 +14,6 @@
 	<modules>
 		<module>swift2</module>
 		<module>swift3</module>
+		<module>swift5</module>
 	</modules>
 </project>

--- a/swift/swift5/README.md
+++ b/swift/swift5/README.md
@@ -1,0 +1,69 @@
+# Swift 5
+
+An ANTLR4 grammar for Swift 5 (Swift 5.4).
+
+Based on:
+
+* [Official documentation](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/zzSummaryOfTheGrammar.html) (it is incomplete)
+* [Source code of swift compiler](https://github.com/apple/swift)
+* [ANTLR4 grammar for Swift 3](https://github.com/antlr/grammars-v4/tree/master/swift/swift3)
+* Actual behavior
+
+Notes:
+
+* Official documentation is incomplete
+
+Known issues and limitations:
+
+* Does not work exactly as swift compiler, but designed to support pure Swift 5.4 syntax
+* Contains workarounds for context dependent rules and mutually left-recursive rules, so the grammar can be changed (at the moment this line is written, there is a `statements_impl` rule and a `inner_postfix_expression` rule)
+* It is not yet used on large projects
+* It is not well tested yet
+* It can contain ambiguities or wrong rules
+
+About ambiguities, official documentation and aforementioned `statements_impl`.
+It can not tell the difference between this:
+
+```Swift
+func x() -> Int { return 1 }
+let y = x()
+print(y) // prints "1"
+```
+
+and this:
+
+```Swift
+func x() -> Int { return 1 }
+let y = x
+()
+print(y) // prints "(Function)"
+```
+
+Yes, it is somehow documented, but it is not a part of grammar.
+
+If you want to contribute, please test the grammar carefully on the source 
+code of Swift itself. See below.
+
+## Contributing
+
+### Making non-breaking changes
+
+How-to:
+
+* Clone this repo
+* Ensure you have maven installed
+* `cd grammars-v4/swift5`
+* `mvn test`
+* It will test the grammar with your changes.
+
+If something goes wrong you can debug it.
+
+Go to this folder:
+
+* `cd grammars-v4/swift3/target/classes/`
+
+Use one of the following commands (requires grun):
+
+* `grun Swift5 top_level -gui -tree path/to/file.swift`
+* `grun Swift5 the_rule_you_are_working_on -gui -tree path/to/file.swift`
+* `grun Swift5 start -tokens path/to/file.swift`

--- a/swift/swift5/Swift5.g4
+++ b/swift/swift5/Swift5.g4
@@ -1,0 +1,1372 @@
+grammar Swift5;
+
+top_level: statements? EOF;
+
+// Statements
+statement:
+	(
+		expression
+		| declaration
+		| loop_statement
+		| branch_statement
+		| labeled_statement
+		| control_transfer_statement
+		| defer_statement
+		| do_statement
+	) ';'?
+	| compiler_control_statement;
+
+statements: statements_impl[-1];
+
+statements_impl[int indexBefore]
+	locals[int indexAfter = -1]:
+	{SwiftSupport.isSeparatedStatement(_input, $indexBefore)}? statement {$indexAfter = _input.index();} statements_impl
+		[$indexAfter]?;
+
+// Loop Statements
+loop_statement: for_in_statement | while_statement | repeat_while_statement;
+
+// For-In Statement
+for_in_statement:
+	'for' 'case'? pattern 'in' expression where_clause? code_block;
+
+// While Statement
+while_statement: 'while' condition_list code_block;
+
+condition_list: condition (',' condition)*;
+
+condition:
+	expression
+	| availability_condition
+	| case_condition
+	| optional_binding_condition;
+
+case_condition: 'case' pattern initializer;
+
+optional_binding_condition: ('let' | 'var') pattern initializer;
+
+// Repeat-While Statement
+repeat_while_statement: 'repeat' code_block 'while' expression;
+
+// Branch Statements
+branch_statement: if_statement | guard_statement | switch_statement;
+
+// If Statement
+if_statement: 'if' condition_list code_block else_clause?;
+else_clause: 'else' code_block | 'else' if_statement;
+
+// Guard Statement
+guard_statement: 'guard' condition_list 'else' code_block;
+
+// Switch Statement
+switch_statement: 'switch' expression '{' switch_cases? '}';
+switch_cases: switch_case switch_cases?;
+switch_case: (case_label | default_label) statements
+	| conditional_switch_case;
+case_label: attributes? 'case' case_item_list ':';
+case_item_list: pattern where_clause? (',' pattern where_clause?)*;
+default_label: attributes? 'default' ':';
+where_clause: 'where' where_expression;
+where_expression: expression;
+conditional_switch_case:
+	switch_if_directive_clause switch_elseif_directive_clauses? switch_else_directive_clause? endif_directive;
+switch_if_directive_clause: if_directive compilation_condition switch_cases?;
+switch_elseif_directive_clauses:
+	elseif_directive_clause switch_elseif_directive_clauses?;
+switch_elseif_directive_clause:
+	elseif_directive compilation_condition switch_cases?;
+switch_else_directive_clause: else_directive switch_cases?;
+
+// Labeled Statement
+labeled_statement:
+	statement_label (
+		loop_statement
+		| if_statement
+		| switch_statement
+		| do_statement
+	);
+
+statement_label: label_name ':';
+label_name: identifier;
+
+// Control Transfer Statements
+control_transfer_statement:
+	break_statement
+	| continue_statement
+	| fallthrough_statement
+	| return_statement
+	| throw_statement;
+
+// Break Statement
+break_statement: 'break' label_name?;
+
+// Continue Statement
+continue_statement: 'continue' label_name?;
+
+// Fallthrough Statement
+fallthrough_statement: 'fallthrough';
+
+// Return Statement
+return_statement: 'return' expression?;
+
+// Throw Statement
+throw_statement: 'throw' expression;
+
+// Defer Statement
+defer_statement: 'defer' code_block;
+
+// Do Statement
+do_statement: 'do' code_block catch_clauses?;
+catch_clauses: catch_clause+;
+catch_clause: 'catch' catch_pattern_list? code_block;
+catch_pattern_list: catch_pattern (catch_pattern ',' catch_pattern)*;
+catch_pattern: pattern where_clause?;
+
+// Compiler Control Statements
+compiler_control_statement:
+	conditional_compilation_block
+	| line_control_statement
+	| diagnostic_statement;
+
+// Conditional Compilation Block
+conditional_compilation_block:
+	if_directive_clause elseif_directive_clauses? else_directive_clause? endif_directive;
+
+if_directive_clause: if_directive compilation_condition statements?;
+
+elseif_directive_clauses: elseif_directive_clause+;
+elseif_directive_clause: elseif_directive compilation_condition statements?;
+else_directive_clause: else_directive statements?;
+
+if_directive: '#if';
+elseif_directive: '#elseif';
+else_directive: '#else';
+endif_directive: '#endif';
+
+compilation_condition:
+	platform_condition
+	| identifier
+	| boolean_literal
+	| '(' compilation_condition ')'
+	| '!' compilation_condition
+	| compilation_condition (
+		compilation_condition_AND
+		| compilation_condition_OR
+	) compilation_condition;
+
+platform_condition:
+	'os' '(' operating_system ')'
+	| 'arch' '(' architecture ')'
+	| ('swift' | 'compiler') '(' (
+		compilation_condition_GE
+		| compilation_condition_L
+	) swift_version ')'
+	| 'canImport' '(' module_name ')'
+	| 'targetEnvironment' '(' environment ')';
+
+swift_version: Decimal_digits swift_version_continuation?;
+swift_version_continuation: '.' Decimal_digits swift_version_continuation?;
+
+operating_system: 'macOS' | 'iOS' | 'watchOS' | 'tvOS' | 'Linux' | 'Windows';
+architecture: 'i386' | 'x86_64' | 'arm' | 'arm64';
+
+module_name: identifier;
+environment: 'simulator' | 'macCatalyst';
+
+// Line Control Statement
+line_control_statement:
+	'#sourceLocation' '(' ('file' ':' file_name ',' 'line' ':' line_number)? ')';
+
+line_number: Decimal_literal; // TODO: A decimal integer greater than zero
+file_name: Static_string_literal;
+
+// Compile-Time Diagnostic Statement
+diagnostic_statement: ('#error' | '#warning') '(' diagnostic_message ')';
+
+diagnostic_message: Static_string_literal;
+
+// Availability Condition
+availability_condition: '#available' '(' availability_arguments ')';
+
+availability_arguments: availability_argument (',' availability_argument)*;
+
+availability_argument: Platform_name Platform_version | '*';
+
+fragment Platform_name:
+	'iOS'
+	| 'iOSApplicationExtension'
+	| 'macOS'
+	| 'macOSApplicationExtension'
+	| 'macCatalyst'
+	| 'macCatalystApplicationExtension'
+	| 'watchOS'
+	| 'tvOS';
+
+fragment Platform_version:
+	Decimal_digits
+	| Decimal_digits '.' Decimal_digits
+	| Decimal_digits '.' Decimal_digits '.' Decimal_digits;
+
+// Generic Parameter Clause
+generic_parameter_clause: '<' generic_parameter_list '>';
+generic_parameter_list: generic_parameter (',' generic_parameter)*;
+generic_parameter:
+	type_name (':' (type_identifier | protocol_composition_type))?;
+
+generic_where_clause: 'where' requirement_list;
+requirement_list: requirement (',' requirement)*;
+requirement: conformance_requirement | same_type_requirement;
+
+conformance_requirement:
+	type_identifier ':' (type_identifier | protocol_composition_type);
+same_type_requirement:
+	type_identifier same_type_equals (type_identifier | type);
+
+// Generic Argument Clause
+generic_argument_clause: '<' generic_argument_list '>';
+generic_argument_list: generic_argument (',' generic_argument)*;
+generic_argument: type;
+
+// Declarations
+declaration:
+	import_declaration
+	| constant_declaration
+	| variable_declaration
+	| typealias_declaration
+	| function_declaration
+	| enum_declaration
+	| struct_declaration
+	| class_declaration
+	| protocol_declaration
+	| initializer_declaration
+	| deinitializer_declaration
+	| extension_declaration
+	| subscript_declaration
+	| operator_declaration
+	| precedence_group_declaration;
+
+declarations: declaration+;
+
+// Top-Level Code
+top_level_declaration: statements?;
+
+// Code Blocks
+code_block: '{' statements? '}';
+
+// Import Declaration
+import_declaration: attributes? 'import' import_kind? import_path;
+import_kind:
+	'typealias'
+	| 'struct'
+	| 'class'
+	| 'enum'
+	| 'protocol'
+	| 'let'
+	| 'var'
+	| 'func';
+import_path: import_path_identifier ('.' import_path_identifier)*;
+import_path_identifier: identifier | operator;
+
+// Constant Declaration
+constant_declaration:
+	attributes? declaration_modifiers? 'let' pattern_initializer_list;
+pattern_initializer_list: pattern_initializer (',' pattern_initializer)*;
+pattern_initializer: pattern initializer?;
+initializer: '=' expression;
+
+// Variable Declaration
+variable_declaration:
+	variable_declaration_head (
+		pattern_initializer_list
+		| variable_name (
+			initializer willSet_didSet_block
+			| type_annotation (
+				code_block
+				| (
+					getter_setter_block
+					| getter_setter_keyword_block
+					| initializer? willSet_didSet_block
+				)
+			)
+		)
+	);
+
+variable_declaration_head: attributes? declaration_modifiers? 'var';
+variable_name: identifier;
+
+getter_setter_block:
+	'{' (getter_clause setter_clause? | setter_clause getter_clause) '}'
+	| code_block;
+getter_clause: attributes? mutation_modifier? 'get' code_block;
+setter_clause: attributes? mutation_modifier? 'set' setter_name? code_block;
+setter_name: '(' identifier ')';
+
+getter_setter_keyword_block:
+	'{' (
+		getter_keyword_clause setter_keyword_clause?
+		| setter_keyword_clause getter_keyword_clause
+	) '}';
+getter_keyword_clause: attributes? mutation_modifier? 'get';
+setter_keyword_clause: attributes? mutation_modifier? 'set';
+
+willSet_didSet_block:
+	'{' (willSet_clause didSet_clause? | didSet_clause willSet_clause?) '}';
+willSet_clause: attributes? 'willSet' setter_name? code_block;
+didSet_clause: attributes? 'didSet' setter_name? code_block;
+
+// Type Alias Declaration
+typealias_declaration:
+	attributes? access_level_modifier? 'typealias' typealias_name generic_parameter_clause? typealias_assignment;
+typealias_name: identifier;
+typealias_assignment: type;
+
+// Function Declaration
+function_declaration:
+	function_head function_name generic_parameter_clause? function_signature generic_where_clause? function_body?;
+
+function_head: attributes? declaration_modifiers? 'func';
+
+function_name: identifier | operator;
+
+function_signature:
+	parameter_clause ('throws'? | 'rethrows') function_result?;
+
+function_result: arrow_operator attributes? type;
+
+function_body: code_block;
+
+parameter_clause: '(' parameter_list? ')';
+parameter_list: parameter (',' parameter)*;
+
+parameter:
+	external_parameter_name? local_parameter_name type_annotation (
+		default_argument_clause?
+		| range_operator
+	);
+external_parameter_name: identifier;
+local_parameter_name: identifier;
+default_argument_clause: '=' expression;
+
+// Enumeration Declaration
+enum_declaration:
+	attributes? access_level_modifier? union_style_enum
+	| raw_value_style_enum;
+
+union_style_enum:
+	'indirect'? 'enum' enum_name generic_parameter_clause? type_inheritance_clause? generic_where_clause? '{'
+		union_style_enum_members? '}';
+
+union_style_enum_members: union_style_enum_member+;
+
+union_style_enum_member:
+	declaration
+	| union_style_enum_case_clause
+	| compiler_control_statement;
+
+union_style_enum_case_clause:
+	attributes? 'indirect'? 'case' union_style_enum_case_list;
+
+union_style_enum_case_list:
+	union_style_enum_case (',' union_style_enum_case)*;
+
+union_style_enum_case:
+	opaque_type
+	| enum_case_name (tuple_type | '(' type ')')?;
+
+enum_name: identifier;
+
+enum_case_name: identifier;
+
+raw_value_style_enum:
+	'enum' enum_name generic_parameter_clause? type_inheritance_clause generic_where_clause? '{'
+		raw_value_style_enum_members '}';
+
+raw_value_style_enum_members: raw_value_style_enum_member+;
+
+raw_value_style_enum_member:
+	declaration
+	| raw_value_style_enum_case_clause
+	| compiler_control_statement;
+
+raw_value_style_enum_case_clause:
+	attributes? 'case' raw_value_style_enum_case_list;
+
+raw_value_style_enum_case_list:
+	raw_value_style_enum_case (',' raw_value_style_enum_case)*;
+
+raw_value_style_enum_case: enum_case_name raw_value_assignment?;
+
+raw_value_assignment: '=' raw_value_literal;
+
+raw_value_literal: numeric_literal | Static_string_literal | boolean_literal;
+
+// Structure Declaration
+struct_declaration:
+	attributes? access_level_modifier? 'struct' struct_name generic_parameter_clause? type_inheritance_clause?
+		generic_where_clause? struct_body;
+struct_name: identifier;
+struct_body: '{' struct_members? '}';
+struct_members: struct_member+;
+struct_member: declaration | compiler_control_statement;
+
+// Class Declaration
+class_declaration:
+	attributes? access_level_modifier? 'final'? 'class' class_name generic_parameter_clause? type_inheritance_clause?
+		generic_where_clause? class_body
+	| attributes? 'final' access_level_modifier? 'class' class_name generic_parameter_clause? type_inheritance_clause?
+		generic_where_clause? class_body;
+class_name: identifier;
+class_body: '{' class_members '}';
+class_members: class_member+;
+class_member: declaration | compiler_control_statement;
+
+// Protocol Declaration
+protocol_declaration:
+	attributes? access_level_modifier? 'protocol' protocol_name type_inheritance_clause? generic_where_clause?
+		protocol_body;
+protocol_name: identifier;
+protocol_body: '{' protocol_members? '}';
+protocol_members: protocol_member+;
+
+protocol_member: protocol_member_declaration | compiler_control_statement;
+
+protocol_member_declaration:
+	protocol_property_declaration
+	| protocol_method_declaration
+	| protocol_initializer_declaration
+	| protocol_subscript_declaration
+	| protocol_associated_type_declaration
+	| typealias_declaration;
+
+// Protocol Property Declaration
+protocol_property_declaration:
+	variable_declaration_head variable_name type_annotation getter_setter_keyword_block;
+
+// Protocol Method Declaration
+protocol_method_declaration:
+	function_head function_name generic_parameter_clause? function_signature generic_where_clause?;
+
+// Protocol Initializer Declaration
+protocol_initializer_declaration:
+	initializer_head generic_parameter_clause? parameter_clause (
+		'throws'?
+		| 'rethrows'
+	) generic_where_clause?;
+
+// Protocol Subscript Declaration
+protocol_subscript_declaration:
+	subscript_head subscript_result generic_where_clause? getter_setter_keyword_block;
+
+// Protocol Associated Type Declaration
+protocol_associated_type_declaration:
+	attributes? access_level_modifier? 'associatedtype' typealias_name type_inheritance_clause? typealias_assignment?
+		generic_where_clause?;
+
+// Initializer Declaration
+initializer_declaration:
+	initializer_head generic_parameter_clause? parameter_clause (
+		'throws'
+		| 'rethrows'
+	)? generic_where_clause? initializer_body;
+
+initializer_head: attributes? declaration_modifiers? 'init' ('?' | '!')?;
+
+initializer_body: code_block;
+
+// Deinitializer Declaration
+deinitializer_declaration: attributes? 'deinit' code_block;
+
+// Extension Declaration
+extension_declaration:
+	attributes? access_level_modifier? 'extension' type_identifier type_inheritance_clause? generic_where_clause?
+		extension_body;
+extension_body: '{' extension_members '}';
+extension_members: extension_member+;
+extension_member: declaration | compiler_control_statement;
+
+// Subscript Declaration
+subscript_declaration:
+	subscript_head subscript_result generic_where_clause? (
+		code_block
+		| getter_setter_block
+		| getter_setter_keyword_block
+	);
+
+subscript_head:
+	attributes? declaration_modifiers? 'subscript' generic_parameter_clause? parameter_clause;
+subscript_result: arrow_operator attributes? type;
+
+// Operator Declaration
+operator_declaration:
+	prefix_operator_declaration
+	| postfix_operator_declaration
+	| infix_operator_declaration;
+
+prefix_operator_declaration: 'prefix' 'operator' operator;
+postfix_operator_declaration: 'postfix' 'operator' operator;
+infix_operator_declaration: 'infix' 'operator' operator infix_operator_group?;
+
+infix_operator_group: ':' precedence_group_name;
+
+// Precedence Group Declaration
+precedence_group_declaration:
+	'precedencegroup' precedence_group_name '{' precedence_group_attributes? '}';
+precedence_group_attributes: precedence_group_attribute+;
+
+precedence_group_attribute:
+	precedence_group_relation
+	| precedence_group_assignment
+	| precedence_group_associativity;
+
+precedence_group_relation:
+	('higherThan' | 'lowerThan') ':' precedence_group_names;
+
+precedence_group_assignment: 'assignment' ':' boolean_literal;
+
+precedence_group_associativity:
+	'associativity' ':' ('left' | 'right' | 'none');
+
+precedence_group_names: precedence_group_name (',' precedence_group_name)*;
+precedence_group_name: identifier;
+
+// Declaration Modifiers
+declaration_modifier:
+	'class'
+	| 'convenience'
+	| 'dynamic'
+	| 'final'
+	| 'infix'
+	| 'lazy'
+	| 'optional'
+	| 'override'
+	| 'postfix'
+	| 'prefix'
+	| 'required'
+	| 'static'
+	| 'unowned' ('(' ('safe' | 'unsafe') ')')?
+	| 'weak'
+	| access_level_modifier
+	| mutation_modifier;
+
+declaration_modifiers: declaration_modifier+;
+
+access_level_modifier:
+	('private' | 'fileprivate' | 'internal' | 'public' | 'open') (
+		'(' 'set' ')'
+	)?;
+
+mutation_modifier: 'mutating' | 'nonmutating';
+
+// Patterns 
+
+//The following sets of rules are mutually left-recursive [pattern, Type-Casting], to avoid this they were integrated into the same rule.
+pattern:
+	(wildcard_pattern | identifier_pattern | tuple_pattern) type_annotation?
+	| value_binding_pattern
+	| enum_case_pattern
+	| optional_pattern
+	| 'is' type
+	| pattern 'as' type
+	| expression_pattern;
+
+// Wildcard Pattern
+wildcard_pattern: '_';
+
+// identifier Pattern
+identifier_pattern: identifier;
+
+// Value-Binding Pattern
+value_binding_pattern: 'var' pattern | 'let' pattern;
+
+// Tuple Pattern
+tuple_pattern: '(' tuple_pattern_element_list? ')';
+tuple_pattern_element_list:
+	tuple_pattern_element (',' tuple_pattern_element)*;
+tuple_pattern_element: (identifier ':')? pattern;
+
+// Enumeration Case Pattern 
+enum_case_pattern: type_identifier? '.' enum_case_name tuple_pattern?;
+
+// Optional Pattern
+optional_pattern: identifier_pattern '?';
+
+// Expression Pattern
+expression_pattern: expression;
+
+// Attributes
+attribute: '@' attribute_name attribute_argument_clause?;
+attribute_name: identifier;
+attribute_argument_clause: '(' balanced_tokens? ')';
+attributes: attribute+;
+balanced_tokens: balanced_token+;
+
+balanced_token:
+	'(' balanced_tokens? ')'
+	| '[' balanced_tokens? ']'
+	| '{' balanced_tokens? '}'
+	//Any identifier, keyword, literal, or operator Any punctuation except (, ), [, ], {, or }
+	| identifier
+	| Keyword
+	| literal
+	| operator
+	| balanced_token_punctuation;
+
+balanced_token_punctuation:
+	('.' | ',' | ':' | ';' | '=' | '@' | '#' | '`' | '?')
+	| arrow_operator
+	| {SwiftSupport.isPrefixOp(_input)}? '&'
+	| {SwiftSupport.isPostfixOp(_input)}? '!';
+
+// Expressions
+expression: try_operator? prefix_expression binary_expressions?;
+
+expression_list: expression (',' expression)*;
+
+// Prefix Expressions
+prefix_expression: prefix_operator? postfix_expression | in_out_expression;
+
+in_out_expression: '&' identifier;
+
+// Try Operator
+try_operator: 'try' '?' | 'try' '!' | 'try';
+
+// Binary Expressions
+binary_expression:
+	binary_operator prefix_expression
+	| (assignment_operator | conditional_operator) try_operator? prefix_expression
+	| type_casting_operator;
+
+binary_expressions: binary_expression+;
+
+// Conditional Operator
+conditional_operator: '?' expression ':';
+
+// Ternary Conditional Operator
+type_casting_operator: ('is' | 'as' ( '?' | '!')?) type;
+
+// Primary Expressions
+primary_expression:
+	identifier generic_argument_clause?
+	| literal_expression
+	| self_expression
+	| superclass_expression
+	| closure_expression
+	| parenthesized_expression
+	| tuple_expression
+	| implicit_member_expression
+	| wildcard_expression
+	| key_path_expression
+	| selector_expression
+	| key_path_string_expression;
+
+// Literal Expression
+literal_expression:
+	literal
+	| array_literal
+	| dictionary_literal
+	| playground_literal
+	| '#file'
+	| '#fileID'
+	| '#filePath'
+	| '#line'
+	| '#column'
+	| '#function'
+	| '#dsohandle';
+
+array_literal: '[' array_literal_items? ']';
+
+array_literal_items: array_literal_item (',' array_literal_item)* ','?;
+
+array_literal_item: expression;
+
+dictionary_literal: '[' (dictionary_literal_items | ':') ']';
+
+dictionary_literal_items:
+	dictionary_literal_item (',' dictionary_literal_item)* ','?;
+
+dictionary_literal_item: expression ':' expression;
+
+playground_literal:
+	'#colorLiteral' '(' 'red' ':' expression ',' 'green' ':' expression ',' 'blue' ':' expression ',' 'alpha' ':'
+		expression ')'
+	| '#fileLiteral' '(' 'resourceName' ':' expression ')'
+	| '#imageLiteral' '(' 'resourceName' ':' expression ')';
+
+// Self Expression
+self_expression:
+	'self'
+	| self_method_expression
+	| self_subscript_expression
+	| self_initializer_expression;
+
+self_method_expression: 'self' '.' identifier;
+
+self_subscript_expression: 'self' '[' function_call_argument_list ']';
+
+self_initializer_expression: 'self' '.' 'init';
+
+// Superclass Expression
+superclass_expression:
+	superclass_method_expression
+	| superclass_subscript_expression
+	| superclass_initializer_expression;
+
+superclass_method_expression: 'super' '.' identifier;
+superclass_subscript_expression: 'super' '[' function_call_argument_list ']';
+superclass_initializer_expression: 'super' '.' 'init';
+
+// Capture Lists
+closure_expression: '{' closure_signature? statements? '}';
+
+closure_signature:
+	capture_list? closure_parameter_clause 'throws'? function_result? 'in'
+	| capture_list 'in';
+
+closure_parameter_clause: '(' closure_parameter_list? ')' | identifier_list;
+
+closure_parameter_list: closure_parameter (',' closure_parameter)*;
+
+closure_parameter: closure_parameter_name (type_annotation range_operator?)?;
+
+closure_parameter_name: identifier;
+
+capture_list: '[' capture_list_items ']';
+
+capture_list_items: capture_list_item (',' capture_list_item)*;
+
+capture_list_item: capture_specifier? expression;
+
+capture_specifier: 'weak' | 'unowned' | 'unowned(safe)' | 'unowned(unsafe)';
+
+// Implicit Member Expression
+implicit_member_expression:
+	'.' identifier; // let a: MyType = .default; static let `default` = MyType()
+
+// Parenthesized Expression
+parenthesized_expression: '(' expression ')';
+
+// Tuple Expression
+tuple_expression: '(' ')' | '(' tuple_element ',' tuple_element_list ')';
+
+tuple_element_list: tuple_element (',' tuple_element)*;
+
+tuple_element: expression | identifier ':' expression;
+
+// Wildcard Expression
+wildcard_expression: '_';
+
+// Key-Path Expression
+key_path_expression: '\\' type? '.' key_path_components;
+key_path_components: key_path_component ('.' key_path_component)*;
+key_path_component: identifier key_path_postfixes? | key_path_postfixes;
+key_path_postfixes: key_path_postfix+;
+key_path_postfix: '?' | '!' | 'self' | '[' function_call_argument_list ']';
+
+// Selector Expression
+selector_expression: '#selector' '(' ('getter:' | 'setter:')? expression ')';
+
+// Key-Path String Expression
+key_path_string_expression: '#keyPath' '(' expression ')';
+
+// Postfix Expressions
+
+//The following sets of rules are mutually left-recursive [postfix_expression, function_call_expression,
+// initializer_expression, explicit_member_expression, postfix_self_expression, subscript_expression,
+// forced_value_expression, optional_chaining_expression], to avoid this the rule inner_postfix_expression was
+// implemented.
+postfix_expression:
+	postfix_expression postfix_operator
+	| function_call_expression
+	| initializer_expression
+	| explicit_member_expression
+	| postfix_self_expression
+	| subscript_expression
+	| forced_value_expression
+	| optional_chaining_expression
+	| primary_expression;
+
+inner_postfix_expression:
+	function_call_argument_clause
+	| function_call_argument_clause? trailing_closures
+	| '.' (
+		'init' ('(' argument_names ')')?
+		| Decimal_digits
+		| identifier (generic_argument_clause | '(' argument_names ')')?
+		| 'self'
+	)
+	| '[' function_call_argument_list ']'
+	| '!'
+	| '?';
+
+// Function Call Expression
+function_call_expression:
+	primary_expression inner_postfix_expression* (
+		function_call_argument_clause
+		| function_call_argument_clause? trailing_closures
+	);
+
+function_call_argument_clause: '(' function_call_argument_list? ')';
+
+function_call_argument_list:
+	function_call_argument (',' function_call_argument)*;
+
+function_call_argument:
+	expression
+	| identifier ':' (expression | operator)
+	| operator;
+
+trailing_closures: closure_expression labeled_trailing_closures?;
+
+labeled_trailing_closures: labeled_trailing_closure+;
+
+labeled_trailing_closure: identifier ':' closure_expression;
+
+// Initializer Expression 
+initializer_expression:
+	primary_expression inner_postfix_expression* '.' 'init' (
+		'(' argument_names ')'
+	)?;
+
+// Explicit Member Expression
+explicit_member_expression:
+	primary_expression inner_postfix_expression* '.' (
+		Decimal_digits
+		| identifier (generic_argument_clause | '(' argument_names ')')?
+	);
+
+argument_names: argument_name+;
+argument_name: identifier ':';
+
+// Postfix Self Expression
+postfix_self_expression:
+	primary_expression inner_postfix_expression* '.' 'self';
+
+// Subscript Expression
+subscript_expression:
+	primary_expression inner_postfix_expression* '[' function_call_argument_list ']';
+
+// Forced-Value Expression
+forced_value_expression: primary_expression inner_postfix_expression* '!';
+
+// Optional-Chaining Expression
+optional_chaining_expression:
+	primary_expression inner_postfix_expression* '?';
+
+// Types
+
+// The following sets of rules are mutually left-recursive [type, optional_type, implicitly_unwrapped_optional_type, metatype_type], to avoid this they were integrated into the same rule.
+type:
+	function_type
+	| array_type
+	| dictionary_type
+	| type_identifier
+	| tuple_type
+	| protocol_composition_type
+	| opaque_type
+	| type (
+		'?' //optional_type
+		| '!' //implicitly_unwrapped_optional_type
+		| '.' 'Type'
+		| '.' 'Protocol'
+	) //metatype_type
+	| any_type
+	| self_type
+	| '(' type ')';
+
+// Type Annotation
+type_annotation: ':' attributes? 'inout'? type;
+
+// Type identifier
+type_identifier: type_name generic_argument_clause? ('.' type_identifier)?;
+
+type_name: identifier;
+
+// Tuple Type
+tuple_type: '(' tuple_type_element_list? ')';
+tuple_type_element_list: tuple_type_element (',' tuple_type_element)+;
+tuple_type_element: element_name type_annotation | type;
+element_name: identifier;
+
+// Function Type
+function_type:
+	attributes? function_type_argument_clause 'throws'? arrow_operator type;
+
+function_type_argument_clause:
+	'(' (function_type_argument_list range_operator?)? ')';
+
+function_type_argument_list:
+	function_type_argument (',' function_type_argument)*;
+
+function_type_argument:
+	attributes? 'inout'? type
+	| argument_label type_annotation;
+
+argument_label: identifier;
+
+// Array Type
+array_type: '[' type ']';
+
+// Dictionary Type
+dictionary_type: '[' type ':' type ']';
+
+// Protocol Composition Type
+protocol_composition_type:
+	type_identifier '&' protocol_composition_continuation;
+protocol_composition_continuation:
+	type_identifier
+	| protocol_composition_type;
+
+// Opaque Type
+opaque_type: 'some' type;
+
+// Any Type
+any_type: 'Any';
+
+// Self Type
+self_type: 'Self';
+
+// Type Inheritance Clause
+type_inheritance_clause: ':' type_inheritance_list;
+
+type_inheritance_list: type_identifier (',' type_identifier)*;
+
+// Identifiers
+identifier:
+	(
+		'Linux'
+		| 'Windows'
+		| 'alpha'
+		| 'arch'
+		| 'arm'
+		| 'arm64'
+		| 'assignment'
+		| 'blue'
+		| 'canImport'
+		| 'compiler'
+		| 'file'
+		| 'green'
+		| 'higherThan'
+		| 'i386'
+		| 'iOS'
+		| 'iOSApplicationExtension'
+		| 'line'
+		| 'lowerThan'
+		| 'macCatalyst'
+		| 'macCatalystApplicationExtension'
+		| 'macOS'
+		| 'macOSApplicationExtension'
+		| 'os'
+		| 'precedencegroup'
+		| 'red'
+		| 'resourceName'
+		| 'safe'
+		| 'simulator'
+		| 'some'
+		| 'swift'
+		| 'targetEnvironment'
+		| 'tvOS'
+		| 'u'
+		| 'unsafe'
+		| 'watchOS'
+		| 'x86_64'
+
+		// Keywords reserved in particular contexts
+		| 'associativity'
+		| 'convenience'
+		| 'dynamic'
+		| 'didSet'
+		| 'final'
+		| 'get'
+		| 'infix'
+		| 'indirect'
+		| 'lazy'
+		| 'left'
+		| 'mutating'
+		| 'none'
+		| 'nonmutating'
+		| 'optional'
+		| 'override'
+		| 'postfix'
+		| 'precedence'
+		| 'prefix'
+		| 'Protocol'
+		| 'required'
+		| 'right'
+		| 'set'
+		| 'Type'
+		| 'unowned'
+		| 'weak'
+		| 'willSet'
+	)
+	| Identifier;
+
+Identifier:
+	Identifier_head Identifier_characters?
+	| '`' (Keyword | Identifier_head Identifier_characters?) '`'
+	| Implicit_parameter_name
+	| Property_wrapper_projection;
+
+identifier_list: identifier | (',' identifier);
+
+fragment Identifier_head:
+	[a-zA-Z]
+	| '_'
+	| '\u00A8'
+	| '\u00AA'
+	| '\u00AD'
+	| '\u00AF'
+	| [\u00B2-\u00B5]
+	| [\u00B7-\u00BA]
+	| [\u00BC-\u00BE]
+	| [\u00C0-\u00D6]
+	| [\u00D8-\u00F6]
+	| [\u00F8-\u00FF]
+	| [\u0100-\u02FF]
+	| [\u0370-\u167F]
+	| [\u1681-\u180D]
+	| [\u180F-\u1DBF]
+	| [\u1E00-\u1FFF]
+	| [\u200B-\u200D]
+	| [\u202A-\u202E]
+	| [\u203F-\u2040]
+	| '\u2054'
+	| [\u2060-\u206F]
+	| [\u2070-\u20CF]
+	| [\u2100-\u218F]
+	| [\u2460-\u24FF]
+	| [\u2776-\u2793]
+	| [\u2C00-\u2DFF]
+	| [\u2E80-\u2FFF]
+	| [\u3004-\u3007]
+	| [\u3021-\u302F]
+	| [\u3031-\u303F]
+	| [\u3040-\uD7FF]
+	| [\uF900-\uFD3D]
+	| [\uFD40-\uFDCF]
+	| [\uFDF0-\uFE1F]
+	| [\uFE30-\uFE44]
+	| [\uFE47-\uFFFD]
+	| [\u{10000}-\u{1FFFD}]
+	| [\u{20000}-\u{2FFFD}]
+	| [\u{30000}-\u{3FFFD}]
+	| [\u{40000}-\u{4FFFD}]
+	| [\u{50000}-\u{5FFFD}]
+	| [\u{60000}-\u{6FFFD}]
+	| [\u{70000}-\u{7FFFD}]
+	| [\u{80000}-\u{8FFFD}]
+	| [\u{90000}-\u{9FFFD}]
+	| [\u{A0000}-\u{AFFFD}]
+	| [\u{B0000}-\u{BFFFD}]
+	| [\u{C0000}-\u{CFFFD}]
+	| [\u{D0000}-\u{DFFFD}]
+	| [\u{E0000}-\u{EFFFD}];
+
+fragment Identifier_character:
+	[0-9]
+	| [\u0300-\u036F]
+	| [\u1DC0-\u1DFF]
+	| [\u20D0-\u20FF]
+	| [\uFE20-\uFE2F]
+	| Identifier_head;
+
+fragment Identifier_characters: Identifier_character+;
+
+fragment Implicit_parameter_name: '$' Decimal_digits;
+
+fragment Property_wrapper_projection: '$' Identifier_characters;
+
+// Keywords and Punctuation
+Keyword:
+	// Keywords used in declarations
+	'associatedtype'
+	| 'class'
+	| 'deinit'
+	| 'enum'
+	| 'extension'
+	| 'fileprivate'
+	| 'func'
+	| 'import'
+	| 'init'
+	| 'inout'
+	| 'internal'
+	| 'let'
+	| 'open'
+	| 'operator'
+	| 'private'
+	| 'protocol'
+	| 'public'
+	| 'rethrows'
+	| 'static'
+	| 'struct'
+	| 'subscript'
+	| 'typealias'
+	| 'var'
+	// Keywords used in statements
+	| 'break'
+	| 'case'
+	| 'continue'
+	| 'default'
+	| 'defer'
+	| 'do'
+	| 'else'
+	| 'fallthrough'
+	| 'for'
+	| 'guard'
+	| 'if'
+	| 'in'
+	| 'repeat'
+	| 'return'
+	| 'switch'
+	| 'where'
+	| 'while'
+	// Keywords used in expressions and types
+	| 'as'
+	| 'Any'
+	| 'catch'
+	| 'false'
+	| 'is'
+	| 'nil'
+	| 'super'
+	| 'self'
+	| 'Self'
+	| 'throw'
+	| 'throws'
+	| 'true'
+	| 'try'
+	// Keywords used in patterns
+	| UNDERSCORE
+	// Keywords that begin with a number sign (#)
+	| '#available'
+	| '#colorLiteral'
+	| '#column'
+	| '#else'
+	| '#elseif'
+	| '#endif'
+	| '#error'
+	| '#file'
+	| '#fileID'
+	| '#fileLiteral'
+	| '#filePath'
+	| '#function'
+	| '#if'
+	| '#imageLiteral'
+	| '#line'
+	| '#selector'
+	| '#sourceLocation'
+	| '#warning';
+
+// Operators
+
+// Assignment Operator
+assignment_operator: {SwiftSupport.isBinaryOp(_input)}? '=';
+
+DOT: '.';
+LCURLY: '{';
+LPAREN: '(';
+LBRACK: '[';
+RCURLY: '}';
+RPAREN: ')';
+RBRACK: ']';
+COMMA: ',';
+COLON: ':';
+SEMI: ';';
+LT: '<';
+GT: '>';
+UNDERSCORE: '_';
+BANG: '!';
+QUESTION: '?';
+AT: '@';
+AND: '&';
+SUB: '-';
+EQUAL: '=';
+OR: '|';
+DIV: '/';
+ADD: '+';
+MUL: '*';
+MOD: '%';
+CARET: '^';
+TILDE: '~';
+
+negate_prefix_operator: {SwiftSupport.isPrefixOp(_input)}? '-';
+
+compilation_condition_AND: {SwiftSupport.isOperator(_input,"&&")}? '&' '&';
+compilation_condition_OR: {SwiftSupport.isOperator(_input,"||")}? '|' '|';
+compilation_condition_GE: {SwiftSupport.isOperator(_input,">=")}? '>' '=';
+compilation_condition_L: {SwiftSupport.isOperator(_input,"<")}? '<';
+arrow_operator: {SwiftSupport.isOperator(_input,"->")}? '-' '>';
+range_operator: {SwiftSupport.isOperator(_input,"...")}? '.' '.' '.';
+same_type_equals: {SwiftSupport.isOperator(_input,"==")}? '=' '=';
+
+binary_operator: {SwiftSupport.isBinaryOp(_input)}? operator;
+
+prefix_operator: {SwiftSupport.isPrefixOp(_input)}? operator;
+
+postfix_operator: {SwiftSupport.isPostfixOp(_input)}? operator;
+
+operator:
+	operator_head operator_characters?
+	| dot_operator_head dot_operator_characters;
+
+operator_head: (
+		'/'
+		| '='
+		| '-'
+		| '+'
+		| '!'
+		| '*'
+		| '%'
+		| '&'
+		| '|'
+		| '<'
+		| '>'
+		| '^'
+		| '~'
+		| '?'
+	) // wrapping in (..) makes it a fast set comparison
+	| Operator_head_other;
+
+Operator_head_other: // valid operator chars not used by Swift itself
+	[\u00A1-\u00A7]
+	| [\u00A9\u00AB]
+	| [\u00AC\u00AE]
+	| [\u00B0-\u00B1\u00B6\u00BB\u00BF\u00D7\u00F7]
+	| [\u2016-\u2017\u2020-\u2027]
+	| [\u2030-\u203E]
+	| [\u2041-\u2053]
+	| [\u2055-\u205E]
+	| [\u2190-\u23FF]
+	| [\u2500-\u2775]
+	| [\u2794-\u2BFF]
+	| [\u2E00-\u2E7F]
+	| [\u3001-\u3003]
+	| [\u3008-\u3020\u3030];
+
+operator_character: operator_head | Operator_following_character;
+Operator_following_character:
+	[\u0300-\u036F]
+	| [\u1DC0-\u1DFF]
+	| [\u20D0-\u20FF]
+	| [\uFE00-\uFE0F]
+	| [\uFE20-\uFE2F]
+	| [\u{E0100}-\u{E01EF}];
+
+operator_characters: (
+		{_input.get(_input.index()-1).getType()!=WS}? operator_character
+	)+;
+
+dot_operator_head: '.';
+dot_operator_character: '.' | operator_character;
+dot_operator_characters: (
+		{_input.get(_input.index()-1).getType()!=WS}? dot_operator_character
+	)+;
+
+// Literals
+literal: numeric_literal | string_literal | boolean_literal | nil_literal;
+
+numeric_literal:
+	negate_prefix_operator? integer_literal
+	| negate_prefix_operator? Floating_point_literal;
+
+boolean_literal: 'true' | 'false';
+
+nil_literal: 'nil';
+
+// Integer Literals
+integer_literal:
+	Decimal_digits
+	| Decimal_literal
+	| Binary_literal
+	| Octal_literal
+	| Hexadecimal_literal;
+
+Binary_literal: '0b' Binary_digit Binary_literal_characters?;
+fragment Binary_digit: [01];
+fragment Binary_literal_character: Binary_digit | '_';
+fragment Binary_literal_characters: Binary_literal_character+;
+
+Octal_literal: '0o' Octal_digit Octal_literal_characters?;
+fragment Octal_digit: [0-7];
+fragment Octal_literal_character: Octal_digit | '_';
+fragment Octal_literal_characters: Octal_literal_character+;
+
+Decimal_digits: Decimal_digit+;
+Decimal_literal: Decimal_digit Decimal_literal_characters?;
+fragment Decimal_digit: [0-9];
+fragment Decimal_literal_character: Decimal_digit | '_';
+fragment Decimal_literal_characters: Decimal_literal_character+;
+
+Hexadecimal_literal: '0x' Hexadecimal_digit Hexadecimal_literal_characters?;
+fragment Hexadecimal_digit: [0-9a-fA-F];
+fragment Hexadecimal_literal_character: Hexadecimal_digit | '_';
+fragment Hexadecimal_literal_characters: Hexadecimal_literal_character+;
+
+// Floating-Point Literals
+Floating_point_literal:
+	Decimal_literal Decimal_fraction? Decimal_exponent?
+	| Hexadecimal_literal Hexadecimal_fraction? Hexadecimal_exponent;
+fragment Decimal_fraction: '.' Decimal_literal;
+fragment Decimal_exponent: Floating_point_e Sign? Decimal_literal;
+fragment Hexadecimal_fraction:
+	'.' Hexadecimal_digit Hexadecimal_literal_characters?;
+fragment Hexadecimal_exponent: Floating_point_p Sign? Decimal_literal;
+fragment Floating_point_e: [eE];
+fragment Floating_point_p: [pP];
+fragment Sign: [+-];
+
+// String Literals
+string_literal:
+	Extended_string_literal_delimiter string_literal Extended_string_literal_delimiter
+	| Static_string_literal
+	| Interpolated_string_literal;
+
+Static_string_literal:
+	'"' Quoted_text? '"'
+	| '"""' [\r\n] Multiline_quoted_text? [\r\n] '"""';
+
+fragment Extended_string_literal_delimiter: '#';
+
+fragment Quoted_text: Quoted_text_item+;
+fragment Quoted_text_item: Escaped_character | ~["\n\r\\];
+
+fragment Multiline_quoted_text: Multiline_quoted_text_item+?;
+
+fragment Multiline_quoted_text_item:
+	Escaped_character
+	| ~[\\]
+	| Escaped_newline;
+
+Interpolated_string_literal:
+	'"' Interpolated_text? '"'
+	| '"""' [\r\n] Multiline_interpolated_text? [\r\n] '"""';
+
+fragment Interpolated_text: Interpolated_text_item+;
+
+fragment Interpolated_text_item:
+	'\\(' (Interpolated_string_literal | Interpolated_text_item)+ ')'
+	| Quoted_text_item;
+
+fragment Multiline_interpolated_text: Multiline_interpolated_text_item+;
+
+fragment Multiline_interpolated_text_item:
+	'\\(' (Interpolated_string_literal | Multiline_interpolated_text_item)+ ')'
+	| Multiline_quoted_text_item;
+
+fragment Escape_sequence: '\\' Extended_string_literal_delimiter;
+
+fragment Escaped_character:
+	Escape_sequence ([0\\tnr"'] | 'u' '{' Unicode_scalar_digits '}');
+
+fragment Unicode_scalar_digits: Hexadecimal_literal+;
+//Between one and eight hexadecimal digits
+
+fragment Escaped_newline: Escape_sequence Inline_spaces? Line_break;
+
+fragment Inline_spaces: [\u0009\u0020];
+
+fragment Line_break: [\u000A\u000D]| '\u000D' '\u000A';
+
+WS: [ \n\r\t\u000B\u000C\u0000]+ -> channel(HIDDEN);
+
+Block_comment: '/*' (Block_comment | .)*? '*/' -> channel(HIDDEN);
+
+Line_comment: '//' .*? ('\n' | EOF) -> channel(HIDDEN);

--- a/swift/swift5/examples/Control Flow/Contents.swift
+++ b/swift/swift5/examples/Control Flow/Contents.swift
@@ -1,0 +1,107 @@
+//: ## Control Flow
+//:
+//: Use `if` and `switch` to make conditionals, and use `for`-`in`, `while`, and `repeat`-`while` to make loops. Parentheses around the condition or loop variable are optional. Braces around the body are required.
+//:
+let individualScores = [75, 43, 103, 87, 12]
+var teamScore = 0
+for score in individualScores {
+    if score > 50 {
+        teamScore += 3
+    } else {
+        teamScore += 1
+    }
+}
+print(teamScore)
+
+//: In an `if` statement, the conditional must be a Boolean expression—this means that code such as `if score { ... }` is an error, not an implicit comparison to zero.
+//:
+//: You can use `if` and `let` together to work with values that might be missing. These values are represented as optionals. An optional value either contains a value or contains `nil` to indicate that a value is missing. Write a question mark (`?`) after the type of a value to mark the value as optional.
+//:
+var optionalString: String? = "Hello"
+print(optionalString == nil)
+
+var optionalName: String? = "John Appleseed"
+var greeting = "Hello!"
+if let name = optionalName {
+    greeting = "Hello, \(name)"
+}
+
+//: - Experiment:
+//: Change `optionalName` to `nil`. What greeting do you get? Add an `else` clause that sets a different greeting if `optionalName` is `nil`.
+//:
+//: If the optional value is `nil`, the conditional is `false` and the code in braces is skipped. Otherwise, the optional value is unwrapped and assigned to the constant after `let`, which makes the unwrapped value available inside the block of code.
+//:
+//: Another way to handle optional values is to provide a default value using the `??` operator. If the optional value is missing, the default value is used instead.
+//:
+let nickname: String? = nil
+let fullName: String = "John Appleseed"
+let informalGreeting = "Hi \(nickname ?? fullName)"
+
+//: Switches support any kind of data and a wide variety of comparison operations—they aren’t limited to integers and tests for equality.
+//:
+let vegetable = "red pepper"
+switch vegetable {
+    case "celery":
+        print("Add some raisins and make ants on a log.")
+    case "cucumber", "watercress":
+        print("That would make a good tea sandwich.")
+    case let x where x.hasSuffix("pepper"):
+        print("Is it a spicy \(x)?")
+    default:
+        print("Everything tastes good in soup.")
+}
+
+//: - Experiment:
+//: Try removing the default case. What error do you get?
+//:
+//: Notice how `let` can be used in a pattern to assign the value that matched the pattern to a constant.
+//:
+//: After executing the code inside the switch case that matched, the program exits from the switch statement. Execution doesn’t continue to the next case, so you don’t need to explicitly break out of the switch at the end of each case’s code.
+//:
+//: You use `for`-`in` to iterate over items in a dictionary by providing a pair of names to use for each key-value pair. Dictionaries are an unordered collection, so their keys and values are iterated over in an arbitrary order.
+//:
+let interestingNumbers = [
+    "Prime": [2, 3, 5, 7, 11, 13],
+    "Fibonacci": [1, 1, 2, 3, 5, 8],
+    "Square": [1, 4, 9, 16, 25],
+]
+var largest = 0
+for (_, numbers) in interestingNumbers {
+    for number in numbers {
+        if number > largest {
+            largest = number
+        }
+    }
+}
+print(largest)
+
+//: - Experiment:
+//: Replace the `_` with a variable name, and keep track of which kind of number was the largest.
+//:
+//: Use `while` to repeat a block of code until a condition changes. The condition of a loop can be at the end instead, ensuring that the loop is run at least once.
+//:
+var n = 2
+while n < 100 {
+    n *= 2
+}
+print(n)
+
+var m = 2
+repeat {
+    m *= 2
+} while m < 100
+print(m)
+
+//: You can keep an index in a loop by using `..<` to make a range of indexes.
+//:
+var total = 0
+for i in 0..<4 {
+    total += i
+}
+print(total)
+
+//: Use `..<` to make a range that omits its upper value, and use `...` to make a range that includes both values.
+//:
+
+
+//: [Previous](@previous) | [Next](@next)

--- a/swift/swift5/examples/Enumerations and Structures/Contents.swift
+++ b/swift/swift5/examples/Enumerations and Structures/Contents.swift
@@ -1,0 +1,104 @@
+//: ## Enumerations and Structures
+//:
+//: Use `enum` to create an enumeration. Like classes and all other named types, enumerations can have methods associated with them.
+//:
+enum Rank: Int {
+    case ace = 1
+    case two, three, four, five, six, seven, eight, nine, ten
+    case jack, queen, king
+
+    func simpleDescription() -> String {
+        switch self {
+            case .ace:
+                return "ace"
+            case .jack:
+                return "jack"
+            case .queen:
+                return "queen"
+            case .king:
+                return "king"
+            default:
+                return String(self.rawValue)
+        }
+    }
+}
+let ace = Rank.ace
+let aceRawValue = ace.rawValue
+
+//: - Experiment:
+//: Write a function that compares two `Rank` values by comparing their raw values.
+//:
+//: By default, Swift assigns the raw values starting at zero and incrementing by one each time, but you can change this behavior by explicitly specifying values. In the example above, `Ace` is explicitly given a raw value of `1`, and the rest of the raw values are assigned in order. You can also use strings or floating-point numbers as the raw type of an enumeration. Use the `rawValue` property to access the raw value of an enumeration case.
+//:
+//: Use the `init?(rawValue:)` initializer to make an instance of an enumeration from a raw value. It returns either the enumeration case matching the raw value or `nil` if there’s no matching `Rank`.
+//:
+if let convertedRank = Rank(rawValue: 3) {
+    let threeDescription = convertedRank.simpleDescription()
+}
+
+//: The case values of an enumeration are actual values, not just another way of writing their raw values. In fact, in cases where there isn’t a meaningful raw value, you don’t have to provide one.
+//:
+enum Suit {
+    case spades, hearts, diamonds, clubs
+
+    func simpleDescription() -> String {
+        switch self {
+            case .spades:
+                return "spades"
+            case .hearts:
+                return "hearts"
+            case .diamonds:
+                return "diamonds"
+            case .clubs:
+                return "clubs"
+        }
+    }
+}
+let hearts = Suit.hearts
+let heartsDescription = hearts.simpleDescription()
+
+//: - Experiment:
+//: Add a `color()` method to `Suit` that returns “black” for spades and clubs, and returns “red” for hearts and diamonds.
+//:
+//: Notice the two ways that the `hearts` case of the enumeration is referred to above: When assigning a value to the `hearts` constant, the enumeration case `Suit.hearts` is referred to by its full name because the constant doesn’t have an explicit type specified. Inside the switch, the enumeration case is referred to by the abbreviated form `.hearts` because the value of `self` is already known to be a suit. You can use the abbreviated form anytime the value’s type is already known.
+//:
+//: If an enumeration has raw values, those values are determined as part of the declaration, which means every instance of a particular enumeration case always has the same raw value. Another choice for enumeration cases is to have values associated with the case—these values are determined when you make the instance, and they can be different for each instance of an enumeration case. You can think of the associated values as behaving like stored properties of the enumeration case instance. For example, consider the case of requesting the sunrise and sunset times from a server. The server either responds with the requested information, or it responds with a description of what went wrong.
+//:
+enum ServerResponse {
+    case result(String, String)
+    case failure(String)
+}
+
+let success = ServerResponse.result("6:00 am", "8:09 pm")
+let failure = ServerResponse.failure("Out of cheese.")
+
+switch success {
+    case let .result(sunrise, sunset):
+        print("Sunrise is at \(sunrise) and sunset is at \(sunset).")
+    case let .failure(message):
+        print("Failure...  \(message)")
+}
+
+//: - Experiment:
+//: Add a third case to `ServerResponse` and to the switch.
+//:
+//: Notice how the sunrise and sunset times are extracted from the `ServerResponse` value as part of matching the value against the switch cases.
+//:
+//: Use `struct` to create a structure. Structures support many of the same behaviors as classes, including methods and initializers. One of the most important differences between structures and classes is that structures are always copied when they’re passed around in your code, but classes are passed by reference.
+//:
+struct Card {
+    var rank: Rank
+    var suit: Suit
+    func simpleDescription() -> String {
+        return "The \(rank.simpleDescription()) of \(suit.simpleDescription())"
+    }
+}
+let threeOfSpades = Card(rank: .three, suit: .spades)
+let threeOfSpadesDescription = threeOfSpades.simpleDescription()
+
+//: - Experiment:
+//: Write a function that returns an array containing a full deck of cards, with one card of each combination of rank and suit.
+//:
+
+
+//: [Previous](@previous) | [Next](@next)

--- a/swift/swift5/examples/Error Handling/Contents.swift
+++ b/swift/swift5/examples/Error Handling/Contents.swift
@@ -1,0 +1,72 @@
+//: ## Error Handling
+//:
+//: You represent errors using any type that adopts the `Error` protocol.
+//:
+enum PrinterError: Error {
+    case outOfPaper
+    case noToner
+    case onFire
+}
+
+//: Use `throw` to throw an error and `throws` to mark a function that can throw an error. If you throw an error in a function, the function returns immediately and the code that called the function handles the error.
+//:
+func send(job: Int, toPrinter printerName: String) throws -> String {
+    if printerName == "Never Has Toner" {
+        throw PrinterError.noToner
+    }
+    return "Job sent"
+}
+
+//: There are several ways to handle errors. One way is to use `do`-`catch`. Inside the `do` block, you mark code that can throw an error by writing `try` in front of it. Inside the `catch` block, the error is automatically given the name `error` unless you give it a different name.
+//:
+do {
+    let printerResponse = try send(job: 1040, toPrinter: "Bi Sheng")
+    print(printerResponse)
+} catch {
+    print(error)
+}
+
+//: - Experiment:
+//: Change the printer name to `"Never Has Toner"`, so that the `send(job:toPrinter:)` function throws an error.
+//:
+//: You can provide multiple `catch` blocks that handle specific errors. You write a pattern after `catch` just as you do after `case` in a switch.
+//:
+do {
+    let printerResponse = try send(job: 1440, toPrinter: "Gutenberg")
+    print(printerResponse)
+} catch PrinterError.onFire {
+    print("I'll just put this over here, with the rest of the fire.")
+} catch let printerError as PrinterError {
+    print("Printer error: \(printerError).")
+} catch {
+    print(error)
+}
+
+//: - Experiment:
+//: Add code to throw an error inside the `do` block. What kind of error do you need to throw so that the error is handled by the first `catch` block? What about the second and third blocks?
+//:
+//: Another way to handle errors is to use `try?` to convert the result to an optional. If the function throws an error, the specific error is discarded and the result is `nil`. Otherwise, the result is an optional containing the value that the function returned.
+//:
+let printerSuccess = try? send(job: 1884, toPrinter: "Mergenthaler")
+let printerFailure = try? send(job: 1885, toPrinter: "Never Has Toner")
+
+//: Use `defer` to write a block of code that’s executed after all other code in the function, just before the function returns. The code is executed regardless of whether the function throws an error. You can use `defer` to write setup and cleanup code next to each other, even though they need to be executed at different times.
+//:
+var fridgeIsOpen = false
+let fridgeContent = ["milk", "eggs", "leftovers"]
+
+func fridgeContains(_ food: String) -> Bool {
+    fridgeIsOpen = true
+    defer {
+        fridgeIsOpen = false
+    }
+
+    let result = fridgeContent.contains(food)
+    return result
+}
+fridgeContains("banana")
+print(fridgeIsOpen)
+
+
+
+//: [Previous](@previous) | [Next](@next)

--- a/swift/swift5/examples/Functions and Closures/Contents.swift
+++ b/swift/swift5/examples/Functions and Closures/Contents.swift
@@ -1,0 +1,103 @@
+//: ## Functions and Closures
+//:
+//: Use `func` to declare a function. Call a function by following its name with a list of arguments in parentheses. Use `->` to separate the parameter names and types from the function’s return type.
+//:
+func greet(person: String, day: String) -> String {
+    return "Hello \(person), today is \(day)."
+}
+greet(person: "Bob", day: "Tuesday")
+
+//: - Experiment:
+//: Remove the `day` parameter. Add a parameter to include today’s lunch special in the greeting.
+//:
+//: By default, functions use their parameter names as labels for their arguments. Write a custom argument label before the parameter name, or write `_` to use no argument label.
+//:
+func greet(_ person: String, on day: String) -> String {
+    return "Hello \(person), today is \(day)."
+}
+greet("John", on: "Wednesday")
+
+//: Use a tuple to make a compound value—for example, to return multiple values from a function. The elements of a tuple can be referred to either by name or by number.
+//:
+func calculateStatistics(scores: [Int]) -> (min: Int, max: Int, sum: Int) {
+    var min = scores[0]
+    var max = scores[0]
+    var sum = 0
+
+    for score in scores {
+        if score > max {
+            max = score
+        } else if score < min {
+            min = score
+        }
+        sum += score
+    }
+
+    return (min, max, sum)
+}
+let statistics = calculateStatistics(scores: [5, 3, 100, 3, 9])
+print(statistics.sum)
+print(statistics.2)
+
+//: Functions can be nested. Nested functions have access to variables that were declared in the outer function. You can use nested functions to organize the code in a function that’s long or complex.
+//:
+func returnFifteen() -> Int {
+    var y = 10
+    func add() {
+        y += 5
+    }
+    add()
+    return y
+}
+returnFifteen()
+
+//: Functions are a first-class type. This means that a function can return another function as its value.
+//:
+func makeIncrementer() -> ((Int) -> Int) {
+    func addOne(number: Int) -> Int {
+        return 1 + number
+    }
+    return addOne
+}
+var increment = makeIncrementer()
+increment(7)
+
+//: A function can take another function as one of its arguments.
+//:
+func hasAnyMatches(list: [Int], condition: (Int) -> Bool) -> Bool {
+    for item in list {
+        if condition(item) {
+            return true
+        }
+    }
+    return false
+}
+func lessThanTen(number: Int) -> Bool {
+    return number < 10
+}
+var numbers = [20, 19, 7, 12]
+hasAnyMatches(list: numbers, condition: lessThanTen)
+
+//: Functions are actually a special case of closures: blocks of code that can be called later. The code in a closure has access to things like variables and functions that were available in the scope where the closure was created, even if the closure is in a different scope when it’s executed—you saw an example of this already with nested functions. You can write a closure without a name by surrounding code with braces (`{}`). Use `in` to separate the arguments and return type from the body.
+//:
+numbers.map({ (number: Int) -> Int in
+    let result = 3 * number
+    return result
+})
+
+//: - Experiment:
+//: Rewrite the closure to return zero for all odd numbers.
+//:
+//: You have several options for writing closures more concisely. When a closure’s type is already known, such as the callback for a delegate, you can omit the type of its parameters, its return type, or both. Single statement closures implicitly return the value of their only statement.
+//:
+let mappedNumbers = numbers.map({ number in 3 * number })
+print(mappedNumbers)
+
+//: You can refer to parameters by number instead of by name—this approach is especially useful in very short closures. A closure passed as the last argument to a function can appear immediately after the parentheses. When a closure is the only argument to a function, you can omit the parentheses entirely.
+//:
+let sortedNumbers = numbers.sorted { $0 > $1 }
+print(sortedNumbers)
+
+
+
+//: [Previous](@previous) | [Next](@next)

--- a/swift/swift5/examples/Generics/Contents.swift
+++ b/swift/swift5/examples/Generics/Contents.swift
@@ -1,0 +1,47 @@
+//: ## Generics
+//:
+//: Write a name inside angle brackets to make a generic function or type.
+//:
+func makeArray<Item>(repeating item: Item, numberOfTimes: Int) -> [Item] {
+    var result = [Item]()
+    for _ in 0..<numberOfTimes {
+         result.append(item)
+    }
+    return result
+}
+makeArray(repeating: "knock", numberOfTimes: 4)
+
+//: You can make generic forms of functions and methods, as well as classes, enumerations, and structures.
+//:
+// Reimplement the Swift standard library's optional type
+enum OptionalValue<Wrapped> {
+    //case none
+    case some(Wrapped)
+}
+//var possibleInteger: OptionalValue<Int> = .none
+//possibleInteger = .some(100)
+
+//: Use `where` right before the body to specify a list of requirements—for example, to require the type to implement a protocol, to require two types to be the same, or to require a class to have a particular superclass.
+//:
+func anyCommonElements<T: Sequence, U: Sequence>(_ lhs: T, _ rhs: U) -> Bool
+    where T.Element: Equatable, T.Element == U.Element
+{
+    for lhsItem in lhs {
+        for rhsItem in rhs {
+            if lhsItem == rhsItem {
+                return true
+            }
+        }
+    }
+   return false
+}
+anyCommonElements([1, 2, 3], [3])
+
+//: - Experiment:
+//: Modify the `anyCommonElements(_:_:)` function to make a function that returns an array of the elements that any two sequences have in common.
+//:
+//: Writing `<T: Equatable>` is the same as writing `<T> ... where T: Equatable`.
+//:
+
+
+//: [Previous](@previous) | [Next](@next)

--- a/swift/swift5/examples/License/Contents.swift
+++ b/swift/swift5/examples/License/Contents.swift
@@ -1,0 +1,44 @@
+/*:
+# License
+IMPORTANT:  This Apple software is supplied to you by Apple
+Inc. ("Apple") in consideration of your agreement to the following
+terms, and your use, installation, modification or redistribution of
+this Apple software constitutes acceptance of these terms.  If you do
+not agree with these terms, please do not use, install, modify or
+redistribute this Apple software.
+
+In consideration of your agreement to abide by the following terms, and
+subject to these terms, Apple grants you a personal, non-exclusive
+license, under Apple's copyrights in this original Apple software (the
+"Apple Software"), to use, reproduce, modify and redistribute the Apple
+Software, with or without modifications, in source and/or binary forms;
+provided that if you redistribute the Apple Software in its entirety and
+without modifications, you must retain this notice and the following
+text and disclaimers in all such redistributions of the Apple Software.
+Neither the name, trademarks, service marks or logos of Apple Inc. may
+be used to endorse or promote products derived from the Apple Software
+without specific prior written permission from Apple.  Except as
+expressly stated in this notice, no other rights or licenses, express or
+implied, are granted by Apple herein, including but not limited to any
+patent rights that may be infringed by your derivative works or by other
+works in which the Apple Software may be incorporated.
+
+The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+
+IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (C) 2021 Apple Inc. All Rights Reserved.
+
+
+[Previous](@previous)*/

--- a/swift/swift5/examples/Objects and Classes/Contents.swift
+++ b/swift/swift5/examples/Objects and Classes/Contents.swift
@@ -1,0 +1,138 @@
+//: ## Objects and Classes
+//:
+//: Use `class` followed by the class’s name to create a class. A property declaration in a class is written the same way as a constant or variable declaration, except that it’s in the context of a class. Likewise, method and function declarations are written the same way.
+//:
+class Shape {
+    var numberOfSides = 0
+    func simpleDescription() -> String {
+        return "A shape with \(numberOfSides) sides."
+    }
+}
+
+//: - Experiment:
+//: Add a constant property with `let`, and add another method that takes an argument.
+//:
+//: Create an instance of a class by putting parentheses after the class name. Use dot syntax to access the properties and methods of the instance.
+//:
+var shape = Shape()
+shape.numberOfSides = 7
+var shapeDescription = shape.simpleDescription()
+
+//: This version of the `Shape` class is missing something important: an initializer to set up the class when an instance is created. Use `init` to create one.
+//:
+class NamedShape {
+    var numberOfSides: Int = 0
+    var name: String
+
+    init(name: String) {
+       self.name = name
+    }
+
+    func simpleDescription() -> String {
+       return "A shape with \(numberOfSides) sides."
+    }
+}
+
+//: Notice how `self` is used to distinguish the `name` property from the `name` argument to the initializer. The arguments to the initializer are passed like a function call when you create an instance of the class. Every property needs a value assigned—either in its declaration (as with `numberOfSides`) or in the initializer (as with `name`).
+//:
+//: Use `deinit` to create a deinitializer if you need to perform some cleanup before the object is deallocated.
+//:
+//: Subclasses include their superclass name after their class name, separated by a colon. There’s no requirement for classes to subclass any standard root class, so you can include or omit a superclass as needed.
+//:
+//: Methods on a subclass that override the superclass’s implementation are marked with `override`—overriding a method by accident, without `override`, is detected by the compiler as an error. The compiler also detects methods with `override` that don’t actually override any method in the superclass.
+//:
+class Square: NamedShape {
+    var sideLength: Double
+
+    init(sideLength: Double, name: String) {
+        self.sideLength = sideLength
+        super.init(name: name)
+        numberOfSides = 4
+    }
+
+    func area() -> Double {
+        return sideLength * sideLength
+    }
+
+    override func simpleDescription() -> String {
+        return "A square with sides of length \(sideLength)."
+    }
+}
+let test = Square(sideLength: 5.2, name: "my test square")
+test.area()
+test.simpleDescription()
+
+//: - Experiment:
+//: Make another subclass of `NamedShape` called `Circle` that takes a radius and a name as arguments to its initializer. Implement an `area()` and a `simpleDescription()` method on the `Circle` class.
+//:
+//: In addition to simple properties that are stored, properties can have a getter and a setter.
+//:
+class EquilateralTriangle: NamedShape {
+    var sideLength: Double = 0.0
+
+    init(sideLength: Double, name: String) {
+        self.sideLength = sideLength
+        super.init(name: name)
+        numberOfSides = 3
+    }
+
+    var perimeter: Double {
+        get {
+             return 3.0 * sideLength
+        }
+        set {
+            sideLength = newValue / 3.0
+        }
+    }
+
+    override func simpleDescription() -> String {
+        return "An equilateral triangle with sides of length \(sideLength)."
+    }
+}
+var triangle = EquilateralTriangle(sideLength: 3.1, name: "a triangle")
+print(triangle.perimeter)
+triangle.perimeter = 9.9
+print(triangle.sideLength)
+
+//: In the setter for `perimeter`, the new value has the implicit name `newValue`. You can provide an explicit name in parentheses after `set`.
+//:
+//: Notice that the initializer for the `EquilateralTriangle` class has three different steps:
+//:
+//: 1. Setting the value of properties that the subclass declares.
+//:
+//: 1. Calling the superclass’s initializer.
+//:
+//: 1. Changing the value of properties defined by the superclass. Any additional setup work that uses methods, getters, or setters can also be done at this point.
+//:
+//: If you don’t need to compute the property but still need to provide code that’s run before and after setting a new value, use `willSet` and `didSet`. The code you provide is run any time the value changes outside of an initializer. For example, the class below ensures that the side length of its triangle is always the same as the side length of its square.
+//:
+class TriangleAndSquare {
+    var triangle: EquilateralTriangle {
+        willSet {
+            square.sideLength = newValue.sideLength
+        }
+    }
+    var square: Square {
+        willSet {
+            triangle.sideLength = newValue.sideLength
+        }
+    }
+    init(size: Double, name: String) {
+        square = Square(sideLength: size, name: name)
+        triangle = EquilateralTriangle(sideLength: size, name: name)
+    }
+}
+var triangleAndSquare = TriangleAndSquare(size: 10, name: "another test shape")
+print(triangleAndSquare.square.sideLength)
+print(triangleAndSquare.triangle.sideLength)
+triangleAndSquare.square = Square(sideLength: 50, name: "larger square")
+print(triangleAndSquare.triangle.sideLength)
+
+//: When working with optional values, you can write `?` before operations like methods, properties, and subscripting. If the value before the `?` is `nil`, everything after the `?` is ignored and the value of the whole expression is `nil`. Otherwise, the optional value is unwrapped, and everything after the `?` acts on the unwrapped value. In both cases, the value of the whole expression is an optional value.
+//:
+let optionalSquare: Square? = Square(sideLength: 2.5, name: "optional square")
+let sideLength = optionalSquare?.sideLength
+
+
+
+//: [Previous](@previous) | [Next](@next)

--- a/swift/swift5/examples/Protocols and Extensions/Contents.swift
+++ b/swift/swift5/examples/Protocols and Extensions/Contents.swift
@@ -1,0 +1,63 @@
+//: ## Protocols and Extensions
+//:
+//: Use `protocol` to declare a protocol.
+//:
+protocol ExampleProtocol {
+     var simpleDescription: String { get }
+     mutating func adjust()
+}
+
+//: Classes, enumerations, and structs can all adopt protocols.
+//:
+class SimpleClass: ExampleProtocol {
+     var simpleDescription: String = "A very simple class."
+     var anotherProperty: Int = 69105
+     func adjust() {
+          simpleDescription += "  Now 100% adjusted."
+     }
+}
+var a = SimpleClass()
+a.adjust()
+let aDescription = a.simpleDescription
+
+struct SimpleStructure: ExampleProtocol {
+     var simpleDescription: String = "A simple structure"
+     mutating func adjust() {
+          simpleDescription += " (adjusted)"
+     }
+}
+var b = SimpleStructure()
+b.adjust()
+let bDescription = b.simpleDescription
+
+//: - Experiment:
+//: Add another requirement to `ExampleProtocol`. What changes do you need to make to `SimpleClass` and `SimpleStructure` so that they still conform to the protocol?
+//:
+//: Notice the use of the `mutating` keyword in the declaration of `SimpleStructure` to mark a method that modifies the structure. The declaration of `SimpleClass` doesn’t need any of its methods marked as mutating because methods on a class can always modify the class.
+//:
+//: Use `extension` to add functionality to an existing type, such as new methods and computed properties. You can use an extension to add protocol conformance to a type that’s declared elsewhere, or even to a type that you imported from a library or framework.
+//:
+extension Int: ExampleProtocol {
+    var simpleDescription: String {
+        return "The number \(self)"
+    }
+    mutating func adjust() {
+        self += 42
+    }
+ }
+print(7.simpleDescription)
+
+//: - Experiment:
+//: Write an extension for the `Double` type that adds an `absoluteValue` property.
+//:
+//: You can use a protocol name just like any other named type—for example, to create a collection of objects that have different types but that all conform to a single protocol. When you work with values whose type is a protocol type, methods outside the protocol definition aren’t available.
+//:
+let protocolValue: ExampleProtocol = a
+print(protocolValue.simpleDescription)
+// print(protocolValue.anotherProperty)  // Uncomment to see the error
+
+//: Even though the variable `protocolValue` has a runtime type of `SimpleClass`, the compiler treats it as the given type of `ExampleProtocol`. This means that you can’t accidentally access methods or properties that the class implements in addition to its protocol conformance.
+//:
+
+
+//: [Previous](@previous) | [Next](@next)

--- a/swift/swift5/examples/Simple Values/Contents.swift
+++ b/swift/swift5/examples/Simple Values/Contents.swift
@@ -1,0 +1,86 @@
+//: # A Swift Tour
+//:
+//: Tradition suggests that the first program in a new language should print the words “Hello, world!” on the screen. In Swift, this can be done in a single line:
+//:
+print("Hello, world!")
+
+//: If you have written code in C or Objective-C, this syntax looks familiar to you—in Swift, this line of code is a complete program. You don’t need to import a separate library for functionality like input/output or string handling. Code written at global scope is used as the entry point for the program, so you don’t need a `main()` function. You also don’t need to write semicolons at the end of every statement.
+//:
+//: This tour gives you enough information to start writing code in Swift by showing you how to accomplish a variety of programming tasks. Don’t worry if you don’t understand something—everything introduced in this tour is explained in detail in the rest of this book.
+//:
+//: ## Simple Values
+//:
+//: Use `let` to make a constant and `var` to make a variable. The value of a constant doesn’t need to be known at compile time, but you must assign it a value exactly once. This means you can use constants to name a value that you determine once but use in many places.
+//:
+var myVariable = 42
+myVariable = 50
+let myConstant = 42
+
+//: A constant or variable must have the same type as the value you want to assign to it. However, you don’t always have to write the type explicitly. Providing a value when you create a constant or variable lets the compiler infer its type. In the example above, the compiler infers that `myVariable` is an integer because its initial value is an integer.
+//:
+//: If the initial value doesn’t provide enough information (or if isn’t an initial value), specify the type by writing it after the variable, separated by a colon.
+//:
+let implicitInteger = 70
+let implicitDouble = 70.0
+let explicitDouble: Double = 70
+
+//: - Experiment:
+//: Create a constant with an explicit type of `Float` and a value of `4`.
+//:
+//: Values are never implicitly converted to another type. If you need to convert a value to a different type, explicitly make an instance of the desired type.
+//:
+let label = "The width is "
+let width = 94
+let widthLabel = label + String(width)
+
+//: - Experiment:
+//: Try removing the conversion to `String` from the last line. What error do you get?
+//:
+//: There’s an even simpler way to include values in strings: Write the value in parentheses, and write a backslash (`\`) before the parentheses. For example:
+//:
+let apples = 3
+let oranges = 5
+let appleSummary = "I have \(apples) apples."
+let fruitSummary = "I have \(apples + oranges) pieces of fruit."
+
+//: - Experiment:
+//: Use `\()` to include a floating-point calculation in a string and to include someone’s name in a greeting.
+//:
+//: Use three double quotation marks (`"""`) for strings that take up multiple lines. Indentation at the start of each quoted line is removed, as long as it matches the indentation of the closing quotation marks. For example:
+//:
+let quotation = """
+I said "I have \(apples) apples."
+And then I said "I have \(apples + oranges) pieces of fruit."
+"""
+
+//: Create arrays and dictionaries using brackets (`[]`), and access their elements by writing the index or key in brackets. A comma is allowed after the last element.
+//:
+var shoppingList = ["catfish", "water", "tulips"]
+shoppingList[1] = "bottle of water"
+
+var occupations = [
+    "Malcolm": "Captain",
+    "Kaylee": "Mechanic",
+ ]
+occupations["Jayne"] = "Public Relations"
+
+//: Arrays automatically grow as you add elements.
+//:
+shoppingList.append("blue paint")
+print(shoppingList)
+
+//: To create an empty array or dictionary, use the initializer syntax.
+//:
+let emptyArray = [String]()
+let emptyDictionary = [String: Float]()
+
+//: If type information can be inferred, you can write an empty array as `[]` and an empty dictionary as `[:]`—for example, when you set a new value for a variable or pass an argument to a function.
+//:
+shoppingList = []
+occupations = [:]
+
+
+
+//: See [License](License) for this sample's licensing information.
+//: 
+//: [Next](@next)

--- a/swift/swift5/pom.xml
+++ b/swift/swift5/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>swift5</artifactId>
+	<packaging>jar</packaging>
+	<name>ANTLR Swift grammar</name>
+	<parent>
+		<groupId>org.antlr.grammars</groupId>
+		<artifactId>switftparent</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<includes>
+					   <include>Swift5.g4</include>
+					</includes>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>top_level</entryPoint>
+					<grammarName>Swift5</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/swift/swift5/src/main/java/SwiftSupport.java
+++ b/swift/swift5/src/main/java/SwiftSupport.java
@@ -1,0 +1,349 @@
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.misc.Interval;
+
+import java.util.BitSet;
+
+public class SwiftSupport {
+    /* TODO
+    There is one caveat to the rules above. If the ! or ? predefined operator
+     has no whitespace on the left, it is treated as a postfix operator,
+     regardless of whether it has whitespace on the right. To use the ? as
+     the optional-chaining operator, it must not have whitespace on the left.
+      To use it in the ternary conditional (? :) operator, it must have
+      whitespace around both sides.
+    */
+
+    /*
+    operator-head : /  =  -  +  !  *  %  <  >  &  |  ^  ~  ?
+      | [\u00A1-\u00A7]
+      | [\u00A9\u00AB]
+      | [\u00AC\u00AE]
+      | [\u00B0-\u00B1\u00B6\u00BB\u00BF\u00D7\u00F7]
+      | [\u2016-\u2017\u2020-\u2027]
+      | [\u2030-\u203E]
+      | [\u2041-\u2053]
+      | [\u2055-\u205E]
+      | [\u2190-\u23FF]
+      | [\u2500-\u2775]
+      | [\u2794-\u2BFF]
+      | [\u2E00-\u2E7F]
+      | [\u3001-\u3003]
+      | [\u3008-\u3030]
+      ;
+     */
+    public static final BitSet operatorHead = new BitSet(0x10000);
+    public static final BitSet operatorCharacter;
+
+    public static final BitSet leftWS = new BitSet(255);
+    public static final BitSet rightWS = new BitSet(255);
+
+    static {
+        // operator-head → /  =­  -­  +­  !­  *­  %­  <­  >­  &­  |­  ^­  ~­  ?­
+        operatorHead.set('/');
+        operatorHead.set('=');
+        operatorHead.set('-');
+        operatorHead.set('+');
+        operatorHead.set('!');
+        operatorHead.set('*');
+        operatorHead.set('%');
+        operatorHead.set('&');
+        operatorHead.set('|');
+        operatorHead.set('<');
+        operatorHead.set('>');
+        operatorHead.set('^');
+        operatorHead.set('~');
+        operatorHead.set('?');
+        
+        // operator-head → U+00A1–U+00A7
+        operatorHead.set(0x00A1,0x00A7+1);
+        
+        // operator-head → U+00A9 or U+00AB
+        operatorHead.set(0x00A9);
+        operatorHead.set(0x00AB);
+
+        // operator-head → U+00AC or U+00AE
+        operatorHead.set(0x00AC);
+        operatorHead.set(0x00AE);
+            
+        // operator-head → U+00B0–U+00B1, U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7
+        operatorHead.set(0x00B0,0x00B1+1);
+        operatorHead.set(0x00B6);
+        operatorHead.set(0x00BB);
+        operatorHead.set(0x00BF);
+        operatorHead.set(0x00D7);
+        operatorHead.set(0x00F7);
+        
+        // operator-head → U+2016–U+2017 or U+2020–U+2027
+        operatorHead.set(0x2016,0x2017+1);
+        operatorHead.set(0x2020,0x2027+1);
+        
+        // operator-head → U+2030–U+203E
+        operatorHead.set(0x2030,0x203E+1);
+        
+        // operator-head → U+2041–U+2053
+        operatorHead.set(0x2041,0x2053+1);
+        
+        // operator-head → U+2055–U+205E
+        operatorHead.set(0x2055,0x205E+1);
+        
+        // operator-head → U+2190–U+23FF
+        operatorHead.set(0x2190,0x23FF+1);
+        
+        // operator-head → U+2500–U+2775
+        operatorHead.set(0x2500,0x2775+1);
+        
+        // operator-head → U+2794–U+2BFF
+        operatorHead.set(0x2794,0x2BFF+1);
+        
+        // operator-head → U+2E00–U+2E7F
+        operatorHead.set(0x2E00,0x2E7F+1);
+        
+        // operator-head → U+3001–U+3003
+        operatorHead.set(0x3001,0x3003+1);
+        
+        // operator-head → U+3008–U+3030
+        operatorHead.set(0x3008,0x3020+1);
+
+        operatorHead.set(0x3030);
+        
+        // operator-character → operator-head­
+        operatorCharacter = (BitSet)operatorHead.clone();
+        
+        // operator-character → U+0300–U+036F
+        operatorCharacter.set(0x0300,0x036F+1);
+        // operator-character → U+1DC0–U+1DFF
+        operatorCharacter.set(0x1DC0,0x1DFF+1);
+        // operator-character → U+20D0–U+20FF
+        operatorCharacter.set(0x20D0,0x20FF+1);
+        // operator-character → U+FE00–U+FE0F
+        operatorCharacter.set(0xFE00,0xFE0F+1);
+        // operator-character → U+FE20–U+FE2F
+        operatorCharacter.set(0xFE20,0xFE2F+1);
+        operatorCharacter.set(0xE0100,0xE01EF+1);
+        
+        // operator-character → U+E0100–U+E01EF
+        // Java works with 16-bit unicode chars. However, it can work for targets in other languages, e.g. in Swift
+        // operatorCharacter.set(0xE0100,0xE01EF+1);
+
+        leftWS.set(Swift5Parser.WS);
+        leftWS.set(Swift5Parser.LPAREN);
+        leftWS.set(Swift5Parser.LBRACK);
+        leftWS.set(Swift5Parser.LCURLY);
+        leftWS.set(Swift5Parser.COMMA);
+        leftWS.set(Swift5Parser.COLON);
+        leftWS.set(Swift5Parser.SEMI);
+
+        rightWS.set(Swift5Parser.WS);
+        rightWS.set(Swift5Parser.RPAREN);
+        rightWS.set(Swift5Parser.RBRACK);
+        rightWS.set(Swift5Parser.RCURLY);
+        rightWS.set(Swift5Parser.COMMA);
+        rightWS.set(Swift5Parser.COLON);
+        rightWS.set(Swift5Parser.SEMI);
+        rightWS.set(Swift5Parser.Line_comment);
+        rightWS.set(Swift5Parser.Block_comment);
+    }
+    
+    private static boolean isCharacterFromSet(Token token, BitSet bitSet) {
+        if (token.getType() == Token.EOF) {
+            return false;
+        } else {
+            String text = token.getText();
+            int codepoint = text.codePointAt(0);
+            if (Character.charCount(codepoint) != text.length()) {
+                // not a single character
+                return false;
+            } else {
+                return operatorCharacter.get(codepoint);
+            }
+        }
+    }
+
+    public static boolean isOperatorHead(Token token) {
+        return isCharacterFromSet(token, operatorHead);
+    }
+    
+    public static boolean isOperatorCharacter(Token token) {
+        return isCharacterFromSet(token, operatorCharacter);
+    }
+
+    public static boolean isOpNext(TokenStream tokens) {
+        int start = tokens.index();
+        Token lt = tokens.get(start);
+        int stop = getLastOpTokenIndex(tokens);
+        if ( stop==-1 ) return false;
+        // System.out.printf("isOpNext: i=%d t='%s'", start, lt.getText());
+        // System.out.printf(", op='%s'\n", tokens.getText(Interval.of(start,stop)));
+        return true;
+    }
+
+    /** Find stop token index of next operator; return -1 if not operator. */
+    public static int getLastOpTokenIndex(TokenStream tokens) {
+        int currentTokenIndex = tokens.index(); // current on-channel lookahead token index
+        Token currentToken = tokens.get(currentTokenIndex);
+        
+        //System.out.println("getLastOpTokenIndex: "+currentToken.getText());
+        
+        
+        // operator → dot-operator-head­ dot-operator-characters
+        if (currentToken.getType() == Swift5Parser.DOT && tokens.get(currentTokenIndex + 1).getType() == Swift5Parser.DOT) {
+            //System.out.println("DOT");
+                
+            // dot-operator
+            currentTokenIndex += 2; // point at token after ".."
+            currentToken = tokens.get(currentTokenIndex);
+            
+            // dot-operator-character → .­ | operator-character­
+            while (currentToken.getType() == Swift5Parser.DOT || isOperatorCharacter(currentToken)) {
+                //System.out.println("DOT");
+                currentTokenIndex++;
+                currentToken = tokens.get(currentTokenIndex);
+            }
+
+            //System.out.println("result: "+(currentTokenIndex - 1));
+            return currentTokenIndex - 1;
+        }
+        
+        // operator → operator-head­ operator-characters­?
+        
+        if (isOperatorHead(currentToken)) {
+            //System.out.println("isOperatorHead");
+                
+            tokens.getText(); // TODO. This line strangely fixes crash at mvn test, however, mvn compile gives me perfect working binary.
+            currentToken = tokens.get(currentTokenIndex);
+            while (isOperatorCharacter(currentToken)) {
+                //System.out.println("isOperatorCharacter");
+                currentTokenIndex++;
+                currentToken = tokens.get(currentTokenIndex);
+            }
+            //System.out.println("result: "+(currentTokenIndex - 1));
+            return currentTokenIndex - 1;
+        } else {
+            //System.out.println("result: "+(-1));
+            return -1;
+        }
+    }
+
+    /**
+     "If an operator has whitespace around both sides or around neither side,
+     it is treated as a binary operator. As an example, the + operator in a+b
+     and a + b is treated as a binary operator."
+     */
+    public static boolean isBinaryOp(TokenStream tokens) {
+        int stop = getLastOpTokenIndex(tokens);
+        if ( stop==-1 ) return false;
+
+        int start = tokens.index();
+        Token prevToken = tokens.get(start-1); // includes hidden-channel tokens
+        Token nextToken = tokens.get(stop+1);
+        boolean prevIsWS = isLeftOperatorWS(prevToken);
+        boolean nextIsWS = isRightOperatorWS(nextToken);
+        boolean result = prevIsWS && nextIsWS || (!prevIsWS && !nextIsWS);
+        String text = tokens.getText(Interval.of(start, stop));
+        //System.out.println("isBinaryOp: '"+prevToken+"','"+text+"','"+nextToken+"' is "+result);
+        return result;
+    }
+
+    /**
+     "If an operator has whitespace on the left side only, it is treated as a
+     prefix unary operator. As an example, the ++ operator in a ++b is treated
+     as a prefix unary operator."
+    */
+    public static boolean isPrefixOp(TokenStream tokens) {
+        int stop = getLastOpTokenIndex(tokens);
+        if ( stop==-1 ) return false;
+
+        int start = tokens.index();
+        Token prevToken = tokens.get(start-1); // includes hidden-channel tokens
+        Token nextToken = tokens.get(stop+1);
+        boolean prevIsWS = isLeftOperatorWS(prevToken);
+        boolean nextIsWS = isRightOperatorWS(nextToken);
+        boolean result = prevIsWS && !nextIsWS;
+        String text = tokens.getText(Interval.of(start, stop));
+        // System.out.println("isPrefixOp: '"+prevToken+"','"+text+"','"+nextToken+"' is "+result);
+        return result;
+    }
+
+    /**
+     "If an operator has whitespace on the right side only, it is treated as a
+     postfix unary operator. As an example, the ++ operator in a++ b is treated
+     as a postfix unary operator."
+
+     "If an operator has no whitespace on the left but is followed immediately
+     by a dot (.), it is treated as a postfix unary operator. As an example,
+     the ++ operator in a++.b is treated as a postfix unary operator (a++ .b
+     rather than a ++ .b)."
+     */
+    public static boolean isPostfixOp(TokenStream tokens) {
+        int stop = getLastOpTokenIndex(tokens);
+        if ( stop==-1 ) return false;
+
+        int start = tokens.index();
+        Token prevToken = tokens.get(start-1); // includes hidden-channel tokens
+        Token nextToken = tokens.get(stop+1);
+        boolean prevIsWS = isLeftOperatorWS(prevToken);
+        boolean nextIsWS = isRightOperatorWS(nextToken);
+        boolean result =
+            !prevIsWS && nextIsWS ||
+            !prevIsWS && nextToken.getType()==Swift5Parser.DOT;
+        String text = tokens.getText(Interval.of(start, stop));
+        // System.out.println("isPostfixOp: '"+prevToken+"','"+text+"','"+nextToken+"' is "+result);
+        return result;
+    }
+
+    public static boolean isOperator(TokenStream tokens, String op) {
+        int stop = getLastOpTokenIndex(tokens);
+        if ( stop==-1 ) return false;
+
+        int start = tokens.index();
+        String text = tokens.getText(Interval.of(start, stop));
+        // System.out.println("text: '"+text+"', op: '"+op+"', text.equals(op): '"+text.equals(op)+"'");
+
+        // for (int i = 0; i <= stop; i++) {
+        //     System.out.println("token["+i+"] = '"+tokens.getText(Interval.of(i, i))+"'");
+        // }
+        
+        return text.equals(op);
+    }
+
+    public static boolean isLeftOperatorWS(Token t) {
+        return leftWS.get(t.getType());
+    }
+
+    public static boolean isRightOperatorWS(Token t) {
+        return rightWS.get(t.getType()) || t.getType()==Token.EOF;
+    }
+
+    public static boolean isSeparatedStatement(TokenStream tokens, int indexOfPreviousStatement) {
+        //System.out.println("------");
+        //System.out.println("indexOfPreviousStatement: " + indexOfPreviousStatement);
+
+        int indexFrom = indexOfPreviousStatement - 1;
+        int indexTo = tokens.index() - 1;
+        
+        // Stupid check for new line and semicolon, can be optimized
+        if (indexFrom >= 0) {
+            while (indexFrom >= 0 && tokens.get(indexFrom).getChannel() == Token.HIDDEN_CHANNEL) {
+                indexFrom--;
+            }
+
+            //System.out.println("from: '" + tokens.getText(Interval.of(indexFrom, indexFrom))+"', "+tokens.get(indexFrom));
+            //System.out.println("to: '" + tokens.getText(Interval.of(indexTo, indexTo))+"', "+tokens.get(indexTo));
+            //System.out.println("in_between: '" + tokens.getText(Interval.of(indexFrom, indexTo)));
+            
+            if (tokens.getText(Interval.of(indexFrom, indexTo)).contains("\n")
+                || tokens.getText(Interval.of(indexFrom, indexTo)).contains(";"))
+            {
+                return true;
+            } else {
+                //for (int i = previousIndex; i < currentIndex; i++)
+                
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
For my college degree project I decided to contribute to the ANTLR4 grammar repo by updating the Swift grammar to version 5.
The grammar is heavily based on the Official documentation for Swift 5.4, and some workarounds are based on the ANTLR4 grammar for Swift 3.
It works well for the tests I have made, however I would appreciate some help for some more robust testing.
I hope this contribution will be welcomed.