### PR TITLE
Fix for Issue 2411 (java grammars, ...)

### DIFF
--- a/_scripts/skip-go.txt
+++ b/_scripts/skip-go.txt
@@ -21,8 +21,6 @@ hypertalk
 icalendar
 inf
 informix
-java/java
-java/java8
 java/java9
 javadoc
 javascript/ecmascript

--- a/java/java8/Java8Parser.g4
+++ b/java/java8/Java8Parser.g4
@@ -752,7 +752,7 @@ statementNoShortIf
 
 statementWithoutTrailingSubstatement
 	:	block
-	|	emptyStatement
+	|	emptyStatement_
 	|	expressionStatement
 	|	assertStatement
 	|	switchStatement
@@ -765,7 +765,7 @@ statementWithoutTrailingSubstatement
 	|	tryStatement
 	;
 
-emptyStatement
+emptyStatement_
 	:	';'
 	;
 

--- a/java/java9/Java9Parser.g4
+++ b/java/java9/Java9Parser.g4
@@ -808,7 +808,7 @@ statementNoShortIf
 
 statementWithoutTrailingSubstatement
 	:	block
-	|	emptyStatement
+	|	emptyStatement_
 	|	expressionStatement
 	|	assertStatement
 	|	switchStatement
@@ -821,7 +821,7 @@ statementWithoutTrailingSubstatement
 	|	tryStatement
 	;
 
-emptyStatement
+emptyStatement_
 	:	';'
 	;
 

--- a/javascript/ecmascript/CSharp/ECMAScript.g4
+++ b/javascript/ecmascript/CSharp/ECMAScript.g4
@@ -201,7 +201,7 @@ sourceElement
 statement
  : block
  | variableStatement
- | emptyStatement
+ | emptyStatement_
  | {this.InputStream.LA(1) != OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
@@ -256,7 +256,7 @@ initialiser
 
 /// EmptyStatement :
 ///     ;
-emptyStatement
+emptyStatement_
  : SemiColon
  ;
 

--- a/javascript/ecmascript/CSharpSharwell/ECMAScript.g4
+++ b/javascript/ecmascript/CSharpSharwell/ECMAScript.g4
@@ -201,7 +201,7 @@ sourceElement
 statement
  : block
  | variableStatement
- | emptyStatement
+ | emptyStatement_
  | {_input.LA(1) != OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
@@ -256,7 +256,7 @@ initialiser
 
 /// EmptyStatement :
 ///     ;
-emptyStatement
+emptyStatement_
  : SemiColon
  ;
 

--- a/javascript/ecmascript/ECMAScript.g4
+++ b/javascript/ecmascript/ECMAScript.g4
@@ -221,7 +221,7 @@ sourceElement
 statement
  : block
  | variableStatement
- | emptyStatement
+ | emptyStatement_
  | {_input.LA(1) != OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
@@ -276,7 +276,7 @@ initialiser
 
 /// EmptyStatement :
 ///     ;
-emptyStatement
+emptyStatement_
  : SemiColon
  ;
 

--- a/javascript/ecmascript/JavaScript/ECMAScript.g4
+++ b/javascript/ecmascript/JavaScript/ECMAScript.g4
@@ -181,7 +181,7 @@ sourceElement
 statement
  : block
  | variableStatement
- | emptyStatement
+ | emptyStatement_
  | {this._input.LA(1).type != ECMAScriptParser.OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
@@ -236,7 +236,7 @@ initialiser
 
 /// EmptyStatement :
 ///     ;
-emptyStatement
+emptyStatement_
  : SemiColon
  ;
 

--- a/javascript/ecmascript/Python/ECMAScript.g4
+++ b/javascript/ecmascript/Python/ECMAScript.g4
@@ -205,7 +205,7 @@ sourceElement
 statement
  : block
  | variableStatement
- | emptyStatement
+ | emptyStatement_
  | {self._input.LA(1) != ECMAScriptParser.OpenBrace}? expressionStatement
  | ifStatement
  | iterationStatement
@@ -260,7 +260,7 @@ initialiser
 
 /// EmptyStatement :
 ///     ;
-emptyStatement
+emptyStatement_
  : SemiColon
  ;
 

--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -48,7 +48,7 @@ statement
     | variableStatement
     | importStatement
     | exportStatement
-    | emptyStatement
+    | emptyStatement_
     | classDeclaration
     | expressionStatement
     | ifStatement
@@ -131,7 +131,7 @@ variableDeclaration
     : assignable ('=' singleExpression)? // ECMAScript 6: Array & Object Matching
     ;
 
-emptyStatement
+emptyStatement_
     : SemiColon
     ;
 
@@ -237,7 +237,7 @@ classTail
 
 classElement
     : (Static | {this.n("static")}? identifier | Async)* (methodDefinition | assignable '=' objectLiteral ';')
-    | emptyStatement
+    | emptyStatement_
     | '#'? propertyName '=' singleExpression
     ;
 

--- a/javascript/jsx/JavaScriptParser.g4
+++ b/javascript/jsx/JavaScriptParser.g4
@@ -48,7 +48,7 @@ statement
     | variableStatement
     | importStatement
     | exportStatement
-    | emptyStatement
+    | emptyStatement_
     | classDeclaration
     | expressionStatement
     | ifStatement
@@ -131,7 +131,7 @@ variableDeclaration
     : assignable ('=' singleExpression)? // ECMAScript 6: Array & Object Matching
     ;
 
-emptyStatement
+emptyStatement_
     : SemiColon
     ;
 
@@ -238,7 +238,7 @@ classTail
 
 classElement
     : (Static | {this.n("static")}? identifier | Async)* (methodDefinition | assignable '=' objectLiteral ';')
-    | emptyStatement
+    | emptyStatement_
     | '#'? propertyName '=' singleExpression
     ;
 

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -336,7 +336,7 @@ statement
     : block
     | importStatement
     | exportStatement
-    | emptyStatement
+    | emptyStatement_
     | abstractDeclaration //ADDED
     | decoratorList
     | classDeclaration
@@ -406,7 +406,7 @@ variableDeclaration
     : ( identifierOrKeyWord | arrayLiteral | objectLiteral) typeAnnotation? singleExpression? ('=' typeParameters? singleExpression)? // ECMAScript 6: Array & Object Matching
     ;
 
-emptyStatement
+emptyStatement_
     : SemiColon
     ;
 

--- a/kirikiri-tjs/TJSParser.g4
+++ b/kirikiri-tjs/TJSParser.g4
@@ -12,7 +12,7 @@ program
 statement
     : block 
     | variableStatement
-    | emptyStatement
+    | emptyStatement_
     | classDeclaration
     | expressionStatement
     | ifStatement
@@ -45,7 +45,7 @@ variable
     : Identifier ('=' expression)?
     ;
 
-emptyStatement
+emptyStatement_
     : SemiColon
     ;
 

--- a/pascal/pascal.g4
+++ b/pascal/pascal.g4
@@ -300,7 +300,7 @@ simpleStatement
    : assignmentStatement
    | procedureStatement
    | gotoStatement
-   | emptyStatement
+   | emptyStatement_
    ;
 
 assignmentStatement
@@ -406,7 +406,7 @@ gotoStatement
    : GOTO label
    ;
 
-emptyStatement
+emptyStatement_
    :
    ;
 

--- a/php/PhpParser.g4
+++ b/php/PhpParser.g4
@@ -209,11 +209,11 @@ statement
     | throwStatement
     | gotoStatement
     | declareStatement
-    | emptyStatement
+    | emptyStatement_
     | inlineHtmlStatement
     ;
 
-emptyStatement
+emptyStatement_
     : SemiColon
     ;
 

--- a/protobuf3/Protobuf3.g4
+++ b/protobuf3/Protobuf3.g4
@@ -21,7 +21,7 @@ proto
       | packageStatement
       | optionStatement
       | topLevelDef
-      | emptyStatement
+      | emptyStatement_
     )*
   ;
 
@@ -75,7 +75,7 @@ fieldNumber
 // Oneof and oneof field
 
 oneof
-  : ONEOF oneofName LC ( optionStatement | oneofField | emptyStatement )* RC
+  : ONEOF oneofName LC ( optionStatement | oneofField | emptyStatement_ )* RC
   ;
 
 oneofField
@@ -164,7 +164,7 @@ enumBody
 enumElement
   : optionStatement
   | enumField
-  | emptyStatement
+  | emptyStatement_
   ;
 
 enumField
@@ -197,7 +197,7 @@ messageElement
   | oneof
   | mapField
   | reserved
-  | emptyStatement
+  | emptyStatement_
   ;
 
 // service
@@ -209,13 +209,13 @@ serviceDef
 serviceElement
   : optionStatement
   | rpc
-  | emptyStatement
+  | emptyStatement_
   ;
 
 rpc
   : RPC rpcName LP ( STREAM )? messageType RP
         RETURNS LP ( STREAM )? messageType RP
-        (LC ( optionStatement | emptyStatement )* RC | SEMI)
+        (LC ( optionStatement | emptyStatement_ )* RC | SEMI)
   ;
 
 // lexical
@@ -234,7 +234,7 @@ blockLit
   : LC ( ident COLON constant )* RC
   ;
 
-emptyStatement: SEMI;
+emptyStatement_: SEMI;
 
 // Lexical elements
 

--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -35,8 +35,8 @@ root
     ;
 
 sqlStatements
-    : (sqlStatement (MINUS MINUS)? SEMI? | emptyStatement)*
-    (sqlStatement ((MINUS MINUS)? SEMI)? | emptyStatement)
+    : (sqlStatement (MINUS MINUS)? SEMI? | emptyStatement_)*
+    (sqlStatement ((MINUS MINUS)? SEMI)? | emptyStatement_)
     ;
 
 sqlStatement
@@ -45,7 +45,7 @@ sqlStatement
     | administrationStatement | utilityStatement
     ;
 
-emptyStatement
+emptyStatement_
     : SEMI
     ;
 


### PR DESCRIPTION
This change eliminates the Go target symbol conflict "emptyStatement". I changed all grammars that had the conflict (java/java8, java/java9, javascript/..., kirikiri-tjs, pascal, php, protobuf3, sql/...), but I only added testing of the Go target for java/java8. The java/java target now works with Antlr 4.9.3, so I also added that for the Go target testing as well.

Eventually, when we have a new version of Antlr that implements symbol conflict resolution properly, we can rename all these symbol conflicts back (without the underscore).