### PR TITLE
TSQL: OVER clause was added for sequence

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3631,9 +3631,9 @@ select_list_elem
     : asterisk
     | column_elem
     | udt_elem
-    | LOCAL_ID (assignment_operator | '=') ( expression | NEXT VALUE FOR table_name)
+    | LOCAL_ID (assignment_operator | '=') ( expression | NEXT VALUE FOR table_name over_clause?)
     | expression_elem
-    | NEXT VALUE FOR table_name as_column_alias?
+    | NEXT VALUE FOR table_name over_clause? as_column_alias?
     ;
 
 table_sources

--- a/sql/tsql/examples/dml_select.sql
+++ b/sql/tsql/examples/dml_select.sql
@@ -647,6 +647,19 @@ GO
 SELECT NEXT VALUE FOR [dbo].[sequenceName]
 GO
 
+-- NEXT VALUE FOR OVER into variable
+DECLARE @T BIGINT;
+
+SELECT @T = NEXT VALUE FOR dbo.sequenceName OVER (ORDER BY SOME_COLUMN ASC)
+FROM (SELECT SOME_COLUMN = 1) AS T
+
+GO
+
+-- NEXT VALUE FOR OVER without variable
+SELECT NEXT VALUE FOR dbo.sequenceName OVER (ORDER BY SOME_COLUMN ASC)
+FROM (SELECT SOME_COLUMN = 1) AS T
+GO
+
 --Select with linked server
 SELECT * FROM [linkedServerName]..[schema].[table] tbl
 GO


### PR DESCRIPTION
`over_order_by_clause` was added for `NEXT VALUE FOR`.
Syntax description: https://docs.microsoft.com/en-us/sql/t-sql/functions/next-value-for-transact-sql?view=sql-server-ver16
