### PR TITLE
Fix for Issue 2433 -- Rust is case sensitive

### DIFF
--- a/rust/pom.xml
+++ b/rust/pom.xml
@@ -61,7 +61,6 @@
 					<showTree>false</showTree>
 					<entryPoint>crate</entryPoint>
 					<grammarName>Rust</grammarName>
-					<caseInsensitive>true</caseInsensitive>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>
 				</configuration>


### PR DESCRIPTION
Although not explicitly stated in the Rust "Spec", Rust is case sensitive. I checked this against the compiler against a few examples (changing keywords to mixed case, referencing variables in a different case from the definition). Anyway, "true" for the "caseInsensitiveType" in the Antlr Maven Plugin is not a valid value, and the element "caseInsensitive" as far as I know is not even a valid element! So, it is best to remove the element.