### PR TITLE
Move Antlr4cs source code to Antlr4cs/ and add CSharp/ port.

### DIFF
--- a/_scripts/skip-csharp.txt
+++ b/_scripts/skip-csharp.txt
@@ -30,7 +30,6 @@ python/python3alt
 python/tiny-python
 rego
 rexx
-sql/plsql
 stringtemplate
 swift-fin
 swift/swift2

--- a/sql/plsql/.trgen-ignore
+++ b/sql/plsql/.trgen-ignore
@@ -1,0 +1,2 @@
+examples/
+examples-sql-script/

--- a/sql/plsql/Antlr4cs/PlSqlLexerBase.cs
+++ b/sql/plsql/Antlr4cs/PlSqlLexerBase.cs
@@ -1,0 +1,18 @@
+using Antlr4.Runtime;
+
+namespace PlSqlParseTree
+{
+    public abstract class PlSqlLexerBase : Lexer
+    {
+        public PlSqlLexerBase(ICharStream input)
+            : base(input)
+        {
+        }
+
+        protected bool IsNewlineAtPos(int pos)
+        {
+            int la = _input.La(pos);
+            return la == -1 || la == '\n';
+        }
+    }
+}

--- a/sql/plsql/Antlr4cs/PlSqlParserBase.cs
+++ b/sql/plsql/Antlr4cs/PlSqlParserBase.cs
@@ -1,12 +1,8 @@
 using Antlr4.Runtime;
-using System;
-using System.IO;
-using System.Reflection;
-using Antlr4.Runtime;
-using Antlr4.Runtime.Misc;
-using Antlr4.Runtime;
 
-public abstract class PlSqlParserBase : Parser
+namespace PlSqlParseTree
+{
+    public abstract class PlSqlParserBase : Parser
     {
         private bool _isVersion10 = false;
         private bool _isVersion12 = true;
@@ -16,10 +12,6 @@ public abstract class PlSqlParserBase : Parser
         {
         }
 
-	public PlSqlParserBase(ITokenStream input, TextWriter output, TextWriter errorOutput) : this(input)
-	{
-	}
-
         public bool isVersion10() => _isVersion10;
 
         public bool isVersion12() => _isVersion12;
@@ -28,3 +20,4 @@ public abstract class PlSqlParserBase : Parser
 
         public bool setVersion12(bool value) => _isVersion12 = value;
     }
+}

--- a/sql/plsql/CSharp/PlSqlLexerBase.cs
+++ b/sql/plsql/CSharp/PlSqlLexerBase.cs
@@ -1,18 +1,29 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
 using Antlr4.Runtime;
 
-namespace PlSqlParseTree
-{
     public abstract class PlSqlLexerBase : Lexer
     {
+        ICharStream myinput;
+
+	protected PlSqlLexerBase(ICharStream input, TextWriter output, TextWriter errorOutput)
+			: base(input, output, errorOutput)
+	{
+		myinput = input;
+	}
+
         public PlSqlLexerBase(ICharStream input)
             : base(input)
-        {
-        }
+	{
+		myinput = input;
+	}
 
         protected bool IsNewlineAtPos(int pos)
         {
-            int la = _input.La(pos);
-            return la == -1 || la == '\n';
+		int la = myinput.LA(pos);
+		return la == -1 || la == '\n';
         }
     }
-}


### PR DESCRIPTION
This change fixes #2219:

* The files in sql/plsql/CSharp/ were moved to the proper place (sql/plsql/Antlr4cs), and source code to be used with the official Antlr4 tool and runtime added in place.
* A .trgen-ignore file was added to stop useless, wasteful copying of unessential files.
* The C# skip list was fixed to add sql/plsql to CI testing. 