### PR TITLE
Allow omitting semicolon before closing parenthesis

### DIFF
--- a/golang/Go/GoParser.g4
+++ b/golang/Go/GoParser.g4
@@ -372,5 +372,6 @@ eos:
 	SEMI
 	| EOF
 	| { p.lineTerminatorAhead() }?
-	| { p.checkPreviousTokenText("}") }?;
+	| { p.checkPreviousTokenText("}") }?
+	| { p.checkPreviousTokenText(")") }?;
 

--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -372,5 +372,6 @@ eos:
 	SEMI
 	| EOF
 	| {lineTerminatorAhead()}?
-	| {checkPreviousTokenText("}")}?;
+	| {checkPreviousTokenText("}")}?
+	| {checkPreviousTokenText(")")}?;
 

--- a/golang/examples/imports.go
+++ b/golang/examples/imports.go
@@ -1,0 +1,7 @@
+package samples
+
+import ("fmt"; "time")
+
+func PrintNow() {
+	fmt.Println(time.Now())
+}


### PR DESCRIPTION
The Go specification allows omitting semicolons before closing parentheses. This is already implemented for closing curly braces, but not for parentheses. The most common use case for this is multi-imports like:

`
import ("firstimport"; "secondimport")
`

See also examples/imports.go