### PR TITLE
Add extend option

### DIFF
--- a/protobuf3/Protobuf3.g4
+++ b/protobuf3/Protobuf3.g4
@@ -148,6 +148,7 @@ reservedFieldNames
 topLevelDef
   : messageDef
   | enumDef
+  | extendDef
   | serviceDef
   ;
 
@@ -193,12 +194,26 @@ messageElement
   : field
   | enumDef
   | messageDef
+  | extendDef
   | optionStatement
   | oneof
   | mapField
   | reserved
   | emptyStatement_
   ;
+
+// Extend definition
+//
+// NB: not defined in the spec but supported by protoc and covered by protobuf3 tests
+//     see e.g. php/tests/proto/test_import_descriptor_proto.proto
+//     of https://github.com/protocolbuffers/protobuf
+// it also was discussed here: https://github.com/protocolbuffers/protobuf/issues/4610
+
+extendDef
+    :   EXTEND messageType LC ( field
+                                 | emptyStatement_
+                                 )* RC
+    ;
 
 // service
 
@@ -286,6 +301,7 @@ MAX: 'max';
 ENUM: 'enum';
 MESSAGE: 'message';
 SERVICE: 'service';
+EXTEND: 'extend';
 RPC: 'rpc';
 STREAM: 'stream';
 RETURNS: 'returns';
@@ -337,8 +353,8 @@ fragment HEX_DIGIT: [0-9A-Fa-f];
 
 // comments
 WS  :   [ \t\r\n\u000C]+ -> skip;
-LINE_COMMENT: '//' ~[\r\n]* -> skip;
-COMMENT: '/*' .*? '*/' -> skip;
+LINE_COMMENT: '//' ~[\r\n]* -> channel(HIDDEN);
+COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
 
 keywords
   : SYNTAX
@@ -371,6 +387,7 @@ keywords
   | ENUM
   | MESSAGE
   | SERVICE
+  | EXTEND
   | RPC
   | STREAM
   | RETURNS


### PR DESCRIPTION
Extend definition added back as it was omitted in the current grammar.