### PR TITLE
Fix Issue #2613

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -301,6 +301,7 @@ directDeclarator
     |   directDeclarator '(' identifierList? ')'
     |   Identifier ':' DigitSequence  // bit field
     |   vcSpecificModifer Identifier // Visual C Extension
+    |   '(' vcSpecificModifer declarator ')' // Visual C Extension
     ;
 
 vcSpecificModifer

--- a/c/C.g4
+++ b/c/C.g4
@@ -210,7 +210,6 @@ typeSpecifier
     |   enumSpecifier
     |   typedefName
     |   '__typeof__' '(' constantExpression ')' // GCC extension
-    |   typeSpecifier pointer
     ;
 
 structOrUnionSpecifier
@@ -301,8 +300,18 @@ directDeclarator
     |   directDeclarator '(' parameterTypeList ')'
     |   directDeclarator '(' identifierList? ')'
     |   Identifier ':' DigitSequence  // bit field
-    |   '(' typeSpecifier? pointer directDeclarator ')' // function pointer like: (__cdecl *f)
+    |   vcSpecificModifer Identifier // Visual C Extension
     ;
+
+vcSpecificModifer
+    :   ('__cdecl' 
+    |   '__clrcall' 
+    |   '__stdcall' 
+    |   '__fastcall' 
+    |   '__thiscall' 
+    |   '__vectorcall') 
+    ;
+
 
 gccDeclaratorExtension
     :   '__asm' '(' StringLiteral+ ')'


### PR DESCRIPTION
### Related to [issue #2613](https://github.com/antlr/grammars-v4/issues/2613)
The current parser for pointers in the declaration is not correct. The error is produced by the [pull request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270).

The [pull request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270) claims that it add the parser rules for function returns pointer type & function pointer.
However, the parser rules had actually been already supported by the original grammar, which is referred from 
the [C language standard](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1548.pdf).

According to the related [issue #1065](https://github.com/antlr/grammars-v4/issues/1065) and the [issue #1066](https://github.com/antlr/grammars-v4/issues/1066), I guess what @smwikipedia wants to do is to make the grammar support a Microsoft Visual C extension `__cdecl`. The [pull request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270) make the following changes:

```antlr4
typeSpecifier
    :   ('void'
    |   'char'
    ...
    |   enumSpecifier
    |   typedefName
    |   '__typeof__' '(' constantExpression ')' // GCC extension
    |   typeSpecifier pointer // => Added by pull request #1067
    ;
directDeclarator
    :   Identifier
    |   '(' declarator ')'
    |   directDeclarator '[' typeQualifierList? assignmentExpression? ']'
    |   directDeclarator '[' 'static' typeQualifierList? assignmentExpression ']'
    |   directDeclarator '[' typeQualifierList 'static' assignmentExpression ']'
    |   directDeclarator '[' typeQualifierList? '*' ']'
    |   directDeclarator '(' parameterTypeList ')'
    |   directDeclarator '(' identifierList? ')'
    |   Identifier ':' DigitSequence  // bit field
    |   '(' typeSpecifier? pointer directDeclarator ')' // function pointer like: (__cdecl *f) => Added by pull request #1067
    ;
```

This change makes `typeSpecifier` can accept a pointer, which is not consistent with the [C language standard](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1548.pdf) (section 6.7.2, page 110). 
This is a mistake because we know that for a C declaration:
```c
int * x, y;
```
In the C standard, only `int` is `typeSpecifier`, which specifies the type for `*x` and `y`. Thus, we conclude that `x` is a pointer of `int` and `y` is `int`.
However, if we allow  `typeSpecifier` to accept a pointer, the analysis result will become that both `x` and `y` are pointers of `int`, which is completely wrong!

To solve the @smwikipedia's problem, i.e., make the grammar to support a Microsoft Visual C extension `__cdecl`, I referred to the 
[Microsoft document](https://docs.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-170) and made the following changes (including reverting the [pull request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270)).
```antlr4
typeSpecifier
    :   ('void'
    |   'char'
    ...
    |   enumSpecifier
    |   typedefName
    |   '__typeof__' '(' constantExpression ')' // GCC extension
    ;
directDeclarator
    :   Identifier
    |   '(' declarator ')'
    |   directDeclarator '[' typeQualifierList? assignmentExpression? ']'
    |   directDeclarator '[' 'static' typeQualifierList? assignmentExpression ']'
    |   directDeclarator '[' typeQualifierList 'static' assignmentExpression ']'
    |   directDeclarator '[' typeQualifierList? '*' ']'
    |   directDeclarator '(' parameterTypeList ')'
    |   directDeclarator '(' identifierList? ')'
    |   Identifier ':' DigitSequence  // bit field
    |   vcSpecificModifer Identifier // Visual C Extension <= My fix
    |  '(' vcSpecificModifer declarator ')' // Visual C Extension <= My fix
    ;
vcSpecificModifer
    :   ('__cdecl' 
    |   '__clrcall' 
    |   '__stdcall' 
    |   '__fastcall' 
    |   '__thiscall' 
    |   '__vectorcall') 
    ;
```
After that, the comment by @Dzialo3 in the [pull request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270) is also resolved.

## Parser Tree Example

I made some examples to show the changes of the parser tree for the C standard, [pull request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270), and my fix.

```c
int *x; // a pointer of int
```
C Standard Result:
![image](https://user-images.githubusercontent.com/22745869/167248301-2a5d2cfb-ac72-4784-aa19-f11f3ca23877.png)

[Pull Request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270) Result:
![image](https://user-images.githubusercontent.com/22745869/167248285-f2d374e6-4e1a-4f0e-abde-ef2b6d3cbf78.png)

My Fix Result:
![image](https://user-images.githubusercontent.com/22745869/167248318-9d6354c3-9d16-4679-a173-0e456bb2c1cb.png)


```c
int *x(int, int); // a function, whose return type is a pointer of int and the parameter are two int
```
C Standard Result:
![image](https://user-images.githubusercontent.com/22745869/167248310-38877ac5-81f8-41a1-9da1-b52e0700a4b7.png)

[Pull Request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270) Result:
![image](https://user-images.githubusercontent.com/22745869/167248290-f06c801f-9c06-454c-8c0b-9db2ba6e9ca7.png)

My Fix Result:
![image](https://user-images.githubusercontent.com/22745869/167248321-a18a585c-5d87-4b0f-9437-6adc5d2ac261.png)


```c
int * __cdecl x(int, int); // a function labeled with __cdecl, whose return type is a pointer of int and the paramater are two int
```
C Standard Result: Not support visual C extension

[Pull Request #1067](https://github.com/antlr/grammars-v4/commit/15fdfb1f46b8e97c3b8db72ec2825e26535b4270) Result:
![image](https://user-images.githubusercontent.com/22745869/167248296-f55032ae-384d-48cf-a02b-72e796b1ca85.png)

My Fix Result:
![image](https://user-images.githubusercontent.com/22745869/167248323-1adc0c30-e422-4863-a3c8-56a8fee80ea4.png)


### Test my fix on a more complex example
```c
int * (* __cdecl x)(int, int); // a function pointer labeled with __cdecl, whose return type is a pointer of int and the paramater are two int
```
![image](https://user-images.githubusercontent.com/22745869/167248329-1d2d2a32-13e6-4c24-ae8c-09090d294adc.png)

