### PR TITLE
Fix for issue #2367.

### DIFF
--- a/_scripts/skip-go.txt
+++ b/_scripts/skip-go.txt
@@ -33,6 +33,7 @@ kirikiri-tjs
 kotlin/kotlin
 kotlin/kotlin-formal
 lambda
+less
 logo/logo
 logo/ucb-logo
 lpc
@@ -64,6 +65,7 @@ rego
 rexx
 rust
 scala
+scss
 sieve
 smalltalk
 smtlibv2


### PR DESCRIPTION
This is a *temporary* work-around/fix for #2367 where the Go runtime has a bug with a very important, two-level hash tree for ATNConfig, which I will fix over in the Antlr4 runtime. This change simply skips testing of these grammars for now by adding the two grammars to the "skip list".