### PR TITLE
Fix Issue #2607

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -227,7 +227,7 @@ structDeclarationList
     :   structDeclaration+
     ;
 
-structDeclaration
+structDeclaration // The first two rules have priority order and cannot be simplified to one expression.
     :   specifierQualifierList structDeclaratorList ';'
     |   specifierQualifierList ';'
     |   staticAssertDeclaration

--- a/c/C.g4
+++ b/c/C.g4
@@ -228,7 +228,8 @@ structDeclarationList
     ;
 
 structDeclaration
-    :   specifierQualifierList structDeclaratorList? ';'
+    :   specifierQualifierList structDeclaratorList ';'
+    |   specifierQualifierList ';'
     |   staticAssertDeclaration
     ;
 


### PR DESCRIPTION
# [C Language] Error Parsing of Structure Declarations
[Issue #2607](https://github.com/antlr/grammars-v4/issues/2607)

## Fix
Here I made a priority adjustment to it.
```antlr4
structDeclaration
    :   specifierQualifierList structDeclaratorList ';'
    :   specifierQualifierList ';'
    |   staticAssertDeclaration
    ;
```

## Problem Example:
```c
struct A { int x;};
```

In `c.g4`, `int x;` above is a `structDeclaration`, which has the following definition:

```antlr4
structDeclaration
    :   specifierQualifierList structDeclaratorList? ';'
    |   staticAssertDeclaration
    ;
```
A correct analysis should treat the identifier `x` as a part of `structDeclaratorList`.
However, with the definition for `structDeclaratorList` above. I found that
`x` was incorrectly parsed into `specifierQualifierList`. It is because `specifierQualifierList` may
contain `typedefName`, which finally can accept an identifier. 
