### PR TITLE
Added support for nested template strings

### DIFF
--- a/javascript/javascript/Antlr4cs/JavaScriptLexerBase.cs
+++ b/javascript/javascript/Antlr4cs/JavaScriptLexerBase.cs
@@ -28,6 +28,17 @@ public abstract class JavaScriptLexerBase : Lexer
     /// </summary>
     private bool _useStrictCurrent = false;
 
+    /// <summary>
+    /// Keeps track of the the current depth of nested template string backticks.
+    /// E.g. after the X in:
+    ///
+    /// `${a ? `${X
+    ///
+    /// templateDepth will be 2. This variable is needed to determine if a `}` is a
+    /// plain CloseBrace, or one that closes an expression inside a template string.
+    /// </summary>
+    private int _templateDepth = 0;
+
     public JavaScriptLexerBase(ICharStream input)
         : base(input)
     {
@@ -53,6 +64,11 @@ public abstract class JavaScriptLexerBase : Lexer
     public bool IsStrictMode()
     {
         return _useStrictCurrent;
+    }
+
+    public bool IsInTemplateString()
+    {
+        return _templateDepth > 0;
     }
 
     /// <summary>
@@ -102,6 +118,16 @@ public abstract class JavaScriptLexerBase : Lexer
                 scopeStrictModes.Push(_useStrictCurrent);
             }
         }
+    }
+
+    public void IncreaseTemplateDepth()
+    {
+        _templateDepth++;
+    }
+
+    public void DecreaseTemplateDepth()
+    {
+        _templateDepth--;
     }
 
     /// <summary>

--- a/javascript/javascript/CSharp/JavaScriptLexerBase.cs
+++ b/javascript/javascript/CSharp/JavaScriptLexerBase.cs
@@ -29,6 +29,17 @@ public abstract class JavaScriptLexerBase : Lexer
     /// </summary>
     private bool _useStrictCurrent = false;
 
+    /// <summary>
+    /// Keeps track of the the current depth of nested template string backticks.
+    /// E.g. after the X in:
+    ///
+    /// `${a ? `${X
+    ///
+    /// templateDepth will be 2. This variable is needed to determine if a `}` is a
+    /// plain CloseBrace, or one that closes an expression inside a template string.
+    /// </summary>
+    private int _templateDepth = 0;
+
     public JavaScriptLexerBase(ICharStream input)
         : base(input)
     {
@@ -58,6 +69,11 @@ public abstract class JavaScriptLexerBase : Lexer
     public bool IsStrictMode()
     {
         return _useStrictCurrent;
+    }
+
+    public bool IsInTemplateString()
+    {
+        return _templateDepth > 0;
     }
 
     /// <summary>
@@ -107,6 +123,16 @@ public abstract class JavaScriptLexerBase : Lexer
                 scopeStrictModes.Push(_useStrictCurrent);
             }
         }
+    }
+
+    public void IncreaseTemplateDepth()
+    {
+        _templateDepth++;
+    }
+
+    public void DecreaseTemplateDepth()
+    {
+        _templateDepth--;
     }
 
     /// <summary>

--- a/javascript/javascript/Java/JavaScriptLexerBase.java
+++ b/javascript/javascript/Java/JavaScriptLexerBase.java
@@ -25,6 +25,16 @@ public abstract class JavaScriptLexerBase extends Lexer
      * Can be defined during parsing, see StringFunctions.js and StringGlobal.js samples
      */
     private boolean useStrictCurrent = false;
+    /**
+     * Keeps track of the the current depth of nested template string backticks.
+     * E.g. after the X in:
+     *
+     * `${a ? `${X
+     *
+     * templateDepth will be 2. This variable is needed to determine if a `}` is a
+     * plain CloseBrace, or one that closes an expression inside a template string.
+     */
+    private int templateDepth = 0;
 
     public JavaScriptLexerBase(CharStream input) {
         super(input);
@@ -45,6 +55,10 @@ public abstract class JavaScriptLexerBase extends Lexer
 
     public boolean IsStrictMode() {
         return useStrictCurrent;
+    }
+
+    public boolean IsInTemplateString() {
+        return this.templateDepth > 0;
     }
 
     /**
@@ -92,6 +106,14 @@ public abstract class JavaScriptLexerBase extends Lexer
                 scopeStrictModes.push(useStrictCurrent);
             }
         }
+    }
+
+    public void IncreaseTemplateDepth() {
+        this.templateDepth++;
+    }
+
+    public void DecreaseTemplateDepth() {
+        this.templateDepth--;
     }
 
     /**

--- a/javascript/javascript/JavaScriptLexer.g4
+++ b/javascript/javascript/JavaScriptLexer.g4
@@ -44,6 +44,7 @@ CloseBracket:                   ']';
 OpenParen:                      '(';
 CloseParen:                     ')';
 OpenBrace:                      '{' {this.ProcessOpenBrace();};
+TemplateCloseBrace:             {this.IsInTemplateString()}? '}' -> popMode;
 CloseBrace:                     '}' {this.ProcessCloseBrace();};
 SemiColon:                      ';';
 Comma:                          ',';
@@ -188,8 +189,7 @@ StringLiteral:                 ('"' DoubleStringCharacter* '"'
              |                  '\'' SingleStringCharacter* '\'') {this.ProcessStringLiteral();}
              ;
 
-// TODO: `${`tmp`}`
-TemplateStringLiteral:          '`' ('\\`' | ~'`')* '`';
+BackTick:                       '`' {this.IncreaseTemplateDepth();} -> pushMode(TEMPLATE);
 
 WhiteSpaces:                    [\t\u000B\u000C\u0020\u00A0]+ -> channel(HIDDEN);
 
@@ -201,6 +201,12 @@ LineTerminator:                 [\r\n\u2028\u2029] -> channel(HIDDEN);
 HtmlComment:                    '<!--' .*? '-->' -> channel(HIDDEN);
 CDataComment:                   '<![CDATA[' .*? ']]>' -> channel(HIDDEN);
 UnexpectedCharacter:            . -> channel(ERROR);
+
+mode TEMPLATE;
+
+BackTickInside:                 '`' {this.DecreaseTemplateDepth();} -> type(BackTick), popMode;
+TemplateStringStartExpression:  '${' -> pushMode(DEFAULT_MODE);
+TemplateStringAtom:             ~[`];
 
 // Fragment rules
 

--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -346,7 +346,7 @@ singleExpression
     | <assoc=right> singleExpression '=' singleExpression                   # AssignmentExpression
     | <assoc=right> singleExpression assignmentOperator singleExpression    # AssignmentOperatorExpression
     | Import '(' singleExpression ')'                                       # ImportExpression
-    | singleExpression TemplateStringLiteral                                # TemplateStringExpression  // ECMAScript 6
+    | singleExpression templateStringLiteral                                # TemplateStringExpression  // ECMAScript 6
     | yieldStatement                                                        # YieldExpression // ECMAScript 6
     | This                                                                  # ThisExpression
     | identifier                                                            # IdentifierExpression
@@ -402,10 +402,19 @@ literal
     : NullLiteral
     | BooleanLiteral
     | StringLiteral
-    | TemplateStringLiteral
+    | templateStringLiteral
     | RegularExpressionLiteral
     | numericLiteral
     | bigintLiteral
+    ;
+
+templateStringLiteral
+    : BackTick templateStringAtom* BackTick
+    ;
+
+templateStringAtom
+    : TemplateStringAtom
+    | TemplateStringStartExpression singleExpression TemplateCloseBrace
     ;
 
 numericLiteral

--- a/javascript/javascript/examples/TemplateStrings.js
+++ b/javascript/javascript/examples/TemplateStrings.js
@@ -1,0 +1,13 @@
+var empty = ``;
+
+var simple = `foobar`;
+
+var lineBreak = `
+`;
+
+var nested = `aaa${`bbb`}ccc`;
+
+// https://stackoverflow.com/questions/67618203/antlr4-parsing-templateliteral-in-jsx/67632704?noredirect=1#comment119548351_67632704
+let str =
+    `${dsName}${parameterStr ? `( ${parameterStr} )` : ""}${returns ? `{
+${returns}}` : ""}`;

--- a/javascript/jsx/Java/JavaScriptLexerBase.java
+++ b/javascript/jsx/Java/JavaScriptLexerBase.java
@@ -26,6 +26,16 @@ public abstract class JavaScriptLexerBase extends Lexer
      * Can be defined during parsing, see StringFunctions.js and StringGlobal.js samples
      */
     private boolean useStrictCurrent = false;
+    /**
+     * Keeps track of the the current depth of nested template string backticks.
+     * E.g. after the X in:
+     *
+     * `${a ? `${X
+     *
+     * templateDepth will be 2. This variable is needed to determine if a `}` is a
+     * plain CloseBrace, or one that closes an expression inside a template string.
+     */
+    private int templateDepth = 0;
 
     public JavaScriptLexerBase(CharStream input) {
         super(input);
@@ -46,6 +56,10 @@ public abstract class JavaScriptLexerBase extends Lexer
 
     public boolean IsStrictMode() {
         return useStrictCurrent;
+    }
+
+    public boolean IsInTemplateString() {
+        return this.templateDepth > 0;
     }
 
     /**
@@ -93,6 +107,14 @@ public abstract class JavaScriptLexerBase extends Lexer
                 scopeStrictModes.push(useStrictCurrent);
             }
         }
+    }
+
+    public void IncreaseTemplateDepth() {
+        this.templateDepth++;
+    }
+
+    public void DecreaseTemplateDepth() {
+        this.templateDepth--;
     }
 
     /**

--- a/javascript/jsx/JavaScriptLexer.g4
+++ b/javascript/jsx/JavaScriptLexer.g4
@@ -41,6 +41,7 @@ CloseBracket:                   ']';
 OpenParen:                      '(';
 CloseParen:                     ')';
 OpenBrace:                      '{' {this.ProcessOpenBrace();};
+TemplateCloseBrace:             {this.IsInTemplateString()}? '}' -> popMode;
 CloseBrace:                     '}' {this.ProcessCloseBrace();};
 SemiColon:                      ';';
 Comma:                          ',';
@@ -187,8 +188,7 @@ StringLiteral:                 ('"' DoubleStringCharacter* '"'
 
 LinkLiteral: ('http' 's'? | 'ftp' | 'file') '://' [a-zA-Z0-9./?=]+; // TODO Could be more precise
 
-// TODO: `${`tmp`}`
-TemplateStringLiteral:          '`' ('\\`' | ~'`')* '`';
+BackTick:                       '`' {this.IncreaseTemplateDepth();} -> pushMode(TEMPLATE);
 
 WhiteSpaces:                    [\t\u000B\u000C\u0020\u00A0]+ -> channel(HIDDEN);
 
@@ -206,6 +206,12 @@ HtmlComment:                    '<!--' .*? '-->' -> channel(HIDDEN);
 CDataComment:                   '<![CDATA[' .*? ']]>' -> channel(HIDDEN);
 UnexpectedCharacter:            . -> channel(ERROR);
 CDATA:                          '<![CDATA[' .*? ']]>' -> channel(HIDDEN);
+
+mode TEMPLATE;
+
+BackTickInside:                 '`' {this.DecreaseTemplateDepth();} -> type(BackTick), popMode;
+TemplateStringStartExpression:  '${' -> pushMode(DEFAULT_MODE);
+TemplateStringAtom:             ~[`];
 
 //
 // html tag declarations

--- a/javascript/jsx/JavaScriptParser.g4
+++ b/javascript/jsx/JavaScriptParser.g4
@@ -347,7 +347,7 @@ singleExpression
     | <assoc=right> singleExpression '=' singleExpression                   # AssignmentExpression
     | <assoc=right> singleExpression assignmentOperator singleExpression    # AssignmentOperatorExpression
     | Import '(' singleExpression ')'                                       # ImportExpression
-    | singleExpression TemplateStringLiteral                                # TemplateStringExpression  // ECMAScript 6
+    | singleExpression templateStringLiteral                                # TemplateStringExpression  // ECMAScript 6
     | yieldStatement                                                        # YieldExpression // ECMAScript 6
     | This                                                                  # ThisExpression
     | identifier                                                            # IdentifierExpression
@@ -457,10 +457,19 @@ literal
     : NullLiteral
     | BooleanLiteral
     | StringLiteral
-    | TemplateStringLiteral
+    | templateStringLiteral
     | RegularExpressionLiteral
     | numericLiteral
     | bigintLiteral
+    ;
+
+templateStringLiteral
+    : BackTick templateStringAtom* BackTick
+    ;
+
+templateStringAtom
+    : TemplateStringAtom
+    | TemplateStringStartExpression singleExpression TemplateCloseBrace
     ;
 
 numericLiteral

--- a/javascript/jsx/examples/TemplateStrings.js
+++ b/javascript/jsx/examples/TemplateStrings.js
@@ -1,0 +1,13 @@
+var empty = ``;
+
+var simple = `foobar`;
+
+var lineBreak = `
+`;
+
+var nested = `aaa${`bbb`}ccc`;
+
+// https://stackoverflow.com/questions/67618203/antlr4-parsing-templateliteral-in-jsx/67632704?noredirect=1#comment119548351_67632704
+let str =
+    `${dsName}${parameterStr ? `( ${parameterStr} )` : ""}${returns ? `{
+${returns}}` : ""}`;

--- a/javascript/typescript/CSharp/TypeScriptLexerBase.cs
+++ b/javascript/typescript/CSharp/TypeScriptLexerBase.cs
@@ -67,7 +67,7 @@ public abstract class TypeScriptLexerBase : Lexer
         return _useStrictCurrent;
     }
 
-    public boolean IsInTemplateString()
+    public bool IsInTemplateString()
     {
         return _templateDepth > 0;
     }

--- a/javascript/typescript/CSharp/TypeScriptLexerBase.cs
+++ b/javascript/typescript/CSharp/TypeScriptLexerBase.cs
@@ -67,7 +67,7 @@ public abstract class TypeScriptLexerBase : Lexer
         return _useStrictCurrent;
     }
 
-    protected boolean IsInTemplateString()
+    public boolean IsInTemplateString()
     {
         return _templateDepth > 0;
     }
@@ -125,12 +125,12 @@ public abstract class TypeScriptLexerBase : Lexer
         }
     }
 
-    protected void IncreaseTemplateDepth()
+    public void IncreaseTemplateDepth()
     {
         _templateDepth++;
     }
 
-    protected void DecreaseTemplateDepth()
+    public void DecreaseTemplateDepth()
     {
         _templateDepth--;
     }

--- a/javascript/typescript/CSharp/TypeScriptLexerBase.cs
+++ b/javascript/typescript/CSharp/TypeScriptLexerBase.cs
@@ -67,6 +67,11 @@ public abstract class TypeScriptLexerBase : Lexer
         return _useStrictCurrent;
     }
 
+    protected boolean IsInTemplateString()
+    {
+        return _templateDepth > 0;
+    }
+
     /// <summary>
     /// Return the next token from the character stream and records this last
     /// token in case it resides on the default channel. This recorded token

--- a/javascript/typescript/CSharp/TypeScriptLexerBase.cs
+++ b/javascript/typescript/CSharp/TypeScriptLexerBase.cs
@@ -30,6 +30,17 @@ public abstract class TypeScriptLexerBase : Lexer
     /// </summary>
     private bool _useStrictCurrent;
 
+    /// <summary>
+    /// Keeps track of the the current depth of nested template string backticks.
+    /// E.g. after the X in:
+    ///
+    /// `${a ? `${X
+    ///
+    /// templateDepth will be 2. This variable is needed to determine if a `}` is a
+    /// plain CloseBrace, or one that closes an expression inside a template string.
+    /// </summary>
+    private int _templateDepth = 0;
+
     public TypeScriptLexerBase(ICharStream input, TextWriter output, TextWriter errorOutput)
         : base(input, output, errorOutput)
     {
@@ -107,6 +118,16 @@ public abstract class TypeScriptLexerBase : Lexer
                 _scopeStrictModes.Push(_useStrictCurrent);
             }
         }
+    }
+
+    protected void IncreaseTemplateDepth()
+    {
+        _templateDepth++;
+    }
+
+    protected void DecreaseTemplateDepth()
+    {
+        _templateDepth--;
     }
 
     /// <summary>

--- a/javascript/typescript/Java/TypeScriptLexerBase.java
+++ b/javascript/typescript/Java/TypeScriptLexerBase.java
@@ -25,6 +25,16 @@ public abstract class TypeScriptLexerBase extends Lexer
      * Can be defined during parsing, see StringFunctions.js and StringGlobal.js samples
      */
     private boolean useStrictCurrent = false;
+    /**
+     * Keeps track of the the current depth of nested template string backticks.
+     * E.g. after the X in:
+     *
+     * `${a ? `${X
+     *
+     * templateDepth will be 2. This variable is needed to determine if a `}` is a
+     * plain CloseBrace, or one that closes an expression inside a template string.
+     */
+    private int templateDepth = 0;
 
     public TypeScriptLexerBase(CharStream input) {
         super(input);
@@ -41,6 +51,10 @@ public abstract class TypeScriptLexerBase extends Lexer
 
     public boolean IsStrictMode() {
         return useStrictCurrent;
+    }
+
+    public boolean IsInTemplateString() {
+        return this.templateDepth > 0;
     }
 
     /**
@@ -88,6 +102,14 @@ public abstract class TypeScriptLexerBase extends Lexer
                 scopeStrictModes.push(useStrictCurrent);
             }
         }
+    }
+
+    public void IncreaseTemplateDepth() {
+        this.templateDepth++;
+    }
+
+    public void DecreaseTemplateDepth() {
+        this.templateDepth--;
     }
 
     /**

--- a/javascript/typescript/Java/TypeScriptLexerBase.java
+++ b/javascript/typescript/Java/TypeScriptLexerBase.java
@@ -104,11 +104,11 @@ public abstract class TypeScriptLexerBase extends Lexer
         }
     }
 
-    public void IncreaseTemplateDepth() {
+    protected void IncreaseTemplateDepth() {
         this.templateDepth++;
     }
 
-    public void DecreaseTemplateDepth() {
+    protected void DecreaseTemplateDepth() {
         this.templateDepth--;
     }
 

--- a/javascript/typescript/TypeScriptLexer.g4
+++ b/javascript/typescript/TypeScriptLexer.g4
@@ -16,6 +16,7 @@ CloseBracket:                   ']';
 OpenParen:                      '(';
 CloseParen:                     ')';
 OpenBrace:                      '{' {this.ProcessOpenBrace();};
+TemplateCloseBrace:             {this.IsInTemplateString()}? '}' -> popMode;
 CloseBrace:                     '}' {this.ProcessCloseBrace();};
 SemiColon:                      ';';
 Comma:                          ',';
@@ -179,7 +180,7 @@ StringLiteral:                 ('"' DoubleStringCharacter* '"'
              |                  '\'' SingleStringCharacter* '\'') {this.ProcessStringLiteral();}
              ;
 
-TemplateStringLiteral:          '`' ('\\`' | ~'`')* '`';
+BackTick:                       '`' {this.IncreaseTemplateDepth();} -> pushMode(TEMPLATE);
 
 WhiteSpaces:                    [\t\u000B\u000C\u0020\u00A0]+ -> channel(HIDDEN);
 
@@ -191,6 +192,12 @@ LineTerminator:                 [\r\n\u2028\u2029] -> channel(HIDDEN);
 HtmlComment:                    '<!--' .*? '-->' -> channel(HIDDEN);
 CDataComment:                   '<![CDATA[' .*? ']]>' -> channel(HIDDEN);
 UnexpectedCharacter:            . -> channel(ERROR);
+
+mode TEMPLATE;
+
+BackTickInside:                 '`' {this.DecreaseTemplateDepth();} -> type(BackTick), popMode;
+TemplateStringStartExpression:  '${' -> pushMode(DEFAULT_MODE);
+TemplateStringAtom:             ~[`];
 
 // Fragment rules
 

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -117,7 +117,7 @@ typeReference
     ;
 
 nestedTypeGeneric
-    : typeIncludeGeneric 
+    : typeIncludeGeneric
     | typeGeneric
     ;
 
@@ -689,7 +689,7 @@ singleExpression
     | singleExpression '?' singleExpression ':' singleExpression             # TernaryExpression
     | singleExpression '=' singleExpression                                  # AssignmentExpression
     | singleExpression assignmentOperator singleExpression                   # AssignmentOperatorExpression
-    | singleExpression TemplateStringLiteral                                 # TemplateStringExpression  // ECMAScript 6
+    | singleExpression templateStringLiteral                                 # TemplateStringExpression  // ECMAScript 6
     | iteratorBlock                                                          # IteratorsExpression // ECMAScript 6
     | generatorBlock                                                         # GeneratorsExpression // ECMAScript 6
     | generatorFunctionDeclaration                                           # GeneratorsFunctionExpression // ECMAScript 6
@@ -742,9 +742,18 @@ literal
     : NullLiteral
     | BooleanLiteral
     | StringLiteral
-    | TemplateStringLiteral
+    | templateStringLiteral
     | RegularExpressionLiteral
     | numericLiteral
+    ;
+
+templateStringLiteral
+    : BackTick templateStringAtom* BackTick
+    ;
+
+templateStringAtom
+    : TemplateStringAtom
+    | TemplateStringStartExpression singleExpression TemplateCloseBrace
     ;
 
 numericLiteral

--- a/javascript/typescript/examples/TemplateStrings.js
+++ b/javascript/typescript/examples/TemplateStrings.js
@@ -1,0 +1,13 @@
+var empty = ``;
+
+var simple = `foobar`;
+
+var lineBreak = `
+`;
+
+var nested = `aaa${`bbb`}ccc`;
+
+// https://stackoverflow.com/questions/67618203/antlr4-parsing-templateliteral-in-jsx/67632704?noredirect=1#comment119548351_67632704
+let str =
+    `${dsName}${parameterStr ? `( ${parameterStr} )` : ""}${returns ? `{
+${returns}}` : ""}`;


### PR DESCRIPTION
Added support for nested template strings:

```js
`aaa${`bbb`}ccc`
```

Mentioned in https://github.com/antlr/grammars-v4/issues/1555