### PR TITLE
[MySQL] Support `OR REPLACE` when creating trigger

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -225,7 +225,7 @@ createTablespaceNdb
     ;
 
 createTrigger
-    : CREATE ownerStatement?
+    : CREATE (OR REPLACE)? ownerStatement?  // OR is MariaDB-specific only
       TRIGGER thisTrigger=fullId
       triggerTime=(BEFORE | AFTER)
       triggerEvent=(INSERT | UPDATE | DELETE)

--- a/sql/mysql/Positive-Technologies/examples/ddl_create.sql
+++ b/sql/mysql/Positive-Technologies/examples/ddl_create.sql
@@ -304,6 +304,11 @@ BEGIN
 END
 #end
 #begin
+-- Create trigger 6
+-- delimiter //
+create or replace trigger trg_my1 before delete on test.t1 for each row begin insert into log_table values ("delete row from test.t1"); insert into t4 values (old.col1, old.col1 + 5, old.col1 + 7); end; -- //-- delimiter ;
+#end
+#begin
 -- Create view
 create or replace view my_view1 as select 1 union select 2 limit 0,5;
 create algorithm = merge view my_view2(col1, col2) as select * from t2 with check option;


### PR DESCRIPTION
Strictly speaking `CREATE OR REPLACE` trigger is not supported in
MySQL [1], however, MariaDB supportes it [2].

[1] https://dev.mysql.com/doc/refman/8.0/en/create-trigger.html
[2] https://mariadb.com/kb/en/create-trigger/