### PR TITLE
Add placeholders of parameters to T-SQL grammar for prepared statements

### DIFF
--- a/sql/tsql/TSqlLexer.g4
+++ b/sql/tsql/TSqlLexer.g4
@@ -939,6 +939,8 @@ BIT_OR:              '|';
 BIT_AND:             '&';
 BIT_XOR:             '^';
 
+PLACEHOLDER:         '?';
+
 fragment LETTER:       [A-Z_];
 fragment DEC_DOT_DEC:  (DEC_DIGIT+ '.' DEC_DIGIT+ |  DEC_DIGIT+ '.' | '.' DEC_DIGIT+);
 fragment HEX_DIGIT:    [0-9A-F];

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3182,6 +3182,9 @@ expression
     | DOLLAR_ACTION
     ;
 
+parameter
+    : PLACEHOLDER;
+
 time_zone
     : AT_KEYWORD TIME ZONE expression
     ;
@@ -4012,6 +4015,7 @@ constant
     | sign? DECIMAL
     | sign? (REAL | FLOAT)  // float or decimal
     | sign? dollar='$' (DECIMAL | FLOAT)       // money
+    | parameter
     ;
 
 sign

--- a/sql/tsql/examples/parameters.sql
+++ b/sql/tsql/examples/parameters.sql
@@ -1,0 +1,1 @@
+SELECT * FROM t WHERE ID = ?


### PR DESCRIPTION
JDBC prepared statements have placeholders for parameters. This addition to the grammar allow parsing of prepared statements.
See added example.