### PR TITLE
Fix for Issue 2182, CI requires a watchdog program for runaway tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
     - name: Install trgen
       shell: pwsh
       run: |
-        dotnet tool install -g trgen --version 0.6.5
-        dotnet tool install -g trwdog --version 0.6.2
+        dotnet tool install -g trgen --version 0.7.0
+        dotnet tool install -g trwdog --version 0.7.0
         if ("${{ matrix.os }}" -eq "ubuntu-latest") {
             echo "$HOME/.dotnet/tools" >> $env:GITHUB_PATH
         }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
     - name: Install trgen
       shell: pwsh
       run: |
-        dotnet tool install -g trgen --version 0.6.4
-        dotnet tool install -g trwdog --version 0.6.1
+        dotnet tool install -g trgen --version 0.6.5
+        dotnet tool install -g trwdog --version 0.6.2
         if ("${{ matrix.os }}" -eq "ubuntu-latest") {
             echo "$HOME/.dotnet/tools" >> $env:GITHUB_PATH
         }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,7 @@ jobs:
       shell: pwsh
       run: |
         dotnet tool install -g trgen --version 0.5.3
+        dotnet tool install -g trwdog --version 0.6.0
         if ("${{ matrix.os }}" -eq "ubuntu-latest") {
             echo "$HOME/.dotnet/tools" >> $env:GITHUB_PATH
         }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
     - name: Install trgen
       shell: pwsh
       run: |
-        dotnet tool install -g trgen --version 0.5.3
-        dotnet tool install -g trwdog --version 0.6.0
+        dotnet tool install -g trgen --version 0.6.4
+        dotnet tool install -g trwdog --version 0.6.1
         if ("${{ matrix.os }}" -eq "ubuntu-latest") {
             echo "$HOME/.dotnet/tools" >> $env:GITHUB_PATH
         }

--- a/_scripts/readme.md
+++ b/_scripts/readme.md
@@ -2,9 +2,13 @@
 
 This directory contains scripts for CI testing.
 
-* regtest.sh -- This script is a Bash-based script to test any target. To
-run, make sure you are at the root directory of grammar-vs/, then type `bash regtest.sh <target>` where `<target>` is CSharp, Java, Cpp, Dart, Go, or one
-of the other targets.
+* regtest.sh -- This is a Bash-based script to test any target. To
+run, cd to grammar-vs/, then type `bash regtest.sh <target>` where `<target>` is CSharp, Java, Cpp, Dart, Go, or one
+of the other targets. To test the target, you will need the NET SDK installed,
+access to the internet, and to toolchain for the target you want to test.
+For CSharp, it will download the Antlr4 tool and runtime. For the other
+targets, you will need to download the Antlr4 tool antlr-4.9.2-complete.jar and
+place it in /tmp.
 
 * test.ps1 -- this is a Powershell script for testing, similar to regtest.sh.
 
@@ -16,28 +20,41 @@ to build and run the parse with the examples, so you do not need to memorize how
 to build and run the parser for the given target.
 
 To build and run the parser using the makefiles, you must be in an environment
-that provides make and Bash. Ubuntu provides that out of the box; for Windows,
-you must use MinGW64, pacman install [make](https://packages.msys2.org/package/mingw-w64-x86_64-make)
-and provide a symbolic link to "make" once installed. I don't know why,
-but the package doesn't define just a plain old "make.exe" like a sane person would.
+that provides make and Bash. Ubuntu provides that out of the box. For Windows,
+you must use MinGW64, then "pacman install [make](https://packages.msys2.org/package/mingw-w64-x86_64-make)"
+and provide a symbolic linked file for "make" once installed. I don't know why,
+but the package doesn't define just a plain old "make.exe".
 
     cd to a grammar directory, e.g., `cd abnf`.
-    trgen -t CSharp
+    trgen -t CSharp --template-sources-directory _scripts/templates/ --antlr-tool-path /tmp/antlr-4.9.2-complete.jar
     make
     make test
 
-You can look at the generated makefile to see what is exactly done.
-Makefiles are human readable, easy to understand, but only work on
-MinGW64 for Windows, or in a shell in Ubuntu. The makefiles do not set
-up your environment; you will need to do that yourself.
+Please note the parameters to trgen: "--template-sources-directory" is used
+to say where to find the templates used in this repo for the driver programs.
+By default, trgen has a collection of generic templates, and while they are
+generic, you might want to test the grammars in this repo with the templates
+used in CI builds.
 
-For Windows or Ubuntu, you are very likely going to need to provide
-a "~/.trgen.rc" file. For Windows, you will need to provide a full
-Windows path name for the Antlr jar file:
+For Windows or Ubuntu, you may want to provide
+a "~/.trgen.rc" file to override defaults for that program.
+For example,
 
-	{
-	"antlr_tool_path" : "c:/users/kenne/downloads/antlr-4.9.2-complete.jar"
-	}
+    {
+        "antlr_tool_path" : "c:/users/kenne/downloads/antlr-4.9.2-complete.jar"
+    }
+
+For the trwdog tool, you may want to override the default 5 minute timeout
+for parse tests to complete, e.g., if you are on a slow machine. To do that,
+create a "~/.trwdog.rc" file.
+
+    {
+        "Timeout" : 2
+    }
+
+
+The home directory is computed via the C# runtime:
+`Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)`.
 
 # Templates for CI testing
 
@@ -52,7 +69,7 @@ the trgen tool may not add the new template files into your generated code.
 ## What version of trgen do I use?
 
 You should take care to specify a version when installing the trgen tool.
-I change the tool often, and there may be regressions. Currently version 0.5.3
+I change the tool often, and there may be regressions. Currently version 0.7.0
 works well.
 
 ## Structure

--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -153,11 +153,11 @@ part1()
 {
     date
     dotnet tool uninstall -g trgen
-    dotnet tool install -g trgen --version 0.5.3
+    dotnet tool install -g trgen --version 0.6.4
     dotnet tool uninstall -g trxml2
     dotnet tool install -g trxml2 --version 0.5.0
     dotnet tool uninstall -g trwdog
-    dotnet tool install -g trwdog --version 0.6.0
+    dotnet tool install -g trwdog --version 0.6.1
     # 1) Generate driver source code from poms.
     rm -rf `find . -name Generated -type d`
     echo "Generating drivers."

--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -153,11 +153,11 @@ part1()
 {
     date
     dotnet tool uninstall -g trgen
-    dotnet tool install -g trgen --version 0.6.4
+    dotnet tool install -g trgen --version 0.6.5
     dotnet tool uninstall -g trxml2
     dotnet tool install -g trxml2 --version 0.5.0
     dotnet tool uninstall -g trwdog
-    dotnet tool install -g trwdog --version 0.6.1
+    dotnet tool install -g trwdog --version 0.6.2
     # 1) Generate driver source code from poms.
     rm -rf `find . -name Generated -type d`
     echo "Generating drivers."

--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -156,6 +156,8 @@ part1()
     dotnet tool install -g trgen --version 0.5.3
     dotnet tool uninstall -g trxml2
     dotnet tool install -g trxml2 --version 0.5.0
+    dotnet tool uninstall -g trwdog
+    dotnet tool install -g trwdog --version 0.6.0
     # 1) Generate driver source code from poms.
     rm -rf `find . -name Generated -type d`
     echo "Generating drivers."

--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -153,11 +153,11 @@ part1()
 {
     date
     dotnet tool uninstall -g trgen
-    dotnet tool install -g trgen --version 0.6.5
+    dotnet tool install -g trgen --version 0.7.0
     dotnet tool uninstall -g trxml2
-    dotnet tool install -g trxml2 --version 0.5.0
+    dotnet tool install -g trxml2 --version 0.7.0
     dotnet tool uninstall -g trwdog
-    dotnet tool install -g trwdog --version 0.6.2
+    dotnet tool install -g trwdog --version 0.7.0
     # 1) Generate driver source code from poms.
     rm -rf `find . -name Generated -type d`
     echo "Generating drivers."

--- a/_scripts/templates/Antlr4cs/Program.cs
+++ b/_scripts/templates/Antlr4cs/Program.cs
@@ -69,8 +69,8 @@ public class Program
         }
         else if (input != null)
         {
-	    str = new Antlr4.Runtime.AntlrInputStream(
-		    new MemoryStream(Encoding.UTF8.GetBytes(input ?? "")));
+            str = new Antlr4.Runtime.AntlrInputStream(
+                    new MemoryStream(Encoding.UTF8.GetBytes(input ?? "")));
         } else if (file_name != null)
         {
             FileStream fs = new FileStream(file_name, FileMode.Open);

--- a/_scripts/templates/Antlr4cs/makefile
+++ b/_scripts/templates/Antlr4cs/makefile
@@ -4,7 +4,7 @@ default:
 	dotnet restore
 	dotnet build
 run:
-	dotnet run $(RUNARGS)
+	trwdog dotnet run $(RUNARGS)
 clean:
 	dotnet clean
 	rm -rf bin obj

--- a/_scripts/templates/Antlr4cs/test.sh
+++ b/_scripts/templates/Antlr4cs/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    cat "$file" | ./bin/Debug/net5.0/<exec_name>
+    cat "$file" | trwdog ./bin/Debug/net5.0/<exec_name>
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Antlr4cs/tester.psm1
+++ b/_scripts/templates/Antlr4cs/tester.psm1
@@ -1,0 +1,25 @@
+function Build-Grammar {
+    $msg = dotnet build -o CSharp
+    return @{
+        Message = $msg
+        Success = $LASTEXITCODE -eq 0
+    }
+}
+
+function Test-Case {
+    param (
+        $InputFile,
+        $TokenFile,
+        $TreeFile,
+        $ErrorFile
+    )
+    $o = dotnet CSharp/Test.dll -file $InputFile
+    $failed = $LASTEXITCODE -ne 0
+    if ($failed -and $errorFile) {
+        return $true
+    }
+    if(!$failed -and !$errorFile){
+        return $true
+    }
+    return $false
+}

--- a/_scripts/templates/Antlr4cs/tester.psm1
+++ b/_scripts/templates/Antlr4cs/tester.psm1
@@ -13,7 +13,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = dotnet CSharp/Test.dll -file $InputFile
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/CSharp/makefile
+++ b/_scripts/templates/CSharp/makefile
@@ -4,7 +4,7 @@ default:
 	dotnet restore
 	dotnet build
 run:
-	dotnet run $(RUNARGS)
+	trwdog dotnet run $(RUNARGS)
 clean:
 	dotnet clean
 	rm -rf bin obj

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    cat "$file" | ./bin/Debug/net5.0/<exec_name>
+    cat "$file" | trwdog ./bin/Debug/net5.0/<exec_name>
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/CSharp/tester.psm1
+++ b/_scripts/templates/CSharp/tester.psm1
@@ -13,7 +13,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = dotnet CSharp/Test.dll -file $InputFile
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/Cpp/Program.cpp
+++ b/_scripts/templates/Cpp/Program.cpp
@@ -91,17 +91,17 @@ int TryParse(std::vector\<std::string>& args)
     auto duration = std::chrono::duration_cast\<std::chrono::microseconds>(after - before);
     if (listener_parser->had_error || listener_lexer->had_error)
     {
-        std::cout \<\< "Parse failed." \<\< std::endl;
+        std::cerr \<\< "Parse failed." \<\< std::endl;
     }
     else
     {
-        std::cout \<\< "Parse succeeded." \<\< std::endl;
+        std::cerr \<\< "Parse succeeded." \<\< std::endl;
     }
     if (show_tree)
     {
 //        System.Console.Error.WriteLine(tree.ToStringTree(parser));
     }
-    std::cout \<\< "Time: " \<\< formatDuration(duration.count()) \<\< std::endl;
+    std::cerr \<\< "Time: " \<\< formatDuration(duration.count()) \<\< std::endl;
     return 0;
 }
 

--- a/_scripts/templates/Cpp/makefile
+++ b/_scripts/templates/Cpp/makefile
@@ -2,7 +2,7 @@
 default:
 	rm -rf build; mkdir build; cd build; cmake .. <cmake_target>; $(MAKE)
 run:
-	cd build; ./<exec_name> $(RUNARGS)
+	cd build; trwdog ./<exec_name> $(RUNARGS)
 clean:
 	rm -rf build
 test:

--- a/_scripts/templates/Cpp/test.sh
+++ b/_scripts/templates/Cpp/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    ./build/<exec_name> -file "$file"
+    trwdog ./build/<exec_name> -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Dart/cli.dart
+++ b/_scripts/templates/Dart/cli.dart
@@ -12,34 +12,34 @@ class CaseChangingCharStream extends CharStream {
         CharStream stream;
         bool upper;
 
-	CaseChangingCharStream(CharStream str, bool up)
-	{
-		stream = str;
-		upper = up;
-	}
+    CaseChangingCharStream(CharStream str, bool up)
+    {
+        stream = str;
+        upper = up;
+    }
 
-	@override
-	int get index {
-		return stream.index;
-	}
+    @override
+    int get index {
+        return stream.index;
+    }
 
-	@override
-	int get size {
-		return stream.size;
-	}
+    @override
+    int get size {
+        return stream.size;
+    }
 
-//	@override
-//	void reset() {
-//		stream.reset();
-//	}
+//  @override
+//  void reset() {
+//      stream.reset();
+//  }
 
-	@override
-	void consume() {
-		stream.consume();
-	}
+    @override
+    void consume() {
+        stream.consume();
+    }
 
-	@override
-	int LA(int offset) {
+    @override
+    int LA(int offset) {
             int c = stream.LA(offset);
 
             if (c \<= 0)
@@ -64,37 +64,37 @@ class CaseChangingCharStream extends CharStream {
                     o = o + (97 - 65);
                 return o;
             }
-	}
+    }
 
-	@override
-	int mark() {
-		return stream.mark();
-	}
+    @override
+    int mark() {
+        return stream.mark();
+    }
 
-	@override
-	void release(int marker) {
-		stream.release(marker);
-	}
+    @override
+    void release(int marker) {
+        stream.release(marker);
+    }
 
-	@override
-	void seek(int _index) {
-		stream.seek(_index);
-	}
+    @override
+    void seek(int _index) {
+        stream.seek(_index);
+    }
 
-//	String getText(Interval interval)
-//	{
-//		this.stream.getText(interval);
-//	}
+//  String getText(Interval interval)
+//  {
+//      this.stream.getText(interval);
+//  }
 
-	@override
-	String toString() {
-		return this.stream.toString();
-	}
+    @override
+    String toString() {
+        return this.stream.toString();
+    }
 
-	@override
-	String get sourceName {
-		return stream.sourceName;
-	}
+    @override
+    String get sourceName {
+        return stream.sourceName;
+    }
 
 @override
     noSuchMethod(Invocation msg) => "got ${msg.memberName} "
@@ -130,13 +130,13 @@ void main(List\<String> args) async {
     }>
     if (input == null && file_name == null)
     {
-	    final List\<int> bytes = \<int>[];
-	    int byte = stdin.readByteSync();
-	    while (byte >= 0) {
-		    bytes.add(byte);
-		    byte = stdin.readByteSync();
-	    }
-	    input = utf8.decode(bytes);
+        final List\<int> bytes = \<int>[];
+        int byte = stdin.readByteSync();
+        while (byte >= 0) {
+            bytes.add(byte);
+            byte = stdin.readByteSync();
+        }
+        input = utf8.decode(bytes);
         str = await InputStream.fromString(input);
     } else if (input != null)
     {
@@ -154,7 +154,7 @@ void main(List\<String> args) async {
         for (int i = 0; ; ++i)
         {
             var token = lexer.nextToken();
-	        print(token.toString());
+            print(token.toString());
             if (token.type == -1)
                 break;
         }
@@ -169,11 +169,11 @@ void main(List\<String> args) async {
     var tree = parser.<start_symbol>();
     if (parser.numberOfSyntaxErrors > 0)
     {
-        print("Parse failed.");
+        stderr.writeln("Parse failed.");
     }
     else
     {
-        print("Parse succeeded.");
+        stderr.writeln("Parse succeeded.");
     }
     if (show_tree)
     {

--- a/_scripts/templates/Dart/makefile
+++ b/_scripts/templates/Dart/makefile
@@ -16,7 +16,7 @@ clean:
 	rm -f $(GENERATED)
 	rm -f pubspec.lock
 run:
-	dart run cli.dart $(RUNARGS)
+	trwdog dart run cli.dart $(RUNARGS)
 <tool_grammar_tuples:{x | <x.GeneratedFileName> : <x.GrammarFileName>
 	java -jar $(JAR) -Dlanguage=Dart <antlr_tool_args:{y | <y> } > $\<
 } >

--- a/_scripts/templates/Dart/makefile
+++ b/_scripts/templates/Dart/makefile
@@ -16,7 +16,7 @@ clean:
 	rm -f $(GENERATED)
 	rm -f pubspec.lock
 run:
-	trwdog dart run cli.dart $(RUNARGS)
+	trwdog <if(os_win)>dart.bat<else>dart<endif> run cli.dart $(RUNARGS)
 <tool_grammar_tuples:{x | <x.GeneratedFileName> : <x.GrammarFileName>
 	java -jar $(JAR) -Dlanguage=Dart <antlr_tool_args:{y | <y> } > $\<
 } >

--- a/_scripts/templates/Dart/test.sh
+++ b/_scripts/templates/Dart/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    dart run cli.dart -file "$file"
+    trwdog dart run cli.dart -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Dart/test.sh
+++ b/_scripts/templates/Dart/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog dart run cli.dart -file "$file"
+    trwdog <if(os_win)>dart.bat<else>dart<endif> run cli.dart -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Dart/tester.psm1
+++ b/_scripts/templates/Dart/tester.psm1
@@ -29,7 +29,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = ./cli.exe -file $InputFile
+    $o = trwdog ./cli.exe -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/Go/Program.go
+++ b/_scripts/templates/Go/Program.go
@@ -2,8 +2,8 @@
 
 package main
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
     "io"
     "github.com/antlr/antlr4/runtime/Go/antlr"
     "./parser"
@@ -12,28 +12,28 @@ import (
 <endif>
 )
 type CustomErrorListener struct {
-	errors int
+    errors int
 }
 
 func NewCustomErrorListener() *CustomErrorListener {
-	return new(CustomErrorListener)
+    return new(CustomErrorListener)
 }
 
 func (l *CustomErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
-	l.errors += 1
-	antlr.ConsoleErrorListenerINSTANCE.SyntaxError(recognizer, offendingSymbol, line, column, msg, e)
+    l.errors += 1
+    antlr.ConsoleErrorListenerINSTANCE.SyntaxError(recognizer, offendingSymbol, line, column, msg, e)
 }
 
 func (l *CustomErrorListener) ReportAmbiguity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, exact bool, ambigAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
-	antlr.ConsoleErrorListenerINSTANCE.ReportAmbiguity(recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs)
+    antlr.ConsoleErrorListenerINSTANCE.ReportAmbiguity(recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs)
 }
 
 func (l *CustomErrorListener) ReportAttemptingFullContext(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, conflictingAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
-	antlr.ConsoleErrorListenerINSTANCE.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs)
+    antlr.ConsoleErrorListenerINSTANCE.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs)
 }
 
 func (l *CustomErrorListener) ReportContextSensitivity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex, prediction int, configs antlr.ATNConfigSet) {
-	antlr.ConsoleErrorListenerINSTANCE.ReportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, configs)
+    antlr.ConsoleErrorListenerINSTANCE.ReportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, configs)
 }
 
 
@@ -42,8 +42,8 @@ func main() {
     var show_tokens = false
     var file_name = ""
     var input = ""
-	var str antlr.CharStream = nil
-	for i := 0; i \< len(os.Args); i = i + 1 {
+    var str antlr.CharStream = nil
+    for i := 0; i \< len(os.Args); i = i + 1 {
         if os.Args[i] == "-tokens" {
             show_tokens = true
             continue
@@ -51,22 +51,22 @@ func main() {
             show_tree = true
             continue
         } else if os.Args[i] == "-input" {
-			i = i + 1
-			input = os.Args[i]
+            i = i + 1
+            input = os.Args[i]
         } else if os.Args[i] == "-file" {
-			i = i + 1
-			file_name = os.Args[i]
-		}
+            i = i + 1
+            file_name = os.Args[i]
+        }
     }
     if input == "" && file_name == "" {
         var b []byte = make([]byte, 1)
         var st = ""
-	    for {
-		    _, err := os.Stdin.Read(b)
+        for {
+            _, err := os.Stdin.Read(b)
             if err == io.EOF {
                 break
             }
-		    st = st + string(b)
+            st = st + string(b)
         }
         str = antlr.NewInputStream(st)
     } else if input != "" {
@@ -79,46 +79,46 @@ func main() {
 <endif>
     var lexer = <go_lexer_name>(str);
     if show_tokens {
-		j := 0
-	    for {
-		    t := lexer.NextToken()
-			// missing ToString() of all types.
-			fmt.Print(j)
-			fmt.Print(" ")
-			//	    fmt.Print(t.String())
-			fmt.Print(" ")
-			fmt.Println(t.GetText())
-			if t.GetTokenType() == antlr.TokenEOF {
-				break
-			}
-			j = j + 1
-	    }
+        j := 0
+        for {
+            t := lexer.NextToken()
+            // missing ToString() of all types.
+            fmt.Print(j)
+            fmt.Print(" ")
+            //      fmt.Print(t.String())
+            fmt.Print(" ")
+            fmt.Println(t.GetText())
+            if t.GetTokenType() == antlr.TokenEOF {
+                break
+            }
+            j = j + 1
+        }
         // missing
         // lexer.reset()
     }
-	// Requires additional 0??
+    // Requires additional 0??
     var tokens = antlr.NewCommonTokenStream(lexer, 0)
     var parser = <go_parser_name>(tokens)
 
-	lexerErrors := &CustomErrorListener{}
-	lexer.RemoveErrorListeners()
-	lexer.AddErrorListener(lexerErrors)
+    lexerErrors := &CustomErrorListener{}
+    lexer.RemoveErrorListeners()
+    lexer.AddErrorListener(lexerErrors)
 
-	parserErrors := &CustomErrorListener{}
-	parser.RemoveErrorListeners()
-	parser.AddErrorListener(parserErrors)
+    parserErrors := &CustomErrorListener{}
+    parser.RemoveErrorListeners()
+    parser.AddErrorListener(parserErrors)
 
-	// mutated name--not lowercase.
+    // mutated name--not lowercase.
     var tree = parser.<cap_start_symbol>()
-	// missing
+    // missing
     if parserErrors.errors > 0 || lexerErrors.errors > 0 {
-        fmt.Println("Parse failed.");
+        os.Stderr.WriteString("Parse failed.");
     } else {
-        fmt.Println("Parse succeeded.")
+        os.Stderr.WriteString("Parse succeeded.")
     }
     if show_tree {
-		ss := tree.ToStringTree(parser.RuleNames, parser)
-		fmt.Println(ss)
+        ss := tree.ToStringTree(parser.RuleNames, parser)
+        fmt.Println(ss)
     }
     if parserErrors.errors > 0 || lexerErrors.errors > 0 {
         os.Exit(1)

--- a/_scripts/templates/Go/makefile
+++ b/_scripts/templates/Go/makefile
@@ -14,7 +14,7 @@ clean:
 	rm -f *.tokens *.interp
 	rm -f $(GENERATED)
 run:
-	export GO111MODULE=auto; go run Program.go $(RUNARGS)
+	export GO111MODULE=auto; trwdog go run Program.go $(RUNARGS)
 <tool_grammar_tuples:{x | <x.GeneratedFileName> : <x.GrammarFileName>
 	java -jar $(JAR) -Dlanguage=Go <antlr_tool_args:{y | <y> } > $\<
 } >

--- a/_scripts/templates/Go/test.sh
+++ b/_scripts/templates/Go/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    go run Program.go -file "$file"
+    trwdog go run Program.go -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -29,7 +29,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = ./Program -file $InputFile
+    $o = trwdog ./Program -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/Java/Program.java
+++ b/_scripts/templates/Java/Program.java
@@ -69,9 +69,9 @@ public class Program {
         lexer.addErrorListener(lexer_listener);
         ParseTree tree = parser.<start_symbol>();
         if (listener.had_error || lexer_listener.had_error)
-            System.out.println("Parse failed.");
+            System.err.println("Parse failed.");
         else
-            System.out.println("Parse succeeded.");
+            System.err.println("Parse succeeded.");
         if (show_tree)
         {
             System.out.println(tree.toStringTree(parser));

--- a/_scripts/templates/Java/makefile
+++ b/_scripts/templates/Java/makefile
@@ -21,7 +21,7 @@ clean:
 	rm -f *.tokens
 	rm -f $(GENERATED)
 run:
-	java -classpath $(CLASSPATH) Program $(RUNARGS)
+	trwdog java -classpath $(CLASSPATH) Program $(RUNARGS)
 <tool_grammar_tuples:{x | <x.GeneratedFileName> : <x.GrammarFileName>
 	java -jar $(JAR) <antlr_tool_args:{y | <y> } > $\<
 } >

--- a/_scripts/templates/Java/test.sh
+++ b/_scripts/templates/Java/test.sh
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    java -classpath $CLASSPATH Program -file "$file"
+    trwdog java -classpath $CLASSPATH Program -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Java/tester.psm1
+++ b/_scripts/templates/Java/tester.psm1
@@ -22,7 +22,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = java Program -file $InputFile
+    $o = trwdog java Program -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/JavaScript/index.js
+++ b/_scripts/templates/JavaScript/index.js
@@ -10,19 +10,19 @@ const strops = require('typescript-string-operations');
 let fs = require('fs-extra')
 
 function getChar() {
-	let buffer = Buffer.alloc(1);
-	var xx = fs.readSync(0, buffer, 0, 1);
-	if (xx === 0) {
-		return '';
-	}
+    let buffer = Buffer.alloc(1);
+    var xx = fs.readSync(0, buffer, 0, 1);
+    if (xx === 0) {
+        return '';
+    }
     return buffer.toString('utf8');
 }
 
 class MyErrorListener extends antlr4.error.ErrorListener {
-	syntaxError(recognizer, offendingSymbol, line, column, msg, err) {
-		num_errors++;
-		console.error(`${offendingSymbol} line ${line}, col ${column}: ${msg}`);
-	}
+    syntaxError(recognizer, offendingSymbol, line, column, msg, err) {
+        num_errors++;
+        console.error(`${offendingSymbol} line ${line}, col ${column}: ${msg}`);
+    }
 }
 
 var show_tokens = false;
@@ -98,11 +98,11 @@ if (show_tree)
 }
 if (num_errors > 0)
 {
-    console.log('Parse failed.');
+    console.error('Parse failed.');
     process.exitCode = 1;
 }
 else
 {
-    console.log('Parse succeeded.');
+    console.error('Parse succeeded.');
     process.exitCode = 0;
 }

--- a/_scripts/templates/JavaScript/makefile
+++ b/_scripts/templates/JavaScript/makefile
@@ -16,7 +16,7 @@ clean:
 	rm -f *.tokens
 	rm -f $(GENERATED)
 run:
-	node index.js $(RUNARGS)
+	trwdog node index.js $(RUNARGS)
 <tool_grammar_tuples:{x | <x.GeneratedFileName> : <x.GrammarFileName>
 	java -jar $(JAR) -Dlanguage=JavaScript <antlr_tool_args:{y | <y> } > $\<
 } >

--- a/_scripts/templates/JavaScript/test.sh
+++ b/_scripts/templates/JavaScript/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    node index.js -file "$file"
+    trwdog node index.js -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/JavaScript/tester.psm1
+++ b/_scripts/templates/JavaScript/tester.psm1
@@ -22,7 +22,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = node index.js -file $InputFile
+    $o = trwdog node index.js -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/Python3/Program.py
+++ b/_scripts/templates/Python3/Program.py
@@ -87,10 +87,10 @@ def main(argv):
     if (show_tree):
         print(tree.toStringTree(recog=parser))
     if p_listener.num_errors > 0 or l_listener.num_errors > 0:
-        print('Parse failed.');
+        print('Parse failed.', file=sys.stderr);
         sys.exit(1)
     else:
-        print('Parse succeeded.');
+        print('Parse succeeded.', file=sys.stderr);
         sys.exit(0)
 
 if __name__ == '__main__':

--- a/_scripts/templates/Python3/makefile
+++ b/_scripts/templates/Python3/makefile
@@ -16,7 +16,7 @@ clean:
 	rm -f *.tokens
 	rm -f $(GENERATED)
 run:
-	python Program.py $(RUNARGS)
+	trwdog python Program.py $(RUNARGS)
 <tool_grammar_tuples:{x | <x.GeneratedFileName> : <x.GrammarFileName>
 	java -jar $(JAR) -Dlanguage=Python3 <antlr_tool_args:{y | <y> } > $\<
 } >

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog -t 240 python Program.py -file "$file"
+    trwdog python Program.py -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    python Program.py -file "$file"
+    trwdog python Program.py -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -8,7 +8,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog python Program.py -file "$file"
+    trwdog -t 240 python Program.py -file "$file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -22,7 +22,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog python Program.py -file $InputFile
+    $o = trwdog -t 240 python Program.py -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -22,7 +22,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog -t 240 python Program.py -file $InputFile
+    $o = trwdog python Program.py -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -22,7 +22,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = python Program.py -file $InputFile
+    $o = trwdog python Program.py -file $InputFile
     $failed = $LASTEXITCODE -ne 0
     if ($failed -and $errorFile) {
         return $true

--- a/_scripts/templates/files
+++ b/_scripts/templates/files
@@ -3,6 +3,7 @@
 ./Antlr4cs/Program.cs
 ./Antlr4cs/Test.csproj
 ./Antlr4cs/test.sh
+./Antlr4cs/tester.psm1
 ./Arithmetic.g4
 ./Cpp/CaseChangingCharStream.cpp
 ./Cpp/CaseChangingCharStream.h


### PR DESCRIPTION
## Introduction
This is a fix to #2182, for CI builds that "hang", or just simply take way too long. Runaway tests have happened several times: [CI 742](https://github.com/antlr/grammars-v4/actions/runs/813077171), [CI 789](https://github.com/antlr/grammars-v4/actions/runs/811386045), [CI 764](https://github.com/antlr/grammars-v4/actions/runs/794538366), and typically occur for one of the slower targets, such as Go or Javascript. Hangs could happen for a number of reasons: a bug in the runtime or a poor choice of a data structure. Until now, the "skip lists" were used to manage this problem, which would involve testing first on the developer's machine before submitting the PR. Some changes [were made](https://github.com/antlr/grammars-v4/commit/7830e465420ce433fca22f2d50cc8de1e76c39c9#diff-b384a886f95430e252ae85c366cc5984d0a8d75701640a2caeb2eee3da67315dR19) to stop testing all parses once one parse fails, but it doesn't fix the "hang" problem.

Unfortunately, even if a developer can test the changes locally, testing is incomplete until the PR is actually submitted:
* The developer's machine supports only one OS.
* The developer's machine has different hardware than what is used for Github Actions.
* The developer's machine doesn't have enough resources, or the right resources installed.
* Github Actions is not implemented on a developer's machine.
* If the grammar is misspelled in the list, the regular expression generated from the skip list won't match the actual name of the grammar.
* When the grammar is added, the default behavior for CI is to test across all targets. Modifying the skip is an afterthought.

## Overall solution
This change adds a [watchdog program](https://github.com/kaby76/Domemtech.Trash/tree/main/trwdog) wrapper to the tests in the templates for each target. The watchdog program is very simple: spawn a process of a program specified by the command-line arguments to the program. At the same time, start a timer for 5 minutes. If the program does not terminate within the timeout period, kill the process tree and return an error. Otherwise, return the result of the spawned process.

## Implementation details
Changes were made to:
* The .github actions, to set up the environment by installing the watchdog program. Two files were modified to install the newest version of trgen and trwdog, the watchdog program, when the build starts.
* "trwdog" is invoked with the command line args to call the target toolchain parser. About two dozen files required the change.  I removed tabs in the source code since my editors don't handle tab expansion correctly when programs are debugged.
* The timeout period for the watchdog program defaults to 5 minutes. While one can pass an option to trwdog for a different timer, I felt it would be too verbose to pass the parameter on each trwdog call in all ~20 or so files. Instead, if one wants to set a different timeout period, create a JSON file for the option in ~/.trwdog.rc. It is likely I will add other options.
* The watchdog program currently only performs time-outs, so it doesn't check high memory usage as I mentioned in the issue. Usually, the two are interrelated.