### PR TITLE
Modify hiveParser's expression rules to implement AND/OR priority

### DIFF
--- a/sql/hive/v2/IdentifiersParser.g4
+++ b/sql/hive/v2/IdentifiersParser.g4
@@ -372,7 +372,7 @@ expression
     | expression precedenceAmpersandOperator expression
     | expression precedenceBitwiseOrOperator expression
     | expression precedenceComparisonOperator expression
-    | expression (KW_NOT)? precedenceRegexpOperator expression
+    | expression KW_NOT? precedenceRegexpOperator expression
     | expression (KW_NOT)? KW_LIKE KW_ANY expressionsInParenthesis
     | expression (KW_NOT)? KW_LIKE KW_ALL expressionsInParenthesis
     | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn

--- a/sql/hive/v2/IdentifiersParser.g4
+++ b/sql/hive/v2/IdentifiersParser.g4
@@ -290,10 +290,7 @@ precedenceUnaryOperator
     ;
 
 isCondition
-    : (KW_NOT)? KW_NULL
-    | (KW_NOT)? KW_TRUE
-    | (KW_NOT)? KW_FALSE
-    | (KW_NOT)? KW_DISTINCT KW_FROM
+    : KW_NOT? (KW_NULL | KW_TRUE | KW_FALSE | KW_DISTINCT | KW_FROM)
     ;
 
 precedenceBitwiseXorOperator

--- a/sql/hive/v2/IdentifiersParser.g4
+++ b/sql/hive/v2/IdentifiersParser.g4
@@ -373,8 +373,7 @@ expression
     | expression precedenceBitwiseOrOperator expression
     | expression precedenceComparisonOperator expression
     | expression KW_NOT? precedenceRegexpOperator expression
-    | expression (KW_NOT)? KW_LIKE KW_ANY expressionsInParenthesis
-    | expression (KW_NOT)? KW_LIKE KW_ALL expressionsInParenthesis
+    | expression KW_NOT? KW_LIKE (KW_ANY | KW_ALL) expressionsInParenthesis
     | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn
     | expression (KW_NOT)? KW_BETWEEN expression KW_AND expression
     | KW_EXISTS subQueryExpression

--- a/sql/hive/v2/IdentifiersParser.g4
+++ b/sql/hive/v2/IdentifiersParser.g4
@@ -374,8 +374,8 @@ expression
     | expression precedenceComparisonOperator expression
     | expression KW_NOT? precedenceRegexpOperator expression
     | expression KW_NOT? KW_LIKE (KW_ANY | KW_ALL) expressionsInParenthesis
-    | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn
-    | expression (KW_NOT)? KW_BETWEEN expression KW_AND expression
+    | expression KW_NOT? KW_IN precedenceSimilarExpressionIn
+    | expression KW_NOT? KW_BETWEEN expression KW_AND expression
     | KW_EXISTS subQueryExpression
     | precedenceNotOperator expression
     | expression precedenceLogicOperator expression

--- a/sql/hive/v2/IdentifiersParser.g4
+++ b/sql/hive/v2/IdentifiersParser.g4
@@ -290,12 +290,10 @@ precedenceUnaryOperator
     ;
 
 isCondition
-    : KW_NULL
-    | KW_TRUE
-    | KW_FALSE
-    | KW_NOT KW_NULL
-    | KW_NOT KW_TRUE
-    | KW_NOT KW_FALSE
+    : (KW_NOT)? KW_NULL
+    | (KW_NOT)? KW_TRUE
+    | (KW_NOT)? KW_FALSE
+    | (KW_NOT)? KW_DISTINCT KW_FROM
     ;
 
 precedenceBitwiseXorOperator
@@ -332,35 +330,23 @@ precedenceRegexpOperator
     | KW_REGEXP
     ;
 
-precedenceSimilarOperator
-    : precedenceRegexpOperator
-    | LESSTHANOREQUALTO
+precedenceComparisonOperator
+    : LESSTHANOREQUALTO
     | LESSTHAN
     | GREATERTHANOREQUALTO
     | GREATERTHAN
-    ;
-
-precedenceDistinctOperator
-    : KW_IS KW_DISTINCT KW_FROM
-    ;
-
-precedenceEqualOperator
-    : EQUAL
+    | EQUAL
     | EQUAL_NS
     | NOTEQUAL
-    | KW_IS KW_NOT KW_DISTINCT KW_FROM
     ;
 
 precedenceNotOperator
     : KW_NOT
     ;
 
-precedenceAndOperator
+precedenceLogicOperator
     : KW_AND
-    ;
-
-precedenceOrOperator
-    : KW_OR
+    | KW_OR
     ;
 
 //precedenceFieldExpression
@@ -388,30 +374,16 @@ expression
     | expression precedenceConcatenateOperator expression
     | expression precedenceAmpersandOperator expression
     | expression precedenceBitwiseOrOperator expression
-    | expression precedenceSimilarExpressionPart
+    | expression precedenceComparisonOperator expression
+    | expression (KW_NOT)? precedenceRegexpOperator expression
+    | expression (KW_NOT)? KW_LIKE KW_ANY expressionsInParenthesis
+    | expression (KW_NOT)? KW_LIKE KW_ALL expressionsInParenthesis
+    | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn
+    | expression (KW_NOT)? KW_BETWEEN expression KW_AND expression
     | KW_EXISTS subQueryExpression
-    | expression (precedenceEqualOperator | precedenceDistinctOperator) expression
     | precedenceNotOperator expression
-    | expression precedenceAndOperator expression
-    | expression precedenceOrOperator expression
+    | expression precedenceLogicOperator expression
     | LPAREN expression RPAREN
-    ;
-
-subQueryExpression
-    : LPAREN selectStatement RPAREN
-    ;
-
-precedenceSimilarExpressionPart
-    : precedenceSimilarOperator expression
-    | precedenceSimilarExpressionAtom
-    | KW_NOT precedenceSimilarExpressionPartNot
-    ;
-
-precedenceSimilarExpressionAtom
-    : KW_IN precedenceSimilarExpressionIn
-    | KW_BETWEEN expression KW_AND expression
-    | KW_LIKE KW_ANY expressionsInParenthesis
-    | KW_LIKE KW_ALL expressionsInParenthesis
     ;
 
 precedenceSimilarExpressionIn
@@ -419,9 +391,8 @@ precedenceSimilarExpressionIn
     | expressionsInParenthesis
     ;
 
-precedenceSimilarExpressionPartNot
-    : precedenceRegexpOperator expression
-    | precedenceSimilarExpressionAtom
+subQueryExpression
+    : LPAREN selectStatement RPAREN
     ;
 
 booleanValue

--- a/sql/hive/v3/IdentifiersParser.g4
+++ b/sql/hive/v3/IdentifiersParser.g4
@@ -372,7 +372,7 @@ expression
     | expression precedenceAmpersandOperator expression
     | expression precedenceBitwiseOrOperator expression
     | expression precedenceComparisonOperator expression
-    | expression (KW_NOT)? precedenceRegexpOperator expression
+    | expression KW_NOT? precedenceRegexpOperator expression
     | expression (KW_NOT)? KW_LIKE KW_ANY expressionsInParenthesis
     | expression (KW_NOT)? KW_LIKE KW_ALL expressionsInParenthesis
     | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn

--- a/sql/hive/v3/IdentifiersParser.g4
+++ b/sql/hive/v3/IdentifiersParser.g4
@@ -373,8 +373,7 @@ expression
     | expression precedenceBitwiseOrOperator expression
     | expression precedenceComparisonOperator expression
     | expression KW_NOT? precedenceRegexpOperator expression
-    | expression (KW_NOT)? KW_LIKE KW_ANY expressionsInParenthesis
-    | expression (KW_NOT)? KW_LIKE KW_ALL expressionsInParenthesis
+    | expression KW_NOT? KW_LIKE (KW_ANY | KW_ALL) expressionsInParenthesis
     | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn
     | expression (KW_NOT)? KW_BETWEEN expression KW_AND expression
     | KW_EXISTS subQueryExpression

--- a/sql/hive/v3/IdentifiersParser.g4
+++ b/sql/hive/v3/IdentifiersParser.g4
@@ -290,10 +290,7 @@ precedenceUnaryOperator
     ;
 
 isCondition
-    : (KW_NOT)? KW_NULL
-    | (KW_NOT)? KW_TRUE
-    | (KW_NOT)? KW_FALSE
-    | (KW_NOT)? KW_DISTINCT KW_FROM
+    : KW_NOT? (KW_NULL | KW_TRUE | KW_FALSE | KW_DISTINCT KW_FROM)
     ;
 
 precedenceBitwiseXorOperator

--- a/sql/hive/v3/IdentifiersParser.g4
+++ b/sql/hive/v3/IdentifiersParser.g4
@@ -374,8 +374,8 @@ expression
     | expression precedenceComparisonOperator expression
     | expression KW_NOT? precedenceRegexpOperator expression
     | expression KW_NOT? KW_LIKE (KW_ANY | KW_ALL) expressionsInParenthesis
-    | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn
-    | expression (KW_NOT)? KW_BETWEEN expression KW_AND expression
+    | expression KW_NOT? KW_IN precedenceSimilarExpressionIn
+    | expression KW_NOT? KW_BETWEEN expression KW_AND expression
     | KW_EXISTS subQueryExpression
     | precedenceNotOperator expression
     | expression precedenceLogicOperator expression

--- a/sql/hive/v3/IdentifiersParser.g4
+++ b/sql/hive/v3/IdentifiersParser.g4
@@ -290,12 +290,10 @@ precedenceUnaryOperator
     ;
 
 isCondition
-    : KW_NULL
-    | KW_TRUE
-    | KW_FALSE
-    | KW_NOT KW_NULL
-    | KW_NOT KW_TRUE
-    | KW_NOT KW_FALSE
+    : (KW_NOT)? KW_NULL
+    | (KW_NOT)? KW_TRUE
+    | (KW_NOT)? KW_FALSE
+    | (KW_NOT)? KW_DISTINCT KW_FROM
     ;
 
 precedenceBitwiseXorOperator
@@ -332,35 +330,23 @@ precedenceRegexpOperator
     | KW_REGEXP
     ;
 
-precedenceSimilarOperator
-    : precedenceRegexpOperator
-    | LESSTHANOREQUALTO
+precedenceComparisonOperator
+    : LESSTHANOREQUALTO
     | LESSTHAN
     | GREATERTHANOREQUALTO
     | GREATERTHAN
-    ;
-
-precedenceDistinctOperator
-    : KW_IS KW_DISTINCT KW_FROM
-    ;
-
-precedenceEqualOperator
-    : EQUAL
+    | EQUAL
     | EQUAL_NS
     | NOTEQUAL
-    | KW_IS KW_NOT KW_DISTINCT KW_FROM
     ;
 
 precedenceNotOperator
     : KW_NOT
     ;
 
-precedenceAndOperator
+precedenceLogicOperator
     : KW_AND
-    ;
-
-precedenceOrOperator
-    : KW_OR
+    | KW_OR
     ;
 
 //precedenceFieldExpression
@@ -388,30 +374,16 @@ expression
     | expression precedenceConcatenateOperator expression
     | expression precedenceAmpersandOperator expression
     | expression precedenceBitwiseOrOperator expression
-    | expression precedenceSimilarExpressionPart
+    | expression precedenceComparisonOperator expression
+    | expression (KW_NOT)? precedenceRegexpOperator expression
+    | expression (KW_NOT)? KW_LIKE KW_ANY expressionsInParenthesis
+    | expression (KW_NOT)? KW_LIKE KW_ALL expressionsInParenthesis
+    | expression (KW_NOT)? KW_IN precedenceSimilarExpressionIn
+    | expression (KW_NOT)? KW_BETWEEN expression KW_AND expression
     | KW_EXISTS subQueryExpression
-    | expression (precedenceEqualOperator | precedenceDistinctOperator) expression
     | precedenceNotOperator expression
-    | expression precedenceAndOperator expression
-    | expression precedenceOrOperator expression
+    | expression precedenceLogicOperator expression
     | LPAREN expression RPAREN
-    ;
-
-subQueryExpression
-    : LPAREN selectStatement RPAREN
-    ;
-
-precedenceSimilarExpressionPart
-    : precedenceSimilarOperator expression
-    | precedenceSimilarExpressionAtom
-    | KW_NOT precedenceSimilarExpressionPartNot
-    ;
-
-precedenceSimilarExpressionAtom
-    : KW_IN precedenceSimilarExpressionIn
-    | KW_BETWEEN expression KW_AND expression
-    | KW_LIKE KW_ANY expressionsInParenthesis
-    | KW_LIKE KW_ALL expressionsInParenthesis
     ;
 
 precedenceSimilarExpressionIn
@@ -419,9 +391,8 @@ precedenceSimilarExpressionIn
     | expressionsInParenthesis
     ;
 
-precedenceSimilarExpressionPartNot
-    : precedenceRegexpOperator expression
-    | precedenceSimilarExpressionAtom
+subQueryExpression
+    : LPAREN selectStatement RPAREN
     ;
 
 booleanValue


### PR DESCRIPTION
Modify hiveParser's expression rules to implement AND/OR's priority and make the structure of expression more clearer.

example, SQL: `SELECT c1, c2 FROM t1 WHERE c1 > 1 AND c2 < 3;`

old ParseTree :

![old ParseTree](https://file.makeyourchoice.cn/img/github/hiveBefore.jpg)

new ParseTree :

![new ParseTree](https://file.makeyourchoice.cn/img/github/hiveAfter.jpg)