### PR TITLE
[Hive grammer] Fix the priority problem of 'BETWEEN AND' and 'AND' 

### DIFF
--- a/sql/hive/v3/IdentifiersParser.g4
+++ b/sql/hive/v3/IdentifiersParser.g4
@@ -362,24 +362,28 @@ precedenceLogicOperator
 //precedenceAndExpression
 //precedenceOrExpression
 expression
-    : atomExpression ((LSQUARE expression RSQUARE) | (DOT identifier))*
-    | precedenceUnaryOperator expression
-    | expression KW_IS isCondition
-    | expression precedenceBitwiseXorOperator expression
-    | expression precedenceStarOperator expression
-    | expression precedencePlusOperator expression
-    | expression precedenceConcatenateOperator expression
-    | expression precedenceAmpersandOperator expression
-    | expression precedenceBitwiseOrOperator expression
-    | expression precedenceComparisonOperator expression
-    | expression KW_NOT? precedenceRegexpOperator expression
-    | expression KW_NOT? KW_LIKE (KW_ANY | KW_ALL) expressionsInParenthesis
-    | expression KW_NOT? KW_IN precedenceSimilarExpressionIn
-    | expression KW_NOT? KW_BETWEEN expression KW_AND expression
-    | KW_EXISTS subQueryExpression
-    | precedenceNotOperator expression
-    | expression precedenceLogicOperator expression
+    : expression precedenceLogicOperator expression
     | LPAREN expression RPAREN
+    | precedenceExpression
+    ;
+
+precedenceExpression
+    : atomExpression ((LSQUARE expression RSQUARE) | (DOT identifier))*
+    | precedenceUnaryOperator precedenceExpression
+    | precedenceExpression KW_IS isCondition
+    | precedenceExpression precedenceBitwiseXorOperator precedenceExpression
+    | precedenceExpression precedenceStarOperator precedenceExpression
+    | precedenceExpression precedencePlusOperator precedenceExpression
+    | precedenceExpression precedenceConcatenateOperator precedenceExpression
+    | precedenceExpression precedenceAmpersandOperator precedenceExpression
+    | precedenceExpression precedenceBitwiseOrOperator precedenceExpression
+    | precedenceExpression precedenceComparisonOperator precedenceExpression
+    | precedenceExpression KW_NOT? precedenceRegexpOperator precedenceExpression
+    | precedenceExpression KW_NOT? KW_LIKE (KW_ANY | KW_ALL) expressionsInParenthesis
+    | precedenceExpression KW_NOT? KW_IN precedenceSimilarExpressionIn
+    | precedenceExpression KW_NOT? KW_BETWEEN precedenceExpression KW_AND precedenceExpression
+    | KW_EXISTS subQueryExpression
+    | precedenceNotOperator precedenceExpression
     ;
 
 precedenceSimilarExpressionIn


### PR DESCRIPTION
Fix the priority problem of 'BETWEEN AND' expression and 'AND' logical operator.
For example:
```sql
SELECT a FROM t1 WHERE a BETWEEN 1*2 AND 10 AND b IN (SELECT b FROM t2) AND c > 1
```
the old parse tree:
![](https://file.makeyourchoice.cn/img/oldParseTree.jpg)

It can be clearly seen that the priorities of 'BETWEEN AND' expression and 'AND' logical operator are wrong, which may lead to errors in analysis

the new parse tree:
![](https://file.makeyourchoice.cn/img/github/newParseTree.jpg)

