### PR TITLE
JavascriptParser/TypeScriptParser: No trailing-comma for empty object

### DIFF
--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -366,7 +366,7 @@ assignable
     ;
 
 objectLiteral
-    : '{' (propertyAssignment (',' propertyAssignment)*)? ','? '}'
+    : '{' (propertyAssignment (',' propertyAssignment)* ','?)? '}'
     ;
 
 anonymousFunction

--- a/javascript/javascript/examples/ObjectInitializer.js
+++ b/javascript/javascript/examples/ObjectInitializer.js
@@ -1,0 +1,12 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Object Literal
+// Initialization syntax for object literals
+// https://262.ecma-international.org/11.0/#prod-ObjectLiteral
+//------------------------------------------------------------------------------
+
+obj = { };
+obj = { item1: "item1", item2: "item2" };
+obj = { item1: "item1", item2: "item2", };
+

--- a/javascript/jsx/JavaScriptParser.g4
+++ b/javascript/jsx/JavaScriptParser.g4
@@ -417,7 +417,7 @@ assignable
     ;
 
 objectLiteral
-    : '{' (propertyAssignment (',' propertyAssignment)*)? ','? '}'
+    : '{' (propertyAssignment (',' propertyAssignment)* ','?)? '}'
     ;
 
 objectExpressionSequence

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -607,7 +607,7 @@ arrayElement                      // ECMAScript 6: Spread Operator
     ;
 
 objectLiteral
-    : '{' (propertyAssignment (',' propertyAssignment)*)? ','? '}'
+    : '{' (propertyAssignment (',' propertyAssignment)* ','?)? '}'
     ;
 
 // MODIFIED

--- a/javascript/typescript/examples/ObjectInitializer.ts
+++ b/javascript/typescript/examples/ObjectInitializer.ts
@@ -1,0 +1,12 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Object Literal
+// Initialization syntax for object literals
+// https://262.ecma-international.org/11.0/#prod-ObjectLiteral
+//------------------------------------------------------------------------------
+
+let obj = { };
+obj = { item1: "item1", item2: "item2" };
+obj = { item1: "item1", item2: "item2", };
+


### PR DESCRIPTION
# Problem
I was digging through the `JavaScriptParser.g4` and came across the following rule.

```antlr
objectLiteral
    : '{' (propertyAssignment (',' propertyAssignment)*)? ','? '}'
    ;
````

Which means that the following syntax is correct:
```js
const o = {,};
```
![antlr4_parse_tree_incorrect](https://user-images.githubusercontent.com/32540014/130328928-fc8d8c8f-a2a5-4121-976e-3b4cc6c6949a.jpg)

## Steps to create syntax tree
```
1. cd ./grammars-v4/javascript
2. mvn clean compile
3. cd ./javascript/target/classes
4. grun JavaScript -gui
5. const o = {,};
6. ^D
```

According to the ECMAScript 2020 specifications ObjectLiterals should follow the following specification.
```
ObjectLiteral[Yield, Await]:
   {}
   {PropertyDefinitionList[?Yield, ?Await]}
   {PropertyDefinitionList[?Yield, ?Await],}
```
Source: https://262.ecma-international.org/11.0/#prod-ObjectLiteral

# Solution
I decided to create a PR, bringing the  `','?` (trailing-comma) inside the capture group.
```antlr
objectLiteral
    : '{' (propertyAssignment (',' propertyAssignment)* ','?)? '}'
    ;
````

Which produces the following syntax tree:
![antlr4_parse_tree_correct](https://user-images.githubusercontent.com/32540014/130328844-5d7288ca-c103-4dac-8ddf-73e1a6315e02.jpg)