### PR TITLE
support for new listagg syntax

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -3918,6 +3918,10 @@ numeric_function
    | GREATEST '(' expressions ')'
    ;
 
+listagg_overflow_clause
+    : ON OVERFLOW (ERROR | TRUNCATE) (CHAR_STRING)? ((WITH | WITHOUT) COUNT)?
+    ;
+
 other_function
     : over_clause_keyword function_argument_analytic over_clause?
     | /*TODO stantard_function_enabling_using*/ regular_id function_argument_modeling using_clause?
@@ -3926,6 +3930,8 @@ other_function
     | COALESCE '(' table_element (',' (numeric | quoted_string))? ')'
     | COLLECT '(' (DISTINCT | UNIQUE)? concatenation collect_order_by_part? ')'
     | within_or_over_clause_keyword function_argument within_or_over_part+
+    | LISTAGG '(' (ALL | DISTINCT | UNIQUE)? argument (',' CHAR_STRING)? listagg_overflow_clause? ')'
+      (WITHIN GROUP '(' order_by_clause ')')? over_clause?
     | cursor_name ( PERCENT_ISOPEN | PERCENT_FOUND | PERCENT_NOTFOUND | PERCENT_ROWCOUNT )
     | DECOMPOSE '(' concatenation (CANONICAL | COMPATIBILITY)? ')'
     | EXTRACT '(' regular_id FROM concatenation ')'
@@ -3979,7 +3985,6 @@ over_clause_keyword
 within_or_over_clause_keyword
     : CUME_DIST
     | DENSE_RANK
-    | LISTAGG
     | PERCENT_RANK
     | PERCENTILE_CONT
     | PERCENTILE_DISC

--- a/sql/plsql/examples/analytic_query.sql
+++ b/sql/plsql/examples/analytic_query.sql
@@ -28,9 +28,15 @@ select deptno
 from emp;
 
 select deptno
-   , ename
-   , hiredate
-   , listagg(ename, ',' ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as employees
+     , ename
+     , hiredate
+     , listagg(ename, ',' ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as employees
+from emp;
+
+select deptno
+     , ename
+     , hiredate
+     , listagg(UNIQUE ename, ',' ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as employees
 from emp;
 
  select metric_id ,bsln_guid ,timegroup ,obs_value as obs_value 

--- a/sql/plsql/examples/analytic_query.sql
+++ b/sql/plsql/examples/analytic_query.sql
@@ -37,6 +37,7 @@ select deptno
      , ename
      , hiredate
      , listagg(UNIQUE ename, ',' ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as employees
+     , listagg(UNIQUE edepartment, ',' ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as edepartments
 from emp;
 
  select metric_id ,bsln_guid ,timegroup ,obs_value as obs_value 


### PR DESCRIPTION
As per documentation found at [PL/SQL Reference](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/LISTAGG.html#GUID-B6E50D8E-F467-425B-9436-F7F8BF38D466) by Oracle, `LISTAGG` analytic function now supports a new syntax.

This PR provides support for this new syntax and resolves #2558.