### PR TITLE
Fix name of Python-specific ANTLRv4 lexer grammar

### DIFF
--- a/antlr/antlr4/Python3/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/Python3/ANTLRv4Lexer.g4
@@ -39,7 +39,7 @@
 // Lexer specification
 // ======================================================
 
-lexer grammar ANTLRv4LexerPythonTarget;
+lexer grammar ANTLRv4Lexer;
 
 options { superClass = LexerAdaptor; }
 import LexBasic;


### PR DESCRIPTION
When someone wants to build an ANTLRv4 parser for Python, they need to take `antlr/antlr4/{ANTLRv4Parser.g4,LexBasic.g4}` and `antlr/antlr4/Python3/{ANTLRv4Lexer.g4,LexerAdaptor}`.
However, currently, passing those to the tool gives an error as the Python-specific lexer grammar file contains a name (`ANTLRv4LexerPythonTarget`) that does not match the file name.

```
$ java -jar antlr-4.9.2-complete.jar ANTLRv4Lexer.g4 ANTLRv4Parser.g4 -Dlanguage=Python3
error(8): ANTLRv4Lexer.g4:42:14: grammar name ANTLRv4LexerPythonTarget and file name ANTLRv4Lexer.g4 differ
```

Thus, it needs manual editing to work.

This PR proposes to change the lexer grammar name to the correct `ANTLRv4Lexer`.
