### PR TITLE
Issue 2386

### DIFF
--- a/_scripts/readme.md
+++ b/_scripts/readme.md
@@ -7,7 +7,7 @@ run, cd to grammar-vs/, then type `bash regtest.sh <target>` where `<target>` is
 of the other targets. To test the target, you will need the NET SDK installed,
 access to the internet, and to toolchain for the target you want to test.
 For CSharp, it will download the Antlr4 tool and runtime. For the other
-targets, you will need to download the Antlr4 tool antlr-4.9.2-complete.jar and
+targets, you will need to download the Antlr4 tool antlr-4.9.3-complete.jar and
 place it in /tmp.
 
 * test.ps1 -- this is a Powershell script for testing, similar to regtest.sh.
@@ -26,7 +26,7 @@ and provide a symbolic linked file for "make" once installed. I don't know why,
 but the package doesn't define just a plain old "make.exe".
 
     cd to a grammar directory, e.g., `cd abnf`.
-    trgen -t CSharp --template-sources-directory _scripts/templates/ --antlr-tool-path /tmp/antlr-4.9.2-complete.jar
+    trgen -t CSharp --template-sources-directory _scripts/templates/ --antlr-tool-path /tmp/antlr-4.9.3-complete.jar
     make
     make test
 
@@ -41,7 +41,7 @@ a "~/.trgen.rc" file to override defaults for that program.
 For example,
 
     {
-        "antlr_tool_path" : "c:/users/kenne/downloads/antlr-4.9.2-complete.jar"
+        "antlr_tool_path" : "c:/users/kenne/downloads/antlr-4.9.3-complete.jar"
     }
 
 For the trwdog tool, you may want to override the default 5 minute timeout

--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -161,7 +161,7 @@ part1()
     # 1) Generate driver source code from poms.
     rm -rf `find . -name Generated -type d`
     echo "Generating drivers."
-    bad=`trgen --todo-pattern "$todo_pattern" -t "$target" --template-sources-directory _scripts/templates/ --antlr-tool-path /tmp/antlr-4.9.2-complete.jar`
+    bad=`trgen --todo-pattern "$todo_pattern" -t "$target" --template-sources-directory _scripts/templates/ --antlr-tool-path /tmp/antlr-4.9.3-complete.jar`
     for i in $bad; do failed=`add "$failed" "$i"`; done
     date
 }

--- a/_scripts/templates/CSharp/Test.csproj
+++ b/_scripts/templates/CSharp/Test.csproj
@@ -10,7 +10,7 @@
 \</Antlr4>
 } >  \</ItemGroup>
   \<ItemGroup>
-    \<PackageReference Include="Antlr4.Runtime.Standard" Version ="4.9.2" />
+    \<PackageReference Include="Antlr4.Runtime.Standard" Version ="4.9.3" />
     \<PackageReference Include="Antlr4BuildTasks" Version = "8.14" PrivateAssets="all" />
   \</ItemGroup>
   \<PropertyGroup>

--- a/_scripts/templates/Dart/cli.dart
+++ b/_scripts/templates/Dart/cli.dart
@@ -9,8 +9,8 @@ import 'dart:convert';
 <if (case_insensitive_type)>
 
 class CaseChangingCharStream extends CharStream {
-        CharStream stream;
-        bool upper;
+    CharStream stream = InputStream.fromString('');
+    bool upper = false;
 
     CaseChangingCharStream(CharStream str, bool up)
     {
@@ -40,7 +40,7 @@ class CaseChangingCharStream extends CharStream {
 
     @override
     int LA(int offset) {
-            int c = stream.LA(offset);
+            int c = stream.LA(offset)!;
 
             if (c \<= 0)
             {

--- a/_scripts/templates/Dart/cli.dart
+++ b/_scripts/templates/Dart/cli.dart
@@ -8,97 +8,64 @@ import 'dart:convert';
 
 <if (case_insensitive_type)>
 
+/// This class supports case-insensitive lexing by wrapping an existing
+/// {@link CharStream} and forcing the lexer to see either upper or
+/// lowercase characters. Grammar literals should then be either upper or
+/// lower case such as 'BEGIN' or 'begin'. The text of the character
+/// stream is unaffected. Example: input 'BeGiN' would match lexer rule
+/// 'BEGIN' if constructor parameter upper=true but getText() would return
+/// 'BeGiN'.
 class CaseChangingCharStream extends CharStream {
-    CharStream stream = InputStream.fromString('');
-    bool upper = false;
+  final CharStream stream;
+  final bool upper;
 
-    CaseChangingCharStream(CharStream str, bool up)
-    {
-        stream = str;
-        upper = up;
+  /// Constructs a new CaseChangingCharStream wrapping the given [stream] forcing
+  /// all characters to upper case or lower case depending on [upper].
+  CaseChangingCharStream(this.stream, this.upper);
+
+  @override
+  int? LA(int i) {
+    int? c = stream.LA(i);
+    if (c == null || c \<= 0) {
+      return c;
     }
-
-    @override
-    int get index {
-        return stream.index;
+    String newCaseStr;
+    if (upper) {
+      newCaseStr = String.fromCharCode(c).toUpperCase();
+    } else {
+      newCaseStr = String.fromCharCode(c).toLowerCase();
     }
-
-    @override
-    int get size {
-        return stream.size;
+    // Skip changing case if length changes (e.g., ß -> SS).
+    if (newCaseStr.length != 1) {
+      return c;
+    } else {
+      return newCaseStr.codeUnitAt(0);
     }
+  }
 
-//  @override
-//  void reset() {
-//      stream.reset();
-//  }
+  @override
+  String get sourceName => stream.sourceName;
 
-    @override
-    void consume() {
-        stream.consume();
-    }
+  @override
+  void consume() => stream.consume();
 
-    @override
-    int LA(int offset) {
-            int c = stream.LA(offset)!;
+  @override
+  String getText(Interval interval) => stream.getText(interval);
 
-            if (c \<= 0)
-            {
-                return c;
-            }
+  @override
+  int get index => stream.index;
 
-            int o = c;
-            if (upper)
-            {
-                // Dart extremely painful--there is no simple function that
-                // maps a single character to upper-/lower- case. Do this the
-                // old fashion way to just get some damn thing working. I am
-                // not an expert at pouring over 1000's of web pages to find the
-                // function and SO has nothing.
-                if (97 \<= o && o \<= 122)
-                    o = o + (65 - 97);
-                return o;
-            }
-            else {
-                if (65 \<= o && o \<= 90)
-                    o = o + (97 - 65);
-                return o;
-            }
-    }
+  @override
+  int mark() => stream.mark();
 
-    @override
-    int mark() {
-        return stream.mark();
-    }
+  @override
+  void release(int marker) => stream.release(marker);
 
-    @override
-    void release(int marker) {
-        stream.release(marker);
-    }
+  @override
+  void seek(int index) => stream.seek(index);
 
-    @override
-    void seek(int _index) {
-        stream.seek(_index);
-    }
-
-//  String getText(Interval interval)
-//  {
-//      this.stream.getText(interval);
-//  }
-
-    @override
-    String toString() {
-        return this.stream.toString();
-    }
-
-    @override
-    String get sourceName {
-        return stream.sourceName;
-    }
-
-@override
-    noSuchMethod(Invocation msg) => "got ${msg.memberName} "
-                      "with arguments ${msg.positionalArguments}";
+  @override
+  int get size => stream.size;
 }
 
 <endif>

--- a/_scripts/templates/Dart/pubspec.yaml
+++ b/_scripts/templates/Dart/pubspec.yaml
@@ -2,7 +2,7 @@
 name: cli
 description: A sample command-line application.
 environment:
-  sdk: '>=2.8.1 \<3.0.0'
+  sdk: '>=2.12.0 \<3.0.0'
 dependencies:
   antlr4: 4.9.3
 dev_dependencies:

--- a/_scripts/templates/Dart/pubspec.yaml
+++ b/_scripts/templates/Dart/pubspec.yaml
@@ -4,7 +4,7 @@ description: A sample command-line application.
 environment:
   sdk: '>=2.8.1 \<3.0.0'
 dependencies:
-  antlr4: 4.9.2
+  antlr4: 4.9.3
 dev_dependencies:
   pedantic: ^1.9.0
   test: ^1.14.4

--- a/_scripts/templates/Go/makefile
+++ b/_scripts/templates/Go/makefile
@@ -9,7 +9,7 @@ SOURCES = $(GENERATED) Program.go
 default: classes
 classes: $(SOURCES)
 	@if [ "$(GOPATH)" = "" ]; then echo "GOPATH must be defined, usually c:/users/youruserid/."; exit 1; fi
-	export GO111MODULE=auto; go get github.com/antlr/antlr4/runtime/Go/antlr
+	GO111MODULE=on go get -u github.com/antlr/antlr4/runtime/Go/antlr@4.9.3
 clean:
 	rm -f *.tokens *.interp
 	rm -f $(GENERATED)

--- a/_scripts/templates/JavaScript/package.json
+++ b/_scripts/templates/JavaScript/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "^4.9.2",
+    "antlr4": "^4.9.3",
     "fs-extra": "^9.1.0",
     "typescript-string-operations": "^1.4.1"
   },

--- a/_scripts/templates/Python3/requirements.txt
+++ b/_scripts/templates/Python3/requirements.txt
@@ -1,2 +1,2 @@
-antlr4-python3-runtime
+antlr4-python3-runtime==4.9.3
 readchar

--- a/java/java9/Dart/Java9LexerBase.dart
+++ b/java/java9/Dart/Java9LexerBase.dart
@@ -35,27 +35,27 @@ import 'dart:convert';
 abstract class Java9LexerBase extends Lexer
 {
     Java9LexerBase(CharStream input) : super(input)
-	{
+    {
     }
 
     bool Check1()
     {
-        return Character.isJavaIdentifierStart(inputStream.LA(-1));
+        return Character.isJavaIdentifierStart(inputStream.LA(-1)!);
     }
 
     bool Check2()
     {
-        return Character.isJavaIdentifierStart(Character.toCodePoint(inputStream.LA(-2), inputStream.LA(-1)));
+        return Character.isJavaIdentifierStart(Character.toCodePoint(inputStream.LA(-2)!, inputStream.LA(-1)!));
     }
 
     bool Check3()
     {
-        return Character.isJavaIdentifierPart(inputStream.LA(-1));
+        return Character.isJavaIdentifierPart(inputStream.LA(-1)!);
     }
 
     bool Check4()
     {
-        return Character.isJavaIdentifierPart(Character.toCodePoint(inputStream.LA(-2), inputStream.LA(-1)));
+        return Character.isJavaIdentifierPart(Character.toCodePoint(inputStream.LA(-2)!, inputStream.LA(-1)!));
     }
 }
 
@@ -89,7 +89,7 @@ class Character
 
     static int toCodePoint(int high, int low)
     {
-		List<int> encoded = List<int>(2);
+		List<int> encoded = List.filled(2, 0, growable: false);
 		encoded.add(high);
 		encoded.add(low);
 		return base64.encode(encoded).codeUnitAt(0);

--- a/unicode/graphemes/Graphemes.g4
+++ b/unicode/graphemes/Graphemes.g4
@@ -12,7 +12,7 @@ fragment TextPresentationSequence: EmojiPresentationCharacter VS15;
 fragment EmojiPresentationSequence: TextPresentationCharacter VS16;
 fragment EmojiCharacter: [\p{Emoji}];
 fragment EmojiModifierSequence:
-    EmojiCharacter [\p{Grapheme_Cluster_Break=E_Modifier}];
+    EmojiCharacter ('\u{1F3FB}' | '\u{1F3FC}' | '\u{1F3FD}' | '\u{1F3FE}' | '\u{1F3FF}');
 fragment EmojiFlagSequence:
     [\p{Grapheme_Cluster_Break=Regional_Indicator}] [\p{Grapheme_Cluster_Break=Regional_Indicator}];
 fragment ExtendedPictographic: [\p{Extended_Pictographic}];

--- a/unicode/graphemes/Graphemes.g4
+++ b/unicode/graphemes/Graphemes.g4
@@ -12,7 +12,7 @@ fragment TextPresentationSequence: EmojiPresentationCharacter VS15;
 fragment EmojiPresentationSequence: TextPresentationCharacter VS16;
 fragment EmojiCharacter: [\p{Emoji}];
 fragment EmojiModifierSequence:
-    . [\p{Grapheme_Cluster_Break=E_Modifier}];
+    EmojiCharacter [\p{Grapheme_Cluster_Break=E_Modifier}];
 fragment EmojiFlagSequence:
     [\p{Grapheme_Cluster_Break=Regional_Indicator}] [\p{Grapheme_Cluster_Break=Regional_Indicator}];
 fragment ExtendedPictographic: [\p{Extended_Pictographic}];

--- a/unicode/graphemes/Graphemes.g4
+++ b/unicode/graphemes/Graphemes.g4
@@ -12,7 +12,7 @@ fragment TextPresentationSequence: EmojiPresentationCharacter VS15;
 fragment EmojiPresentationSequence: TextPresentationCharacter VS16;
 fragment EmojiCharacter: [\p{Emoji}];
 fragment EmojiModifierSequence:
-    [\p{Grapheme_Cluster_Break=E_Base}\p{Grapheme_Cluster_Break=E_Base_GAZ}] [\p{Grapheme_Cluster_Break=E_Modifier}];
+    . [\p{Grapheme_Cluster_Break=E_Modifier}];
 fragment EmojiFlagSequence:
     [\p{Grapheme_Cluster_Break=Regional_Indicator}] [\p{Grapheme_Cluster_Break=Regional_Indicator}];
 fragment ExtendedPictographic: [\p{Extended_Pictographic}];


### PR DESCRIPTION
This change moves the "test.pm1" build and associated files to Antlr 4.9.3.

The PR includes changes for hardwired version numbers in the templates and in the scripts. The change also includes an update to the templates for Python3 and Go to force the 4.9.3 version of the runtime to be used.

Also in this PR is a change for unicode/graphemes. Antlr 4.9.3 does not handle the grammar, and gives a cryptic error message which is explained elsewhere.

This PR just modifies the version of Antlr4 for the build. A separate PR should be performed to: (a) move to a  more recent version of trgen; (b) add the JavaScript target; (c) update the skip lists. One variable at a time.

