### PR TITLE
use specific runtime version in golang test

### DIFF
--- a/_scripts/templates/Go/Program.go
+++ b/_scripts/templates/Go/Program.go
@@ -6,9 +6,9 @@ import (
     "os"
     "io"
     "github.com/antlr/antlr4/runtime/Go/antlr"
-    "./parser"
+    "example.com/myparser/parser"
 <if (case_insensitive_type)>
-    "./antlr_resource"
+    "example.com/myparser/antlr_resource"
 <endif>
 )
 type CustomErrorListener struct {

--- a/_scripts/templates/Go/go.mod
+++ b/_scripts/templates/Go/go.mod
@@ -1,0 +1,3 @@
+module example.com/myparser
+
+go 1.17

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -8,6 +8,7 @@ function Build-Grammar {
         \}
     \}
 }>
+    $env:GO111MODULE = "on"
     $g = go get github.com/antlr/antlr4/runtime/Go/antlr@4.9.3
     if($LASTEXITCODE -ne 0){
         return @{

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -8,7 +8,7 @@ function Build-Grammar {
         \}
     \}
 }>
-    $g = go get github.com/antlr/antlr4/runtime/Go/antlr
+    $g = go get github.com/antlr/antlr4/runtime/Go/antlr@4.9.3
     if($LASTEXITCODE -ne 0){
         return @{
             Message = $g


### PR DESCRIPTION
Fix runtime version issue mentioned in https://github.com/antlr/grammars-v4/pull/2429#issuecomment-999423065

Although run test with latest ANTLR seems beneficial, we'd better do that as a test of ANTLR itself. That require a tester designed to work with local package repo, just remove version constraint is not the correct way.