### PR TITLE
[MySQL] Support using variables in KILL command

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -1835,7 +1835,7 @@ flushStatement
 
 killStatement
     : KILL connectionFormat=(CONNECTION | QUERY)?
-      decimalLiteral+
+      (decimalLiteral+ | mysqlVariable)
     ;
 
 loadIndexIntoCache

--- a/sql/mysql/Positive-Technologies/examples/kill.sql
+++ b/sql/mysql/Positive-Technologies/examples/kill.sql
@@ -1,0 +1,8 @@
+#begin
+KILL CONNECTION 12345;
+KILL QUERY 12345;
+KILL CONNECTION @conn_variable;
+KILL QUERY @query_variable;
+KILL CONNECTION @@global_variable;
+KILL QUERY @@global_variable;
+#end


### PR DESCRIPTION
CLI example:

    mysql> SET @conn=11;
    Query OK, 0 rows affected (0.00 sec)

    mysql> KILL CONNECTION @conn;
    Query OK, 0 rows affected (0.00 sec)