### PR TITLE
Fix empty init statements in Go control flow

### DIFF
--- a/golang/Go/GoParser.g4
+++ b/golang/Go/GoParser.g4
@@ -155,21 +155,21 @@ fallthroughStmt: FALLTHROUGH;
 deferStmt: DEFER expression;
 
 ifStmt:
-	IF (terminatedSimpleStmt)? expression block (
+	IF terminatedSimpleStmt? expression block (
 		ELSE (ifStmt | block)
 	)?;
 
 switchStmt: exprSwitchStmt | typeSwitchStmt;
 
 exprSwitchStmt:
-	SWITCH (terminatedSimpleStmt)? expression? L_CURLY exprCaseClause* R_CURLY;
+	SWITCH terminatedSimpleStmt? expression? L_CURLY exprCaseClause* R_CURLY;
 
 exprCaseClause: exprSwitchCase COLON statementList?;
 
 exprSwitchCase: CASE expressionList | DEFAULT;
 
 typeSwitchStmt:
-	SWITCH (terminatedSimpleStmt)? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
+	SWITCH terminatedSimpleStmt? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
 
 typeSwitchGuard: (IDENTIFIER DECLARE_ASSIGN)? primaryExpr DOT L_PAREN TYPE R_PAREN;
 

--- a/golang/Go/GoParser.g4
+++ b/golang/Go/GoParser.g4
@@ -106,6 +106,14 @@ simpleStmt:
 	| shortVarDecl
 	| emptyStmt;
 
+terminatedSimpleStmt:
+	sendStmt SEMI
+	| incDecStmt SEMI
+	| assignment SEMI
+	| expressionStmt SEMI
+	| shortVarDecl SEMI
+	| emptyStmt;
+
 expressionStmt: expression;
 
 sendStmt: channel = expression RECEIVE expression;
@@ -147,21 +155,21 @@ fallthroughStmt: FALLTHROUGH;
 deferStmt: DEFER expression;
 
 ifStmt:
-	IF (simpleStmt SEMI)? expression block (
+	IF (terminatedSimpleStmt)? expression block (
 		ELSE (ifStmt | block)
 	)?;
 
 switchStmt: exprSwitchStmt | typeSwitchStmt;
 
 exprSwitchStmt:
-	SWITCH (simpleStmt SEMI)? expression? L_CURLY exprCaseClause* R_CURLY;
+	SWITCH (terminatedSimpleStmt)? expression? L_CURLY exprCaseClause* R_CURLY;
 
 exprCaseClause: exprSwitchCase COLON statementList?;
 
 exprSwitchCase: CASE expressionList | DEFAULT;
 
 typeSwitchStmt:
-	SWITCH (simpleStmt SEMI)? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
+	SWITCH (terminatedSimpleStmt)? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
 
 typeSwitchGuard: (IDENTIFIER DECLARE_ASSIGN)? primaryExpr DOT L_PAREN TYPE R_PAREN;
 
@@ -182,7 +190,7 @@ recvStmt: (expressionList ASSIGN | identifierList DECLARE_ASSIGN)? recvExpr = ex
 forStmt: FOR (expression | forClause | rangeClause)? block;
 
 forClause:
-	initStmt = simpleStmt? SEMI expression? SEMI postStmt = simpleStmt?;
+	initStmt = terminatedSimpleStmt expression? SEMI postStmt = simpleStmt?;
 
 rangeClause: (
 		expressionList ASSIGN

--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -155,21 +155,21 @@ fallthroughStmt: FALLTHROUGH;
 deferStmt: DEFER expression;
 
 ifStmt:
-	IF (terminatedSimpleStmt)? expression block (
+	IF terminatedSimpleStmt? expression block (
 		ELSE (ifStmt | block)
 	)?;
 
 switchStmt: exprSwitchStmt | typeSwitchStmt;
 
 exprSwitchStmt:
-	SWITCH (terminatedSimpleStmt)? expression? L_CURLY exprCaseClause* R_CURLY;
+	SWITCH terminatedSimpleStmt? expression? L_CURLY exprCaseClause* R_CURLY;
 
 exprCaseClause: exprSwitchCase COLON statementList?;
 
 exprSwitchCase: CASE expressionList | DEFAULT;
 
 typeSwitchStmt:
-	SWITCH (terminatedSimpleStmt)? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
+	SWITCH terminatedSimpleStmt? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
 
 typeSwitchGuard: (IDENTIFIER DECLARE_ASSIGN)? primaryExpr DOT L_PAREN TYPE R_PAREN;
 

--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -190,7 +190,7 @@ recvStmt: (expressionList ASSIGN | identifierList DECLARE_ASSIGN)? recvExpr = ex
 forStmt: FOR (expression | forClause | rangeClause)? block;
 
 forClause:
-	initStmt = simpleStmt? SEMI expression? SEMI postStmt = simpleStmt?;
+	initStmt = terminatedSimpleStmt expression? SEMI postStmt = simpleStmt?;
 
 rangeClause: (
 		expressionList ASSIGN

--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -106,6 +106,14 @@ simpleStmt:
 	| shortVarDecl
 	| emptyStmt;
 
+terminatedSimpleStmt:
+	sendStmt SEMI
+	| incDecStmt SEMI
+	| assignment SEMI
+	| expressionStmt SEMI
+	| shortVarDecl SEMI
+	| emptyStmt;
+
 expressionStmt: expression;
 
 sendStmt: channel = expression RECEIVE expression;
@@ -147,21 +155,21 @@ fallthroughStmt: FALLTHROUGH;
 deferStmt: DEFER expression;
 
 ifStmt:
-	IF (simpleStmt SEMI)? expression block (
+	IF (terminatedSimpleStmt)? expression block (
 		ELSE (ifStmt | block)
 	)?;
 
 switchStmt: exprSwitchStmt | typeSwitchStmt;
 
 exprSwitchStmt:
-	SWITCH (simpleStmt SEMI)? expression? L_CURLY exprCaseClause* R_CURLY;
+	SWITCH (terminatedSimpleStmt)? expression? L_CURLY exprCaseClause* R_CURLY;
 
 exprCaseClause: exprSwitchCase COLON statementList?;
 
 exprSwitchCase: CASE expressionList | DEFAULT;
 
 typeSwitchStmt:
-	SWITCH (simpleStmt SEMI)? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
+	SWITCH (terminatedSimpleStmt)? typeSwitchGuard L_CURLY typeCaseClause* R_CURLY;
 
 typeSwitchGuard: (IDENTIFIER DECLARE_ASSIGN)? primaryExpr DOT L_PAREN TYPE R_PAREN;
 

--- a/golang/examples/empty_init.go
+++ b/golang/examples/empty_init.go
@@ -1,0 +1,23 @@
+package samples
+
+import (
+	"fmt"
+)
+
+func main() {
+	if  true {
+    fmt.Print("Hello")
+  }
+
+	x := 1
+
+  switch ; x {
+  default: fmt.Print(" World") 
+  }
+
+  var y interface{} = 1
+
+  switch ; y.(type) {
+  default: fmt.Println("!")
+  } 
+}

--- a/golang/examples/empty_init.go
+++ b/golang/examples/empty_init.go
@@ -5,11 +5,11 @@ import (
 )
 
 func main() {
-	if  true {
+  if ; true {
     fmt.Print("Hello")
   }
 
-	x := 1
+  x := 1
 
   switch ; x {
   default: fmt.Print(" ") 

--- a/golang/examples/empty_init.go
+++ b/golang/examples/empty_init.go
@@ -12,12 +12,17 @@ func main() {
 	x := 1
 
   switch ; x {
-  default: fmt.Print(" World") 
+  default: fmt.Print(" ") 
   }
 
   var y interface{} = 1
 
   switch ; y.(type) {
-  default: fmt.Println("!")
+  default: fmt.Println("World")
   } 
+
+  for ; true ; {
+    fmt.Println("!")
+  }
+
 }


### PR DESCRIPTION
The current parser cannot parse control flow with empty init statements such as:

```Go
if ; true {
  doSomething()
}
```

because the `simpleStmt` rule includes an emtpy statement that consists of only a semicolon, so it expects two semicolons. This also leads it to successfully parse this incorrect for loop:

```Go
for ;; true ; {
  doSomething()
}
```

This pull request adds a new rule `terminatedSimpleStmt`, which includes the semicolon for  all productions of `simpleStmt` except for the empty statement, which already contains a semicolon. This seems to be the simplest way to fix this issue, but it does introduce a new rule.