### PR TITLE
[C#] Avoid member accesses being parsed as `type_` when followed by `unary_expressions`.

### DIFF
--- a/csharp/CSharpParser.g4
+++ b/csharp/CSharpParser.g4
@@ -16,7 +16,7 @@ compilation_unit
 
 //B.2.1 Basic concepts
 
-namespace_or_type_name 
+namespace_or_type_name
 	: (identifier type_argument_list? | qualified_alias_member) ('.' identifier type_argument_list?)*
 	;
 
@@ -40,18 +40,18 @@ tuple_element
     : type_ identifier?
     ;
 
-simple_type 
+simple_type
 	: numeric_type
 	| BOOL
 	;
 
-numeric_type 
+numeric_type
 	: integral_type
 	| floating_point_type
 	| DECIMAL
 	;
 
-integral_type 
+integral_type
 	: SBYTE
 	| BYTE
 	| SHORT
@@ -63,30 +63,33 @@ integral_type
 	| CHAR
 	;
 
-floating_point_type 
+floating_point_type
 	: FLOAT
 	| DOUBLE
 	;
 
 /** namespace_or_type_name, OBJECT, STRING */
-class_type 
+class_type
 	: namespace_or_type_name
 	| OBJECT
 	| DYNAMIC
 	| STRING
 	;
 
-type_argument_list 
+type_argument_list
 	: '<' type_ ( ',' type_)* '>'
 	;
 
 //B.2.4 Expressions
-argument_list 
+argument_list
 	: argument ( ',' argument)*
 	;
 
 argument
-	: (identifier ':')? refout=(REF | OUT | IN)? (VAR | type_)? expression
+	: (identifier ':')? refout=(REF | OUT | IN)?
+	  ( expression
+	  | (VAR | type_) expression
+	  )
 	;
 
 expression
@@ -427,7 +430,7 @@ local_function_body
     ;
 
 labeled_Statement
-	: identifier ':' statement  
+	: identifier ':' statement
 	;
 
 embedded_statement
@@ -477,7 +480,7 @@ local_variable_declaration
 	| FIXED pointer_type fixed_pointer_declarators
 	;
 
-local_variable_type 
+local_variable_type
 	: VAR
 	| type_
 	;


### PR DESCRIPTION
Fixes `C#` parser to prevent member accesses being parsed as `type_` sub-productions when followed by `unary_expressions`. This is achieved by ensuring that `expression` productions have precedence over `type_` productions.


For example in the following derivation:
```csharp
public class ClassName {
    Constructor MethodName(Object a, String b, int c) {
        return new Constructor(field, a.b, a.b + c.d, e.f.g + h);
    }
}
```
sub-derivation `a.b + c.d` is now parsed as:
```
...argument...additive_expression(
    multiplicative_expression...(...a, member_access('.', ...b)),
    '+',
    multiplicative_expression...(...a, ...member_access('.', ...b)),
 )
```

instead of:
```
...argument(
    _type...(a, '.', b),
    ...expression...(
        ...'+', 
        ...primary_expression(
            ...a,
            ...member_access('.', ...b)
        )
    )
```

A similar argument can be made for sub-production `a.f.g + h`, which is now parsed as an `additive_epression` of instead of a `_type(e.f.g), unary_expression('+', '+ h')`.