### PR TITLE
[Swift] Support willSet / didSet accessors without var init

### DIFF
--- a/swift/swift5/Swift5Parser.g4
+++ b/swift/swift5/Swift5Parser.g4
@@ -314,9 +314,9 @@ variable_declaration:
 		variable_name (
 			initializer willSet_didSet_block
 			| type_annotation (
-				getter_setter_block // contains code_block
+			    initializer? willSet_didSet_block
+				| getter_setter_block // contains code_block
 				| getter_setter_keyword_block
-				| initializer? willSet_didSet_block
 			)
 		)
 		| pattern_initializer_list

--- a/swift/swift5/examples/Objects and Classes/Contents.swift
+++ b/swift/swift5/examples/Objects and Classes/Contents.swift
@@ -53,6 +53,8 @@ class Square: NamedShape {
     func area() -> Double {
         return sideLength * sideLength
     }
+    
+    var diameter: Double { sideLength * sqrt(2) }
 
     override func simpleDescription() -> String {
         return "A square with sides of length \(sideLength)."
@@ -113,7 +115,7 @@ class TriangleAndSquare {
         }
     }
     var square: Square {
-        willSet {
+        didSet {
             triangle.sideLength = newValue.sideLength
         }
     }


### PR DESCRIPTION
Currently, the Swift v5 grammar fails to correctly parse `willSet` / `didSet` on a variable without an initializer:
```Swift
var x: Int = 0 { didSet { print("works!") }
var y: Int?    { didSet { print("fails!) }
```
This happens, since the grammar interprets the outer block already as a getter and then the inner block as a closure. This was fixed by reordering the rules. 