### PR TITLE
[JavaScript/Python3 target] Fix for #2703

### DIFF
--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -201,6 +201,10 @@ part2()
     # 2) Build driver code.
     echo "Building."
     date
+    if [[ -f transformGrammar.py ]]
+    then
+        python3 transformGrammar.py
+    fi
     case "$target" in
         CSharp) build_file_type="Test.csproj" ;;
         *) build_file_type="makefile" ;;

--- a/_scripts/skip-python3.txt
+++ b/_scripts/skip-python3.txt
@@ -33,7 +33,6 @@ infosapient
 java/java9
 javadoc
 javascript/ecmascript
-javascript/javascript
 javascript/jsx
 javascript/typescript
 joss

--- a/_scripts/test.ps1
+++ b/_scripts/test.ps1
@@ -86,6 +86,10 @@ function Test-Grammar {
             FailedCases = @()
         }
     }
+    $hasTransform = Test-Path transformGrammar.py
+    if ($hasTransform) {
+        python3 transformGrammar.py
+    }
 
     # build
 

--- a/javascript/javascript/Python3/README.md
+++ b/javascript/javascript/Python3/README.md
@@ -1,18 +1,17 @@
-# Python base Lexer and Parser for JavaScript
+# JavaScript parser for the Python3 target
 ---
-This is a base lexer and parser for the JavaScript language for Antlr4
+This directory contains the base class code for the JavaScript parser. To use the
+JavaScript grammar for Python3, run:
+```
+python transformGrammar.py
+antlr4 -Dlanguage=Python3 -o gen *.g4
+```
+The [transformGrammar.py](https://github.com/antlr/grammars-v4/blob/master/javascript/javascript/Python3/transformGrammar.py) script modifies the split grammar for Python3.
+The grammar must be modified for Python3.
 
-Baecause the Lexer and Parser use special commands you first need to transform the grammar files:
+The generate parser works with this Python3 driver:
 
-- python transformGrammar.py JavaScriptParser.g4
-- python transformGrammar.py JavaScriptLexer.g4
-
-Then do the antlr thing:
-- antlr4 -Dlanguage=Python3 -o gen *.g4
-
-I have tested with the below code with a sampling of example JavaScript files from the examples directory.
-
-```python
+```
 import sys
 from antlr4 import *
 import JavaScriptLexer
@@ -39,3 +38,5 @@ if __name__ == '__main__':
     print("Running")
     main(sys.argv)
 ```
+
+(Updated 13 July 2022 by Ken Domino.)

--- a/javascript/javascript/Python3/transformGrammar.py
+++ b/javascript/javascript/Python3/transformGrammar.py
@@ -1,11 +1,11 @@
 import sys, os, re, shutil
 
-if __name__ == "__main__":
-    print("Python utility to transform the JavaScript Parser and Lexer grammars to work with a python output")
-    if len(sys.argv) == 1:
-        print(f"""Please run this script as {sys.argv[0]} <grammar>.g4""")
-        sys.exit(0)
-    file_path = sys.argv[1]
+def main(argv):
+    fix("JavaScriptLexer.g4")
+    fix("JavaScriptParser.g4")
+
+def fix(file_path):
+    print("Altering " + file_path)
     if not os.path.exists(file_path):
         print(f"Could not find file: {file_path}")
         sys.exit(1)
@@ -34,5 +34,9 @@ if __name__ == "__main__":
             output_file.write(x)
             output_file.flush()
 
+    print("Writing ...")
     input_file.close()
     output_file.close()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/javascript/javascript/Python3/transformGrammar.py
+++ b/javascript/javascript/Python3/transformGrammar.py
@@ -27,8 +27,10 @@ if __name__ == "__main__":
             output_file.flush()
     elif file_name.lower() == "javascriptlexer.g4":
         for x in input_file:
-            if '!this.IsStrictMode' in x:
-                x = x.replace('!this.Is', 'not self.is')
+            if '!this.' in x:
+                x = x.replace('!this.', 'not self.')
+            if 'this.' in x:
+                x = x.replace('this.', 'self.')
             output_file.write(x)
             output_file.flush()
 


### PR DESCRIPTION
This change fixes #2703 , adds "preprocessing" to grammars using "python3 transformGrammar.py" and adds the script to the build. Until we have "target-agnostic grammars", we are stuck in hell. But, at least this change will force people to consider what they do when modifying a grammar while not considering all targets.