### PR TITLE
[TSql] Add xml_type_definition to data_type

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3199,7 +3199,7 @@ xml_type_definition
     ;
 
 xml_schema_collection
-    : ID '.' ID
+    : id_ '.' id_
     ;
 
 column_def_table_constraints
@@ -4535,6 +4535,7 @@ data_type
     | ext_type=id_ IDENTITY ('(' seed=DECIMAL ',' inc=DECIMAL ')')?
     | double_prec=DOUBLE PRECISION?
     | unscaled_type=id_
+    | xml_type_definition
     ;
 
 default_value


### PR DESCRIPTION
In current state parser will not create a proper AST with case like this 
````sql
CREATE TABLE [Person].[Person](
						[BusinessEntityID] [int] NOT NULL,
						[PersonType] [nchar](2) NOT NULL,
						[AdditionalContactInfo] xml(CONTENT [Person].[AdditionalContactInfoSchemaCollection]) NULL,
						[Demographics] xml(CONTENT [Person].[IndividualSurveySchemaCollection]) NULL,
						[rowguid] [uniqueidentifier] ROWGUIDCOL  NOT NULL,
						[ModifiedDate] [datetime] NOT NULL)
````

This PR adds _xml_data_type_ to  _data_type_ to fix this.