### PR TITLE
[rexx] Set EOLs in test files in a way that works for both Maven and trgen.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -91,6 +91,9 @@ access_log text
 unicode/graphemes/examples/*.txt eol=lf
 # T-SQL tests with trees can fail with multiline strings
 sql/tsql/examples/*.sql eol=lf
+# Rexx places EOL on default channel, so the .tree's contain EOL.
+# Make sure EOL's are consistent regardless of OS.
+rexx/examples/* eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 # Currently the /vb6/**/*.cls and *.frm file need this, otherwise the grammar fails. 

--- a/rexx/pom.xml
+++ b/rexx/pom.xml
@@ -46,7 +46,7 @@
 					<showTree>false</showTree>
 					<entryPoint>file_</entryPoint>
 					<grammarName>Rexx</grammarName>
-					<exampleFiles>temp-examples/</exampleFiles>
+					<exampleFiles>examples/</exampleFiles>
 					<testFileExtension></testFileExtension>
 					<packageName></packageName>
 				</configuration>
@@ -54,43 +54,6 @@
 					<execution>
 						<goals>
 							<goal>test</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>prepare-examples</id>
-						<phase>process-test-resources</phase>
-						<configuration>
-							<tasks>
-								<delete dir="${basedir}/temp-examples" quiet="true" />
-								<mkdir dir="${basedir}/temp-examples" />
-								<fixcrlf srcdir="${basedir}/examples"
-									destdir="${basedir}/temp-examples"
-									eol="lf"
-									eof="asis"
-									fixlast="false"
-								/>
-							</tasks>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>delete-temp-files</id>
-						<phase>test</phase>
-						<configuration>
-							<tasks>
-								<delete dir="${basedir}/temp-examples" />
-							</tasks>
-						</configuration>
-						<goals>
-							<goal>run</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
As suggested by @kaby76 in #2821: "_If the .tree files contain EOL tokens because the rexx grammar [places them on the default channel](https://github.com/antlr/grammars-v4/blob/553522db0536ca80e0535351a19bdd8cbcc14e77/rexx/RexxLexer.g4#L141), why don't we just set git attributes for these files on check out?_"

Fixes #2821.