### PR TITLE
Flatbuffers.g4 update: fixed size arrays, escape sequences in strings, inf/nan for floats, keywords as identifiers,...

### DIFF
--- a/flatbuffers/FlatBuffers.g4
+++ b/flatbuffers/FlatBuffers.g4
@@ -1,81 +1,197 @@
-
 grammar FlatBuffers ;
 
 // Parser rules
 
-schema : include_* ( namespace_decl | type_decl | enum_decl | root_decl | file_extension_decl | file_identifier_decl | attribute_decl | rpc_decl | object_ )* ;
+schema : include_* ( namespace_decl | type_decl | enum_decl | union_decl | root_decl | file_extension_decl | file_identifier_decl | attribute_decl | rpc_decl | object_ )* ;
 
-include_ : 'include' STRING_CONSTANT ';' ;
+include_ : ( INCLUDE | NATIVE_INCLUDE ) STRING_CONSTANT SEMI ;
 
-namespace_decl : 'namespace' IDENT ( '.' IDENT )* ';' ;
+namespace_decl : NAMESPACE identifier ( DOT identifier )* SEMI ;
 
-attribute_decl : 'attribute' STRING_CONSTANT ';' ;
+attribute_decl : ATTRIBUTE STRING_CONSTANT SEMI ;
 
-type_decl : ( 'table' | 'struct' ) IDENT metadata '{' ( field_decl )* '}' ;
+type_decl : ( TABLE | STRUCT ) identifier metadata LC ( field_decl )* RC ;
 
-enum_decl : ( 'enum' IDENT ( ':' type_ )? | 'union' IDENT ) metadata '{' commasep_enumval_decl '}' ;
+enum_decl : ENUM identifier ( COLON type_ )? metadata LC commasep_enumval_decl RC ;
 
-root_decl : 'root_type' IDENT ';' ;
+union_decl : UNION identifier metadata LC commasep_unionval_with_opt_alias RC ;
 
-field_decl : IDENT ':' type_ ( '=' scalar )? metadata ';' ;
+root_decl : ROOT_TYPE identifier SEMI ;
 
-rpc_decl : 'rpc_service' IDENT '{' rpc_method+ '}' ;
+field_decl : identifier COLON type_ ( EQ scalar )? metadata SEMI ;
 
-rpc_method : IDENT '(' IDENT ')' ':' IDENT metadata ';' ;
+rpc_decl : RPC_SERVICE identifier LC rpc_method+ RC ;
 
-// fixed original grammar: allow namespaces for IDENTs
-type_ : '[' type_ ']' | BASE_TYPE_NAME | ns_ident ;
+rpc_method : identifier LP identifier RP COLON identifier metadata SEMI ;
 
-enumval_decl : ns_ident ( '=' integer_const )? ;
+type_ : LB type_ ( COLON integer_const )? RB | BASE_TYPE_NAME | ns_ident ;
 
-commasep_enumval_decl : enumval_decl ( ',' enumval_decl )* ','? ;
+enumval_decl : ns_ident ( EQ integer_const )? ;
 
-ident_with_opt_single_value : IDENT ( ':' single_value )? ;
+commasep_enumval_decl : enumval_decl ( COMMA enumval_decl )* COMMA? ;
 
-commasep_ident_with_opt_single_value : ident_with_opt_single_value ( ',' ident_with_opt_single_value )* ;
+unionval_with_opt_alias : ns_ident ( COLON ns_ident )? ( EQ integer_const )? ;
 
-metadata : ( '(' commasep_ident_with_opt_single_value ')' )? ;
+commasep_unionval_with_opt_alias : unionval_with_opt_alias ( COMMA unionval_with_opt_alias )* COMMA? ;
 
-// fix original grammar: enum values (IDENT) are allowed as well
-scalar : INTEGER_CONSTANT | HEX_INTEGER_CONSTANT | FLOAT_CONSTANT | IDENT ;
+ident_with_opt_single_value : identifier ( COLON single_value )? ;
 
-object_ : '{' commasep_ident_with_value '}' ;
+commasep_ident_with_opt_single_value : ident_with_opt_single_value ( COMMA ident_with_opt_single_value )* ;
 
-ident_with_value : IDENT ':' value ;
+metadata : ( LP commasep_ident_with_opt_single_value RP )? ;
 
-commasep_ident_with_value : ident_with_value ( ',' ident_with_value )* ','? ;
+scalar : INTEGER_CONSTANT | HEX_INTEGER_CONSTANT | FLOAT_CONSTANT | identifier ;
+
+object_ : LC commasep_ident_with_value RC ;
+
+ident_with_value : identifier COLON value ;
+
+commasep_ident_with_value : ident_with_value ( COMMA ident_with_value )* COMMA? ;
 
 single_value : scalar | STRING_CONSTANT ;
 
-value : single_value | object_ | '[' commasep_value ']' ;
+value : single_value | object_ | LB commasep_value RB ;
 
-commasep_value : value( ',' value )* ','? ;
+commasep_value : value( COMMA value )* COMMA? ;
 
-file_extension_decl : 'file_extension' STRING_CONSTANT ;
+file_extension_decl : FILE_EXTENSION STRING_CONSTANT ;
 
-file_identifier_decl : 'file_identifier' STRING_CONSTANT ;
+file_identifier_decl : FILE_IDENTIFIER STRING_CONSTANT ;
 
-ns_ident : IDENT ( '.' IDENT )* ;
+ns_ident : identifier ( DOT identifier )* ;
 
 integer_const :  INTEGER_CONSTANT | HEX_INTEGER_CONSTANT ;
 
+identifier: IDENT | keywords;
+
+keywords
+  : ATTRIBUTE
+  | ENUM
+  | FILE_EXTENSION
+  | FILE_IDENTIFIER
+  | INCLUDE
+  | NATIVE_INCLUDE
+  | NAMESPACE
+  | ROOT_TYPE
+  | RPC_SERVICE
+  | STRUCT
+  | TABLE
+  | UNION
+  ;
+
 // Lexer rules
 
-STRING_CONSTANT : '"' ~["\r\n]* '"' ;
+// keywords
+ATTRIBUTE:  'attribute';
+ENUM:       'enum';
+FILE_EXTENSION: 'file_extension';
+FILE_IDENTIFIER: 'file_identifier';
+INCLUDE:    'include';
+NATIVE_INCLUDE:    'native_include';
+NAMESPACE:  'namespace';
+ROOT_TYPE:  'root_type';
+RPC_SERVICE:'rpc_service';
+STRUCT:     'struct';
+TABLE:      'table';
+UNION:      'union';
+
+// symbols
+SEMI: ';';
+EQ: '=';
+LP: '(';
+RP: ')';
+LB: '[';
+RB: ']';
+LC: '{';
+RC: '}';
+DOT: '.';
+COMMA: ',';
+COLON: ':';
+PLUS: '+';
+MINUS: '-';
+
+fragment
+DECIMAL_DIGIT
+    :   [0-9]
+    ;
+
+fragment
+HEXADECIMAL_DIGIT
+    :   [0-9a-fA-F]
+    ;
+
+fragment
+ESCAPE_SEQUENCE
+    :   SIMPLE_ESCAPE_SEQUENCE
+    |   HEXADECIMAL_ESCAPE_SEQUENCE
+    |	UNICODE_ESCAPE_SEQUENCE
+    ;
+
+fragment
+SIMPLE_ESCAPE_SEQUENCE
+    :   '\\' ['"?bfnrtv\\/]
+    ;
+    
+fragment
+HEXADECIMAL_ESCAPE_SEQUENCE
+    :   '\\x' HEXADECIMAL_DIGIT+
+    ;
+
+fragment
+UNICODE_ESCAPE_SEQUENCE
+    :   '\\u' HEXADECIMAL_DIGIT+
+    ;
+
+STRING_CONSTANT
+    :   '"' SCHAR_SEQUENCE? '"'
+    ;
+
+fragment
+SCHAR_SEQUENCE
+    :   SCHAR+
+    ;
+
+fragment
+SCHAR
+    :   ~["\\\r\n]
+    |   ESCAPE_SEQUENCE
+    ;
 
 BASE_TYPE_NAME : 'bool' | 'byte' | 'ubyte' | 'short' | 'ushort' | 'int' | 'uint' | 'float' | 'long' | 'ulong' | 'double' | 'int8' | 'uint8' | 'int16' | 'uint16' | 'int32' | 'uint32' | 'int64' | 'uint64' | 'float32' | 'float64' | 'string' ;
 
 IDENT : [a-zA-Z_] [a-zA-Z0-9_]* ;
 
-HEX_INTEGER_CONSTANT : [-+]? '0' [xX][0-9a-fA-F]+ ;
+HEX_INTEGER_CONSTANT : [-+]? '0' [xX] HEXADECIMAL_DIGIT+ ;
 
-INTEGER_CONSTANT : [-+]? [0-9]+ | 'true' | 'false' ;
+INTEGER_CONSTANT : [-+]? DECIMAL_DIGIT+ | 'true' | 'false' ;
 
-FLOAT_CONSTANT : '-'? [0-9]+ '.' [0-9]+ (('e'|'E') ('+'|'-')? [0-9]+ )? ;
+FLOAT_CONSTANT : (PLUS|MINUS)? FLOATLIT ;
+
+// Floating-point literals
+
+fragment
+FLOATLIT
+    :   (   DECIMALS DOT DECIMALS? EXPONENT?
+        |   DECIMALS EXPONENT
+        |   DOT DECIMALS EXPONENT?
+        )
+    |   'inf'
+    |   'nan'
+    ;
+
+fragment
+DECIMALS
+    :   DECIMAL_DIGIT+
+    ;
+
+fragment
+EXPONENT
+    :   ('e' | 'E') (PLUS|MINUS)? DECIMALS
+    ;
 
 BLOCK_COMMENT:	'/*' .*? '*/' -> channel(HIDDEN);
 
 // fixed original grammar: allow line comments
 COMMENT : '//' ~[\r\n]* -> channel(HIDDEN);
 
-WHITESPACE : [ \t\r\n] -> skip ;
+WS : [ \t\r\n] -> skip ;


### PR DESCRIPTION
- support fixed size arrays (size can be specified as decimal or hexadecimal integer)
- support escape sequences in strings
- allow keywords as identifiers like flatc (e.g. field named attribute)
- support aliases in union values
- add inf and nan to floating point literals
- add native_include

-> with this grammar all .fbs in the flatbuffers tests folder can be parse except from union_vector.fbs because of the union alias for string.