### PR TITLE
Partial fix for #3462, agc grammar

### DIFF
--- a/agc/agc.g4
+++ b/agc/agc.g4
@@ -87,31 +87,31 @@ argument
    ;
 
 ws
-   : WS
+   : WS_
    ;
 
 eol
-   : WS? EOL
+   : WS_? EOL_
    ;
 
 comment
-   : COMMENT
+   : COMMENT_
    ;
 
 label
-   : LABEL
+   : LABEL_
    | register_
    | standard_opcode
    | pseudo_opcode
    ;
 
 variable
-   : LABEL
+   : LABEL_
    | register_
    | standard_opcode
    | pseudo_opcode
-   | LPAREN LABEL RPAREN
-   | variable LPAREN LABEL RPAREN
+   | LPAREN LABEL_ RPAREN
+   | variable LPAREN LABEL_ RPAREN
    ;
 
 expression
@@ -131,11 +131,11 @@ atom
    ;
 
 inte
-   : INTE
+   : INTE_
    ;
 
 decimal
-   : (PLUS | MINUS)? DECIMAL
+   : (PLUS | MINUS)? DECIMAL_
    ;
 
 register_
@@ -545,7 +545,7 @@ ZL : 'ZL';
 ZOUT : 'ZOUT';
 ZQ : 'ZQ';
 
-COMMENT
+COMMENT_
    : '#' ~ [\r\n]*
    ;
 
@@ -581,24 +581,24 @@ RPAREN
    : ')'
    ;
 
-EOL
+EOL_
    : [\r\n]+
    ;
 
-LABEL
+LABEL_
    : [a-zA-Z0-9_.+\\\-/*=&]+
    ;
 
-INTE
+INTE_
    : [0-9]+ ('DEC' | 'D')
    ;
 
-DECIMAL
+DECIMAL_
    : ([0-9]+ ('.' [0-9]+)?)
    | ('.' [0-9]+)
    ;
 
-WS
+WS_
    : [ \t]+
    ;
 


### PR DESCRIPTION
This PR changes several symbols in the grammar to allow PHP to work.

PHP tests work although several take 2m. The ATN trace and PT output is the same with C#.

```
#
err=0
SAVEIFS=$IFS
IFS=$(echo -en "\n\b")
for g in `find examples -type f | grep -v '.errors$' | grep -v '.tree$'`
do
  file="$g"
  x1="${g##*.}"
  if [ "$x1" != "errors" ]
  then
    echo "$file"
    pushd Generated-PHP
    php -d memory_limit=1G Test.php -tree -trace "../$file" > o.txt
    dos2unix o.txt
    popd
    pushd Generated-CSharp
    ./bin/Debug/net6.0/Test.exe -tree -trace "../$file" > o.txt
    dos2unix o.txt
    popd
    diff Generated-PHP/o.txt Generated-CSharp/o.txt
  fi
done
```