### PR TITLE
Removed outdated comment

### DIFF
--- a/sql/mysql/Positive-Technologies/README.md
+++ b/sql/mysql/Positive-Technologies/README.md
@@ -3,10 +3,3 @@
 An ANTLR4 grammar for MySQL based on version 5.6 and 5.7 of 
 [http://dev.mysql.com/doc/refman/5.6/en/](http://dev.mysql.com/doc/refman/5.6/en/).
 [http://dev.mysql.com/doc/refman/5.7/en/](http://dev.mysql.com/doc/refman/5.7/en/).
-
-## Usage, important note
-
-As SQL grammar are normally not case sensitive but this grammar implementation is, you must use a custom [character stream](https://github.com/antlr/antlr4/blob/master/runtime/Java/src/org/antlr/v4/runtime/CharStream.java) that converts all characters to uppercase before sending them to the lexer.
-
-You could find more information [here](https://github.com/antlr/antlr4/blob/master/doc/case-insensitive-lexing.md#custom-character-streams-approach) with implementations for various target languages.
-


### PR DESCRIPTION
The comment about using a custom character stream is no longer needed after the addition of `options { caseInsensitive = true; }` to the lexer grammar in https://github.com/antlr/grammars-v4/commit/c810ec33085922e2138efd1b3268c481997f9573#diff-1cb407f308a0912bae7df6e93484f4592fbfdc65ae8e52fa1fc49a5d28e8d700