### PR TITLE
Fix for #2682, sparql for Go.

### DIFF
--- a/_scripts/skip-go.txt
+++ b/_scripts/skip-go.txt
@@ -71,7 +71,6 @@ scss
 sieve
 smalltalk
 smtlibv2
-sparql
 sql/hive/v2
 sql/hive/v3
 sql/mysql

--- a/sparql/Sparql.g4
+++ b/sparql/Sparql.g4
@@ -297,7 +297,7 @@ iriRefOrFunction
     ;
 
 rdfLiteral
-    : string ( LANGTAG | ( '^^' iriRef ) )?
+    : string_ ( LANGTAG | ( '^^' iriRef ) )?
     ;
 
 numericLiteral
@@ -327,7 +327,7 @@ booleanLiteral
     | 'false'
     ;
 
-string
+string_
     : STRING_LITERAL1
     | STRING_LITERAL2
     /* | STRING_LITERAL_LONG('0'..'9') | STRING_LITERAL_LONG('0'..'9')*/


### PR DESCRIPTION
Renamed "string" to "string_" and added the Go target.