### PR TITLE
Remove duplicate alternatives from the `theOperator` in CPP grammar.

### DIFF
--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -791,7 +791,6 @@ theOperator:
 	| PlusAssign
 	| MinusAssign
 	| StarAssign
-	| Assign
 	| ModAssign
 	| XorAssign
 	| AndAssign

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -802,7 +802,6 @@ theOperator:
 	| Equal
 	| NotEqual
 	| LessEqual
-	| GreaterEqual
 	| AndAnd
 	| OrOr
 	| PlusPlus


### PR DESCRIPTION
There are two `Assign` in the `theOperator` parser rule in the CPP grammar.