### PR TITLE
fix arrayCreation is parsed into functionCall

### DIFF
--- a/php/PhpParser.g4
+++ b/php/PhpParser.g4
@@ -449,6 +449,7 @@ expression
 
     | Print expression                                          #PrintExpression
 
+    | arrayCreation                                             #ArrayCreationExpression
     | chain                                                     #ChainExpression
     | constant                                                  #ScalarExpression
     | string                                                    #ScalarExpression
@@ -456,7 +457,6 @@ expression
 
     | BackQuoteString                                           #BackQuoteStringExpression
     | parentheses                                               #ParenthesisExpression
-    | arrayCreation                                             #ArrayCreationExpression
 
     | Yield                                                     #SpecialWordExpression
     | List '(' assignmentList ')' Eq expression                 #SpecialWordExpression


### PR DESCRIPTION
The php `array()` keyword is recognized as a function, it should be an `arrayCreation`.

### What version of Antlr are you using?

Version 4.9.3，but i think almost all versions have the same problem

###  Reproduce

```php
<?php
        $arr = array(1, 2, 3);

```

Actual result
![image](https://user-images.githubusercontent.com/8477236/172378654-ae520e6d-f0e1-4150-a23e-bcfefb629838.png)

Expected result
![image](https://user-images.githubusercontent.com/8477236/172380312-895c7acc-bac1-4665-b953-8a6d29dcae57.png)

