### PR TITLE
Add HTDP Racket BSL and ISL with lambda grammars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,8 @@
 				<module>python</module>
 				<module>quakemap</module>
 				<module>r</module>
+				<module>racket-bsl</module>
+				<module>racket-isl</module>
 				<module>rcs</module>
 				<module>redcode</module>
                 <module>refal</module>

--- a/racket-bsl/BSL.g4
+++ b/racket-bsl/BSL.g4
@@ -1,0 +1,111 @@
+/* Based on documentation provided at https://docs.racket-lang.org/htdp-langs/beginner.html */
+grammar BSL;
+
+program
+    : defOrExpr+
+    ;
+
+defOrExpr
+    : definition
+    | expr
+    | testCase
+    | libraryRequire
+    ;
+
+definition
+    : '(' 'define' '(' name NAME+ ')' expr ')'
+    | '(' 'define' name expr ')'
+    | '(' 'define' name '(' 'lambda' '(' NAME+ ')' expr ')' ')'
+    | '(' 'define-struct' name '(' name* ')' ')'
+    ;
+
+expr: '(' name expr+ ')'
+    | '(' 'cond' ('[' expr expr ']')+ ')'
+    | '(' 'cond' ('[' expr expr ']')*  '[' 'else ' expr ']' ')'
+    | '(' 'if'  expr expr expr ')'
+    | '(' 'and' expr expr+ ')'
+    | '(' 'or'  expr expr+ ')'
+    | '’()'
+    | name
+    | NUMBER
+    | BOOLEAN
+    | STRING
+    | CHARACTER
+    ;
+
+testCase
+    : '(' 'check-expect' expr expr ')'
+    | '(' 'check-random' expr expr ')'
+    | '(' 'check-within' expr expr expr ')'
+    | '(' 'check-member-of' expr expr+ ')'
+    | '(' 'check-satisfied' expr name ')'
+    | '(' 'check-error' expr expr? ')'
+    ;
+
+libraryRequire
+    : '(' 'require' STRING ')'
+    | '(' 'require' name ')'
+    | '(' 'require' '(' name STRING ('(' STRING+ ')')? ')' ')'
+    | '(' 'require' '(' name STRING pkg ')' ')'
+    ;
+
+pkg: '(' STRING STRING NUMBER NUMBER ')'
+   ;
+
+name: SYMBOL
+    | NAME
+    ;
+
+// A symbol is a quote character followed by a name. A symbol is a value, just like 42, '(), or #false.
+SYMBOL
+    : '’' NAME
+    ;
+
+// A name or a variable is a sequence of characters not including a space or one of the following:
+//   " , ' ` ( ) [ ] { } | ; #
+NAME: ([$%&!*+\\^_~]|[--:<-Za-z])+
+    ;
+
+// A number is a number such as 123, 3/2, or 5.5.
+NUMBER
+    : INT
+    | INT '.' [0-9]* [1-9]
+    | INT '/' INT
+    ;
+
+INT: [1-9] [0-9]*
+   | '0'
+   ;
+
+BOOLEAN
+    : '#true'
+    | '#T'
+    | '#t'
+    | '#false'
+    | '#F'
+    | '#f'
+    ;
+
+// A string is a sequence of characters enclosed by a pair of ".
+// Unlike symbols, strings may be split into characters and manipulated by a variety of functions.
+// For example, "abcdef", "This is a string", and "This is a string with \" inside" are all strings.
+STRING
+    : '"' ([ -~])* '"'
+    ;
+
+// A character begins with #\ and has the name of the character.
+// For example, #\a, #\b, and #\space are characters.
+CHARACTER
+    : '#' '\u005C' [A-Za-z0-9]
+    | '#' '\u005C' 'space'
+    ;
+
+LANG: '#lang' ~ ('\n' | '\r')* '\r'? '\n' -> channel (HIDDEN)
+    ;
+
+COMMENT
+   : ';' ~ ('\n' | '\r')* '\r'? '\n' -> channel (HIDDEN)
+   ;
+
+WS: (' ' | '\r' | '\t' | '\u000C' | '\n') -> channel (HIDDEN)
+  ;

--- a/racket-bsl/README.md
+++ b/racket-bsl/README.md
@@ -1,0 +1,3 @@
+# Racket BSL
+
+A simple ANTLR4 grammar for the [Racket BSL](https://docs.racket-lang.org/htdp-langs/beginner.html).

--- a/racket-bsl/examples/temperature-conversion.rkt
+++ b/racket-bsl/examples/temperature-conversion.rkt
@@ -1,0 +1,9 @@
+#lang htdp/bsl
+
+(require rackunit)
+
+(define (fahrenheit->celsius f)
+    (* 5/9 (- f 32)))
+
+(check-expect (fahrenheit->celsius 212) 100)
+(check-expect (fahrenheit->celsius -40) -40)

--- a/racket-bsl/pom.xml
+++ b/racket-bsl/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>racket-bsl</artifactId>
+	<packaging>jar</packaging>
+	<name>HTDP Racket grammar</name>
+	<parent>
+		<groupId>org.antlr.grammars</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<includes>
+						<include>BSL.g4</include>
+					</includes>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>program</entryPoint>
+					<grammarName>BSL</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/racket-isl/ISL.g4
+++ b/racket-isl/ISL.g4
@@ -1,0 +1,148 @@
+/* Based on documentation provided at https://docs.racket-lang.org/htdp-langs/intermediate-lam.html */
+grammar ISL;
+
+program
+    : defOrExpr+
+    ;
+
+defOrExpr
+    : definition
+    | expr
+    | testCase
+    | libraryRequire
+    ;
+
+definition
+    : '(' 'define' '(' name NAME+ ')' expr ')'
+    | '(' 'define' name expr ')'
+    | '(' 'define-struct' name '(' name* ')' ')'
+    ;
+
+expr: '(' 'begin' expr+ ')'
+    | '(' 'begin0' expr+ ')'
+    | '(' 'set!' NAME expr ')'
+    | '(' 'delay' expr ')'
+    | '(' 'lambda' '(' NAME* ')' expr ')'
+    | '(' 'λ' '(' NAME* ')' expr ')'
+    | '(' 'local' '[' definition* ']' expr ')'
+    | '(' 'letrec' '(' ('[' name expr ']')* ')' expr ')'
+    | '(' 'shared' '(' ('[' name expr ']')* ')' expr ')'
+    | '(' 'let' '(' ('[' name expr ']')* ')' expr ')'
+    | '(' 'let*' '(' ('[' name expr ']')* ')' expr ')'
+    | '(' 'recur' name '(' ('[' name expr']')* ')' expr ')'
+    | '(' expr expr* ')'
+    | '(' 'cond' ('[' expr expr ']')+ ')'
+    | '(' 'cond' ('[' expr expr ']')*  '[' 'else ' expr ']' ')'
+    | '(' 'if'  expr expr expr ')'
+    | '(' 'and' expr expr expr+ ')'
+    | '(' 'or'  expr expr expr+ ')'
+    | '(' 'time' expr ')'
+    | name
+    | '’' quoted
+    | '‘' quasiQuoted
+    | '\u0027' '()'
+    | NUMBER
+    | BOOLEAN
+    | STRING
+    | CHARACTER
+    ;
+
+quoted
+    : NAME
+    | STRING
+    | CHARACTER
+    | '(' quoted* ')'
+    | '’' quoted
+    | '‘' quoted
+    | ',' quoted
+    | ',@' quoted
+    ;
+
+quasiQuoted
+    : NAME
+    | NUMBER
+    | STRING
+    | CHARACTER
+    | '(' quasiQuoted* ')'
+    | '’' quasiQuoted
+    | '‘' quasiQuoted
+    | ',' expr
+    | ',@' expr
+    ;
+
+testCase
+    : '(' 'check-expect' expr expr ')'
+    | '(' 'check-random' expr expr ')'
+    | '(' 'check-within' expr expr expr ')'
+    | '(' 'check-member-of' expr expr+ ')'
+    | '(' 'check-satisfied' expr name ')'
+    | '(' 'check-error' expr expr? ')'
+    ;
+
+libraryRequire
+    : '(' 'require' STRING ')'
+    | '(' 'require' name ')'
+    | '(' 'require' '(' name STRING ('(' STRING+ ')')? ')' ')'
+    | '(' 'require' '(' name STRING pkg ')' ')'
+    ;
+
+pkg: '(' STRING STRING NUMBER NUMBER ')'
+   ;
+
+name: SYMBOL
+    | NAME
+    ;
+
+// A symbol is a quote character followed by a name. A symbol is a value, just like 42, '(), or #false.
+SYMBOL
+    : '’' NAME
+    ;
+
+// A name or a variable is a sequence of characters not including a space or one of the following:
+//   " , ' ` ( ) [ ] { } | ; #
+NAME: ([$%&!*+\\^_~] | [--:<-Za-z])+
+    ;
+
+// A number is a number such as 123, 3/2, or 5.5.
+NUMBER
+    : INT
+    | INT '.' [0-9]* [1-9]
+    | INT '/' INT
+    ;
+
+INT: [1-9] [0-9]*
+   | '0'
+   ;
+
+BOOLEAN
+    : '#true'
+    | '#T'
+    | '#t'
+    | '#false'
+    | '#F'
+    | '#f'
+    ;
+
+// A string is a sequence of characters enclosed by a pair of ".
+// Unlike symbols, strings may be split into characters and manipulated by a variety of functions.
+// For example, "abcdef", "This is a string", and "This is a string with \" inside" are all strings.
+STRING
+    : '"' ([ -~])* '"'
+    ;
+
+// A character begins with #\ and has the name of the character.
+// For example, #\a, #\b, and #\space are characters.
+CHARACTER
+    : '#' '\u005C' [A-Za-z0-9]
+    | '#' '\u005C' 'space'
+    ;
+
+LANG: '#lang' ~ ('\n' | '\r')* '\r'? '\n' -> channel (HIDDEN)
+    ;
+
+COMMENT
+    : ';' ~ ('\n' | '\r')* '\r'? '\n' -> channel (HIDDEN)
+    ;
+
+WS: (' ' | '\r' | '\t' | '\u000C' | '\n') -> channel (HIDDEN)
+  ;

--- a/racket-isl/README.md
+++ b/racket-isl/README.md
@@ -1,0 +1,4 @@
+# Racket ISL
+
+A simple ANTLR4 grammar for the
+[Racket ISL (with lambda)](https://docs.racket-lang.org/htdp-langs/intermediate-lam.html).

--- a/racket-isl/examples/list-contains.rkt
+++ b/racket-isl/examples/list-contains.rkt
@@ -1,0 +1,14 @@
+#lang htdp/isl
+
+(require rackunit)
+
+(define contains (lambda (l item) 
+                   (if (equal? l '()) 
+                        #f
+                        (if (equal? item (first l)) 
+                            #t
+                            (contains (rest l) item)))))
+
+(define z (list 1 2 3))
+(check-expect (contains 1 z) #true)
+(check-expect (contains 4 z) #false)

--- a/racket-isl/pom.xml
+++ b/racket-isl/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>racket-isl</artifactId>
+	<packaging>jar</packaging>
+	<name>HTDP Racket grammar</name>
+	<parent>
+		<groupId>org.antlr.grammars</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<includes>
+						<include>ISL.g4</include>
+					</includes>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>program</entryPoint>
+					<grammarName>ISL</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
A simple ANTLR4 grammars for the [BSL](https://docs.racket-lang.org/htdp-langs/beginner.html) and [ISL (with lambda)](https://docs.racket-lang.org/htdp-langs/intermediate-lam.html) Racket grammars.
