### PR TITLE
[TSql] raiserror accepts null as arguments

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -324,7 +324,7 @@ print_statement
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/raiserror-transact-sql
 raiseerror_statement
     : RAISERROR '(' msg=(DECIMAL | STRING | LOCAL_ID) ',' severity=constant_LOCAL_ID ','
-    state=constant_LOCAL_ID (',' constant_LOCAL_ID)* ')' (WITH (LOG | SETERROR | NOWAIT))? ';'?
+    state=constant_LOCAL_ID (',' (constant_LOCAL_ID | NULL_))* ')' (WITH (LOG | SETERROR | NOWAIT))? ';'?
     | RAISERROR DECIMAL formatstring=(STRING | LOCAL_ID | DOUBLE_QUOTE_ID) (',' argument=(DECIMAL | STRING | LOCAL_ID))*
     ;
 

--- a/sql/tsql/examples/raiseerror.sql
+++ b/sql/tsql/examples/raiseerror.sql
@@ -1,4 +1,5 @@
     raiserror 721350 "Fehler %1!.", @err
     raiserror 72958 'Quartal %1!.', @quartal
     raiserror 641523 'Sülz.'
+    raiserror ( N'%s', 10, 1, NULL );
 


### PR DESCRIPTION
```sql
RAISERROR (N'%s', -- Message text.  
           10, -- Severity,  
           1, -- State,  
           NULL); -- First argument supplies the string.  
-- The message text returned is: '(null)'.  
GO
```

As added in examples. Didn't change `constant_LOCALID` as it is also used with `SET`.