### PR TITLE
Fix build for aql grammar/PHP target.

### DIFF
--- a/_scripts/skip-php.txt
+++ b/_scripts/skip-php.txt
@@ -5,6 +5,7 @@ antlr/antlr2
 antlr/antlr3
 antlr/antlr4
 apex
+aql
 asn/asn_3gpp
 cobol85
 cool


### PR DESCRIPTION
* Added grammar aql to the PHP skip list so that the target is not tested on this grammar. All other targets tested.