### PR TITLE
🐞 fix(JavaScript): Add optional chaining to member index expression

### DIFF
--- a/javascript/javascript/JavaScriptLexer.g4
+++ b/javascript/javascript/JavaScriptLexer.g4
@@ -50,6 +50,7 @@ SemiColon:                      ';';
 Comma:                          ',';
 Assign:                         '=';
 QuestionMark:                   '?';
+QuestionMarkDot:                '?.';
 Colon:                          ':';
 Ellipsis:                       '...';
 Dot:                            '.';

--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -311,6 +311,7 @@ expressionSequence
 singleExpression
     : anonymousFunction                                                     # FunctionExpression
     | Class identifier? classTail                                           # ClassExpression
+    | singleExpression '?.' singleExpression                                # OptionalChainExpression
     | singleExpression '?.'? '[' expressionSequence ']'                     # MemberIndexExpression
     | singleExpression '?'? '.' '#'? identifierName                         # MemberDotExpression
     // Split to try `new Date()` first, then `new Date`.

--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -311,7 +311,7 @@ expressionSequence
 singleExpression
     : anonymousFunction                                                     # FunctionExpression
     | Class identifier? classTail                                           # ClassExpression
-    | singleExpression '[' expressionSequence ']'                           # MemberIndexExpression
+    | singleExpression '?.'? '[' expressionSequence ']'                     # MemberIndexExpression
     | singleExpression '?'? '.' '#'? identifierName                         # MemberDotExpression
     // Split to try `new Date()` first, then `new Date`.
     | New singleExpression arguments                                        # NewExpression

--- a/javascript/javascript/examples/OptionalChain.js
+++ b/javascript/javascript/examples/OptionalChain.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// optional chain
+
+var a = b??c;
+var d = e?.f?.g;
+var h = i?.j();
+var k = l?.['m']?.n?.['o'];

--- a/javascript/javascript/examples/OptionalChain.js
+++ b/javascript/javascript/examples/OptionalChain.js
@@ -1,8 +1,9 @@
 "use strict";
 
-// optional chain
+// Optional Chain
+//
+// https://262.ecma-international.org/11.0/#prod-OptionalChain
 
-var a = b??c;
 var d = e?.f?.g;
 var h = i?.j();
 var k = l?.['m']?.n?.['o'];

--- a/javascript/javascript/examples/Stage3.js
+++ b/javascript/javascript/examples/Stage3.js
@@ -11,7 +11,3 @@ class CF {
     #priv_var = 9961;
 
 }
-
-var a = b??c;
-var d = e?.f?.g;
-var h = i?.j();

--- a/javascript/javascript/examples/Stage3.js
+++ b/javascript/javascript/examples/Stage3.js
@@ -11,3 +11,5 @@ class CF {
     #priv_var = 9961;
 
 }
+
+var a = b??c;


### PR DESCRIPTION
There is a bug in the `MemberIndexExpression` when optional chaining is used. E.g.

```js
a?.['b']; // Antlr complains '[' is not expected at position 4.
a.map(b => { return b?.['c']; }); // Antlr complains '(' is not expected at position 6.
```

The fix is as following.

1. Add `QuestionMarkDot:                '?.';`.
2. Update MemberIndexExpression to `| singleExpression '?.'? '[' expressionSequence ']'                     # MemberIndexExpression`.

I have tried the fix in my personal project and it works well.