### PR TITLE
Split concatenation into "normal" and "blank" concatenation

### DIFF
--- a/rexx/RexxLexer.g4
+++ b/rexx/RexxLexer.g4
@@ -1,4 +1,5 @@
 lexer grammar RexxLexer;
+channels { WHITESPACE_CHANNEL }
 
 // Main rules
 // %INCLUDE statement
@@ -8,7 +9,7 @@ LINE_COMMENT                    :   Line_Comment_
                                 ->  channel(HIDDEN);
 BLOCK_COMMENT                   :   Block_Comment_
                                 ->  channel(HIDDEN);
-WHISPACES                       :   Whitespaces_            -> channel(HIDDEN);
+WHITESPACES                     :   Whitespaces_            -> channel(WHITESPACE_CHANNEL);
 CONTINUATION                    :   Continue_               -> channel(HIDDEN);
 
 // Keywords

--- a/rexx/RexxParser.g4
+++ b/rexx/RexxParser.g4
@@ -226,7 +226,20 @@ comparison                  :   concatenation ( comparison_operator concatenatio
                             |   CMPS_NM
                             |   CMPS_NL
                             ;
-concatenation               :   addition ( CONCAT? addition )* ;
+concatenation               :   addition (concatenation_op addition)* ;
+ concatenation_op           :   {
+                                   (getTokenStream().get(getCurrentToken().getTokenIndex()-1).getChannel() == RexxLexer.WHITESPACE_CHANNEL)
+                                }? blank_concatenation_op // If previous token is whitespace, this is blank-concatenation.
+                            |   normal_concatenation_op
+                            ;
+  normal_concatenation_op   :   {
+                                   (getTokenStream().get(getCurrentToken().getTokenIndex()-1).getChannel() != RexxLexer.WHITESPACE_CHANNEL)
+                                }? // If previous token is not whitespace, this is abuttal-concatenation.
+                                // Note: no token or rule to match here, just the predicate.
+                            |   CONCAT
+                            ;
+  blank_concatenation_op    :   ; // Note: no token or rule to match here, just the predicate.
+
 addition                    :   multiplication ( additive_operator multiplication )* ;
   additive_operator         :   PLUS
                             |   MINUS

--- a/rexx/examples/test_concatenation.rex
+++ b/rexx/examples/test_concatenation.rex
@@ -1,0 +1,15 @@
+/* */
+
+/* Explicit concatenation: */
+say "Now is the winter " || "of our discontent"
+
+/* Abuttal concatenation: */
+say "Made glorious "Summer()
+
+/* Blank concatenation: */
+say "By this sun" "of York"
+
+exit
+
+Summer: procedure
+return "summer"


### PR DESCRIPTION
Split concatenation into "normal" and "blank" concatenation, with separate parser rules for each (`normal_concatenation_op`,
 and `blank_concatenation_op`, resp.) and support concatenation-via-abuttal as a form of "normal" concatenation.

Lexer:
* Move whitespace from the HIDDEN channel to a new WHITESPACES channel, for detection in the parser.

Parser:
* Split the `concatenation` rule into the necessary parts, and use semantic predicates (in Java, for now) to detect if there is whitespace between the values (`blank_concatenation_op`), if there is a concatenation operator (`||`) between them (`normal_concatenation_op`), or if there are no tokens between them (`normal_concatenation_op`).

Also add a test case (`examples\test_concatenation.rex`) that should parse correctly, as per the comments.

All test cases pass `mvn test`, including the new one.