### PR TITLE
Support IF EXISTS in DROP FOREIGN KEY expression

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -658,7 +658,7 @@ alterSpecification
     | RENAME indexFormat=(INDEX | KEY) uid TO uid                   #alterByRenameIndex
     | ALTER INDEX uid (VISIBLE | INVISIBLE)                         #alterByAlterIndexVisibility
     | DROP indexFormat=(INDEX | KEY) uid                            #alterByDropIndex
-    | DROP FOREIGN KEY uid                                          #alterByDropForeignKey
+    | DROP FOREIGN KEY ifExists? uid                                #alterByDropForeignKey
     | DISABLE KEYS                                                  #alterByDisableKeys
     | ENABLE KEYS                                                   #alterByEnableKeys
     | RENAME renameFormat=(TO | AS)? (uid | fullId)                 #alterByRename


### PR DESCRIPTION
Caused by https://issues.redhat.com/browse/DBZ-5077 .

According to https://mariadb.com/kb/en/alter-table/ , in MariaDB construction `DROP FOREIGN KEY [IF EXISTS] fk_symbol` is valid.