### PR TITLE
fix hex float

### DIFF
--- a/golang/GoLexer.g4
+++ b/golang/GoLexer.g4
@@ -142,7 +142,7 @@ HEX_FLOAT_LIT          : '0' [xX] HEX_MANTISSA HEX_EXPONENT
 fragment HEX_MANTISSA  : ('_'? HEX_DIGIT)+ ('.' ( '_'? HEX_DIGIT )*)?
                        | '.' HEX_DIGIT ('_'? HEX_DIGIT)*;
 
-fragment HEX_EXPONENT  : [pP] [+-] DECIMALS;
+fragment HEX_EXPONENT  : [pP] [+-]? DECIMALS;
 
 
 IMAGINARY_LIT          : (DECIMAL_LIT | BINARY_LIT |  OCTAL_LIT | HEX_LIT | FLOAT_LIT) 'i' -> mode(NLSEMI);

--- a/golang/examples/float.go
+++ b/golang/examples/float.go
@@ -1,0 +1,5 @@
+package float
+
+func main() float64 {
+	return 0x3.p10 // should be parsed as hexadecimal float lit
+}	


### PR DESCRIPTION
`+/-` should be optional in the hex float exponent:
`hex_exponent      = ( "p" | "P" ) [ "+" | "-" ] decimal_digits .`