### PR TITLE
Add support for parse tree verification in tests

### DIFF
--- a/_scripts/skip-java.txt
+++ b/_scripts/skip-java.txt
@@ -7,6 +7,7 @@ lambda
 metric
 molecule
 p
+php
 powerbuilder
 python/python2
 python/python3-py

--- a/_scripts/skip-java.why
+++ b/_scripts/skip-java.why
@@ -1,0 +1,2 @@
+php
+	antlr4 issue #2677(https://github.com/antlr/antlr4/issues/2677) descibes a null-pointer exception that occurs when trying to parse any of the examples for this parser.  When that bug is fixed, this parser can be removed from skip-java.txt.

--- a/_scripts/templates/Antlr4cs/Program.cs
+++ b/_scripts/templates/Antlr4cs/Program.cs
@@ -112,7 +112,7 @@ public class Program
         }
         if (show_tree)
         {
-            System.Console.Error.WriteLine(tree.ToStringTree(parser));
+            System.Console.Out.WriteLine(tree.ToStringTree(parser));
         }
         System.Environment.Exit(parser.NumberOfSyntaxErrors > 0 ? 1 : 0);
     }

--- a/_scripts/templates/Antlr4cs/test.sh
+++ b/_scripts/templates/Antlr4cs/test.sh
@@ -31,7 +31,7 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/Antlr4cs/test.sh
+++ b/_scripts/templates/Antlr4cs/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog ./bin/Debug/net6.0/<exec_name> -file "$file"
+    trwdog ./bin/Debug/net6.0/<exec_name> -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -28,6 +29,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/Antlr4cs/test.sh
+++ b/_scripts/templates/Antlr4cs/test.sh
@@ -13,7 +13,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/Antlr4cs/tester.psm1
+++ b/_scripts/templates/Antlr4cs/tester.psm1
@@ -15,7 +15,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree > $treeOutFile
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/Antlr4cs/tester.psm1
+++ b/_scripts/templates/Antlr4cs/tester.psm1
@@ -14,8 +14,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+    # Save input and output character encodings and switch to UTF-8.
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -26,10 +31,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Antlr4cs/tester.psm1
+++ b/_scripts/templates/Antlr4cs/tester.psm1
@@ -14,13 +14,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/CSharp/Program.cs
+++ b/_scripts/templates/CSharp/Program.cs
@@ -186,7 +186,7 @@ public class Program
         }
         if (show_tree)
         {
-            System.Console.Error.WriteLine(tree.ToStringTree(parser));
+            System.Console.Out.WriteLine(tree.ToStringTree(parser));
         }
         if (show_profile)
         {

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -31,7 +31,8 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      #diff -q "$file".tree "$tree_file" > /dev/null
+      diff "$file".tree "$tree_file"
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -31,7 +31,6 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      #diff -q "$file".tree "$tree_file" > /dev/null
       diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -32,7 +32,7 @@ do
     if [ -f "$file".tree ]
     then
       #diff -q "$file".tree "$tree_file" > /dev/null
-      diff "$file".tree "$tree_file"
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    cat "$file" | trwdog ./bin/Debug/net6.0/<exec_name>
+    cat "$file" | trwdog ./bin/Debug/net6.0/<exec_name> -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -28,6 +29,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -13,7 +13,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/CSharp/tester.psm1
+++ b/_scripts/templates/CSharp/tester.psm1
@@ -15,7 +15,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree > $treeOutFile
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/CSharp/tester.psm1
+++ b/_scripts/templates/CSharp/tester.psm1
@@ -14,8 +14,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+    Save input and output character encodings and switch to UTF-8.
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8r
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -26,10 +31,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/CSharp/tester.psm1
+++ b/_scripts/templates/CSharp/tester.psm1
@@ -1,4 +1,5 @@
 # Template generated code from trgen <version>
+# Template generated code from trgen <version>
 function Build-Grammar {
     $msg = dotnet build -o CSharp
     return @{
@@ -14,7 +15,7 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    Save input and output character encodings and switch to UTF-8.
+    # Save input and output character encodings and switch to UTF-8.
     $oldInputEncoding = [console]::InputEncoding
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding

--- a/_scripts/templates/CSharp/tester.psm1
+++ b/_scripts/templates/CSharp/tester.psm1
@@ -14,13 +14,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/CSharp/tester.psm1
+++ b/_scripts/templates/CSharp/tester.psm1
@@ -21,7 +21,7 @@ function Test-Case {
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8r
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/Cpp/Program.cpp
+++ b/_scripts/templates/Cpp/Program.cpp
@@ -105,7 +105,7 @@ int TryParse(std::vector\<std::string>& args)
         std::cout \<\< tree->toStringTree(parser, false) \<\< std::endl;
     }
     std::cerr \<\< "Time: " \<\< formatDuration(duration.count()) \<\< std::endl;
-    return 0;
+    return listener_parser->had_error || listener_lexer->had_error ? 1 : 0;
 }
 
 int main(int argc, const char * argv[])

--- a/_scripts/templates/Cpp/Program.cpp
+++ b/_scripts/templates/Cpp/Program.cpp
@@ -102,7 +102,7 @@ int TryParse(std::vector\<std::string>& args)
     }
     if (show_tree)
     {
-//        System.Console.Error.WriteLine(tree.ToStringTree(parser));
+        std::out \<\< tree.ToStringTree(parser) \<\< std:end1;
     }
     std::cerr \<\< "Time: " \<\< formatDuration(duration.count()) \<\< std::endl;
     return 0;

--- a/_scripts/templates/Cpp/Program.cpp
+++ b/_scripts/templates/Cpp/Program.cpp
@@ -102,7 +102,7 @@ int TryParse(std::vector\<std::string>& args)
     }
     if (show_tree)
     {
-        std::cout \<\< tree.ToStringTree(parser) \<\< std::endl;
+        std::cout \<\< tree->toStringTree(parser, false) \<\< std::endl;
     }
     std::cerr \<\< "Time: " \<\< formatDuration(duration.count()) \<\< std::endl;
     return 0;

--- a/_scripts/templates/Cpp/Program.cpp
+++ b/_scripts/templates/Cpp/Program.cpp
@@ -102,7 +102,7 @@ int TryParse(std::vector\<std::string>& args)
     }
     if (show_tree)
     {
-        std::out \<\< tree.ToStringTree(parser) \<\< std:end1;
+        std::cout \<\< tree.ToStringTree(parser) \<\< std::endl;
     }
     std::cerr \<\< "Time: " \<\< formatDuration(duration.count()) \<\< std::endl;
     return 0;

--- a/_scripts/templates/Cpp/Program.cpp
+++ b/_scripts/templates/Cpp/Program.cpp
@@ -115,6 +115,6 @@ int main(int argc, const char * argv[])
     {
         args.push_back(argv[i]);
     }   
-    TryParse(args);
+    return TryParse(args);
 }
 

--- a/_scripts/templates/Cpp/test.sh
+++ b/_scripts/templates/Cpp/test.sh
@@ -31,7 +31,7 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/Cpp/test.sh
+++ b/_scripts/templates/Cpp/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog ./build/<exec_name> -file "$file"
+    trwdog ./build/<exec_name> -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -28,6 +29,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/Cpp/test.sh
+++ b/_scripts/templates/Cpp/test.sh
@@ -13,7 +13,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/Dart/test.sh
+++ b/_scripts/templates/Dart/test.sh
@@ -31,7 +31,7 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/Dart/test.sh
+++ b/_scripts/templates/Dart/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog <if(os_win)>./cli.exe<else>./cli<endif> -file "$file"
+    trwdog <if(os_win)>./cli.exe<else>./cli<endif> -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -28,6 +29,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/Dart/test.sh
+++ b/_scripts/templates/Dart/test.sh
@@ -13,7 +13,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/Dart/tester.psm1
+++ b/_scripts/templates/Dart/tester.psm1
@@ -37,7 +37,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog ./cli.exe -file $InputFile -tree > $treeOutFile
+    $o = trwdog ./cli.exe -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/Dart/tester.psm1
+++ b/_scripts/templates/Dart/tester.psm1
@@ -36,8 +36,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+    # Save input and output character encodings and switch to UTF-8.
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog ./cli.exe -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog ./cli.exe -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -48,10 +53,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Dart/tester.psm1
+++ b/_scripts/templates/Dart/tester.psm1
@@ -36,13 +36,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog ./cli.exe -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog ./cli.exe -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Go/Test.go
+++ b/_scripts/templates/Go/Test.go
@@ -110,12 +110,12 @@ func main() {
     start := time.Now()
     var tree = parser.<cap_start_symbol>()
     elapsed := time.Since(start)
-    fmt.Fprintf(os.stderr, "Time: %.3f s", elapsed.Seconds())
-    fmt.Fprintln(os.stderr)
+    fmt.Fprintf(os.Stderr, "Time: %.3f s", elapsed.Seconds())
+    fmt.Fprintln(os.Stderr)
     if parserErrors.errors > 0 || lexerErrors.errors > 0 {
-        fmt.Fprintln(os.stderr, "Parse failed.");
+        fmt.Fprintln(os.Stderr, "Parse failed.");
     } else {
-        fmt.Fprintln(os.stderr, "Parse succeeded.")
+        fmt.Fprintln(os.Stderr, "Parse succeeded.")
     }
     if show_tree {
         ss := tree.ToStringTree(parser.RuleNames, parser)

--- a/_scripts/templates/Go/Test.go
+++ b/_scripts/templates/Go/Test.go
@@ -110,12 +110,12 @@ func main() {
     start := time.Now()
     var tree = parser.<cap_start_symbol>()
     elapsed := time.Since(start)
-    fmt.Printf("Time: %.3f s", elapsed.Seconds())
-    fmt.Println()
+    fmt.Fprintf(os.stderr, "Time: %.3f s", elapsed.Seconds())
+    fmt.Fprintln(os.stderr)
     if parserErrors.errors > 0 || lexerErrors.errors > 0 {
-        fmt.Println("Parse failed.");
+        fmt.Fprintln(os.stderr, "Parse failed.");
     } else {
-        fmt.Println("Parse succeeded.")
+        fmt.Fprintln(os.stderr, "Parse succeeded.")
     }
     if show_tree {
         ss := tree.ToStringTree(parser.RuleNames, parser)

--- a/_scripts/templates/Go/test.sh
+++ b/_scripts/templates/Go/test.sh
@@ -31,7 +31,7 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/Go/test.sh
+++ b/_scripts/templates/Go/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog ./<exec_name> -file "$file"
+    trwdog ./<exec_name> -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -28,6 +29,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/Go/test.sh
+++ b/_scripts/templates/Go/test.sh
@@ -13,7 +13,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -43,8 +43,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+    # Save input and output character encodings and switch to UTF-8.
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog ./Test -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog ./Test -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -55,10 +60,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -43,13 +43,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog ./Test -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog ./Test -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -44,7 +44,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog ./Test -file $InputFile -tree > $treeOutFile
+    $o = trwdog ./Test -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/Java/Program.java
+++ b/_scripts/templates/Java/Program.java
@@ -6,8 +6,12 @@ import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.tree.ParseTree;
 import java.time.Instant;
 import java.time.Duration;
+import java.nio.charset.StandardCharsets;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 
 public class Program {
+    private static PrintWriter stdout_utf8 = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true);
     public static void main(String[] args) throws  FileNotFoundException, IOException
     {
         boolean show_tree = false;
@@ -75,7 +79,7 @@ public class Program {
         ErrorListener lexer_listener = new ErrorListener();
         ErrorListener listener = new ErrorListener();
         parser.removeErrorListeners();
-	    lexer.removeErrorListeners();
+        lexer.removeErrorListeners();
         parser.addErrorListener(listener);
         lexer.addErrorListener(lexer_listener);
         Instant start = Instant.now();
@@ -89,7 +93,7 @@ public class Program {
             System.err.println("Parse succeeded.");
         if (show_tree)
         {
-            System.out.println(tree.toStringTree(parser));
+            stdout_utf8.println(tree.toStringTree(parser));
         }
         java.lang.System.exit(listener.had_error || lexer_listener.had_error ? 1 : 0);
     }

--- a/_scripts/templates/Java/test.sh
+++ b/_scripts/templates/Java/test.sh
@@ -33,7 +33,7 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/Java/test.sh
+++ b/_scripts/templates/Java/test.sh
@@ -4,6 +4,7 @@ CLASSPATH=$JAR<if(path_sep_semi)>\;<else>:<endif>.
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -11,7 +12,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog java -classpath $CLASSPATH Program -file "$file"
+    trwdog java -classpath $CLASSPATH Program -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -30,6 +31,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/Java/test.sh
+++ b/_scripts/templates/Java/test.sh
@@ -15,7 +15,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/Java/tester.psm1
+++ b/_scripts/templates/Java/tester.psm1
@@ -24,8 +24,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+	# Save input and output character encodings and switch to UTF-8.
+	$oldInputEncoding = [console]::InputEncoding
+	$oldOutputEncoding = [console]::OutputEncoding
+	$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -36,10 +41,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+	# Restore input and output character encodings.
+	[console]::InputEncoding = $oldInputEncoding
+	[console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Java/tester.psm1
+++ b/_scripts/templates/Java/tester.psm1
@@ -24,13 +24,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog java Program -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Java/tester.psm1
+++ b/_scripts/templates/Java/tester.psm1
@@ -25,9 +25,9 @@ function Test-Case {
         $ErrorFile
     )
 	# Save input and output character encodings and switch to UTF-8.
-	$oldInputEncoding = [console]::InputEncoding
-	$oldOutputEncoding = [console]::OutputEncoding
-	$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
     $treeOutFile = $TreeFile + ".out"
     $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
@@ -45,9 +45,9 @@ function Test-Case {
         $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
-	# Restore input and output character encodings.
-	[console]::InputEncoding = $oldInputEncoding
-	[console]::OutputEncoding = $oldOutputEncoding
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
 
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch

--- a/_scripts/templates/Java/tester.psm1
+++ b/_scripts/templates/Java/tester.psm1
@@ -25,7 +25,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree > $treeOutFile
+    $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/JavaScript/test.sh
+++ b/_scripts/templates/JavaScript/test.sh
@@ -3,6 +3,7 @@ err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 stderr_file=`mktemp --tmpdir=. stderr.XXXXXXXXXX`
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +11,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog node index.js -file "$file" 2> "$stderr_file"
+    trwdog node index.js -file "$file" -tree > "$tree_file" 2> "$stderr_file"
     status="$?"
     head -55 "$stderr_file"
     if [ -f "$file".errors ]
@@ -30,7 +31,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
-rm "$stderr_file"
+rm "$stderr_file" "$tree_file"
 exit $err

--- a/_scripts/templates/JavaScript/test.sh
+++ b/_scripts/templates/JavaScript/test.sh
@@ -15,7 +15,7 @@ do
     head -55 "$stderr_file"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/JavaScript/test.sh
+++ b/_scripts/templates/JavaScript/test.sh
@@ -33,7 +33,7 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/JavaScript/test.sh
+++ b/_scripts/templates/JavaScript/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+stderr_file=`mktemp --tmpdir=. stderr.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,8 +10,9 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog node index.js -file "$file" 2>&1 | head -55
-    status="${PIPESTATUS[0]}"
+    trwdog node index.js -file "$file" 2> "$stderr_file"
+    status="$?"
+    head -55 "$stderr_file"
     if [ -f "$file".errors ]
     then
       if [ "$stat" = "0" ]
@@ -30,4 +32,5 @@ do
     fi
   fi
 done
+rm "$stderr_file"
 exit $err

--- a/_scripts/templates/JavaScript/tester.psm1
+++ b/_scripts/templates/JavaScript/tester.psm1
@@ -23,13 +23,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog node index.js -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog node index.js -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/JavaScript/tester.psm1
+++ b/_scripts/templates/JavaScript/tester.psm1
@@ -24,7 +24,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog node index.js -file $InputFile -tree > $treeOutFile
+    $o = trwdog node index.js -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/JavaScript/tester.psm1
+++ b/_scripts/templates/JavaScript/tester.psm1
@@ -23,8 +23,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+    # Save input and output character encodings and switch to UTF-8.
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog node index.js -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog node index.js -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -35,10 +40,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/PHP/test.sh
+++ b/_scripts/templates/PHP/test.sh
@@ -31,7 +31,8 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      #diff -q "$file".tree "$tree_file" > /dev/null
+      diff "$file".tree "$tree_file"
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/PHP/test.sh
+++ b/_scripts/templates/PHP/test.sh
@@ -31,7 +31,6 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      #diff -q "$file".tree "$tree_file" > /dev/null
       diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]

--- a/_scripts/templates/PHP/test.sh
+++ b/_scripts/templates/PHP/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog php Test.php -file "$file"
+    trwdog php Test.php -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -28,6 +29,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/PHP/test.sh
+++ b/_scripts/templates/PHP/test.sh
@@ -32,7 +32,7 @@ do
     if [ -f "$file".tree ]
     then
       #diff -q "$file".tree "$tree_file" > /dev/null
-      diff "$file".tree "$tree_file"
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/PHP/test.sh
+++ b/_scripts/templates/PHP/test.sh
@@ -13,7 +13,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/PHP/tester.psm1
+++ b/_scripts/templates/PHP/tester.psm1
@@ -23,8 +23,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+	# Save input and output character encodings and switch to UTF-8.
+	$oldInputEncoding = [console]::InputEncoding
+	$oldOutputEncoding = [console]::OutputEncoding
+	$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog php Test.php -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog php Test.php -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -35,10 +40,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+	# Restore input and output character encodings.
+	[console]::InputEncoding = $oldInputEncoding
+	[console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/PHP/tester.psm1
+++ b/_scripts/templates/PHP/tester.psm1
@@ -24,7 +24,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog php Test.php -file $InputFile -tree > $treeOutFile
+    $o = trwdog php Test.php -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/PHP/tester.psm1
+++ b/_scripts/templates/PHP/tester.psm1
@@ -23,13 +23,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog php Test.php -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog php Test.php -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -31,7 +31,7 @@ do
     fi
     if [ -f "$file".tree ]
     then
-      diff -q "$file".tree "$tree_file" > /dev/null
+      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
 	  status="$?"
       if [ "$status" = "0" ]
       then

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog python3 Program.py -file "$file" -tree > "$tree_file"
+    trwdog python3 -X utf8 Program.py -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -2,6 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
+tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -9,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog python3 Program.py -file "$file"
+    trwdog python3 Program.py -file "$file" -tree > "$tree_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -28,6 +29,20 @@ do
         break
       fi
     fi
+    if [ -f "$file".tree ]
+    then
+      diff -q "$file".tree "$tree_file" > /dev/null
+	  status="$?"
+      if [ "$status" = "0" ]
+      then
+        echo Parse tree match succeeded.
+      else
+        echo Expected parse tree match.
+        err=1
+        break
+      fi
+    fi
   fi
 done
+rm "$tree_file"
 exit $err

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -13,7 +13,7 @@ do
     status="$?"
     if [ -f "$file".errors ]
     then
-      if [ "$stat" = "0" ]
+      if [ "$status" = "0" ]
       then
         echo Expected parse fail.
         err=1

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -23,13 +23,22 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-    $o = trwdog python3 Program.py -file $InputFile
+    $treeOutFile = $TreeFile + ".out"
+    $o = trwdog python3 Program.py -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
+    $parseOk = !$failed
     if ($failed -and $errorFile) {
-        return $true
+        $parseOk = $true
     }
     if(!$failed -and !$errorFile){
-        return $true
+        $parseOk = $true
     }
-    return $false
+    $treeMatch = $true
+    if (Test-Path $TreeFile) {
+        $expectedData = Get-Content $TreeFile
+        $actualData = Get-Content $treeOutFile
+        $treeMatch = ($actualData -eq $expectedData)
+    }
+    Remove-Item $treeOutFile
+    return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -23,8 +23,13 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
+    # Save input and output character encodings and switch to UTF-8.
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog python3 -X utf8 Program.py -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
+    $o = trwdog python3 -X utf8 Program.py -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {
@@ -35,10 +40,14 @@ function Test-Case {
     }
     $treeMatch = $true
     if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile
-        $actualData = Get-Content $treeOutFile
+        $expectedData = Get-Content $TreeFile -Encoding UTF8
+        $actualData = Get-Content $treeOutFile -Encoding UTF8
         $treeMatch = ($actualData -eq $expectedData)
     }
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
+
     Remove-Item $treeOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -24,7 +24,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog python3 Program.py -file $InputFile -tree > $treeOutFile
+    $o = trwdog python3 -X utf8 Program.py -file $InputFile -tree > $treeOutFile
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -24,7 +24,7 @@ function Test-Case {
         $ErrorFile
     )
     $treeOutFile = $TreeFile + ".out"
-    $o = trwdog python3 -X utf8 Program.py -file $InputFile -tree > $treeOutFile
+    $o = trwdog python3 -X utf8 Program.py -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile"
     $failed = $LASTEXITCODE -ne 0
     $parseOk = !$failed
     if ($failed -and $errorFile) {

--- a/_scripts/test.ps1
+++ b/_scripts/test.ps1
@@ -161,21 +161,30 @@ function Test-GrammarTestCases {
         if (!$shouldFail) {
             $errorFile = ""
         }
+        $treeFile = "$case.tree"
         Write-Host "--- Testing file $item ---"
-        $ok = Test-Case -InputFile $case -ErrorFile $errorFile
+        $parseOk, $treeMatch = Test-Case -InputFile $case -ErrorFile $errorFile -TreeFile $treeFile
 
-        if (!$ok) {
+        if (!$parseOk) {
             if ($shouldFail) {
-                Write-Host "Text case should return error"
-                Write-Host "$Directory test $case failed" -ForegroundColor Red
+                Write-Host "Test case should return error"
+                Write-Host "$TestDirectory test $case failed" -ForegroundColor Red
                 $failedList += $case
                 continue
             }
             else { 
-                Write-Host "$Directory test $case failed" -ForegroundColor Red
+                Write-Host "$TestDirectory test $case failed" -ForegroundColor Red
                 $failedList += $case
                 continue
             }
+        }
+        if (Test-Path $treeFile) {
+			if ($treeMatch) {
+				Write-Host "Parse tree match succeeded"
+			} else {
+				Write-Host "$TestDirectory test $case parse tree match failed" -ForegroundColor Red
+				$failedList += $case
+			}
         }
     }
     return $failedList

--- a/_scripts/test.ps1
+++ b/_scripts/test.ps1
@@ -147,8 +147,8 @@ function Test-GrammarTestCases {
 
         Write-Host "Test case: $item"
 
-        $case = $item
-        $ext = $case.Extension
+        $case = $item.fullname
+        $ext = $item.Extension
         if (($ext -eq ".errors") -or ($ext -eq ".tree")) {
             continue
         }


### PR DESCRIPTION
The `antlr4test-maven-plugin` tool used in the Maven build system supports test cases where success is not based just on being able to parse a file, but also to generate a parse tree that matches an expected parse tree.  This expected tree is supplied as a file, in the same directory as the test case, with `.tree` appended to the name (_e.g._, `example1.txt` and `example1.txt.tree`).  It compares the tree produced by `org.antlr.v4.runtime.tree.ParseTree.toStringTree()` against the contents of the file, and if they are identical, the test succeeds.  Otherwise, it fails.

This change adds similar support to the `trgen` test system used in the continuous integration system (among other places).  It uses the same expected tree files, and the same ANTLR code to produce the test case's tree.

As with `antlr4test-maven-plugin`, the verification of the parse tree is skipped if there is no expected tree file.

Fixes #2837 