### PR TITLE
Implement full .errors verification in tests

### DIFF
--- a/_scripts/skip-csharp.txt
+++ b/_scripts/skip-csharp.txt
@@ -2,6 +2,7 @@ apex
 asn/asn_3gpp
 clif
 cpp
+csharp
 fortran77
 html
 hypertalk

--- a/_scripts/skip-csharp.why
+++ b/_scripts/skip-csharp.why
@@ -1,0 +1,2 @@
+csharp
+	antlr4 issue #3700(https://github.com/antlr/antlr4/issues/3700) descibes an incorrect error message from `grammars-v4/csharp` example `issue-2612`.  When that bug is fixed, this parser can be removed from skip-csharp.txt.

--- a/_scripts/skip-javascript.txt
+++ b/_scripts/skip-javascript.txt
@@ -27,6 +27,7 @@ powerbuilder
 python/python
 python/python2
 python/python3
+python/python3alt
 python/python3-py
 python/python3-ts
 python/python3-without-actions

--- a/_scripts/skip-javascript.why
+++ b/_scripts/skip-javascript.why
@@ -84,6 +84,8 @@ python/python2
 python/python3
 	ErrorCaptureStackTrace(err) undefined.
 
+python/python3alt
+	"SyntaxError: Unexpected strict mode reserved word", see issue #2858.
 python/python3-py
 	pom.xml does not contain tests, so trgen does not create Generated/. Skip for now.
 	Grammar is not target-agnostic.

--- a/_scripts/skip-php.txt
+++ b/_scripts/skip-php.txt
@@ -36,6 +36,7 @@ kirikiri-tjs
 kotlin/kotlin
 kotlin/kotlin-formal
 kquery
+logo/logo
 logo/ucb-logo
 lpc
 lucene

--- a/_scripts/skip-php.txt
+++ b/_scripts/skip-php.txt
@@ -49,6 +49,7 @@ powerbuilder
 prov-n
 python/python
 python/python3
+python/python3alt
 r
 racket-bsl
 racket-isl

--- a/_scripts/skip-php.why
+++ b/_scripts/skip-php.why
@@ -1,0 +1,2 @@
+python/python3alt
+	"SyntaxError: Unexpected strict mode reserved word", see issue #2858.

--- a/_scripts/skip-php.why
+++ b/_scripts/skip-php.why
@@ -1,2 +1,4 @@
+logo/logo
+	Error mismatch in  example logo_feature_butfail_2.txt.  See issue #2859.
 python/python3alt
 	"SyntaxError: Unexpected strict mode reserved word", see issue #2858.

--- a/_scripts/templates/Antlr4cs/ErrorListener.cs
+++ b/_scripts/templates/Antlr4cs/ErrorListener.cs
@@ -1,0 +1,35 @@
+<if(has_name_space)>namespace <name_space>
+{<endif>
+    public class ErrorListener<Symbol> : IAntlrErrorListener<Symbol>
+    {
+        /// <summary>
+        /// Provides a default instance of
+        /// <see cref="ErrorListener{Symbol}"/>
+        /// .
+        /// </summary>
+        public static readonly ErrorListener<Symbol> Instance = new ErrorListener<Symbol>();
+
+        /// <summary>
+        /// <inheritDoc/>
+        /// <p>
+        /// This implementation prints messages to
+        /// <see cref="System.Console.Out"/>
+        /// containing the
+        /// values of
+        /// <paramref name="line"/>
+        /// ,
+        /// <paramref name="charPositionInLine"/>
+        /// , and
+        /// <paramref name="msg"/>
+        /// using
+        /// the following format.</p>
+        /// <pre>
+        /// line <em>line</em>:<em>charPositionInLine</em> <em>msg</em>
+        /// </pre>
+        /// </summary>
+        public virtual void SyntaxError(IRecognizer recognizer, Symbol offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
+        {
+            System.Console.Out.WriteLine("line " + line + ":" + charPositionInLine + " " + msg);
+        }
+    }
+<if(has_name_space)>}<endif>

--- a/_scripts/templates/Antlr4cs/Program.cs
+++ b/_scripts/templates/Antlr4cs/Program.cs
@@ -109,10 +109,10 @@ public class Program
         else
         {
             System.Console.Error.WriteLine("Parse succeeded.");
-        }
-        if (show_tree)
-        {
-            System.Console.Out.WriteLine(tree.ToStringTree(parser));
+            if (show_tree)
+            {
+                System.Console.Out.WriteLine(tree.ToStringTree(parser));
+            }
         }
         System.Environment.Exit(parser.NumberOfSyntaxErrors > 0 ? 1 : 0);
     }

--- a/_scripts/templates/Antlr4cs/test.sh
+++ b/_scripts/templates/Antlr4cs/test.sh
@@ -2,7 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog ./bin/Debug/net6.0/<exec_name> -file "$file" -tree > "$tree_file"
+    trwdog ./bin/Debug/net6.0/<exec_name> -file "$file" -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -21,12 +21,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -44,5 +67,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/Antlr4cs/test.sh
+++ b/_scripts/templates/Antlr4cs/test.sh
@@ -52,19 +52,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/Antlr4cs/tester.psm1
+++ b/_scripts/templates/Antlr4cs/tester.psm1
@@ -19,26 +19,36 @@ function Test-Case {
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
     # Restore input and output character encodings.
     [console]::InputEncoding = $oldInputEncoding
     [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/CSharp/ErrorListener.cs
+++ b/_scripts/templates/CSharp/ErrorListener.cs
@@ -21,6 +21,6 @@ public class ErrorListener\<S> : ConsoleErrorListener\<S>
         int col, string msg, RecognitionException e)
     {
         had_error = true;
-		if (!_quiet) base.SyntaxError(output, recognizer, offendingSymbol, line, col, msg, e);
+		if (!_quiet) System.Console.Out.WriteLine("line " + line + ":" + col + " " + msg);
     }
 }

--- a/_scripts/templates/CSharp/Program.cs
+++ b/_scripts/templates/CSharp/Program.cs
@@ -178,15 +178,16 @@ public class Program
         System.Console.Error.WriteLine("Time: " + (after - before));
         if (listener_lexer.had_error || listener_parser.had_error)
         {
+            // Listener will have already printed the error(s) to stdout.
             System.Console.Error.WriteLine("Parse failed.");
         }
         else
         {
             System.Console.Error.WriteLine("Parse succeeded.");
-        }
-        if (show_tree)
-        {
-            System.Console.Out.WriteLine(tree.ToStringTree(parser));
+            if (show_tree)
+            {
+                System.Console.Out.WriteLine(tree.ToStringTree(parser));
+            }
         }
         if (show_profile)
         {

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -52,19 +52,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/CSharp/test.sh
+++ b/_scripts/templates/CSharp/test.sh
@@ -2,7 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    cat "$file" | trwdog ./bin/Debug/net6.0/<exec_name> -tree > "$tree_file"
+    cat "$file" | trwdog ./bin/Debug/net6.0/<exec_name> -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -21,12 +21,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -44,5 +67,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/CSharp/tester.psm1
+++ b/_scripts/templates/CSharp/tester.psm1
@@ -20,26 +20,37 @@ function Test-Case {
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog dotnet CSharp/Test.dll -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
     # Restore input and output character encodings.
     [console]::InputEncoding = $oldInputEncoding
     [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Cpp/ErrorListener.cpp
+++ b/_scripts/templates/Cpp/ErrorListener.cpp
@@ -5,5 +5,5 @@
 void ErrorListener::syntaxError(antlr4::Recognizer* recognizer, antlr4::Token* offendingSymbol, size_t line, size_t col, const std::string& msg, std::exception_ptr e)
 {
     had_error = true;
-    antlr4::ConsoleErrorListener::syntaxError(recognizer, offendingSymbol, line, col, msg, e);
+    std::cout \<\< "line " + line + ":" + charPositionInLine + " " + msg \<\< std::endl;
 }

--- a/_scripts/templates/Cpp/ErrorListener.cpp
+++ b/_scripts/templates/Cpp/ErrorListener.cpp
@@ -5,5 +5,5 @@
 void ErrorListener::syntaxError(antlr4::Recognizer* recognizer, antlr4::Token* offendingSymbol, size_t line, size_t col, const std::string& msg, std::exception_ptr e)
 {
     had_error = true;
-    std::cout \<\< "line " + line + ":" + charPositionInLine + " " + msg \<\< std::endl;
+    std::cout \<\< "line " \<\< line \<\< ":" \<\< col \<\< " " \<\< msg \<\< std::endl;
 }

--- a/_scripts/templates/Cpp/Program.cpp
+++ b/_scripts/templates/Cpp/Program.cpp
@@ -94,15 +94,16 @@ int TryParse(std::vector\<std::string>& args)
     auto duration = std::chrono::duration_cast\<std::chrono::microseconds>(after - before);
     if (listener_parser->had_error || listener_lexer->had_error)
     {
+        // Listener will have already printed the error(s) to stdout.
         std::cerr \<\< "Parse failed." \<\< std::endl;
     }
     else
     {
         std::cerr \<\< "Parse succeeded." \<\< std::endl;
-    }
-    if (show_tree)
-    {
-        std::cout \<\< tree->toStringTree(parser, false) \<\< std::endl;
+        if (show_tree)
+        {
+            std::cout \<\< tree->toStringTree(parser, false) \<\< std::endl;
+        }
     }
     std::cerr \<\< "Time: " \<\< formatDuration(duration.count()) \<\< std::endl;
     return listener_parser->had_error || listener_lexer->had_error ? 1 : 0;

--- a/_scripts/templates/Cpp/test.sh
+++ b/_scripts/templates/Cpp/test.sh
@@ -2,7 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog ./build/<exec_name> -file "$file" -tree > "$tree_file"
+    trwdog ./build/<exec_name> -file "$file" -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -21,12 +21,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -44,5 +67,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/Cpp/test.sh
+++ b/_scripts/templates/Cpp/test.sh
@@ -52,19 +52,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/Dart/cli.dart
+++ b/_scripts/templates/Dart/cli.dart
@@ -70,6 +70,27 @@ class CaseChangingCharStream extends CharStream {
 
 <endif>
 
+class MyErrorListener extends BaseErrorListener {
+  /// Provides a default instance of [MyErrorListener].
+  static final INSTANCE = MyErrorListener();
+
+  /// {@inheritDoc}
+  ///
+  /// <p>
+  /// This implementation prints messages to {@link System//err} containing the
+  /// values of [line], [charPositionInLine], and [msg] using
+  /// the following format.</p>
+  ///
+  /// <pre>
+  /// line <em>line</em>:<em>charPositionInLine</em> <em>msg</em>
+  /// </pre>
+  @override
+  void syntaxError(recognizer, offendingSymbol, line, column, msg, e) {
+    stdout.writeln('line $line:$column $msg');
+  }
+}
+
+
 void main(List\<String> args) async {
     var show_tree = false;
     var show_tokens = false;
@@ -129,10 +150,10 @@ void main(List\<String> args) async {
     }
     var tokens = CommonTokenStream(lexer);
     var parser = <parser_name>(tokens);
-//    var listener_lexer = ErrorListener();
-//    var listener_parser = ErrorListener();
-//    lexer.AddErrorListener(listener_lexer);
-//    parser.AddErrorListener(listener_parser);
+    var listener_lexer = MyErrorListener();
+    var listener_parser = MyErrorListener();
+    lexer.addErrorListener(listener_lexer);
+    parser.addErrorListener(listener_parser);
     Stopwatch s = new Stopwatch();
     s.start();
     var tree = parser.<start_symbol>();
@@ -141,15 +162,16 @@ void main(List\<String> args) async {
     stderr.writeln("Time: " + et.toString());
     if (parser.numberOfSyntaxErrors > 0)
     {
+        // Listener will have already printed the error(s) to stdout.
         stderr.writeln("Parse failed.");
     }
     else
     {
         stderr.writeln("Parse succeeded.");
-    }
-    if (show_tree)
-    {
-        print(tree.toStringTree(parser: parser));
+        if (show_tree)
+        {
+            print(tree.toStringTree(parser: parser));
+        }
     }
     exit(parser.numberOfSyntaxErrors > 0 ? 1 : 0);
 }

--- a/_scripts/templates/Dart/test.sh
+++ b/_scripts/templates/Dart/test.sh
@@ -2,7 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog <if(os_win)>./cli.exe<else>./cli<endif> -file "$file" -tree > "$tree_file"
+    trwdog <if(os_win)>./cli.exe<else>./cli<endif> -file "$file" -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -21,12 +21,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -44,5 +67,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/Dart/test.sh
+++ b/_scripts/templates/Dart/test.sh
@@ -52,19 +52,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/Dart/tester.psm1
+++ b/_scripts/templates/Dart/tester.psm1
@@ -41,26 +41,37 @@ function Test-Case {
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog ./cli.exe -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog ./cli.exe -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
     # Restore input and output character encodings.
     [console]::InputEncoding = $oldInputEncoding
     [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Go/Test.go
+++ b/_scripts/templates/Go/Test.go
@@ -22,7 +22,7 @@ func NewCustomErrorListener() *CustomErrorListener {
 
 func (l *CustomErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
     l.errors += 1
-    antlr.ConsoleErrorListenerINSTANCE.SyntaxError(recognizer, offendingSymbol, line, column, msg, e)
+    fmt.Printf("line %d:%d %s", line, column, msg)
 }
 
 func (l *CustomErrorListener) ReportAmbiguity(recognizer antlr.Parser, dfa *antlr.DFA, startIndex, stopIndex int, exact bool, ambigAlts *antlr.BitSet, configs antlr.ATNConfigSet) {
@@ -116,10 +116,10 @@ func main() {
         fmt.Fprintln(os.Stderr, "Parse failed.");
     } else {
         fmt.Fprintln(os.Stderr, "Parse succeeded.")
-    }
-    if show_tree {
-        ss := tree.ToStringTree(parser.RuleNames, parser)
-        fmt.Println(ss)
+        if show_tree {
+            ss := tree.ToStringTree(parser.RuleNames, parser)
+            fmt.Println(ss)
+        }
     }
     if parserErrors.errors > 0 || lexerErrors.errors > 0 {
         os.Exit(1)

--- a/_scripts/templates/Go/test.sh
+++ b/_scripts/templates/Go/test.sh
@@ -2,7 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog ./<exec_name> -file "$file" -tree > "$tree_file"
+    trwdog ./<exec_name> -file "$file" -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -21,12 +21,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -44,5 +67,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/Go/test.sh
+++ b/_scripts/templates/Go/test.sh
@@ -52,19 +52,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/Go/tester.psm1
+++ b/_scripts/templates/Go/tester.psm1
@@ -48,26 +48,36 @@ function Test-Case {
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog ./Test -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog ./Test -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
     # Restore input and output character encodings.
     [console]::InputEncoding = $oldInputEncoding
     [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Java/ErrorListener.java
+++ b/_scripts/templates/Java/ErrorListener.java
@@ -1,10 +1,14 @@
 // Template generated code from trgen <version>
 
 import org.antlr.v4.runtime.*;
+import java.nio.charset.StandardCharsets;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 
 public class ErrorListener extends ConsoleErrorListener
 {
     public boolean had_error = false;
+    private static PrintWriter stdout_utf8 = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true);
     
     @Override
     public void syntaxError(Recognizer\<?, ?> recognizer,
@@ -15,6 +19,6 @@ public class ErrorListener extends ConsoleErrorListener
         RecognitionException e)
     {
         had_error = true;
-        super.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
+        stdout_utf8.println("line " + line + ":" + charPositionInLine + " " + msg);
     }
 }

--- a/_scripts/templates/Java/Program.java
+++ b/_scripts/templates/Java/Program.java
@@ -12,6 +12,7 @@ import java.io.PrintWriter;
 
 public class Program {
     private static PrintWriter stdout_utf8 = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true);
+    private static PrintWriter stderr_utf8 = new PrintWriter(new OutputStreamWriter(System.err, StandardCharsets.UTF_8), true);
     public static void main(String[] args) throws  FileNotFoundException, IOException
     {
         boolean show_tree = false;
@@ -86,14 +87,16 @@ public class Program {
         ParseTree tree = parser.<start_symbol>();
         Instant finish = Instant.now();
         long timeElapsed = Duration.between(start, finish).toMillis();
-        System.err.println("Time: " + (timeElapsed * 1.0) / 1000.0);
-        if (listener.had_error || lexer_listener.had_error)
-            System.err.println("Parse failed.");
-        else
-            System.err.println("Parse succeeded.");
-        if (show_tree)
-        {
-            stdout_utf8.println(tree.toStringTree(parser));
+        stderr_utf8.println("Time: " + (timeElapsed * 1.0) / 1000.0);
+        if (listener.had_error || lexer_listener.had_error) {
+            // Listener will have already printed the error(s) to stdout.
+            stderr_utf8.println("Parse failed.");
+        } else {
+            stderr_utf8.println("Parse succeeded.");
+            if (show_tree)
+            {
+                stdout_utf8.println(tree.toStringTree(parser));
+            }
         }
         java.lang.System.exit(listener.had_error || lexer_listener.had_error ? 1 : 0);
     }

--- a/_scripts/templates/Java/test.sh
+++ b/_scripts/templates/Java/test.sh
@@ -4,7 +4,7 @@ CLASSPATH=$JAR<if(path_sep_semi)>\;<else>:<endif>.
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -12,7 +12,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog java -classpath $CLASSPATH Program -file "$file" -tree > "$tree_file"
+    trwdog java -classpath $CLASSPATH Program -file "$file" -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -23,12 +23,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -46,5 +69,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/Java/test.sh
+++ b/_scripts/templates/Java/test.sh
@@ -54,19 +54,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/Java/tester.psm1
+++ b/_scripts/templates/Java/tester.psm1
@@ -24,31 +24,42 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-	# Save input and output character encodings and switch to UTF-8.
+    # Save input and output character encodings and switch to UTF-8.
     $oldInputEncoding = [console]::InputEncoding
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog java -cp "<antlr_tool_path><if(path_sep_semi)>;<else>:<endif>." Program -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
     # Restore input and output character encodings.
     [console]::InputEncoding = $oldInputEncoding
     [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/JavaScript/index.js
+++ b/_scripts/templates/JavaScript/index.js
@@ -19,7 +19,7 @@ function getChar() {
 class MyErrorListener extends antlr4.error.ErrorListener {
     syntaxError(recognizer, offendingSymbol, line, column, msg, err) {
         num_errors++;
-        console.error(`"line ${line}:${column} ${msg}`);
+        console.log(`line ${line}:${column} ${msg}`);
     }
 }
 

--- a/_scripts/templates/JavaScript/index.js
+++ b/_scripts/templates/JavaScript/index.js
@@ -19,7 +19,7 @@ function getChar() {
 class MyErrorListener extends antlr4.error.ErrorListener {
     syntaxError(recognizer, offendingSymbol, line, column, msg, err) {
         num_errors++;
-        console.error(`${offendingSymbol} line ${line}, col ${column}: ${msg}`);
+        console.error(`"line ${line}:${column} ${msg}`);
     }
 }
 
@@ -90,12 +90,9 @@ if (show_tokens)
     lexer.reset();
 }
 const tree = parser.<start_symbol>();
-if (show_tree)
-{
-    console.log(tree.toStringTree(parser.ruleNames));
-}
 if (num_errors > 0)
 {
+    // Listener will have already printed the error(s) to stdout.
     console.error('Parse failed.');
     process.exitCode = 1;
 }
@@ -103,4 +100,8 @@ else
 {
     console.error('Parse succeeded.');
     process.exitCode = 0;
+    if (show_tree)
+    {
+        console.log(tree.toStringTree(parser.ruleNames));
+    }
 }

--- a/_scripts/templates/JavaScript/test.sh
+++ b/_scripts/templates/JavaScript/test.sh
@@ -3,7 +3,7 @@ err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 stderr_file=`mktemp --tmpdir=. stderr.XXXXXXXXXX`
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -11,7 +11,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog node index.js -file "$file" -tree > "$tree_file" 2> "$stderr_file"
+    trwdog node index.js -file "$file" -tree > "$parse_out_file" 2> "$stderr_file"
     status="$?"
     head -55 "$stderr_file"
     if [ -f "$file".errors ]
@@ -23,12 +23,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -46,5 +69,5 @@ do
     fi
   fi
 done
-rm "$stderr_file" "$tree_file"
+rm "$stderr_file" "$parse_out_file"
 exit $err

--- a/_scripts/templates/JavaScript/test.sh
+++ b/_scripts/templates/JavaScript/test.sh
@@ -54,19 +54,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$stderr_file" "$parse_out_file"

--- a/_scripts/templates/JavaScript/tester.psm1
+++ b/_scripts/templates/JavaScript/tester.psm1
@@ -28,26 +28,36 @@ function Test-Case {
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog node index.js -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog node index.js -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
     # Restore input and output character encodings.
     [console]::InputEncoding = $oldInputEncoding
     [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/PHP/Test.php
+++ b/_scripts/templates/PHP/Test.php
@@ -36,7 +36,7 @@ class MyErrorListener extends BaseErrorListener /*extends ConsoleErrorListener*/
 		string $msg,
 		?RecognitionException $e
 	) : void {
-		\fwrite(\STDERR, \sprintf("line %d:%d %s\n", $line, $charPositionInLine, $msg));
+		\fwrite(\STDOUT, \sprintf("line %d:%d %s\n", $line, $charPositionInLine, $msg));
 		//parent::syntaxError($recognizer,$offendingSymbol,$line,$charPositionInLine,$msg,$e);
 		$this->noError = false;
 	}
@@ -94,10 +94,11 @@ $parserErrorListener = new MyErrorListener();
 $parser->removeErrorListeners();
 $parser->addErrorListener($parserErrorListener);
 $tree = $parser-><start_symbol>();
-if ($show_tree) {
-	print($tree->toStringTree($parser->getRuleNames()) . "\n");
-}
 if ($parserErrorListener->noError&&$lexerErrorListener->noError){
+	if ($show_tree) {
+		print($tree->toStringTree($parser->getRuleNames()) . "\n");
+	}
 	exit(0);
 }
+// Listener will have already printed the error(s) to stdout.
 exit(1);

--- a/_scripts/templates/PHP/test.sh
+++ b/_scripts/templates/PHP/test.sh
@@ -52,19 +52,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/PHP/test.sh
+++ b/_scripts/templates/PHP/test.sh
@@ -2,7 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog php Test.php -file "$file" -tree > "$tree_file"
+    trwdog php Test.php -file "$file" -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -21,12 +21,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -44,5 +67,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/PHP/tester.psm1
+++ b/_scripts/templates/PHP/tester.psm1
@@ -23,31 +23,41 @@ function Test-Case {
         $TreeFile,
         $ErrorFile
     )
-	# Save input and output character encodings and switch to UTF-8.
-	$oldInputEncoding = [console]::InputEncoding
-	$oldOutputEncoding = [console]::OutputEncoding
-	$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+    # Save input and output character encodings and switch to UTF-8.
+    $oldInputEncoding = [console]::InputEncoding
+    $oldOutputEncoding = [console]::OutputEncoding
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog php Test.php -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog php Test.php -file $InputFile-tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
-	# Restore input and output character encodings.
-	[console]::InputEncoding = $oldInputEncoding
-	[console]::OutputEncoding = $oldOutputEncoding
+    # Restore input and output character encodings.
+    [console]::InputEncoding = $oldInputEncoding
+    [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }

--- a/_scripts/templates/Python3/Program.py
+++ b/_scripts/templates/Python3/Program.py
@@ -24,7 +24,7 @@ class MyErrorListener(ErrorListener):
 
     def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
         self.num_errors = self.num_errors + 1
-        super().syntaxError(recognizer, offendingSymbol, line, column, msg, e)
+        print(f"line {line}:{column} {msg}");
 
 def main(argv):
     show_tokens = False
@@ -94,13 +94,14 @@ def main(argv):
     diff = end_time - start_time
     diff_time = diff.total_seconds()
     print(f'Time: {diff_time}', file=sys.stderr);
-    if (show_tree):
-        print(tree.toStringTree(recog=parser))
     if p_listener.num_errors > 0 or l_listener.num_errors > 0:
+        # Listener will have already printed the error(s) to stdout.
         print('Parse failed.', file=sys.stderr);
         sys.exit(1)
     else:
         print('Parse succeeded.', file=sys.stderr);
+        if (show_tree):
+            print(tree.toStringTree(recog=parser))
         sys.exit(0)
 
 if __name__ == '__main__':

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -2,7 +2,7 @@
 err=0
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
-tree_file=`mktemp --tmpdir=. tree.XXXXXXXXXX`
+parse_out_file=`mktemp --tmpdir=. parse_out.XXXXXXXXXX`
 for g in `find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
 do
   file="$g"
@@ -10,7 +10,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo "$file"
-    trwdog python3 -X utf8 Program.py -file "$file" -tree > "$tree_file"
+    trwdog python3 Program.py -file "$file" -tree > "$parse_out_file"
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -21,12 +21,35 @@ do
         break
       else
         echo Expected.
+        diff \<(tr -d "\r\n" \< "$file".errors) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse errors match succeeded.
+        else
+          echo Expected parse errors match.
+          err=1
+          break
+        fi
       fi
-    else
+    else # No .errors file
       if [ "$status" != "0" ]
       then
         err=1
         break
+      fi
+      if [ -f "$file".tree ]
+      then
+        diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$parse_out_file")
+	    status="$?"
+        if [ "$status" = "0" ]
+        then
+          echo Parse tree match succeeded.
+        else
+          echo Expected parse tree match.
+          err=1
+          break
+        fi
       fi
     fi
     if [ -f "$file".tree ]
@@ -44,5 +67,5 @@ do
     fi
   fi
 done
-rm "$tree_file"
+rm "$parse_out_file"
 exit $err

--- a/_scripts/templates/Python3/test.sh
+++ b/_scripts/templates/Python3/test.sh
@@ -52,19 +52,6 @@ do
         fi
       fi
     fi
-    if [ -f "$file".tree ]
-    then
-      diff \<(tr -d "\r\n" \< "$file".tree) \<(tr -d "\r\n" \< "$tree_file")
-	  status="$?"
-      if [ "$status" = "0" ]
-      then
-        echo Parse tree match succeeded.
-      else
-        echo Expected parse tree match.
-        err=1
-        break
-      fi
-    fi
   fi
 done
 rm "$parse_out_file"

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -29,7 +29,7 @@ function Test-Case {
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
     $parseOutFile = $InputFile + ".out"
-    $o = trwdog python3 Program.py -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+    $o = trwdog python3 -X utf8 Program.py -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
     $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
     if ($errorFile) {

--- a/_scripts/templates/Python3/tester.psm1
+++ b/_scripts/templates/Python3/tester.psm1
@@ -28,26 +28,36 @@ function Test-Case {
     $oldOutputEncoding = [console]::OutputEncoding
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
-    $treeOutFile = $TreeFile + ".out"
-    $o = trwdog python3 -X utf8 Program.py -file $InputFile -tree | Out-File -LiteralPath "$treeOutFile" -Encoding UTF8
-    $failed = $LASTEXITCODE -ne 0
-    $parseOk = !$failed
-    if ($failed -and $errorFile) {
-        $parseOk = $true
-    }
-    if(!$failed -and !$errorFile){
-        $parseOk = $true
-    }
+    $parseOutFile = $InputFile + ".out"
+    $o = trwdog python3 Program.py -file $InputFile -tree | Out-File -LiteralPath "$parseOutFile" -Encoding UTF8
+    $parseOk = $LASTEXITCODE -eq 0
     $treeMatch = $true
-    if (Test-Path $TreeFile) {
-        $expectedData = Get-Content $TreeFile -Encoding UTF8
-        $actualData = Get-Content $treeOutFile -Encoding UTF8
-        $treeMatch = ($actualData -eq $expectedData)
+    if ($errorFile) {
+        # If we expected errors, then a failed parse was a successful test.
+        if (!$parseOk) {
+            Write-Host "Expected."
+            # Confirm that the errors we received are the ones we expected.
+            $expectedData = (Get-Content $errorFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $actualData = (Get-Content $parseOutFile -Encoding UTF8) -join "" -replace "\r\n",""
+            $parseOk = ($actualData -eq $expectedData)
+            if ($parseOk) {
+                Write-Host "Error list match succeeded."
+            } else {
+                Write-Host "Expected error list match." -ForegroundColor Red
+            }
+        }
+    } else {
+        if ($parseOk -and (Test-Path $TreeFile)) {
+            # Confirm that the parse tree we received is the one we expected.
+            $expectedData = Get-Content $TreeFile -Encoding UTF8
+            $actualData = Get-Content $parseOutFile -Encoding UTF8
+            $treeMatch = ($actualData -eq $expectedData)
+        }
     }
     # Restore input and output character encodings.
     [console]::InputEncoding = $oldInputEncoding
     [console]::OutputEncoding = $oldOutputEncoding
 
-    Remove-Item $treeOutFile
+    Remove-Item $parseOutFile
     return $parseOk, $treeMatch
 }


### PR DESCRIPTION
In [grammars-v4 issue 2821](https://github.com/antlr/grammars-v4/issues/2821), I  wrote:

> I'm experimenting now with making `trgen` verify ... the [`.errors`](https://github.com/RossPatterson/grammars-v4/blob/master/_scripts/templates/Java/test.sh#L16-L32)  reference files, as `antlr4test-maven-plugin` does in [AssertErrorsErrorListener](https://github.com/antlr/antlr4test-maven-plugin/blob/master/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListener.java#L54-L74) ...  I'm interested in the `.errors` capability because it seems like it should be fully supported.

- All the test drivers (_e.g._, `_scripts/*/Program.*`) have been modified to dump out the detected errors to stdout in the expected format, and to only dump the parse tree if there are no errors.  There are currently no cases of an example that has both a `.errors` file and a `.tree` file, and in my opinion, there is no value in being able to check the parse tree if the parse fails.
- All the test scripts (_i.e._, `_scripts/*/test.sh`, `_scripts/*.tester.psm1`) have been modified to check the detected errors against the reference files, and to only check the parse tree if there are no errors.
- The Java test driver has been modified to dump out the errors in UTF-8.  All the other test drivers already did so.
- I have verified that all the grammars that have ".errors" files in their `examples` directory generate all and only those errors.  There was one exception (see below).
- I have run the Go, Dart, Java, and Python3 test targets for all the grammars they support.  They are all functioning correctly.
- I have run the CSharp test target for all the grammars it supports.  It produces an error mismatch for `csharp` example `issue-2612`, as documented in [`antlr4` issue #3700](https://github.com/antlr/antlr4/issues/3700) by @kaby76 on 2022-05-07.  I have added `csharp` to `_scripts/skip-csharp.txt` and `_scripts/skip-csharp.why` until the issue is fixed.  All other grammars function correctly.
- I do not have the setup to test the Antlr4cs, Cpp, Javascript, and PHP targets, and will rely on the CI checks to test those.  The changes were relatively simple, and barring typos, should work.

Fixes #2838.