### PR TITLE
TSql: Review rule create_or_alter_ddl_trigger for multiple ddl_trigger_operation

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -1970,7 +1970,7 @@ create_or_alter_ddl_trigger
     : ((CREATE (OR ALTER)?) | ALTER) TRIGGER simple_name
       ON (ALL SERVER | DATABASE)
       (WITH dml_trigger_option (',' dml_trigger_option)* )?
-      (FOR | AFTER) ddl_trigger_operation (',' dml_trigger_operation)*
+      (FOR | AFTER) ddl_trigger_operation (',' ddl_trigger_operation)*
       AS sql_clauses+
     ;
 

--- a/sql/tsql/examples/triggers.sql
+++ b/sql/tsql/examples/triggers.sql
@@ -45,6 +45,24 @@ DROP TRIGGER safety
 ON DATABASE;  
 GO  
 
+CREATE TRIGGER triggerOnDatabase
+ON DATABASE
+FOR create_procedure, alter_procedure, drop_procedure,
+    create_table, alter_table, drop_table,
+    create_trigger, alter_trigger, drop_trigger,
+    create_view, alter_view, drop_view,
+    create_function, alter_function, drop_function,
+    create_index, alter_index, drop_index
+AS
+BEGIN
+    declare @variable int        
+END
+GO
+
+DROP TRIGGER triggerOnDatabase  
+ON DATABASE;  
+GO  
+
 CREATE TRIGGER ddl_trig_database   
 ON ALL SERVER   
 FOR CREATE_DATABASE   


### PR DESCRIPTION
In the `create_or_alter_ddl_trigger` rule there is the possibility to put many `ddl_trigger_operation`, not a `dml_trigger_operation`