### PR TITLE
Add Python3 target of python/python3 grammar to build

### DIFF
--- a/_scripts/skip-python3.txt
+++ b/_scripts/skip-python3.txt
@@ -65,7 +65,6 @@ ply
 powerbuilder
 protobuf3
 python/python2
-python/python3
 python/python3-py
 python/python3-ts
 python/python3-without-actions

--- a/python/python3/Python3/Python3LexerBase.py
+++ b/python/python3/Python3/Python3LexerBase.py
@@ -1,8 +1,8 @@
 from typing import TextIO
-
 from antlr4 import *
 from antlr4.Token import CommonToken
-from .Python3Parser import Python3Parser
+from Python3Parser import Python3Parser;
+
 import sys
 from typing import TextIO
 import re

--- a/python/python3/Python3/README.md
+++ b/python/python3/Python3/README.md
@@ -1,0 +1,10 @@
+# Target-specific grammar instructions.
+---
+This directory contains the base class code for a target-specific parser. To use, run:
+```
+python transformGrammar.py
+antlr4 -Dlanguage=Python3 -o gen *.g4
+```
+The transformGrammar.py script modifies the grammar for the target.
+
+(Updated 11 Sep 2022 by Ken Domino.)

--- a/python/python3/Python3/transformGrammar.py
+++ b/python/python3/Python3/transformGrammar.py
@@ -1,0 +1,29 @@
+import sys, os, re, shutil
+
+def main(argv):
+    fix("Python3Lexer.g4")
+    fix("Python3Parser.g4")
+
+def fix(file_path):
+    print("Altering " + file_path)
+    if not os.path.exists(file_path):
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    parts = os.path.split(file_path)
+    file_name = parts[-1]
+    shutil.move(file_path, file_path + ".bak")
+    input_file = open(file_path + ".bak",'r')
+    output_file = open(file_path, 'w')
+    for x in input_file:
+        if '!this.' in x:
+            x = x.replace('!this.', 'not self.')
+        if 'this.' in x:
+            x = x.replace('this.', 'self.')
+        output_file.write(x)
+        output_file.flush()
+    print("Writing ...")
+    input_file.close()
+    output_file.close()
+
+if __name__ == '__main__':
+    main(sys.argv)


### PR DESCRIPTION
PR https://github.com/antlr/grammars-v4/pull/2811 was a good addition. The only thing missing was that the grammar wasn't integrated into the build. This is important because it helps verify that Antlr4 works across targets. This PR changes the code slightly so that it can be tested (renames Python to Python3, the name of the port target; adds transformGrammar.py so "this" gets changed to "self"; and a readme.md to explain how to use the port). The parser works fine, albeit it is kind of slow. I think this may be because of ambiguities in the grammar. This should be investigated at some point. Fixes https://github…com/antlr/grammars-v4/issues/2813