### PR TITLE
Fix for Issue 2204, "CI build fails in Dice"

### DIFF
--- a/dice/DiceNotationParser.g4
+++ b/dice/DiceNotationParser.g4
@@ -19,7 +19,7 @@
  * 
  * This is the notation which RPGs and other tabletop games use to represent operations with dice.
  */
-grammar DiceNotation;
+parser grammar DiceNotationParser;
 
 options { tokenVocab=DiceNotationLexer; }
 

--- a/dice/pom.xml
+++ b/dice/pom.xml
@@ -19,7 +19,7 @@
 					<sourceDirectory>${basedir}</sourceDirectory>
 					<includes>
 					   <include>DiceNotationLexer.g4</include>
-					   <include>DiceNotation.g4</include>
+					   <include>DiceNotationParser.g4</include>
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>


### PR DESCRIPTION
There's a problem with the build in that the Antlr tool isn't being run on both grammars correctly. Dice is a split grammar, but after reading over this, I noticed a problem: the lexer grammar was labeled as a lexer grammar, but the parser grammar was actually a "combined" grammar, not a proper "parser grammar". I changed the name of the "combined" grammar to be a "parser grammar", changed the file name to reflect the parser name, and updated the POM file. I'm hoping this takes care of the build problem.