### PR TITLE
Fix file_extension and file_identifier declarations

### DIFF
--- a/flatbuffers/FlatBuffers.g4
+++ b/flatbuffers/FlatBuffers.g4
@@ -54,9 +54,9 @@ value : single_value | object_ | LB commasep_value RB ;
 
 commasep_value : value( COMMA value )* COMMA? ;
 
-file_extension_decl : FILE_EXTENSION STRING_CONSTANT ;
+file_extension_decl : FILE_EXTENSION STRING_CONSTANT SEMI ;
 
-file_identifier_decl : FILE_IDENTIFIER STRING_CONSTANT ;
+file_identifier_decl : FILE_IDENTIFIER STRING_CONSTANT SEMI ;
 
 ns_ident : identifier ( DOT identifier )* ;
 


### PR DESCRIPTION
This commit fixes parsing of `file_extension` and `file_identifier` declarations. Without semicolon expectation parser will end up prematurely upon first declaration inspection.