### PR TITLE
fortran77: fix gotoStatement

### DIFF
--- a/fortran77/Fortran77Lexer.g4
+++ b/fortran77/Fortran77Lexer.g4
@@ -535,7 +535,7 @@ CTRLREC
 
 
 TO
-   : 'TO'
+   : 'TO' | 'to'
    ;
 
 

--- a/fortran77/Fortran77Parser.g4
+++ b/fortran77/Fortran77Parser.g4
@@ -338,7 +338,7 @@ dataImpliedDoListWhat
    ;
 
 gotoStatement
-   : ((GO | GOTO) to) (unconditionalGoto | computedGoto | assignedGoto)
+   : (GO TO| GOTO) (unconditionalGoto | computedGoto | assignedGoto)
    ;
 
 unconditionalGoto
@@ -881,8 +881,4 @@ logicalConstant
 identifier
    : NAME
    | REAL
-   ;
-
-to
-   : NAME
    ;

--- a/fortran77/examples/goto-example.txt
+++ b/fortran77/examples/goto-example.txt
@@ -6,9 +6,11 @@ c
 
       go to 20
 
-10    write ( *, '(a)' ) '  Hello, world!'
+10    continue
+      write ( *, '(a)' ) '  Hello, world!'
       stop
 
-20    goto 10
+20    continue
+      goto 10
 
       end

--- a/fortran77/examples/goto-example.txt
+++ b/fortran77/examples/goto-example.txt
@@ -1,0 +1,14 @@
+      program main
+
+c*********************************************************************72
+c 
+      implicit none
+
+      go to 20
+
+10    write ( *, '(a)' ) '  Hello, world!'
+      stop
+
+20    goto 10
+
+      end


### PR DESCRIPTION
The gotoStatement should accept "GO TO" and "GOTO".