### PR TITLE
[PromQL] support group modifiers with no labels

### DIFF
--- a/promql/PromQLParser.g4
+++ b/promql/PromQLParser.g4
@@ -114,8 +114,8 @@ without: WITHOUT labelNameList;
 grouping:   (on_ | ignoring) (groupLeft | groupRight)?;
 on_:         ON labelNameList;
 ignoring:   IGNORING labelNameList;
-groupLeft:  GROUP_LEFT labelNameList;
-groupRight: GROUP_RIGHT labelNameList;
+groupLeft:  GROUP_LEFT labelNameList?;
+groupRight: GROUP_RIGHT labelNameList?;
 
 // Label names
 

--- a/promql/examples/join4.txt
+++ b/promql/examples/join4.txt
@@ -1,0 +1,1 @@
+rate(container_cpu_usage_seconds_total[1m]) / on(instance, job) group_left test_num_cpus


### PR DESCRIPTION
PromQL supports group modifiers (`group_left`, `group_right`) with or without label lists.

Example:

`method_code:http_errors:rate5m / ignoring(code) group_left method:http_requests:rate5m`

Reference -- https://prometheus.io/docs/prometheus/latest/querying/operators/#group-modifiers