### PR TITLE
[CI build] Update trgen version for parsing Antlr 4.10 grammars

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,8 +127,8 @@ jobs:
     - name: Install trgen
       shell: pwsh
       run: |
-        dotnet tool install -g trgen --version 0.16.0
-        dotnet tool install -g trwdog --version 0.16.0
+        dotnet tool install -g trgen --version 0.16.1
+        dotnet tool install -g trwdog --version 0.16.1
         if ("${{ matrix.os }}" -eq "ubuntu-latest") {
             echo "$HOME/.dotnet/tools" >> $env:GITHUB_PATH
         }

--- a/_scripts/really-run.ps1
+++ b/_scripts/really-run.ps1
@@ -14,8 +14,8 @@ $antlrPath = _scripts/get-antlr.ps1 "4.10"
 # Set up env as it is used in test script.
 echo "antlr_path=$antlrPath" >> $env:GITHUB_ENV
 
-dotnet tool install -g trgen --version 0.16.0
-dotnet tool install -g trwdog --version 0.16.0
+dotnet tool install -g trgen --version 0.16.1
+dotnet tool install -g trwdog --version 0.16.1
 
 # Call test script.
 $env:ANTLR_JAR_PATH="$antlrPath"

--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -164,11 +164,11 @@ setupdeps()
     date
     echo "Setting up trgen and antlr jar."
     dotnet tool uninstall -g trgen
-    dotnet tool install -g trgen --version 0.16.0
+    dotnet tool install -g trgen --version 0.16.1
     dotnet tool uninstall -g trxml2
-    dotnet tool install -g trxml2 --version 0.16.0
+    dotnet tool install -g trxml2 --version 0.16.1
     dotnet tool uninstall -g trwdog
-    dotnet tool install -g trwdog --version 0.16.0
+    dotnet tool install -g trwdog --version 0.16.1
 	case "${unameOut}" in
 		Linux*)     curl 'https://repo1.maven.org/maven2/org/antlr/antlr4/4.10/antlr4-4.10-complete.jar' -o /tmp/antlr4-4.10-complete.jar;;
 		Darwin*)    curl 'https://repo1.maven.org/maven2/org/antlr/antlr4/4.10/antlr4-4.10-complete.jar' -o /tmp/antlr4-4.10-complete.jar;;


### PR DESCRIPTION
Antlr 4.10 contains a grammar change for parsing "options { ... }" at the lexer-rule level. This is a prerequisite for https://github.com/antlr/grammars-v4/pull/2576 because that PR changes several grammars in grammars-v4 to use the new "caseInsensitive" option.