### PR TITLE
Fix for #2539

### DIFF
--- a/_scripts/skip-cpp.txt
+++ b/_scripts/skip-cpp.txt
@@ -159,6 +159,7 @@ propcalc
 properties
 protobuf3
 prov-n
+python/python
 python/python2
 python/python2-js
 python/python3

--- a/_scripts/skip-csharp.txt
+++ b/_scripts/skip-csharp.txt
@@ -19,6 +19,7 @@ pgn
 php
 pike
 powerbuilder
+python/python
 python/python2
 python/python2-js
 python/python3-py

--- a/_scripts/skip-dart.txt
+++ b/_scripts/skip-dart.txt
@@ -33,6 +33,7 @@ pdn
 pgn
 php
 powerbuilder
+python/python
 python/python2
 python/python3
 python/python3alt

--- a/_scripts/skip-go.txt
+++ b/_scripts/skip-go.txt
@@ -52,6 +52,7 @@ pgn
 php
 ply
 powerbuilder
+python/python
 python/python2
 python/python3
 python/python3alt

--- a/_scripts/skip-javascript.txt
+++ b/_scripts/skip-javascript.txt
@@ -23,6 +23,7 @@ p
 pgn
 php
 powerbuilder
+python/python
 python/python2
 python/python3
 python/python3-py

--- a/_scripts/skip-javascript.why
+++ b/_scripts/skip-javascript.why
@@ -77,6 +77,9 @@ php
 powerbuilder
 	stack overflow.
 
+python/python
+	Grammar is not target-agnostic.
+	
 python/python2
 	pom.xml does not contain tests, so trgen does not create Generated/. Skip for now.
 	Grammar is not target-agnostic.

--- a/_scripts/skip-php.txt
+++ b/_scripts/skip-php.txt
@@ -45,6 +45,7 @@ php
 plucid
 powerbuilder
 prov-n
+python/python
 python/python3
 r
 racket-bsl

--- a/_scripts/skip-python3.txt
+++ b/_scripts/skip-python3.txt
@@ -66,6 +66,7 @@ pl0
 ply
 powerbuilder
 protobuf3
+python/python
 python/python2
 python/python3
 python/python3-py

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
 	<modules>
+		<module>python</module>
 		<module>python2</module>
 		<module>python3</module>
 		<module>python3-py</module>

--- a/python/python/CSharp/PythonLexerBase.cs
+++ b/python/python/CSharp/PythonLexerBase.cs
@@ -1,185 +1,188 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Antlr4.Runtime;
 
-namespace PythonParseTree
+public abstract class PythonLexerBase : Lexer
 {
-    public abstract class PythonLexerBase : Lexer
+    public static int TabSize { get; set; } = 8;
+
+    // The amount of opened braces, brackets and parenthesis.
+    private int _opened;
+
+    // The stack that keeps track of the indentation level.
+    private readonly Stack<int> _indents = new Stack<int>();
+
+    // A circular buffer where extra tokens are pushed on (see the NEWLINE and WS lexer rules).
+    private int _firstTokensInd;
+    private int _lastTokenInd;
+    private IToken[] _buffer = new IToken[32];
+    private IToken _lastToken;
+
+    protected PythonLexerBase(ICharStream charStream)
+        : base(charStream)
     {
-        public static int TabSize { get; set; } = 8;
+    }
 
-        // The amount of opened braces, brackets and parenthesis.
-        private int _opened;
+    protected PythonLexerBase(ICharStream charStream, TextWriter output, TextWriter errorOutput)
+        : base(charStream, output, errorOutput)
+    {
+    }
 
-        // The stack that keeps track of the indentation level.
-        private readonly Stack<int> _indents = new Stack<int>();
+    public override void Emit(IToken token)
+    {
+        base.Emit(token);
 
-        // A circular buffer where extra tokens are pushed on (see the NEWLINE and WS lexer rules).
-        private int _firstTokensInd;
-        private int _lastTokenInd;
-        private IToken[] _buffer = new IToken[32];
-        private IToken _lastToken;
-
-        protected PythonLexerBase(ICharStream charStream)
-            : base(charStream)
+        if (!(_buffer[_firstTokensInd] is null))
         {
-        }
+            IncTokenInd(ref _lastTokenInd);
 
-        public override void Emit(IToken token)
-        {
-            base.Emit(token);
-
-            if (!(_buffer[_firstTokensInd] is null))
+            if (_lastTokenInd == _firstTokensInd)
             {
-                IncTokenInd(ref _lastTokenInd);
+                // Enlarge buffer
+                var newArray = new IToken[_buffer.Length * 2];
+                int destInd = newArray.Length - (_buffer.Length - _firstTokensInd);
 
-                if (_lastTokenInd == _firstTokensInd)
-                {
-                    // Enlarge buffer
-                    var newArray = new IToken[_buffer.Length * 2];
-                    int destInd = newArray.Length - (_buffer.Length - _firstTokensInd);
+                Array.Copy(_buffer, 0, newArray, 0, _firstTokensInd);
+                Array.Copy(_buffer, _firstTokensInd, newArray, destInd, _buffer.Length - _firstTokensInd);
 
-                    Array.Copy(_buffer, 0, newArray, 0, _firstTokensInd);
-                    Array.Copy(_buffer, _firstTokensInd, newArray, destInd, _buffer.Length - _firstTokensInd);
-
-                    _firstTokensInd = destInd;
-                    _buffer = newArray;
-                }
-            }
-
-            _buffer[_lastTokenInd] = token;
-            _lastToken = token;
-        }
-
-        public override IToken NextToken()
-        {
-            // Check if the end-of-file is ahead and there are still some DEDENTS expected.
-            if (_input.La(1) == Eof && _indents.Count > 0)
-            {
-                if (_buffer[_lastTokenInd] is null || _buffer[_lastTokenInd].Type != PythonLexer.LINE_BREAK)
-                {
-                    // First emit an extra line break that serves as the end of the statement.
-                    Emit(PythonLexer.LINE_BREAK);
-                }
-
-                // Now emit as much DEDENT tokens as needed.
-                while (_indents.Count != 0)
-                {
-                    Emit(PythonLexer.DEDENT);
-                    _indents.Pop();
-                }
-            }
-
-            IToken next = base.NextToken();
-
-            if (_buffer[_firstTokensInd] is null)
-            {
-                return next;
-            }
-
-            var result = _buffer[_firstTokensInd];
-            _buffer[_firstTokensInd] = null;
-
-            if (_firstTokensInd != _lastTokenInd)
-            {
-                IncTokenInd(ref _firstTokensInd);
-            }
-
-            return result;
-        }
-
-        protected void HandleNewLine()
-        {
-            Emit(PythonLexer.NEWLINE, Hidden, Text);
-
-            char next = (char) _input.La(1);
-
-            // Process whitespaces in HandleSpaces
-            if (next != ' ' && next != '\t' && IsNotNewLineOrComment(next))
-            {
-                ProcessNewLine(0);
+                _firstTokensInd = destInd;
+                _buffer = newArray;
             }
         }
 
-        protected void HandleSpaces()
+        _buffer[_lastTokenInd] = token;
+        _lastToken = token;
+    }
+
+    public override IToken NextToken()
+    {
+        // Check if the end-of-file is ahead and there are still some DEDENTS expected.
+        if (InputStream.LA(1) == Eof && _indents.Count > 0)
         {
-            char next = (char) _input.La(1);
-
-            if ((_lastToken == null || _lastToken.Type == PythonLexer.NEWLINE) && IsNotNewLineOrComment(next))
+            if (_buffer[_lastTokenInd] is null || _buffer[_lastTokenInd].Type != PythonLexer.LINE_BREAK)
             {
-                // Calculates the indentation of the provided spaces, taking the
-                // following rules into account:
-                //
-                // "Tabs are replaced (from left to right) by one to eight spaces
-                //  such that the total number of characters up to and including
-                //  the replacement is a multiple of eight [...]"
-                //
-                //  -- https://docs.python.org/3.1/reference/lexical_analysis.html#indentation
-
-                int indent = 0;
-
-                foreach (char c in Text)
-                    indent += c == '\t' ? TabSize - indent % TabSize : 1;
-
-                ProcessNewLine(indent);
+                // First emit an extra line break that serves as the end of the statement.
+                Emit(PythonLexer.LINE_BREAK);
             }
 
-            Emit(PythonLexer.WS, Hidden, Text);
-        }
-
-        protected void IncIndentLevel() => _opened++;
-
-        protected void DecIndentLevel()
-        {
-            if (_opened > 0)
+            // Now emit as much DEDENT tokens as needed.
+            while (_indents.Count != 0)
             {
-                --_opened;
+                Emit(PythonLexer.DEDENT);
+                _indents.Pop();
             }
         }
 
-        private bool IsNotNewLineOrComment(char next) =>
-            _opened == 0 && next != '\r' && next != '\n' && next != '\f' && next != '#';
+        IToken next = base.NextToken();
 
-        private void ProcessNewLine(int indent)
+        if (_buffer[_firstTokensInd] is null)
         {
-            Emit(PythonLexer.LINE_BREAK);
-
-            int previous = _indents.Count == 0 ? 0 : _indents.Peek();
-
-            if (indent > previous)
-            {
-                _indents.Push(indent);
-                Emit(PythonLexer.INDENT);
-            }
-            else
-            {
-                // Possibly emit more than 1 DEDENT token.
-                while (_indents.Count != 0 && _indents.Peek() > indent)
-                {
-                    Emit(PythonLexer.DEDENT);
-                    _indents.Pop();
-                }
-            }
+            return next;
         }
 
-        private void IncTokenInd(ref int ind) => ind = (ind + 1) % _buffer.Length;
+        var result = _buffer[_firstTokensInd];
+        _buffer[_firstTokensInd] = null;
 
-        private void Emit(int tokenType, int channel = DefaultTokenChannel, string text = "")
+        if (_firstTokensInd != _lastTokenInd)
         {
-            IToken token =
+            IncTokenInd(ref _firstTokensInd);
+        }
+
+        return result;
+    }
+
+    protected void HandleNewLine()
+    {
+        Emit(PythonLexer.NEWLINE, Hidden, Text);
+
+        char next = (char) InputStream.LA(1);
+
+        // Process whitespaces in HandleSpaces
+        if (next != ' ' && next != '\t' && IsNotNewLineOrComment(next))
+        {
+            ProcessNewLine(0);
+        }
+    }
+
+    protected void HandleSpaces()
+    {
+        char next = (char) InputStream.LA(1);
+
+        if ((_lastToken == null || _lastToken.Type == PythonLexer.NEWLINE) && IsNotNewLineOrComment(next))
+        {
+            // Calculates the indentation of the provided spaces, taking the
+            // following rules into account:
+            //
+            // "Tabs are replaced (from left to right) by one to eight spaces
+            //  such that the total number of characters up to and including
+            //  the replacement is a multiple of eight [...]"
+            //
+            //  -- https://docs.python.org/3.1/reference/lexical_analysis.html#indentation
+
+            int indent = 0;
+
+            foreach (char c in Text)
+                indent += c == '\t' ? TabSize - indent % TabSize : 1;
+
+            ProcessNewLine(indent);
+        }
+
+        Emit(PythonLexer.WS, Hidden, Text);
+    }
+
+    protected void IncIndentLevel() => _opened++;
+
+    protected void DecIndentLevel()
+    {
+        if (_opened > 0)
+        {
+            --_opened;
+        }
+    }
+
+    private bool IsNotNewLineOrComment(char next) =>
+        _opened == 0 && next != '\r' && next != '\n' && next != '\f' && next != '#';
+
+    private void ProcessNewLine(int indent)
+    {
+        Emit(PythonLexer.LINE_BREAK);
+
+        int previous = _indents.Count == 0 ? 0 : _indents.Peek();
+
+        if (indent > previous)
+        {
+            _indents.Push(indent);
+            Emit(PythonLexer.INDENT);
+        }
+        else
+        {
+            // Possibly emit more than 1 DEDENT token.
+            while (_indents.Count != 0 && _indents.Peek() > indent)
+            {
+                Emit(PythonLexer.DEDENT);
+                _indents.Pop();
+            }
+        }
+    }
+
+    private void IncTokenInd(ref int ind) => ind = (ind + 1) % _buffer.Length;
+
+    private void Emit(int tokenType, int channel = DefaultTokenChannel, string text = "")
+    {
+        IToken token =
 #if LIGHT_TOKEN
-                new PT.PM.AntlrUtils.LightToken((PT.PM.AntlrUtils.LightInputStream) _tokenFactorySourcePair.Item2,
-                    tokenType,
-                    channel, -1, CharIndex - text.Length, CharIndex);
+            new PT.PM.AntlrUtils.LightToken((PT.PM.AntlrUtils.LightInputStream) _tokenFactorySourcePair.Item2,
+                tokenType,
+                channel, -1, CharIndex - text.Length, CharIndex);
 #else
-                new CommonToken(_tokenFactorySourcePair, tokenType, channel, CharIndex - text.Length, CharIndex)
-                {
-                    Line = Line,
-                    Column = Column,
-                    Text = text
-                };
+            new CommonToken(Tuple.Create((ITokenSource)this, (ICharStream)InputStream), tokenType, channel, CharIndex - text.Length, CharIndex)
+            {
+                Line = Line,
+                Column = Column,
+                Text = text
+            };
 #endif
-            Emit(token);
-        }
+        Emit(token);
     }
 }

--- a/python/python/CSharp/PythonParserBase.cs
+++ b/python/python/CSharp/PythonParserBase.cs
@@ -1,24 +1,27 @@
 using Antlr4.Runtime;
+using System.IO;
 
-namespace PythonParseTree
+public enum PythonVersion
 {
-    public enum PythonVersion
-    {
-        Autodetect,
-        Python2 = 2,
-        Python3 = 3
-    }
-
-    public abstract class PythonParserBase : Parser
-    {
-        public PythonVersion Version { get; set; }
-
-        protected PythonParserBase(ITokenStream input) : base(input)
-        {
-        }
-
-        protected bool CheckVersion(int version) => Version == PythonVersion.Autodetect || version == (int) Version;
-
-        protected void SetVersion(int requiredVersion) => Version = (PythonVersion) requiredVersion;
-    }
+    Autodetect,
+    Python2 = 2,
+    Python3 = 3
 }
+
+public abstract class PythonParserBase : Parser
+{
+    public PythonVersion Version { get; set; }
+
+    protected PythonParserBase(ITokenStream input) : base(input)
+    {
+    }
+
+    protected PythonParserBase(ITokenStream input, TextWriter output, TextWriter errorOutput)
+        : base(input, output, errorOutput)
+    { }
+
+    protected bool CheckVersion(int version) => Version == PythonVersion.Autodetect || version == (int) Version;
+
+    protected void SetVersion(int requiredVersion) => Version = (PythonVersion) requiredVersion;
+}
+

--- a/python/python/Java/PythonLexerBase.java
+++ b/python/python/Java/PythonLexerBase.java
@@ -1,4 +1,3 @@
-package PythonParseTree;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonToken;

--- a/python/python/Java/PythonParserBase.java
+++ b/python/python/Java/PythonParserBase.java
@@ -1,4 +1,3 @@
-package PythonParseTree;
 
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.TokenStream;

--- a/python/python/Java/PythonVersion.java
+++ b/python/python/Java/PythonVersion.java
@@ -1,4 +1,3 @@
-package PythonParseTree;
 
 public enum PythonVersion {
     Autodetect(0),

--- a/python/python/pom.xml
+++ b/python/python/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>python</artifactId>
+	<packaging>jar</packaging>
+	<name>Python grammar</name>
+	<parent>
+		<groupId>org.antlr.grammars</groupId>
+		<artifactId>pythonparent</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<properties>
+		<!-- location of java sources -->
+		<src.dir>Java</src.dir>
+	</properties>
+	<build>
+		<sourceDirectory>${src.dir}</sourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<includes>
+						<include>PythonLexer.g4</include>
+						<include>PythonParser.g4</include>
+					</includes>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>root</entryPoint>
+					<grammarName>Python</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
* Add python/python to testing, ergo the reason for all the pom.xml and skip lists changed.
* Rewrite CSharp files to use official Antlr4 code in Antlr4.Runtime.Standard. As per [this conversation](https://github.com/antlr/grammars-v4/pull/2497#issuecomment-1036224128), the consensus is that Antlr4cs should no longer to be supported--the Tunnelvision fork from github.com/antlr/antlr4 is not maintained.
* Remove nasty package declarations from code. __It's not portable across targets!__ If you need them, add them into your private copy.