### PR TITLE
CQL3 grammar fixes

### DIFF
--- a/cql3/CqlParser.g4
+++ b/cql3/CqlParser.g4
@@ -180,7 +180,7 @@ createFunction
    ;
 
 codeBlock
-   : CODE_BLOCK
+   : (CODE_BLOCK | STRING_LITERAL)
    ;
 
 paramList
@@ -642,6 +642,7 @@ expressionList
 
 expression
    : constant
+   | functionCall
    | assignmentMap
    | assignmentSet
    | assignmentList
@@ -722,6 +723,7 @@ relalationContainsKey
 functionCall
    : OBJECT_NAME '(' STAR ')'
    | OBJECT_NAME '(' functionArgs? ')'
+   | K_UUID '(' ')'
    ;
 
 functionArgs
@@ -869,6 +871,7 @@ param
 
 paramName
    : OBJECT_NAME
+   | K_INPUT
    ;
 
 kwAdd

--- a/cql3/CqlParser.g4
+++ b/cql3/CqlParser.g4
@@ -180,7 +180,8 @@ createFunction
    ;
 
 codeBlock
-   : (CODE_BLOCK | STRING_LITERAL)
+   : CODE_BLOCK
+   | STRING_LITERAL
    ;
 
 paramList

--- a/cql3/examples/createFunction.cql
+++ b/cql3/examples/createFunction.cql
@@ -8,3 +8,9 @@ LANGUAGE java AS
      r/= state.getInt(0); 
      return Double.valueOf(r); $$ 
 ;
+
+CREATE OR REPLACE FUNCTION setMin(input set<int>) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS '
+                int min = Integer.MAX_VALUE;
+                for (Object i : input) { min = Math.min(min, (Integer) i); }
+                return min;
+            ';

--- a/cql3/examples/insert.cql
+++ b/cql3/examples/insert.cql
@@ -21,3 +21,5 @@ INSERT INTO "students"("id", "address", "name", "[age]", "age", "colu'mn1", "col
     (740, 'hongkong','alice',null,32,'','',172);
 
 INSERT INTO test(a,b,c,d) values(1,['listtext1','listtext2'],{'settext1','settext2'},{'mapkey1':'mapvale2','mapkey2':'mapvalue2'});
+
+INSERT INTO PERSON (id, name) VALUES (uuid(), 'fullname');


### PR DESCRIPTION
Fixes some specific cases, which were missing in CQL3 grammar

* recognizes `uuid()` function, mentioned in https://docs.datastax.com/en/cql-oss/3.1/cql/cql_reference/timeuuid_functions_r.html
* allows to use functionCall for insert statement value arguments https://stackoverflow.com/questions/17945341/how-to-auto-generate-uuid-in-cassandra-cql-3-command-line/25318309#25318309
* allows to set function code as a string literal, code_block definition from https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlCreateFunction.html
* allows using `input` keyword as a parameter for creating function, like in examples mentioned here https://www.batey.info/cassandra-udfs.html