### PR TITLE
Possible to include `*` in BLOCK_COMMENT

### DIFF
--- a/rust/RustLexer.g4
+++ b/rust/RustLexer.g4
@@ -99,8 +99,9 @@ LINE_COMMENT: ('//' (~[/!] | '//') ~[\r\n]* | '//') -> channel (HIDDEN);
 
 BLOCK_COMMENT
    :
-   (
-      '/*'
+   ( '/**/'
+   | '/***/'
+   |  '/*'
       (
          ~[*!]
          | '**'
@@ -108,10 +109,8 @@ BLOCK_COMMENT
       )
       (
          BLOCK_COMMENT_OR_DOC
-         | ~[*]
+         | .
       )*? '*/'
-      | '/**/'
-      | '/***/'
    ) -> channel (HIDDEN)
    ;
 

--- a/rust/examples/comment.rs
+++ b/rust/examples/comment.rs
@@ -19,6 +19,8 @@ pub mod outer_module {
     pub mod inner_module {}
 
     pub mod nested_comments {
+        /* let a = 1*1; */
+
         /* In Rust /* we can /* nest comments */ */ */
 
         // All three types of block comments can contain or be nested inside


### PR DESCRIPTION
Given [the specs](https://doc.rust-lang.org/reference/comments.html):

```
BLOCK_COMMENT :
     /* (~[* !] | ** | BlockCommentOrDoc) (BlockCommentOrDoc | ~*/)* */
   | /**/
   | /***/
```

it says that no closing block-comment can occur: `~*/`. However, inside the ANTLR grammar it was defined as `~[*]`, which is not the same.

Given that the inner block comment is already matched _ungreedily_ (`*?`), it is safe to replace `~[*]` with `.`. I did have to move `/***/` up, otherwise input like `"/***/"` was not matched properly.

Fixes #2604 