### PR TITLE
Fix problems with asm8080 and asmZ80 grammars

### DIFF
--- a/_scripts/skip-cpp.txt
+++ b/_scripts/skip-cpp.txt
@@ -10,10 +10,8 @@ apex
 apt
 arithmetic
 asm/asm6502
-asm/asm8080
 asm/asm8086
 asm/asmMASM
-asm/asmZ80
 asm/masm
 asm/pdp7
 asn/asn

--- a/_scripts/templates/Go/antlr_resource/case_changing_stream.go
+++ b/_scripts/templates/Go/antlr_resource/case_changing_stream.go
@@ -5,7 +5,7 @@ package antlr_resource
 import (
 	"unicode"
 
-	"github.com/antlr/antlr4/runtime/Go/antlr"
+	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
 )
 
 // CaseChangingStream wraps an existing CharStream, but upper cases, or

--- a/asm/asm8080/asm8080.g4
+++ b/asm/asm8080/asm8080.g4
@@ -36,11 +36,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar asm8080;
 
 prog
-   : (line? EOL) + EOF
+   : EOL* ((line EOL)* line EOL*)? EOF
    ;
 
 line
-   : lbl? (instruction | directive)? comment?
+   : lbl? (instruction | directive) comment?
+   | lbl comment?
+   | comment
    ;
 
 instruction
@@ -112,176 +114,141 @@ comment
    : COMMENT
    ;
 
-
 ASSEMBLER_DIRECTIVE
    : (O R G) | (E N D) | (E Q U) | (D B) | (D W) | (D S) | (I F) | (E N D I F) | (S E T)
    ;
-
 
 REGISTER
    : 'A' | 'B' | 'C' | 'D' | 'E' | 'H' | 'L' | 'PC' | 'SP'
    ;
 
-
 OPCODE
    : (M O V) | (M V I) | (L D A) | (S T A) | (L D A X) | (S T A X) | (L H L D) | (S H L D) | (L X I) | (P U S H) | (P O P) | (X T H L) | (S P H L) | (P C H L) | (X C H G) | (A D D) | (S U B) | (I N R) | (D C R) | (C M P) | (A N A) | (O R A) | (X R A) | (A D I) | (S U I) | (C P I) | (A N I) | (O R I) | (X R I) | (D A A) | (A D C) | (A C I) | (S B B) | (S B I) | (D A D) | (I N X) | (D C X) | (J M P) | (C A L L) | (R E T) | (R A L) | (R A R) | (R L C) | (R R C) | (I N) | (O U T) | (C M C) | (S T C) | (C M A) | (H L T) | (N O P) | (D I) | (E I) | (R S T) | (J N Z) | (J Z) | (J N C) | (J C) | (J P O) | (J P E) | (J P) | (J M) | (C N Z) | (C Z) | (C N C) | (C C) | (C P O) | (C P E) | (C P) | (C M) | (R N Z) | (R Z) | (R N C) | (R C) | (R P O) | (R P E) | (R P) | (R M)
    ;
-
 
 fragment A
    : ('a' | 'A')
    ;
 
-
 fragment B
    : ('b' | 'B')
    ;
-
 
 fragment C
    : ('c' | 'C')
    ;
 
-
 fragment D
    : ('d' | 'D')
    ;
-
 
 fragment E
    : ('e' | 'E')
    ;
 
-
 fragment F
    : ('f' | 'F')
    ;
-
 
 fragment G
    : ('g' | 'G')
    ;
 
-
 fragment H
    : ('h' | 'H')
    ;
-
 
 fragment I
    : ('i' | 'I')
    ;
 
-
 fragment J
    : ('j' | 'J')
    ;
-
 
 fragment K
    : ('k' | 'K')
    ;
 
-
 fragment L
    : ('l' | 'L')
    ;
-
 
 fragment M
    : ('m' | 'M')
    ;
 
-
 fragment N
    : ('n' | 'N')
    ;
-
 
 fragment O
    : ('o' | 'O')
    ;
 
-
 fragment P
    : ('p' | 'P')
    ;
-
 
 fragment Q
    : ('q' | 'Q')
    ;
 
-
 fragment R
    : ('r' | 'R')
    ;
-
 
 fragment S
    : ('s' | 'S')
    ;
 
-
 fragment T
    : ('t' | 'T')
    ;
-
 
 fragment U
    : ('u' | 'U')
    ;
 
-
 fragment V
    : ('v' | 'V')
    ;
-
 
 fragment W
    : ('w' | 'W')
    ;
 
-
 fragment X
    : ('x' | 'X')
    ;
-
 
 fragment Y
    : ('y' | 'Y')
    ;
 
-
 fragment Z
    : ('z' | 'Z')
    ;
-
 
 NAME
    : [a-zA-Z] [a-zA-Z0-9."]*
    ;
 
-
 NUMBER
    : '$'? [0-9a-fA-F] + ('H' | 'h')?
    ;
 
-
 COMMENT
-   : ';' ~ [\r\n]* -> skip
+   : ';' ~ [\r\n]*
    ;
-
 
 STRING
    : '\u0027' ~'\u0027'* '\u0027'
    ;
 
-
 EOL
    : [\r\n] +
    ;
-
 
 WS
    : [ \t] -> skip

--- a/asm/asmZ80/asmZ80.g4
+++ b/asm/asmZ80/asmZ80.g4
@@ -36,11 +36,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar asmZ80;
 
 prog
-   : (line? EOL) + EOF
+   : EOL* ((line EOL)* line EOL*)? EOF
    ;
 
 line
-   : lbl? (instruction | directive)? comment?
+   : lbl? (instruction | directive) comment?
+   | lbl comment?
+   | comment
    ;
 
 instruction
@@ -112,176 +114,141 @@ comment
    : COMMENT
    ;
 
-
 REGISTER
    : 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'H' | 'L' | 'I' | 'R' | 'IXH' | 'IXL' | 'IYH' | 'IYL' | 'AF' | 'BC' | 'DE' | 'HL' | 'PC' | 'SP' | 'IX' | 'IY'
    ;
-
 
 ASSEMBLER_DIRECTIVE
    : (O R G) | (E N D) | (E Q U) | (D E F B) | (D E F W) | (D S) | (I F) | (E N D I F) | (S E T)
    ;
 
-
 OPCODE
    : (A D C) | (A D D) | (A N D) | (B I T) | (C A L L) | (C C F) | (C P) | (C P D) | (C P D R) | (C P I) | (C P I R) | (C P L) | (D A A) | (D E C) | (D I) | (D J N Z) | (E I) | (E X) | (E X X) | (I M) | (I N) | (I N C) | (I N D) | (I N D R) | (I N I) | (I N I R) | (J P) | (J R) | (L D) | (L D D) | (L D D R) | (L D I) | (L D I R) | (N E G) | (N O P) | (O R) | (O T D R) | (O T I R) | (O U T) | (O U T D) | (O U T I) | (P O P) | (P U S H) | (R E S) | (R E T) | (R E T I) | (R E T N) | (R L) | (R L A) | (R L C) | (R L C A) | (R L D) | (R R) | (R R A) | (R R C) | (R R C A) | (R R D) | (R S T) | (S B C) | (S C F) | (S E T) | (S L A) | (S L L) | (S L '1') | (S R A) | (S R L) | (S U B) | (X O R)
    ;
-
 
 fragment A
    : ('a' | 'A')
    ;
 
-
 fragment B
    : ('b' | 'B')
    ;
-
 
 fragment C
    : ('c' | 'C')
    ;
 
-
 fragment D
    : ('d' | 'D')
    ;
-
 
 fragment E
    : ('e' | 'E')
    ;
 
-
 fragment F
    : ('f' | 'F')
    ;
-
 
 fragment G
    : ('g' | 'G')
    ;
 
-
 fragment H
    : ('h' | 'H')
    ;
-
 
 fragment I
    : ('i' | 'I')
    ;
 
-
 fragment J
    : ('j' | 'J')
    ;
-
 
 fragment K
    : ('k' | 'K')
    ;
 
-
 fragment L
    : ('l' | 'L')
    ;
-
 
 fragment M
    : ('m' | 'M')
    ;
 
-
 fragment N
    : ('n' | 'N')
    ;
-
 
 fragment O
    : ('o' | 'O')
    ;
 
-
 fragment P
    : ('p' | 'P')
    ;
-
 
 fragment Q
    : ('q' | 'Q')
    ;
 
-
 fragment R
    : ('r' | 'R')
    ;
-
 
 fragment S
    : ('s' | 'S')
    ;
 
-
 fragment T
    : ('t' | 'T')
    ;
-
 
 fragment U
    : ('u' | 'U')
    ;
 
-
 fragment V
    : ('v' | 'V')
    ;
-
 
 fragment W
    : ('w' | 'W')
    ;
 
-
 fragment X
    : ('x' | 'X')
    ;
-
 
 fragment Y
    : ('y' | 'Y')
    ;
 
-
 fragment Z
    : ('z' | 'Z')
    ;
-
 
 NAME
    : [a-zA-Z] [a-zA-Z0-9."]*
    ;
 
-
 NUMBER
    : '$'? [0-9a-fA-F] + ('H' | 'h')?
    ;
 
-
 COMMENT
-   : ';' ~ [\r\n]* -> skip
+   : ';' ~ [\r\n]*
    ;
-
 
 STRING
    : '\u0027' ~'\u0027'* '\u0027'
    ;
 
-
 EOL
    : [\r\n] +
    ;
-
 
 WS
    : [ \t] -> skip

--- a/haskell/CSharp/StackQueue.cs
+++ b/haskell/CSharp/StackQueue.cs
@@ -1,87 +1,43 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 
-/// <summary>
-/// StackQueue - a data structure that has both Stack and Queue interfaces.
-/// </summary>
-/// <typeparam name="NAME"></typeparam>
 public class StackQueue<T> : IEnumerable<T>
 {
-    private int _size;
-    private int _top;
-
-    // Underlying the datatype, we need an array that resizes without changing it's
-    // reference. A straight array cannot work.
     private readonly List<T> _items;
 
     public StackQueue()
     {
-        _size = 10;
-        _top = 0;
-        _items = new List<T>(_size);
-        for (int i = 0; i < _size; ++i)
-        {
-            _items.Add(default);
-        }
+        _items = new List<T>();
     }
 
     public StackQueue(T value)
     {
-        _size = 10;
-        _top = 0;
-        _items = new List<T>(_size);
-        for (int i = 0; i < _size; ++i)
-        {
-            _items.Add(default);
-        }
-
-        _items[_top++] = value;
+        _items = new List<T>();
+        _items.Add(value);
     }
 
     public StackQueue(StackQueue<T> other)
     {
-        _size = other._size;
-        _top = other._top;
-        _items = new List<T>(_size);
-        for (int i = 0; i < _size; ++i)
-        {
-            _items.Add(default);
-        }
-
+        _items = new List<T>();
         _items.AddRange(other._items);
     }
 
     public virtual int Size()
     {
-        return _top;
+        return _items.Count;
     }
 
-    public virtual int Count => _top;
+    public virtual int Count => _items.Count;
 
     public virtual T Pop()
     {
-        if (_top >= _size)
+        if (_items.Count > 0)
         {
-            int old = _size;
-            _size *= 2;
-            _items.Capacity = _size;
-            for (int i = old; i < _size; ++i)
-            {
-                _items.Add(default);
-            }
+            var result = _items[_items.Count - 1];
+            _items.RemoveAt(_items.Count - 1);
+            return result;
         }
-        if (_top > 0)
-        {
-            int index = _top - 1;
-            T cur = _items[index];
-            _items[index] = default;
-            _top -= 1;
-            return cur;
-        }
-        else
-        {
-            return default;
-        }
+        else return default;
     }
 
     public virtual T this[int n]
@@ -97,148 +53,73 @@ public class StackQueue<T> : IEnumerable<T>
 
     public bool Any()
     {
-        return _top > 0;
+        return _items.Count > 0;
     }
 
     public virtual T PeekTop(int n = 0)
     {
-        if (_top >= _size)
+        if (_items.Count - n > 0)
         {
-            int old = _size;
-            _size *= 2;
-            _items.Capacity = _size;
-            for (int i = old; i < _size; ++i)
-            {
-                _items.Add(default);
-            }
+            int index = _items.Count - n - 1;
+            var result = _items[index];
+            return result;
         }
-        if (_top > 0)
-        {
-            int index = _top - 1;
-            T cur = _items[index - n];
-            return cur;
-        }
-        else
-        {
-            return default;
-        }
+        else return default;
     }
 
     public virtual T PeekBottom(int n)
     {
-        if (_top >= _size)
+        if (n >= 0 && n < _items.Count - 1)
         {
-            int old = _size;
-            _size *= 2;
-            _items.Capacity = _size;
-            for (int i = old; i < _size; ++i)
-            {
-                _items.Add(default);
-            }
+            var result = _items[n];
+            return result;
         }
-        if (n >= _top)
-        {
-            return default;
-        }
-
-        T cur = _items[n];
-        return cur;
+        else return default;
     }
 
     public virtual void Push(T value)
     {
-        if (_top >= _size)
-        {
-            int old = _size;
-            _size *= 2;
-            _items.Capacity = _size;
-            for (int i = old; i < _size; ++i)
-            {
-                _items.Add(default);
-            }
-        }
-        _items[_top++] = value;
+        _items.Add(value);
     }
 
     public virtual void Push(IEnumerable<T> collection)
     {
         foreach (T t in collection)
         {
-            if (_top >= _size)
-            {
-                int old = _size;
-                _size *= 2;
-                _items.Capacity = _size;
-                for (int i = old; i < _size; ++i)
-                {
-                    _items.Add(default);
-                }
-            }
-            _items[_top++] = t;
+            _items.Add(t);
         }
     }
 
     public virtual void PushMultiple(params T[] values)
     {
         int count = values.Length;
-        for (int i = 0; i < count; i++)
-        {
-            Push(values[i]);
-        }
+        for (int i = 0; i < count; i++) _items.Add(values[i]);
     }
 
     public virtual void EnqueueTop(T value)
     {
-        // Same as "Push(value)".
         Push(value);
     }
 
     public virtual void EnqueueBottom(T value)
     {
-        if (_top >= _size)
-        {
-            _size *= 2;
-            _items.Capacity = _size;
-        }
-        // "Push" a value on the bottom of the stack.
-        for (int i = _top - 1; i >= 0; --i)
-        {
-            _items[i + 1] = _items[i];
-        }
-
-        _items[0] = value;
-        ++_top;
+        _items.Insert(0, value);
     }
 
     public virtual T DequeueTop()
     {
-        // Same as "Pop()".
         return Pop();
     }
 
     public virtual T DequeueBottom()
     {
-        if (_top >= _size)
+        if (_items.Count > 0)
         {
-            _size *= 2;
-            _items.Capacity = _size;
+            var result = _items[0];
+            _items.RemoveAt(0);
+            return result;
         }
-        // Remove item from bottom of stack.
-        if (_top > 0)
-        {
-            T cur = _items[0];
-            for (int i = 1; i <= _top; ++i)
-            {
-                _items[i - 1] = _items[i];
-            }
-
-            _top--;
-            return cur;
-        }
-        else
-        {
-            return default;
-        }
+        else return default;
     }
 
     public virtual bool Contains(T item)
@@ -248,16 +129,13 @@ public class StackQueue<T> : IEnumerable<T>
 
     public virtual System.Collections.Generic.IEnumerator<T> GetEnumerator()
     {
-        for (int i = _top - 1; i >= 0; i--)
-        {
+        for (int i = _items.Count - 1; i >= 0; i--)
             yield return _items[i];
-        }
     }
+
     IEnumerator IEnumerable.GetEnumerator()
     {
-        for (int i = _top - 1; i >= 0; i--)
-        {
+        for (int i = _items.Count - 1; i >= 0; i--)
             yield return _items[i];
-        }
     }
 }


### PR DESCRIPTION
This PR fixes a few problems with the Go target, which were noticed with https://github.com/antlr/grammars-v4/pull/2802

* Fixed asm8080 and asmZ80 grammars. COMMENT was marked "skip", but this would cause massive slowdowns in Go target.
* Fixed Haskell grammar. Update the StackQueue.cs data structure, which I copied from [Antlr4BuildTasks](https://github.com/kaby76/Antlr4BuildTasks/blob/master/Antlr4BuildTasks/Util/StackQueue.cs). The previous version had bugs, and was overly complicated. 
* Fixed template for Go. This referenced the old 4.10.1 runtime for Go. The 4.11.1 Go runtime is under the subdirectory "v4".