### PR TITLE
[golang/ grammar, Python3 target] Adding the Python3 target.

### DIFF
--- a/_scripts/skip-python3.txt
+++ b/_scripts/skip-python3.txt
@@ -23,7 +23,6 @@ fortran77
 gdscript
 gff3
 gml
-golang
 haskell
 html
 hypertalk

--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -79,7 +79,7 @@ varSpec:
 
 block: L_CURLY statementList? R_CURLY;
 
-statementList: ((SEMI? | EOS? | {closingBracket()}?) statement eos)+;
+statementList: ((SEMI? | EOS? | {this.closingBracket()}?) statement eos)+;
 
 statement:
 	declaration
@@ -376,5 +376,5 @@ eos:
 	SEMI
 	| EOF
 	| EOS
-	| {closingBracket()}?
+	| {this.closingBracket()}?
 	;

--- a/golang/Python3/GoParserBase.py
+++ b/golang/Python3/GoParserBase.py
@@ -1,0 +1,7 @@
+from antlr4 import *
+
+class GoParserBase(Parser):
+
+    def closingBracket(self) -> bool:
+        la = self._input.LA(1)
+        return la == self.R_PAREN or la == self.R_CURLY

--- a/golang/Python3/README.md
+++ b/golang/Python3/README.md
@@ -1,0 +1,12 @@
+# Go parser for the Python3 target
+---
+This directory contains the base class code for the Go parser. To use the
+Go grammar for Python3, run:
+```
+python transformGrammar.py
+antlr4 -Dlanguage=Python3 -o gen *.g4
+```
+The [transformGrammar.py](https://github.com/antlr/grammars-v4/blob/master/golang/Python3/transformGrammar.py) script modifies the split grammar for Python3.
+The grammar must be modified for Python3.
+
+(Updated 20 July 2022 by Ken Domino.)

--- a/golang/Python3/transformGrammar.py
+++ b/golang/Python3/transformGrammar.py
@@ -1,0 +1,33 @@
+import sys, os, re, shutil
+
+def main(argv):
+    fix("GoParser.g4")
+
+def fix(file_path):
+    print("Altering " + file_path)
+    if not os.path.exists(file_path):
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    parts = os.path.split(file_path)
+    file_name = parts[-1]
+
+    if file_name.lower() not in ["goparser.g4", "golexer.g4"]:
+        print("Could not determine which grammar you have specified, please specify either the Paarser or the Lexer")
+        sys.exit(1)
+
+    shutil.move(file_path, file_path + ".bak")
+    input_file = open(file_path + ".bak",'r')
+    output_file = open(file_path, 'w')
+    if file_name.lower() == "goparser.g4":
+        for x in input_file:
+            if 'this.' in x:
+                x = x.replace('this.', 'self.')
+            output_file.write(x)
+            output_file.flush()
+
+    print("Writing ...")
+    input_file.close()
+    output_file.close()
+
+if __name__ == '__main__':
+    main(sys.argv)


### PR DESCRIPTION
This PR fixes #2719 where the Python3 port for the Go grammar is missing. It was mentioned in [this Stackoverflow problem](https://stackoverflow.com/questions/73050657/antlr4-golang-grammar-file). The port was easy, but because there's no "target-agnostic format" for grammars, I rewrote the grammar slightly so the base class method is called with an object reference ("this."). For the Python3 port, run "transformGrammar.py".

Since the port works, I added it to the build.