### PR TITLE
Give the various `expr`s in `select_core` labels.

### DIFF
--- a/sql/sqlite/SQLiteParser.g4
+++ b/sql/sqlite/SQLiteParser.g4
@@ -398,7 +398,10 @@ select_core:
     (
         SELECT_ (DISTINCT_ | ALL_)? result_column (COMMA result_column)* (
             FROM_ (table_or_subquery (COMMA table_or_subquery)* | join_clause)
-        )? (WHERE_ expr)? (GROUP_ BY_ expr (COMMA expr)* (HAVING_ expr)?)? (
+        )? (WHERE_ whereExpr=expr)? (
+          GROUP_ BY_ groupByExpr+=expr (COMMA groupByExpr+=expr)* (
+              HAVING_ havingExpr=expr
+          )?)? (
             WINDOW_ window_name AS_ window_defn (
                 COMMA window_name AS_ window_defn
             )*


### PR DESCRIPTION
In this antlr grammar, `select_core` is a complex grammatical element containing many subpieces. I think it was written this way to mirror the structure of the documentation of `select_core` in [the official SQLite docs](https://www.sqlite.org/syntax/select-core.html). This would be somewhat tricky for a SQLite visitor to read, as the role of the various `expr`s could be ambiguous.

This change adds labels to those `expr`s to allow visitors to quickly see what role each of the `expr`s is playing, reducing the possibility for confusion.