### PR TITLE
Minor TOML 1.0 compatibility fixes

### DIFF
--- a/toml/toml.g4
+++ b/toml/toml.g4
@@ -115,7 +115,7 @@ BIN_INT : '0b' DIGIT_0_1 (DIGIT_0_1 | '_' DIGIT_0_1)* ;
 fragment YEAR : DIGIT DIGIT DIGIT DIGIT ;
 fragment MONTH : DIGIT DIGIT ;
 fragment DAY : DIGIT DIGIT ;
-fragment DELIM : 'T' | 't' ;
+fragment DELIM : 'T' | 't' | ' ' ;
 fragment HOUR : DIGIT DIGIT ;
 fragment MINUTE : DIGIT DIGIT ;
 fragment SECOND : DIGIT DIGIT ;

--- a/toml/toml.g4
+++ b/toml/toml.g4
@@ -55,9 +55,10 @@ date_time : OFFSET_DATE_TIME | LOCAL_DATE_TIME | LOCAL_DATE | LOCAL_TIME ;
 
 array_ : '[' array_values? comment_or_nl ']' ;
 
-array_values : (comment_or_nl value ',' array_values comment_or_nl) | comment_or_nl value ','? ;
+array_values : (comment_or_nl value nl_or_comment ',' array_values comment_or_nl) | comment_or_nl value nl_or_comment ','? ;
 
 comment_or_nl : (COMMENT? NL)* ;
+nl_or_comment : (NL COMMENT?)* ;
 
 table : standard_table | array_table ;
 

--- a/toml/toml.g4
+++ b/toml/toml.g4
@@ -23,7 +23,7 @@ grammar toml;
  * Parser Rules
  */
 
-document : expression (NL expression)* ;
+document : expression (NL expression)* EOF ;
 
 expression : key_value comment | table comment | comment ;
 


### PR DESCRIPTION
This PR addresses the following discrepancies with the TOML spec:
* using a single space as time separator is allowed in offset and local date-time see second paragraph of [offset date-time spec](https://toml.io/en/v1.0.0#offset-date-time))
* adding one or more newlines between array elements and their following commas is allowed (second paragraph of [array spec](https://toml.io/en/v1.0.0#array))
* parser should not silently ignore trailing garbage