### PR TITLE
[csharp grammar/Java target] Fix issue 2612

### DIFF
--- a/_scripts/skip-csharp.txt
+++ b/_scripts/skip-csharp.txt
@@ -4,7 +4,6 @@ asm/masm
 asn/asn_3gpp
 clif
 cpp
-csharp
 fortran77
 html
 hypertalk

--- a/csharp/Java/CSharpParserBase.java
+++ b/csharp/Java/CSharpParserBase.java
@@ -5,16 +5,19 @@ public abstract class CSharpParserBase extends Parser
 {
     protected CSharpParserBase(TokenStream input)
     {
-	super(input);
+        super(input);
     }
 
     protected boolean IsLocalVariableDeclaration()
     {
-	CSharpParser.Local_variable_declarationContext local_var_decl = (CSharpParser.Local_variable_declarationContext)this._ctx;
-	if (local_var_decl == null) return true;
-	CSharpParser.Local_variable_typeContext local_variable_type = local_var_decl.local_variable_type();
-	if (local_variable_type == null) return true;
-	if (local_variable_type.getText().equals("var")) return false;
-	return true;
+        if (!(this._ctx instanceof CSharpParser.Local_variable_declarationContext)) {
+            return false;
+        }
+        CSharpParser.Local_variable_declarationContext local_var_decl = (CSharpParser.Local_variable_declarationContext)this._ctx;
+        if (local_var_decl == null) return true;
+        CSharpParser.Local_variable_typeContext local_variable_type = local_var_decl.local_variable_type();
+        if (local_variable_type == null) return true;
+        if (local_variable_type.getText().equals("var")) return false;
+        return true;
     }
 }

--- a/csharp/examples/issue-2612.txt
+++ b/csharp/examples/issue-2612.txt
@@ -1,0 +1,8 @@
+class A{
+  void a() {
+    int[] nums = {1, 3, 5, 7};
+    for (int num : nums){
+        b(num);
+    }
+  }
+}

--- a/csharp/examples/issue-2612.txt.errors
+++ b/csharp/examples/issue-2612.txt.errors
@@ -1,0 +1,1 @@
+line 4:17 mismatched input ':' expecting {'add', 'alias', '__arglist', 'ascending', 'async', 'await', 'by', 'descending', 'dynamic', 'equals', 'from', 'get', 'group', 'into', 'join', 'let', 'nameof', 'on', 'orderby', 'partial', 'remove', 'select', 'set', 'unmanaged', 'var', 'when', 'where', 'yield', IDENTIFIER, '[', '*', '?'}


### PR DESCRIPTION
https://github.com/antlr/grammars-v4/issues/2612

* Fix the base class code, which @yososs wrote [here](https://github.com/antlr/grammars-v4/issues/2612).
* Add the test to examples/.
* Add csharp/ grammar testing for Java target (now testing targets CSharp and Java).