### PR TITLE
[rexx] Address simplicification comments in PR 2746

### DIFF
--- a/rexx/RexxLexer.g4
+++ b/rexx/RexxLexer.g4
@@ -1,5 +1,4 @@
 lexer grammar RexxLexer;
-channels { WHITESPACE_CHANNEL }
 
 // Main rules
 // %INCLUDE statement
@@ -9,7 +8,7 @@ LINE_COMMENT                    :   Line_Comment_
                                 ->  channel(HIDDEN);
 BLOCK_COMMENT                   :   Block_Comment_
                                 ->  channel(HIDDEN);
-WHITESPACES                     :   Whitespaces_            -> channel(WHITESPACE_CHANNEL);
+WHITESPACES                     :   Whitespaces_            -> channel(HIDDEN);
 CONTINUATION                    :   Continue_               -> channel(HIDDEN);
 
 // Keywords

--- a/rexx/RexxParser.g4
+++ b/rexx/RexxParser.g4
@@ -228,12 +228,12 @@ comparison                  :   concatenation ( comparison_operator concatenatio
                             ;
 concatenation               :   addition (concatenation_op addition)* ;
  concatenation_op           :   {
-                                   (getTokenStream().get(getCurrentToken().getTokenIndex()-1).getChannel() == RexxLexer.WHITESPACE_CHANNEL)
+                                   (getTokenStream().get(getCurrentToken().getTokenIndex()-1).getType() == RexxLexer.WHITESPACES)
                                 }? blank_concatenation_op // If previous token is whitespace, this is blank-concatenation.
                             |   normal_concatenation_op
                             ;
   normal_concatenation_op   :   {
-                                   (getTokenStream().get(getCurrentToken().getTokenIndex()-1).getChannel() != RexxLexer.WHITESPACE_CHANNEL)
+                                   (getTokenStream().get(getCurrentToken().getTokenIndex()-1).getType() != RexxLexer.WHITESPACES)
                                 }? // If previous token is not whitespace, this is abuttal-concatenation.
                                 // Note: no token or rule to match here, just the predicate.
                             |   CONCAT

--- a/rexx/examples/test_concatenation.rex
+++ b/rexx/examples/test_concatenation.rex
@@ -2,12 +2,21 @@
 
 /* Explicit concatenation: */
 say "Now is the winter " || "of our discontent"
+say "Now is the winter " || /*comment*/ "of our discontent"
+say "Now is the winter " || ,
+"of our discontent"
 
 /* Abuttal concatenation: */
 say "Made glorious "Summer()
+say "Made glorious "/*comment*/Summer()
+say "Made glorious ",
+Summer()
 
 /* Blank concatenation: */
 say "By this sun" "of York"
+say "By this sun"/*comment*/ "of York"
+say "By this sun" ,
+ "of York"
 
 exit
 


### PR DESCRIPTION
@KvanTTT had a suggestion for simplifying the change I made in PR #2746.  Since that PR was already merged, here's a new one.  He already reviewed the change over in that PR.  Basically, there was no need to introduce a new channel for the purpose of recognizing significant whitespace, so I reverted that part of the PR and checked the token type instead of the token's channel.