### PR TITLE
Remove RECORD from identifier

### DIFF
--- a/java/java/JavaParser.g4
+++ b/java/java/JavaParser.g4
@@ -469,7 +469,6 @@ identifier
     | YIELD
     | SEALED
     | PERMITS
-    | RECORD
     | VAR
     ;
 

--- a/java/java/examples/Record.java
+++ b/java/java/examples/Record.java
@@ -1,0 +1,4 @@
+public class Record {
+  record R1(int x) {
+  }
+}


### PR DESCRIPTION
Removed the `RECORD` token from the `identifier` parser rule. Now the input:

```java
public class Record {
  record R1(int x) {
  }
}
```

will _not_ be parsed as:

<img width="599" alt="Screenshot 2022-06-30 at 12 54 52" src="https://user-images.githubusercontent.com/281616/176660678-0aaf7179-6fdd-44be-852b-b71bb1411a84.png">

but as:

<img width="607" alt="Screenshot 2022-06-30 at 12 54 32" src="https://user-images.githubusercontent.com/281616/176660735-3b4018bf-54bd-44fc-821a-db78ed963fd7.png">

Fixes #2685 

