### PR TITLE
Fix runtime errors of JavaScript JavaScript parser

### DIFF
--- a/javascript/javascript/JavaScript/JavaScriptLexerBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptLexerBase.js
@@ -44,7 +44,7 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
 
     ProcessOpenBrace() {
         this.useStrictCurrent =
-            this.scopeStrictModes.length > 0 && this.scopeStrictModes[0]
+            this.scopeStrictModes.length > 0 && this.scopeStrictModes[this.scopeStrictModes.length - 1]
                 ? true
                 : this.useStrictDefault;
         this.scopeStrictModes.push(this.useStrictCurrent);
@@ -58,13 +58,9 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
     }
 
     ProcessStringLiteral() {
-        if (
-            this.lastToken !== undefined &&
-            (this.lastToken === null ||
-                this.lastToken.type === JavaScriptLexer.OpenBrace)
-        ) {
-            const text = this._input.strdata.slice(0, "use strict".length);
-            if (text === '"use strict"' || text === "'use strict'") {
+        if (this.lastToken === null ||
+                this.lastToken.type === JavaScriptLexer.OpenBrace) {
+            if (super.text === '"use strict"' || super.text === "'use strict'") {
                 if (this.scopeStrictModes.length > 0) {
                     this.scopeStrictModes.pop();
                 }

--- a/javascript/javascript/JavaScript/JavaScriptLexerBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptLexerBase.js
@@ -9,6 +9,7 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
         this.lastToken = null;
         this.useStrictDefault = false;
         this.useStrictCurrent = false;
+        this.templateDepth = 0;
     }
 
     getStrictDefault() {
@@ -22,6 +23,10 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
 
     IsStrictMode() {
         return this.useStrictCurrent;
+    }
+
+    IsInTemplateString() {
+        return this.templateDepth > 0;
     }
 
     getCurrentToken() {
@@ -67,6 +72,14 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
                 this.scopeStrictModes.push(this.useStrictCurrent);
             }
         }
+    }
+
+    IncreaseTemplateDepth() {
+        this.templateDepth++;
+    }
+
+    DecreaseTemplateDepth() {
+        this.templateDepth--;
     }
 
     IsRegexPossible() {

--- a/javascript/javascript/JavaScript/JavaScriptLexerBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptLexerBase.js
@@ -30,11 +30,11 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
     }
 
     getCurrentToken() {
-        return nextToken.call(this);
+        return this.nextToken();
     }
 
     nextToken() {
-        var next = super.nextToken.call(this);
+        var next = super.nextToken();
 
         if (next.channel === antlr4.Token.DEFAULT_CHANNEL) {
             this.lastToken = next;

--- a/javascript/javascript/JavaScript/JavaScriptParserBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptParserBase.js
@@ -1,7 +1,7 @@
 import antlr4 from 'antlr4';
 import JavaScriptParser from './JavaScriptParser.js';
 
-export default class JavaScriptLexerBase extends antlr4.Parser {
+export default class JavaScriptParserBase extends antlr4.Parser {
 
     constructor(input) {
         super(input);

--- a/javascript/javascript/JavaScript/JavaScriptParserBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptParserBase.js
@@ -19,7 +19,7 @@ export default class JavaScriptLexerBase extends antlr4.Parser {
     // Short form for next(String str)
     n(str)
     {
-        return next(str);
+        return this.next(str);
     }
 
     // Whether the next token value equals to @param str

--- a/javascript/javascript/JavaScript/JavaScriptParserBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptParserBase.js
@@ -1,5 +1,4 @@
 import antlr4 from 'antlr4';
-import JavaScriptLexer from './JavaScriptLexer.js';
 import JavaScriptParser from './JavaScriptParser.js';
 
 export default class JavaScriptLexerBase extends antlr4.Parser {


### PR DESCRIPTION
JavaScript parser written in JavaScript throws "method is not defined" errors.
Also, parsing examples fails because of its incorrect "strict mode" handling.
This PR fixes these issues along with some minor changes.