### PR TITLE
feat: add column aliases, scoped table ref for CREATE MATERIALIZED VIEW in sql/plsql

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -1800,7 +1800,7 @@ create_zonemap_as_subquery
 create_materialized_view
     : CREATE MATERIALIZED VIEW tableview_name
       (OF type_name )?
-//scoped_table_ref and column alias goes here  TODO
+        ( '(' (scoped_table_ref_constraint | mv_column_alias) (',' (scoped_table_ref_constraint | mv_column_alias))* ')' )?
         ( ON PREBUILT TABLE ( (WITH | WITHOUT) REDUCED PRECISION)?
         | physical_properties?  (CACHE | NOCACHE)? parallel_clause? build_clause?
         )
@@ -1812,6 +1812,23 @@ create_materialized_view
         ( (DISABLE | ENABLE) QUERY REWRITE )?
         AS select_only_statement
         ';'
+    ;
+
+scoped_table_ref_constraint
+    : SCOPE FOR '(' ref_column_or_attribute ')' IS 
+        (schema_name '.')? scope_table_name_or_c_alias
+    ;
+
+ref_column_or_attribute
+    : identifier
+    ;
+
+scope_table_name_or_c_alias
+    : identifier
+    ;
+
+mv_column_alias
+    : (identifier | quoted_string) (ENCRYPT encryption_spec)?
     ;
 
 create_mv_refresh

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -1815,16 +1815,7 @@ create_materialized_view
     ;
 
 scoped_table_ref_constraint
-    : SCOPE FOR '(' ref_column_or_attribute ')' IS 
-        (schema_name '.')? scope_table_name_or_c_alias
-    ;
-
-ref_column_or_attribute
-    : identifier
-    ;
-
-scope_table_name_or_c_alias
-    : identifier
+    : SCOPE FOR '(' identifier ')' IS (schema_name '.')? identifier
     ;
 
 mv_column_alias

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -1815,7 +1815,7 @@ create_materialized_view
     ;
 
 scoped_table_ref_constraint
-    : SCOPE FOR '(' identifier ')' IS (schema_name '.')? identifier
+    : SCOPE FOR '(' ref_column_or_attribute=identifier ')' IS (schema_name '.')? scope_table_name_or_c_alias=identifier
     ;
 
 mv_column_alias

--- a/sql/plsql/examples/materialized_views.sql
+++ b/sql/plsql/examples/materialized_views.sql
@@ -79,3 +79,41 @@ CREATE MATERIALIZED VIEW TEST
       SELECT 'A', 'B', 'C'
       FROM DUAL
       JOIN TESTCTE;
+
+-- tests for column aliases
+CREATE MATERIALIZED VIEW sales_mv (year, "prod")
+   BUILD IMMEDIATE
+   REFRESH FAST ON COMMIT
+   AS SELECT t.calendar_year, p.prod_id,
+      SUM(s.amount_sold) AS sum_sales
+      FROM times t, products p, sales s
+      WHERE t.time_id = s.time_id AND p.prod_id = s.prod_id
+      GROUP BY t.calendar_year, p.prod_id;
+
+CREATE MATERIALIZED VIEW sales_mv (year ENCRYPT, prod)
+   BUILD IMMEDIATE
+   REFRESH FAST ON COMMIT
+   AS SELECT t.calendar_year, p.prod_id,
+      SUM(s.amount_sold) AS sum_sales
+      FROM times t, products p, sales s
+      WHERE t.time_id = s.time_id AND p.prod_id = s.prod_id
+      GROUP BY t.calendar_year, p.prod_id;
+
+CREATE MATERIALIZED VIEW sales_mv (year ENCRYPT, prod ENCRYPT USING 'some_algorithm' IDENTIFIED BY pass 'int_algorithm' NO SALT)
+   BUILD IMMEDIATE
+   REFRESH FAST ON COMMIT
+   AS SELECT t.calendar_year, p.prod_id,
+      SUM(s.amount_sold) AS sum_sales
+      FROM times t, products p, sales s
+      WHERE t.time_id = s.time_id AND p.prod_id = s.prod_id
+      GROUP BY t.calendar_year, p.prod_id;
+
+-- tests for scoped table ref constraints
+CREATE MATERIALIZED VIEW sales_mv (year ENCRYPT, prod ENCRYPT, SCOPE FOR (ref_col) IS schema.table_or_alias)
+   BUILD IMMEDIATE
+   REFRESH FAST ON COMMIT
+   AS SELECT t.calendar_year, p.prod_id,
+      SUM(s.amount_sold) AS sum_sales
+      FROM times t, products p, sales s
+      WHERE t.time_id = s.time_id AND p.prod_id = s.prod_id
+      GROUP BY t.calendar_year, p.prod_id;


### PR DESCRIPTION
Option to specify a column alias list and scoped tables reference constraints in the CREATE MATERIALIZED VIEW statement for sql/plsql (was commented as TODO)