### PR TITLE
[scss] Set of backwards compatible bugfixes for SCSS grammar

### DIFF
--- a/scss/ScssLexer.g4
+++ b/scss/ScssLexer.g4
@@ -97,6 +97,8 @@ TILD_EQ         : '~=';
 
 MIXIN           : '@mixin';
 FUNCTION        : '@function';
+FONT_FACE       : '@font-face';
+FORWARD         : '@forward';
 AT_ELSE         : '@else';
 IF              : 'if';
 AT_IF           : '@if';
@@ -106,9 +108,11 @@ AT_EACH         : '@each';
 INCLUDE         : '@include';
 IMPORT          : '@import';
 USE             : '@use';
+REQUIRE         : '@require';
 RETURN          : '@return';
 MEDIA           : '@media';
 CONTENT         : '@content';
+KEYFRAMES       : '@keyframes';
 
 FROM            : 'from';
 TO              : 'to';
@@ -151,6 +155,10 @@ StringLiteral
 Number
   : '-' (('0'..'9')* '.')? ('0'..'9')+
   | (('0'..'9')* '.')? ('0'..'9')+
+  ;
+
+Var
+  : FunctionIdentifier MINUS Identifier RPAREN
   ;
 
 Color

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -47,6 +47,8 @@ statement
   | forDeclaration
   | whileDeclaration
   | eachDeclaration
+  | fontFaceDeclaration
+  | keyframesDeclaration
   ;
 
 
@@ -103,13 +105,20 @@ functionBody
   ;
 
 functionReturn
-  : '@return' commandStatement ';'
+  : RETURN commandStatement SEMI
   ;
 
 functionStatement
-  : commandStatement ';' | statement
+  : commandStatement SEMI | statement
   ;
 
+fontFaceDeclaration
+ : FONT_FACE block
+ ;
+
+keyframesDeclaration
+  : KEYFRAMES identifier? block
+  ;
 
 commandStatement
   : (expression
@@ -132,6 +141,7 @@ expression
   | Color
   | StringLiteral
   | NULL_
+  | Var
   | url
   | variableName
   | functionCall
@@ -157,19 +167,19 @@ conditions
   ;
 
 condition
-  : commandStatement (( '==' | LT | GT | '!=') conditions)?
-  | LPAREN conditions ')'
+  : commandStatement (( EQEQ | LT | GT | NOTEQ) conditions)?
+  | LPAREN conditions RPAREN
   ;
 
 
 variableDeclaration
-  : variableName COLON (propertyValue | listBracketed | map_) '!default'? ';'
+  : variableName COLON (propertyValue | listBracketed | map_) POUND_DEFAULT? SEMI
   ;
 
 
 //for
 forDeclaration
-  : AT_FOR variableName 'from' fromNumber ('to'|'through') throughNumber block
+  : AT_FOR variableName FROM fromNumber (TO|THROUGH) throughNumber block
   ;
 
 fromNumber
@@ -199,8 +209,10 @@ eachValueList
 
 //Imports
 importDeclaration
-  : '@import' referenceUrl ';'
-  | '@use' referenceUrl asClause? withClause? ';'
+  : IMPORT referenceUrl SEMI
+  | REQUIRE  referenceUrl SEMI?
+  | USE referenceUrl asClause? withClause? SEMI?
+  | FORWARD referenceUrl asClause? (showClause | hideClause)?
   ;
 
 referenceUrl
@@ -209,20 +221,32 @@ referenceUrl
     ;
 
 asClause
-  : 'as' ('*' | identifier)
+  : AS (TIMES | identifier)
   ;
 
 withClause
-  : 'with' LPAREN keywordArgument (COMMA keywordArgument)* COMMA? RPAREN
+  : WITH LPAREN keywordArgument (COMMA keywordArgument)* COMMA? RPAREN
   ;
 
 keywordArgument
-  : identifierVariableName ':' expression
+  : identifierVariableName COLON expression
+  ;
+
+hideClause
+  : HIDE memberName (COMMA memberName)*
+  ;
+
+showClause
+  : SHOW memberName (COMMA memberName)
+  ;
+
+memberName
+  : DOLLAR? identifier
   ;
 
 // MEDIA
 mediaDeclaration
-  : '@media' mediaQueryList block
+  : MEDIA mediaQueryList block
   ;
 
 mediaQueryList
@@ -230,8 +254,8 @@ mediaQueryList
   ;
 
 mediaQuery
-  : ('only' | 'not')? mediaType ('and' mediaExpression)*
-  | mediaExpression ('and' mediaExpression)*
+  : (ONLY | NOT)? mediaType (AND_WORD mediaExpression)*
+  | mediaExpression (AND_WORD mediaExpression)*
   ;
 
 // Typically only 'all', 'print', 'screen', and 'speech', but there are some
@@ -241,7 +265,7 @@ mediaType
   ;
 
 mediaExpression
-  : '(' mediaFeature (':' commandStatement)? ')'
+  : LPAREN mediaFeature (COLON commandStatement)? RPAREN
   ;
 
 // Typically 'max-width', 'hover', 'orientation', etc. Many possible values.
@@ -269,10 +293,11 @@ selector
 
 element
   : identifier
-  | '#' identifier
-  | '.' identifier
-  | '&'
-  | '*'
+  | Color identifier
+  | HASH identifier
+  | DOT identifier
+  | AND
+  | TIMES
   | combinator
   | attrib
   | pseudo

--- a/scss/ScssParser.g4
+++ b/scss/ScssParser.g4
@@ -210,8 +210,8 @@ eachValueList
 //Imports
 importDeclaration
   : IMPORT referenceUrl SEMI
-  | REQUIRE  referenceUrl SEMI
-  | USE referenceUrl asClause? withClause? SEMI
+  | REQUIRE  referenceUrl SEMI?
+  | USE referenceUrl asClause? withClause? SEMI?
   | FORWARD referenceUrl asClause? (showClause | hideClause)?
   ;
 

--- a/scss/examples/example1.txt
+++ b/scss/examples/example1.txt
@@ -1,6 +1,10 @@
+@use 'path/to/source'
+
 $title-font: normal 24px/1.5 'Open Sans', sans-serif;
 $cool-red: #F44336;
 $box-shadow-bottom-only: 0 2px 1px 0 rgba(0, 0, 0, 0.2);
+
+@require 'path/to/source'
 
 h1.title {
   font: $title-font;
@@ -12,4 +16,22 @@ div.container {
   background: #fff;
   width: 100%;
   box-shadow: $box-shadow-bottom-only;
+  background-color: var(--app-background-color);
+}
+
+#form {
+  cursor: pointer;
+}
+
+@keyframes spin {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+}
+
+@font-face {
+    font-family: 'Google Material Icons';
+    font-style: normal;
+    font-weight: 400;
+    src: url(http://some-uri.com)
+        format('woff2')
 }

--- a/scss/testsrc/test/java/TestBasicCss.java
+++ b/scss/testsrc/test/java/TestBasicCss.java
@@ -51,6 +51,26 @@ public class TestBasicCss extends TestBase {
   }
 
   @Test
+  public void testIdsAfterBlock() {
+    String[] lines = {
+      ":focus {",
+      "  outline: none;",
+      "}",
+      "#container {",
+      "  top: 0;",
+      "}",
+    };
+
+    assertThat(
+      parse(lines)
+        .statement(1)
+        .ruleset()
+        .selectors()
+        .getText())
+      .isEqualTo("#container");
+  }
+
+  @Test
   public void testBlockWithNoSpacing() {
     String[] lines = {
       "#id1{}",
@@ -219,8 +239,8 @@ public class TestBasicCss extends TestBase {
     };
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
 
-    assertThat(context.property(0).identifier().getText()).isEqualTo("color");
-    ScssParser.PropertyValueContext val = context.property(0).propertyValue();
+    assertThat(context.property_(0).identifier().getText()).isEqualTo("color");
+    ScssParser.PropertyValueContext val = context.property_(0).propertyValue();
     assertThat(val.commandStatement(0).expression().measurement().Number().getText())
         .isEqualTo("1");
     assertThat(val.commandStatement(0).expression().measurement().Unit().getText()).isEqualTo("px");
@@ -448,9 +468,9 @@ public class TestBasicCss extends TestBase {
     String[] lines = {"h1 { p1: -$my-var; }"};
 
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
-    assertThat(context.property(0).identifier().getText()).isEqualTo("p1");
+    assertThat(context.property_(0).identifier().getText()).isEqualTo("p1");
     ScssParser.ExpressionContext expression =
-        context.property(0).propertyValue().commandStatement(0).expression();
+        context.property_(0).propertyValue().commandStatement(0).expression();
     assertThat(expression.getText()).isEqualTo("-$my-var");
     assertThat(expression.variableName().MINUS_DOLLAR()).isNotNull();
     assertThat(expression.variableName().Identifier().getText()).isEqualTo("my-var");
@@ -461,13 +481,13 @@ public class TestBasicCss extends TestBase {
     String[] lines = {"h1 { p1: +(400px - 200px); }"};
 
     ScssParser.BlockContext context = parse(lines).statement(0).ruleset().block();
-    assertThat(context.property(0).identifier().getText()).isEqualTo("p1");
-    assertThat(context.property(0).propertyValue().commandStatement(0).getText())
+    assertThat(context.property_(0).identifier().getText()).isEqualTo("p1");
+    assertThat(context.property_(0).propertyValue().commandStatement(0).getText())
         .isEqualTo("+(400px-200px)");
-    assertThat(context.property(0).propertyValue().commandStatement(0).PLUS_LPAREN()).isNotNull();
+    assertThat(context.property_(0).propertyValue().commandStatement(0).PLUS_LPAREN()).isNotNull();
     assertThat(
             context
-                .property(0)
+                .property_(0)
                 .propertyValue()
                 .commandStatement(0)
                 .commandStatement()
@@ -476,7 +496,7 @@ public class TestBasicCss extends TestBase {
         .isEqualTo("400px");
     assertThat(
             context
-                .property(0)
+                .property_(0)
                 .propertyValue()
                 .commandStatement(0)
                 .commandStatement()
@@ -487,7 +507,7 @@ public class TestBasicCss extends TestBase {
         .isEqualTo("-");
     assertThat(
             context
-                .property(0)
+                .property_(0)
                 .propertyValue()
                 .commandStatement(0)
                 .commandStatement()
@@ -622,8 +642,8 @@ public class TestBasicCss extends TestBase {
     };
 
     ScssParser.StylesheetContext context = parse(lines);
-    assertThat(context.statement(0).ruleset().block().property(0).IMPORTANT()).isNull();
-    assertThat(context.statement(0).ruleset().block().property(1).IMPORTANT()).isNotNull();
+    assertThat(context.statement(0).ruleset().block().property_(0).IMPORTANT()).isNull();
+    assertThat(context.statement(0).ruleset().block().property_(1).IMPORTANT()).isNotNull();
   }
 
   @Test
@@ -638,11 +658,11 @@ public class TestBasicCss extends TestBase {
     };
 
     ScssParser.StylesheetContext context = parse(lines);
-    assertThat(context.statement(0).ruleset().block().property(0).IMPORTANT()).isNotNull();
-    assertThat(context.statement(0).ruleset().block().property(0).block().property(0).IMPORTANT())
+    assertThat(context.statement(0).ruleset().block().property_(0).IMPORTANT()).isNotNull();
+    assertThat(context.statement(0).ruleset().block().property_(0).block().property_(0).IMPORTANT())
         .isNull();
     assertThat(
-            context.statement(0).ruleset().block().property(0).block().lastProperty().IMPORTANT())
+            context.statement(0).ruleset().block().property_(0).block().lastProperty().IMPORTANT())
         .isNotNull();
   }
 
@@ -662,14 +682,14 @@ public class TestBasicCss extends TestBase {
     };
 
     ScssParser.StylesheetContext context = parse(lines);
-    assertThat(context.statement(0).ruleset().block().property(1).identifier().getText())
+    assertThat(context.statement(0).ruleset().block().property_(1).identifier().getText())
         .isEqualTo("transition");
-    assertThat(context.statement(0).ruleset().block().property(1).propertyValue()).isNull();
-    assertThat(context.statement(0).ruleset().block().property(1).block().property(0).getText())
+    assertThat(context.statement(0).ruleset().block().property_(1).propertyValue()).isNull();
+    assertThat(context.statement(0).ruleset().block().property_(1).block().property_(0).getText())
         .isEqualTo("property:font-size;");
-    assertThat(context.statement(0).ruleset().block().property(1).block().property(1).getText())
+    assertThat(context.statement(0).ruleset().block().property_(1).block().property_(1).getText())
         .isEqualTo("duration:4s;");
-    assertThat(context.statement(0).ruleset().block().property(1).block().property(2).getText())
+    assertThat(context.statement(0).ruleset().block().property_(1).block().property_(2).getText())
         .isEqualTo("delay:2s;");
   }
 
@@ -680,13 +700,13 @@ public class TestBasicCss extends TestBase {
     };
 
     ScssParser.StylesheetContext context = parse(lines);
-    assertThat(context.statement(0).ruleset().block().property(0).identifier().getText())
+    assertThat(context.statement(0).ruleset().block().property_(0).identifier().getText())
         .isEqualTo("margin");
-    assertThat(context.statement(0).ruleset().block().property(0).propertyValue().getText())
+    assertThat(context.statement(0).ruleset().block().property_(0).propertyValue().getText())
         .isEqualTo("auto");
-    assertThat(context.statement(0).ruleset().block().property(0).block().property(0).getText())
+    assertThat(context.statement(0).ruleset().block().property_(0).block().property_(0).getText())
         .isEqualTo("bottom:10px;");
-    assertThat(context.statement(0).ruleset().block().property(0).block().property(1).getText())
+    assertThat(context.statement(0).ruleset().block().property_(0).block().property_(1).getText())
         .isEqualTo("top:2px;");
   }
 
@@ -710,15 +730,15 @@ public class TestBasicCss extends TestBase {
     };
 
     ScssParser.StylesheetContext context = parse(lines);
-    assertThat(context.statement(1).ruleset().block().property(0).identifier().getText())
+    assertThat(context.statement(1).ruleset().block().property_(0).identifier().getText())
         .isEqualTo("margin");
-    assertThat(context.statement(1).ruleset().block().property(0).propertyValue()).isNull();
+    assertThat(context.statement(1).ruleset().block().property_(0).propertyValue()).isNull();
     assertThat(
             context
                 .statement(1)
                 .ruleset()
                 .block()
-                .property(0)
+                .property_(0)
                 .block()
                 .statement(0)
                 .includeDeclaration()
@@ -750,6 +770,87 @@ public class TestBasicCss extends TestBase {
         .isEqualTo("right");
   }
 
+  @Test
+  public void testSccVariablePropertyValue() {
+    String[] lines = {
+      "#container {",
+      "  background-color: var(--app-background-color);",
+      "}",
+    };
+
+    assertThat(
+      parse(lines)
+        .statement(0)
+        .ruleset()
+        .block()
+        .property_()
+        .get(0)
+        .propertyValue()
+        .getText())
+      .isEqualTo("var(--app-background-color)");
+  }
+
+  @Test
+  public void testFontFaceDeclaration() {
+    String[] lines = {
+    "@font-face {",
+    "  font-family: 'Google Material Icons';",
+    "  font-style: normal;",
+    "  font-weight: 400;",
+    "  src: url(http://some-uri.com)",
+    "    format('woff2')",
+    "}",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+
+    assertThat(
+      context
+        .statement(0)
+        .fontFaceDeclaration()
+        .FONT_FACE()
+        .getText())
+      .isEqualTo("@font-face");
+
+    assertThat(
+      context
+        .statement(0)
+        .fontFaceDeclaration()
+        .block()
+        .lastProperty()
+        .identifier()
+        .getText())
+      .isEqualTo("src");
+  }
+
+  @Test
+  public void testKeyframesDeclaration() {
+    String[] lines = {
+      "@keyframes spin {",
+      "  transform: rotate(0deg);",
+      "}",
+    };
+
+    ScssParser.StylesheetContext context = parse(lines);
+    assertThat(
+      context
+        .statement(0)
+        .keyframesDeclaration()
+        .KEYFRAMES()
+        .getText())
+      .isEqualTo("@keyframes");
+
+    assertThat(
+      context
+        .statement(0)
+        .keyframesDeclaration()
+        .block()
+        .property_(0)
+        .identifier()
+        .getText())
+      .isEqualTo("transform");
+  }
+
   private ScssParser.SelectorsContext getSelector(String... lines) {
     ScssParser.StylesheetContext context = parse(lines);
     return context.statement(0).ruleset().selectors();
@@ -763,6 +864,6 @@ public class TestBasicCss extends TestBase {
 
     ScssParser.StylesheetContext styleContext = parse(all);
     ScssParser.BlockContext context = styleContext.statement(0).ruleset().block();
-    return context.property(0).propertyValue().commandStatement(0).expression();
+    return context.property_(0).propertyValue().commandStatement(0).expression();
   }
 }

--- a/scss/testsrc/test/java/TestConditionals.java
+++ b/scss/testsrc/test/java/TestConditionals.java
@@ -156,7 +156,7 @@ public class TestConditionals extends TestBase {
 
     ScssParser.EachDeclarationContext context = parse(lines).statement(0).eachDeclaration();
     assertThat(context.variableName(0).getText()).isEqualTo("$animal");
-    ScssParser.ListCommaSeparatedContext list = context.eachValueList().list().listCommaSeparated();
+    ScssParser.ListCommaSeparatedContext list = context.eachValueList().list_().listCommaSeparated();
     assertThat(list.listElement(0).commandStatement().getText()).isEqualTo("puma");
     assertThat(list.listElement(1).commandStatement().getText()).isEqualTo("sea-slug");
     assertThat(list.listElement(2).commandStatement().getText()).isEqualTo("egret");
@@ -176,10 +176,10 @@ public class TestConditionals extends TestBase {
     ScssParser.ListCommaSeparatedContext list1 =
         context
             .eachValueList()
-            .list()
+            .list_()
             .listCommaSeparated()
             .listElement(0)
-            .list()
+            .list_()
             .listCommaSeparated();
     assertThat(list1.listElement(0).commandStatement().getText()).isEqualTo("puma");
     assertThat(list1.listElement(1).commandStatement().getText()).isEqualTo("black");
@@ -188,10 +188,10 @@ public class TestConditionals extends TestBase {
     ScssParser.ListCommaSeparatedContext list2 =
         context
             .eachValueList()
-            .list()
+            .list_()
             .listCommaSeparated()
             .listElement(1)
-            .list()
+            .list_()
             .listCommaSeparated();
     assertThat(list2.listElement(0).commandStatement().getText()).isEqualTo("sea-slug");
     assertThat(list2.listElement(1).commandStatement().getText()).isEqualTo("blue");
@@ -209,7 +209,7 @@ public class TestConditionals extends TestBase {
     assertThat(
             context
                 .eachValueList()
-                .map()
+                .map_()
                 .mapEntry(0)
                 .mapKey()
                 .commandStatement()
@@ -220,7 +220,7 @@ public class TestConditionals extends TestBase {
     assertThat(
             context
                 .eachValueList()
-                .map()
+                .map_()
                 .mapEntry(0)
                 .mapValue()
                 .commandStatement()
@@ -229,10 +229,10 @@ public class TestConditionals extends TestBase {
                 .getText())
         .isEqualTo("2em");
 
-    assertThat(context.eachValueList().map().mapEntry(1).mapKey().getText()).isEqualTo("h2");
-    assertThat(context.eachValueList().map().mapEntry(1).mapValue().getText()).isEqualTo("1.5em");
+    assertThat(context.eachValueList().map_().mapEntry(1).mapKey().getText()).isEqualTo("h2");
+    assertThat(context.eachValueList().map_().mapEntry(1).mapValue().getText()).isEqualTo("1.5em");
 
-    assertThat(context.eachValueList().map().mapEntry(2).mapKey().getText()).isEqualTo("h3");
-    assertThat(context.eachValueList().map().mapEntry(2).mapValue().getText()).isEqualTo("1.2em");
+    assertThat(context.eachValueList().map_().mapEntry(2).mapKey().getText()).isEqualTo("h3");
+    assertThat(context.eachValueList().map_().mapEntry(2).mapValue().getText()).isEqualTo("1.2em");
   }
 }

--- a/scss/testsrc/test/java/TestImports.java
+++ b/scss/testsrc/test/java/TestImports.java
@@ -106,6 +106,12 @@ public class TestImports extends TestBase {
         .isEqualTo("$secondary-color:color.scale($base-color,$lightness:-10%)");
   }
 
+  @Test
+  public void testRequire() {
+    ScssParser.ImportDeclarationContext context = parseImport("@require \"sass:color\";");
+    assertThat(context.referenceUrl().StringLiteral().getText()).isEqualTo("\"sass:color\"");
+  }
+
   private ScssParser.ImportDeclarationContext parseImport(String... lines) {
     ScssParser.StylesheetContext context = parse(lines);
     return context.statement(0).importDeclaration();

--- a/scss/testsrc/test/java/TestListAndMap.java
+++ b/scss/testsrc/test/java/TestListAndMap.java
@@ -63,7 +63,7 @@ public final class TestListAndMap extends TestBase {
     };
 
     ScssParser.ListCommaSeparatedContext list =
-        parse(lines).statement(0).eachDeclaration().eachValueList().list().listCommaSeparated();
+        parse(lines).statement(0).eachDeclaration().eachValueList().list_().listCommaSeparated();
     assertThat(list.listElement()).hasSize(3);
     assertThat(list.listElement(0).commandStatement().getText()).isEqualTo("red");
     assertThat(list.listElement(1).commandStatement().getText()).isEqualTo("blue");
@@ -104,15 +104,15 @@ public final class TestListAndMap extends TestBase {
 
     ScssParser.ListSpaceSeparatedContext outerList =
         parse(lines).statement(0).variableDeclaration().listBracketed().listSpaceSeparated();
-    assertThat(outerList.listElement(0).list().listSpaceSeparated().listElement()).hasSize(2);
-    assertThat(outerList.listElement(1).list().listCommaSeparated().listElement()).hasSize(4);
+    assertThat(outerList.listElement(0).list_().listSpaceSeparated().listElement()).hasSize(2);
+    assertThat(outerList.listElement(1).list_().listCommaSeparated().listElement()).hasSize(4);
     assertThat(
             outerList
                 .listElement(1)
-                .list()
+                .list_()
                 .listCommaSeparated()
                 .listElement(1)
-                .list()
+                .list_()
                 .listSpaceSeparated()
                 .listElement())
         .hasSize(3);
@@ -122,7 +122,7 @@ public final class TestListAndMap extends TestBase {
   public void map() {
     String[] lines = {"$font-weights: (\"regular\": 400, \"medium\": 500, \"bold\": 700);"};
 
-    ScssParser.MapContext map = parse(lines).statement(0).variableDeclaration().map();
+    ScssParser.Map_Context map = parse(lines).statement(0).variableDeclaration().map_();
     assertThat(map.mapEntry()).hasSize(3);
     assertThat(map.mapEntry(0).mapKey().commandStatement().getText()).isEqualTo("\"regular\"");
     assertThat(map.mapEntry(0).mapValue().commandStatement().getText()).isEqualTo("400");
@@ -132,7 +132,7 @@ public final class TestListAndMap extends TestBase {
   public void mapUnquotedKeys() {
     String[] lines = {"$var: (1: 2, a: b, red: blue);"};
 
-    ScssParser.MapContext map = parse(lines).statement(0).variableDeclaration().map();
+    ScssParser.Map_Context map = parse(lines).statement(0).variableDeclaration().map_();
     assertThat(map.mapEntry()).hasSize(3);
     assertThat(map.mapEntry(2).mapKey().commandStatement().getText()).isEqualTo("red");
     assertThat(map.mapEntry(2).mapValue().commandStatement().getText()).isEqualTo("blue");
@@ -150,7 +150,7 @@ public final class TestListAndMap extends TestBase {
       ");",
     };
 
-    ScssParser.MapContext map =
+    ScssParser.Map_Context map =
         parse(lines)
             .statement(0)
             .variableDeclaration()
@@ -160,10 +160,10 @@ public final class TestListAndMap extends TestBase {
             .functionCall()
             .passedParams()
             .passedParam(1)
-            .map();
+            .map_();
     assertThat(map.mapEntry()).hasSize(2);
     ScssParser.ListSpaceSeparatedContext list =
-        map.mapEntry(1).mapValue().list().listSpaceSeparated();
+        map.mapEntry(1).mapValue().list_().listSpaceSeparated();
     assertThat(list.listElement()).hasSize(3);
     assertThat(list.listElement(0).getText()).isEqualTo("1px");
     assertThat(list.listElement(1).getText()).isEqualTo("solid");
@@ -174,14 +174,14 @@ public final class TestListAndMap extends TestBase {
   public void nestedMap() {
     String[] lines = {"$config: (a: (b: (c: d)));"};
 
-    ScssParser.MapContext map = parse(lines).statement(0).variableDeclaration().map();
+    ScssParser.Map_Context map = parse(lines).statement(0).variableDeclaration().map_();
     assertThat(
             map.mapEntry(0)
                 .mapValue()
-                .map()
+                .map_()
                 .mapEntry(0)
                 .mapValue()
-                .map()
+                .map_()
                 .mapEntry(0)
                 .mapValue()
                 .getText())

--- a/scss/testsrc/test/java/TestMedia.java
+++ b/scss/testsrc/test/java/TestMedia.java
@@ -219,7 +219,7 @@ public class TestMedia extends TestBase {
     assertThat(
             innerMedia
                 .block()
-                .property(0)
+                .property_(0)
                 .propertyValue()
                 .commandStatement(0)
                 .expression()

--- a/scss/testsrc/test/java/TestMixinAndInclude.java
+++ b/scss/testsrc/test/java/TestMixinAndInclude.java
@@ -311,7 +311,7 @@ public final class TestMixinAndInclude extends TestBase {
         context.statement(1).ruleset().block().statement(0).includeDeclaration();
     assertThat(include.Identifier().getText()).isEqualTo("hover");
     assertThat(include.functionCall()).isNull();
-    assertThat(include.block().property(0).getText()).isEqualTo("border-width:2px;");
+    assertThat(include.block().property_(0).getText()).isEqualTo("border-width:2px;");
   }
 
   @Test


### PR DESCRIPTION
This is the fix for the parser and tests: 
- fixed syntax errors in the tests
- added `@require` import statement
- added `@keyframe` import statement
- added `@font-face` directive
- added `@forward` directive as per [doc](https://github.com/sass/sass/blob/main/accepted/module-system.md#forward-1)
- added CSS function declaration syntax
- fixed a bug when parser treated CSS identifier as colour
- fixed warnings by replacing string literals in parser
- added more examples in the examples file

The changes are fully backwards compatible.