### PR TITLE
Fix PHP build--4.9.3 Antlr tool must use 0.5.1 PHP runtime.

### DIFF
--- a/_scripts/templates/PHP/makefile
+++ b/_scripts/templates/PHP/makefile
@@ -7,7 +7,7 @@ GENERATED = <tool_grammar_tuples:{x|<x.GeneratedFileName> }>
 SOURCES = $(GENERATED) Test.php
 default: setup classes
 setup:
-	composer require antlr/antlr4-php-runtime
+	composer require antlr/antlr4-php-runtime:0.5.1
 classes: $(SOURCES)
 clean:
 	rm -f *.interp


### PR DESCRIPTION
The build is broken because the call to "composer" pulls in erroneously 0.6.0 of the PHP runtime--it should not. This PR fixes #2515.