### PR TITLE
Add nest generic type  support, such as ’NSDictionary<NSNumber *, NSA…

### DIFF
--- a/objc/ObjectiveCParser.g4
+++ b/objc/ObjectiveCParser.g4
@@ -231,6 +231,7 @@ genericsSpecifier
 
 typeSpecifierWithPrefixes
     : typePrefix* typeSpecifier
+    | typeName
     ;
 
 dictionaryExpression


### PR DESCRIPTION
Add nest generic type  support, such as ’NSDictionary<NSNumber *, NSArray<NSString *> *>’.