### PR TITLE
CPP14Parser Grammar File Updated with Else-If

### DIFF
--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -250,6 +250,7 @@ statementSeq: statement+;
 
 selectionStatement:
 	If LeftParen condition RightParen statement (Else statement)?
+    If LeftParen condition RightParen statement ElseIf LeftParen condition RightParen statement (Else statement)?
 	| Switch LeftParen condition RightParen statement;
 
 condition:


### PR DESCRIPTION
The CPP14Parser Grammar File had no rules written for an else-if selection statement.