### PR TITLE
[Infrastructure] Fix for issue 2667--computation of file stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,16 +7,22 @@
 # to native line endings on checkout.
 *.abnf text
 *.agc text
+*.alg text
+*.asm text
 *.asn text
 *.b text
 *.bas text
+*.bcpl text
 *.bnf text
 *.c text
+*.cc text
 *.cl text
 *.cpp text
 *.cs text
+*.csproj text
 *.css text
 *.csv text
+*.dart text
 *.dgs text
 *.dot text
 *.erl text
@@ -25,6 +31,8 @@
 *.ffn text
 *.fna text
 *.g text
+*.g2 text
+*.g3 text
 *.g4 text
 *.g42 text
 *.gff text
@@ -40,6 +48,7 @@
 *.js text
 *.json text
 *.kt text
+*.lark text
 *.lua text
 *.m text
 *.map text
@@ -58,6 +67,7 @@
 *.py text
 *.rb text
 *.s text
+*.scala text
 *.sh text
 *.smt2 text
 *.sno text
@@ -78,7 +88,7 @@ access_log text
 
 # Declare files that will always have LF line endings on checkout.
 # Unicode input files end with *.txt, but should not be converted on Windows
-/unicode/graphemes/examples/*.txt eol=lf
+unicode/graphemes/examples/*.txt eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 # Currently the /vb6/**/*.cls and *.frm file need this, otherwise the grammar fails. 
@@ -89,5 +99,9 @@ access_log text
 *.pdf binary
 *.png binary
 
-
-**/examples/* linguist-vendored
+**/examples/** linguist-vendored
+**/example-scripts/** linguist-vendored
+**/example-scriptlets/** linguist-vendored
+**/examples-sql-script/** linguist-vendored
+**/examples_todo/** linguist-vendored
+**/example/test_scripts/** linguist-vendored


### PR DESCRIPTION
This PR updates the .gitattributes file for github file stats. The changes are to ignore files under examples/ directories. It also includes changes for git to convert line endings for additional file types in the examples/ directories.