### PR TITLE
[PromQL] support case insensitive keywords

### DIFF
--- a/promql/PromQLLexer.g4
+++ b/promql/PromQLLexer.g4
@@ -28,6 +28,10 @@
 
 lexer grammar PromQLLexer;
 
+// All keywords in PromQL are case insensitive, it is just function,
+// label and metric names that are not.
+options { caseInsensitive=true; }
+
 NUMBER: [0-9]+ ('.' [0-9]+)?;
 
 STRING
@@ -91,7 +95,7 @@ AGGREGATION_OPERATOR
     | 'quantile'
     ;
 
-FUNCTION
+FUNCTION options { caseInsensitive=false; }
     : 'abs'
     | 'absent'
     | 'absent_over_time'
@@ -160,7 +164,7 @@ TIME_RANGE
 
 DURATION: [0-9]+ ('s' | 'm' | 'h' | 'd' | 'w' | 'y');
 
-METRIC_NAME: [a-zA-Z_:] [a-zA-Z0-9_:]*;
-LABEL_NAME:  [a-zA-Z_] [a-zA-Z0-9_]*;
+METRIC_NAME: [a-z_:] [a-z0-9_:]*;
+LABEL_NAME:  [a-z_] [a-z0-9_]*;
 
 WS: [\r\t\n ]+ -> skip;

--- a/promql/examples/vector_match_operation.txt
+++ b/promql/examples/vector_match_operation.txt
@@ -1,1 +1,1 @@
-max by (very, second)(foo_metric{very=~'important', something='else'}) > 0 and on(host,project)(metric_name) > 0
+max by (very, second)(foo_metric{very=~'important', something='else'}) > 0 AND ON(host,project)(metric_name) > 0


### PR DESCRIPTION
The official PromQL parser accepts keywords in any case, so do the same
for the PromQL ANTLR grammar.