### PR TITLE
[PromQL] support last_over_time aggregation

### DIFF
--- a/promql/PromQLLexer.g4
+++ b/promql/PromQLLexer.g4
@@ -151,6 +151,7 @@ FUNCTION options { caseInsensitive=false; }
     | 'quantile_over_time'
     | 'stddev_over_time'
     | 'stdvar_over_time'
+    | 'last_over_time'
     ;
 
 LEFT_BRACE:  '{';

--- a/promql/examples/aggregation3.txt
+++ b/promql/examples/aggregation3.txt
@@ -1,0 +1,1 @@
+last_over_time(container_cpu_usage_seconds_total[1m])


### PR DESCRIPTION
PromQL added a new entry to the list of available `<aggregation>_over_time()` functions.

Reference: https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time