### PR TITLE
Partial upgrade to Antlr 4.10 -- Maven tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 
 # Ignore C# regression temporaries.
 **/Generated/
+
+# Ignore Emacs backup files.
+*~
+\#*\#

--- a/antlr/antlr3/ANTLRv3Lexer.g4
+++ b/antlr/antlr3/ANTLRv3Lexer.g4
@@ -111,7 +111,7 @@ DOUBLE_QUOTE_STRING_LITERAL
 // This seems to be available in Antlr3.
 
 DOUBLE_ANGLE_STRING_LITERAL
-   : '<<' ()*? '>>'
+   : '<<' .*? '>>'
    ;
 
 fragment ESC

--- a/golang/Go/GoParser.g4
+++ b/golang/Go/GoParser.g4
@@ -79,7 +79,7 @@ varSpec:
 
 block: L_CURLY statementList? R_CURLY;
 
-statementList: (eos? statement eos)+;
+statementList: ((SEMI? | EOS? | {closingBracket()}?) statement eos)+;
 
 statement:
 	declaration
@@ -186,7 +186,7 @@ commCase: CASE (sendStmt | recvStmt) | DEFAULT;
 
 recvStmt: (expressionList ASSIGN | identifierList DECLARE_ASSIGN)? recvExpr = expression;
 
-forStmt: FOR (expression | forClause | rangeClause)? block;
+forStmt: FOR (expression? | forClause | rangeClause?) block;
 
 forClause:
 	initStmt = simpleStmt? eos expression? eos postStmt = simpleStmt?;
@@ -286,7 +286,7 @@ primaryExpr:
 	| primaryExpr (
 		(DOT IDENTIFIER)
 		| index
-		| slice
+		| slice_
 		| typeAssertion
 		| arguments
 	);
@@ -353,7 +353,7 @@ functionLit: FUNC signature block; // function
 
 index: L_BRACKET expression R_BRACKET;
 
-slice:
+slice_:
 	L_BRACKET (
 		expression? COLON expression?
 		| expression? COLON expression COLON expression

--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -79,7 +79,7 @@ varSpec:
 
 block: L_CURLY statementList? R_CURLY;
 
-statementList: (eos? statement eos)+;
+statementList: ((SEMI? | EOS? | {closingBracket()}?) statement eos)+;
 
 statement:
 	declaration
@@ -186,7 +186,7 @@ commCase: CASE (sendStmt | recvStmt) | DEFAULT;
 
 recvStmt: (expressionList ASSIGN | identifierList DECLARE_ASSIGN)? recvExpr = expression;
 
-forStmt: FOR (expression | forClause | rangeClause)? block;
+forStmt: FOR (expression? | forClause | rangeClause?) block;
 
 forClause:
 	initStmt = simpleStmt? eos expression? eos postStmt = simpleStmt?;

--- a/kotlin/kotlin-formal/KotlinParser.g4
+++ b/kotlin/kotlin-formal/KotlinParser.g4
@@ -302,7 +302,7 @@ block
     ;
 
 statements
-    : (statement (semis statement)* semis?)?
+    : (statement ((';' | NL)+ statement)* semis?)?
     ;
 
 statement
@@ -885,7 +885,9 @@ excl
 
 semi
     : (';' | NL) NL* // actually, it's WS or comment between ';', here it's handled in lexer (see ;; token)
-    | EOF;
+    | EOF
+    ;
+
 semis // writing this as "semi+" sends antlr into infinite loop or smth
     : (';' | NL)+
     | EOF

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<maven.compiler.source>1.7</maven.compiler.source>
-		<antlr.version>4.9.3</antlr.version>
-		<antlr4test-maven-plugin.version>1.19</antlr4test-maven-plugin.version>
+		<antlr.version>4.10</antlr.version>
+		<antlr4test-maven-plugin.version>1.20</antlr4test-maven-plugin.version>
 		<junit.version>4.13.2</junit.version>
 	</properties>
 	<prerequisites>

--- a/v/V.g4
+++ b/v/V.g4
@@ -668,7 +668,7 @@ literalValue
     ;
 
 elementList
-    : keyedElement (eos keyedElement)*
+    : keyedElement (({lineTerminatorAhead()}? | {_input.LT(1).getText().equals("}") }?) keyedElement)*
     ;
 
 keyedElement


### PR DESCRIPTION
I'm upgrading the build to Antlr 4.10 for the standard Maven/Java tests. The other targets require a little more work, so they will be done separately.