### PR TITLE
[PromQL] Support scientific notation in promql

### DIFF
--- a/promql/PromQLLexer.g4
+++ b/promql/PromQLLexer.g4
@@ -32,7 +32,15 @@ lexer grammar PromQLLexer;
 // label and metric names that are not.
 options { caseInsensitive=true; }
 
-NUMBER: [0-9]+ ('.' [0-9]+)?;
+fragment NUMERAL: [0-9]+ ('.' [0-9]+)?;
+
+fragment SCIENTIFIC_NUMBER
+   : NUMERAL ('e' ('-' | '+')? NUMERAL)?
+   ;
+
+NUMBER
+    : NUMERAL
+    | SCIENTIFIC_NUMBER;
 
 STRING
     : '\'' (~('\'' | '\\') | '\\' .)* '\''

--- a/promql/examples/operators.txt
+++ b/promql/examples/operators.txt
@@ -1,1 +1,1 @@
-((- a ^ 2 * b + c) > 1) and d or e
+((- a ^ 2 * b + c) > 1) and d or e or (a < -1e-05 > 1e-05)


### PR DESCRIPTION
PromQL supports defining numbers using scientific notation, for example:

    some_metric < -1e-07

so add support for this to the grammar.

Reference: https://github.com/prometheus/prometheus/blob/main/promql/parser/lex.go#L754