### PR TITLE
Fix for issue #2749 -- "go get" connection link errors

### DIFF
--- a/_scripts/regtest.sh
+++ b/_scripts/regtest.sh
@@ -162,13 +162,13 @@ test()
 setupdeps()
 {
     date
-    echo "Setting up trgen and antlr jar."
-    dotnet tool uninstall -g trgen
-    dotnet tool install -g trgen --version 0.16.3
-    dotnet tool uninstall -g trxml2
-    dotnet tool install -g trxml2 --version 0.16.3
-    dotnet tool uninstall -g trwdog
-    dotnet tool install -g trwdog --version 0.16.3
+    trgen --version
+    if [ $? != "0" ]
+    then
+        echo "Setting up trgen and antlr jar."
+        dotnet tool install -g trgen --version 0.16.3
+        dotnet tool install -g trxml2 --version 0.16.3
+        dotnet tool install -g trwdog --version 0.16.3
 	case "${unameOut}" in
 		Linux*)     curl 'https://repo1.maven.org/maven2/org/antlr/antlr4/4.10/antlr4-4.10-complete.jar' -o /tmp/antlr4-4.10-complete.jar;;
 		Darwin*)    curl 'https://repo1.maven.org/maven2/org/antlr/antlr4/4.10/antlr4-4.10-complete.jar' -o /tmp/antlr4-4.10-complete.jar;;
@@ -176,8 +176,9 @@ setupdeps()
 		MINGW*)     curl 'https://repo1.maven.org/maven2/org/antlr/antlr4/4.10/antlr4-4.10-complete.jar' -o /tmp/antlr4-4.10-complete.jar;;
 		*)          echo 'unknown machine'
 	esac
-    echo "Done setting up."
-    date
+        echo "Done setting up."
+        date
+    fi
 }
 
 part1()

--- a/_scripts/templates/Go/makefile
+++ b/_scripts/templates/Go/makefile
@@ -9,17 +9,16 @@ default: classes
 classes: setup $(SOURCES) program
 setup:
 	if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
-	-export | grep GO
 	-go env
 	-go version
-	export GO111MODULE=on; go get github.com/antlr/antlr4/runtime/Go/antlr@4.10
+	export GO111MODULE=on; for i in {1..5}; do go get github.com/antlr/antlr4/runtime/Go/antlr@4.10; if [ $$? == "0" ]; then break; fi; done; if [ $$? != "0" ]; then exit 1; fi
 program:
 	export GO111MODULE=on; go build Test.go
 clean:
 	rm -f *.tokens *.interp
 	rm -f $(GENERATED)
 run:
-	export GO111MODULE=on; trwdog go run Test.go $(RUNARGS)
+	trwdog ./<exec_name> $(RUNARGS)
 test: FORCE
 	bash test.sh
 <tool_grammar_tuples:{x | <x.GeneratedFileName> : <x.GrammarFileName>

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -16,7 +16,13 @@ function Build-Grammar {
     # Output go version
     #go version | Write-Host
     $env:GO111MODULE = "on"
-    $g = go get github.com/antlr/antlr4/runtime/Go/antlr@4.10
+    For ($i=0; $i -le 5; $i++) {
+        $g = go get github.com/antlr/antlr4/runtime/Go/antlr@4.10
+        if($LASTEXITCODE -eq 0){
+            Break
+        }
+        Write-Host "go get failed. Trying again."
+    }
     if($LASTEXITCODE -ne 0){
         return @{
             Message = $g


### PR DESCRIPTION
* Changes to _scripts/regtest.sh so we don't uninstall/reinstall Trash tools. It's wasted bandwidth.
* Add a loop around "go get" to repeat 5 times or fail.
* In response to https://github.com/antlr/grammars-v4/pull/2731 build issues.