### PR TITLE
DBZ-4229 CREATE PROCEDURE DDL throws ParsingException

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -1069,7 +1069,7 @@ selectLinesInto
     ;
 
 fromClause
-    : FROM tableSources
+    : (FROM tableSources)?
       (WHERE whereExpr=expression)?
     ;
 

--- a/sql/mysql/Positive-Technologies/examples/ddl_create.sql
+++ b/sql/mysql/Positive-Technologies/examples/ddl_create.sql
@@ -359,6 +359,16 @@ BEGIN
   DECLARE var3 INT unsigned default 2 + var1;
 END -- //-- delimiter ;
 #end
+#begin
+CREATE DEFINER=`system_user`@`%` PROCEDURE `update_order`(IN orderID bigint(11))
+BEGIN  insert into order_config(order_id, attribute, value, performer)
+       SELECT orderID, 'first_attr', 'true', 'AppConfig'
+       WHERE NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'first_attr') OR
+             EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'first_attr' and p2.performer = 'AppConfig')
+       ON DUPLICATE KEY UPDATE value = 'true',
+                            performer = 'AppConfig'; -- Enable second_attr for order
+END
+#end
 -- Create procedure
 -- delimiter //
 CREATE PROCEDURE makesignal(p1 INT)


### PR DESCRIPTION
The sp contains query statements that have `select` and `where` statements, but without `where` statement, causing this parser error.

sp:

```sql
CREATE DEFINER=system_user@% PROCEDURE update_order(IN orderID bigint(11))
BEGIN insert into order_config(order_id, attribute, value, performer)
**SELECT** orderID, 'first_attr', 'true', 'AppConfig'
**WHERE** NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'first_attr') OR
EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'first_attr' and p2.performer = 'AppConfig')
ON DUPLICATE KEY UPDATE value = 'true',
performer = 'AppConfig'; -- Enable second_attr for order
insert into order_config(order_id, attribute, value, performer)
select orderID, 'second_attr', 'true', 'AppConfig'
WHERE NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'second_attr') OR
EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'second_attr' and p2.performer = 'AppConfig')
ON DUPLICATE KEY UPDATE value = 'true',
performer = 'AppConfig'; -- Disable third_attr
INSERT INTO order_config (order_id, attribute, value, customer_conf, is_large, type, performer)
select orderID, 'third_attr', 'false', 1, 0, 3, 'AppConfig'
WHERE NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'third_attr') OR
EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'third_attr' and p2.performer = 'AppConfig')
ON DUPLICATE KEY UPDATE value = 'false',
customer_conf = 1,
type = 3,
is_large = 0,
performer = 'AppConfig';
END
```