### PR TITLE
Fix various problems with asm grammars

### DIFF
--- a/_scripts/skip-cpp.txt
+++ b/_scripts/skip-cpp.txt
@@ -9,11 +9,6 @@ antlr/antlr3
 apex
 apt
 arithmetic
-asm/asm6502
-asm/asm8086
-asm/asmMASM
-asm/masm
-asm/pdp7
 asn/asn
 asn/asn_3gpp
 atl

--- a/_scripts/skip-csharp.txt
+++ b/_scripts/skip-csharp.txt
@@ -1,6 +1,5 @@
 _grammar-test
 apex
-asm/masm
 asn/asn_3gpp
 clif
 cpp

--- a/_scripts/skip-go.txt
+++ b/_scripts/skip-go.txt
@@ -4,11 +4,6 @@ antlr/antlr2
 antlr/antlr3
 antlr/antlr4
 apex
-asm/asmMASM
-asm/masm
-asm/asm8080
-asm/asmZ80
-asm/pdp7
 asn/asn_3gpp
 clif
 cobol85

--- a/_scripts/skip-python3.txt
+++ b/_scripts/skip-python3.txt
@@ -2,8 +2,6 @@ _grammar-test
 antlr/antlr2
 antlr/antlr3
 apex
-asm/asmMASM
-asm/masm
 asn/asn_3gpp
 clif
 cpp

--- a/asm/asm6502/asm6502.g4
+++ b/asm/asm6502/asm6502.g4
@@ -33,22 +33,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar asm6502;
 
 prog
-   : (line? EOL) + EOF
+   : line* EOF
    ;
 
 line
-   : comment
-   | instruction
-   | assemblerinstruction
-   | lbl
+   : (instruction | assemblerinstruction | lbl)? EOL
    ;
 
 instruction
-   : label? opcode argumentlist? comment?
+   : label? opcode argumentlist?
    ;
 
 assemblerinstruction
-   : argument? assembleropcode argumentlist? comment?
+   : argument? assembleropcode argumentlist?
    ;
 
 assembleropcode
@@ -86,10 +83,6 @@ name
 
 number
    : NUMBER
-   ;
-
-comment
-   : COMMENT
    ;
 
 opcode

--- a/asm/asm8080/asm8080.g4
+++ b/asm/asm8080/asm8080.g4
@@ -91,7 +91,7 @@ argument
    | dollar
    | name
    | string_
-   | ('(' expression ')')
+   | '(' expression ')'
    ;
 
 dollar

--- a/asm/asm8086/asm8086.g4
+++ b/asm/asm8086/asm8086.g4
@@ -33,11 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar asm8086;
 
 prog
-   : (line (NOT_ line)* EOL)* EOF
+   : line* EOF
    ;
 
 line
-   : lbl? (assemblerdirective | instruction)? comment?
+   : lbl? (assemblerdirective | instruction)? ('!' instruction)* EOL
    ;
 
 instruction
@@ -120,7 +120,7 @@ assemblerlogical
 assemblerterm
    : name
    | number
-   | (NOT assemblerterm)
+   | NOT assemblerterm
    ;
 
 endif_
@@ -165,13 +165,13 @@ argument
    | register_
    | name
    | string_
-   | (RP expression LP)
-   | ((number | name)? LB expression RB_)
+   | RP expression LP
+   | (number | name)? LB expression RB_
    | ptr expression
    | NOT expression
    | OFFSET expression
    | LENGTH expression
-   | (register_ COLON) expression
+   | register_ COLON expression
    ;
 
 ptr
@@ -345,10 +345,6 @@ rep
    | REPNE
    | REPNZ
    | REPZ
-   ;
-
-comment
-   : COMMENT
    ;
 
 sign : PLUS | MINUS ;

--- a/asm/asmMASM/asmMASM.g4
+++ b/asm/asmMASM/asmMASM.g4
@@ -33,19 +33,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar asmMASM;
 
 prog
-   : (line EOL)* EOF
+   : line* EOF
    ;
 
 line
-   : lbl? (assemblerdirective | masmdirectives | instruction)? comment?
+   : (lbl | endlbl)? (assemblerdirective | masmdirectives | instruction)? EOL
    ;
 
 instruction
-   : rep? opcode? expressionlist?
+   : rep? opcode expressionlist?
    ;
 
 lbl
    : label ':'?
+   ;
+
+endlbl
+   : END name?
    ;
 
 assemblerdirective
@@ -57,6 +61,10 @@ assemblerdirective
    | dw
    | dm
    | ds
+   | include
+   | includelib
+   | invoke
+   | option
    | put
    | assign
    | segment
@@ -65,7 +73,8 @@ assemblerdirective
    | label_
    | assume
    | extern_
-   | (type_ expressionlist +)
+   | public_
+   | type_ expressionlist+
    ;
 
 masmdirectives
@@ -104,8 +113,8 @@ endsegment
    ;
 
 align
-   : (BYTE | WORD | DWORD | PARA | PAGE)
-   | (ALIGN '(' number ')')
+   : BYTE | WORD | DWORD | PARA | PAGE
+   | ALIGN '(' number ')'
    ;
 
 assign
@@ -114,6 +123,22 @@ assign
 
 put
    : PUT expressionlist
+   ;
+
+include
+   : INCLUDE expressionlist
+   ;
+
+includelib
+   : INCLUDELIB expressionlist
+   ;
+
+invoke
+   : INVOKE expressionlist
+   ;
+
+option
+   : OPTION expressionlist
    ;
 
 ds
@@ -142,6 +167,10 @@ equ
 
 extern_
    : EXTERN expression
+   ;
+
+public_
+   : PUBLIC expression
    ;
 
 if_
@@ -180,8 +209,8 @@ argument
    | register_
    | (name ':')? name
    | string
-   | ('(' expression ')')
-   | ('[' expression ']')
+   | '(' expression ')'
+   | '[' expression ']'
    | NOT expression
    | OFFSET expression
    | gross
@@ -237,15 +266,13 @@ rep
    : REP
    ;
 
-comment
-   : COMMENT
-   ;
-
-
 ORG
    : O R G
    ;
 
+END
+   : E N D
+   ;
 
 ENDIF
    : E N D I F
@@ -281,6 +308,22 @@ DS
    : D S
    ;
 
+
+INCLUDE
+   : I N C L U D E
+   ;
+
+INCLUDELIB
+   : I N C L U D E L I B
+   ;
+
+INVOKE
+   : I N V O K E
+   ;
+
+OPTION
+   : O P T I O N
+   ;
 
 PUT
    : P U T
@@ -399,6 +442,9 @@ EXTERN
    : E X T E R N
    ;
 
+PUBLIC
+   : P U B L I C
+   ;
 
 MASMDIRECTIVE
    : '.' [a-zA-Z0-9] +
@@ -428,7 +474,6 @@ STRING2
 COMMENT
    : ';' ~ [\r\n]* -> skip
    ;
-
 
 EOL
    : [\r\n] +

--- a/asm/asmZ80/asmZ80.g4
+++ b/asm/asmZ80/asmZ80.g4
@@ -91,7 +91,7 @@ argument
    | dollar
    | name
    | string_
-   | ('(' expression ')')
+   | '(' expression ')'
    ;
 
 dollar

--- a/asm/masm/MASM.g4
+++ b/asm/masm/MASM.g4
@@ -126,7 +126,7 @@ directive_exp1
    ;
 
 variabledeclaration
-   : Identifier ty (question | String | Integer)
+   : Identifier ty (question | String_ | Integer)
    ;
 
 memory
@@ -1771,7 +1771,7 @@ fragment Exponent
    ;
 
 
-String
+String_
    : ' \'' ('\\' . | ~ ('\\' | '\''))* '\''
    ;
 

--- a/asm/masm/MASM.g4
+++ b/asm/masm/MASM.g4
@@ -20,7 +20,7 @@ segments
    ;
 
 proc
-   : Identifier 'proc' (code)* 'ret' Identifier 'endp'
+   : Identifier 'proc' code* 'ret' Identifier 'endp'
    ;
 
 code
@@ -121,7 +121,8 @@ binary_exp12
    ;
 
 directive_exp1
-   : (directives Identifier | directives)
+   : directives Identifier
+   | directives
    ;
 
 variabledeclaration
@@ -129,7 +130,7 @@ variabledeclaration
    ;
 
 memory
-   : '[' (register_ | Identifier) ('+' ((register_ ('+' (Integer | Hexnum | Octalnum))?) | Integer | Hexnum | Octalnum))? ']'
+   : '[' (register_ | Identifier) ('+' (register_ ('+' (Integer | Hexnum | Octalnum))? | Integer | Hexnum | Octalnum))? ']'
    ;
 
 segmentos


### PR DESCRIPTION
This is a fix for https://github.com/antlr/grammars-v4/issues/2812 and for a few other problems.
* Fixes parser rules that used skip lexer symbols. You can't use a lexer symbol in a parser rule because the lexer will never generate the token.
    * This occurs in asm6502, asm8086, asmMASM.
* Removes useless parentheses. Useless parentheses create confusion in what is already clear on the precedence of the alternative operator ('|'), and concatenation.
    * This occurs in asm8080, asm8086, asmMASM, asmZ80, MASM. 
* Fixes grammars so all "examples/" files parse.
    * Missing `include`, `includelib`, `option`, `invoke`, `public` in asmMASM.
    * In masm, `String` is a symbol conflict for Go, but for some reason, it is not corrected by the Antlr tool everywhere.
    * Fixes missing '!' line separator in asm8086.
* Adds grammars to CI testing.
