### PR TITLE
Fix XML function chain call grammar

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -4218,21 +4218,21 @@ other_function
     | TRANSLATE '(' expression (USING (CHAR_CS | NCHAR_CS))? (',' expression)* ')'
     | TREAT '(' expression AS REF? type_spec ')'
     | TRIM '(' ((LEADING | TRAILING | BOTH)? quoted_string? FROM)? concatenation ')'
-    | XMLAGG '(' expression order_by_clause? ')' ('.' general_element_part)?
+    | XMLAGG '(' expression order_by_clause? ')' ('.' general_element_part)*
     | (XMLCOLATTVAL | XMLFOREST)
-      '(' xml_multiuse_expression_element (',' xml_multiuse_expression_element)* ')' ('.' general_element_part)?
+      '(' xml_multiuse_expression_element (',' xml_multiuse_expression_element)* ')' ('.' general_element_part)*
     | XMLELEMENT
       '(' (ENTITYESCAPING | NOENTITYESCAPING)? (NAME | EVALNAME)? expression
        (/*TODO{input.LT(2).getText().equalsIgnoreCase("xmlattributes")}?*/ ',' xml_attributes_clause)?
-       (',' expression column_alias?)* ')' ('.' general_element_part)?
+       (',' expression column_alias?)* ')' ('.' general_element_part)*
     | XMLEXISTS '(' expression xml_passing_clause? ')'
-    | XMLPARSE '(' (DOCUMENT | CONTENT) concatenation WELLFORMED? ')' ('.' general_element_part)?
+    | XMLPARSE '(' (DOCUMENT | CONTENT) concatenation WELLFORMED? ')' ('.' general_element_part)*
     | XMLPI
-      '(' (NAME identifier | EVALNAME concatenation) (',' concatenation)? ')' ('.' general_element_part)?
+      '(' (NAME identifier | EVALNAME concatenation) (',' concatenation)? ')' ('.' general_element_part)*
     | XMLQUERY
-      '(' concatenation xml_passing_clause? RETURNING CONTENT (NULL_ ON EMPTY)? ')' ('.' general_element_part)?
+      '(' concatenation xml_passing_clause? RETURNING CONTENT (NULL_ ON EMPTY)? ')' ('.' general_element_part)*
     | XMLROOT
-      '(' concatenation (',' xmlroot_param_version_part)? (',' xmlroot_param_standalone_part)? ')' ('.' general_element_part)?
+      '(' concatenation (',' xmlroot_param_version_part)? (',' xmlroot_param_standalone_part)? ')' ('.' general_element_part)*
     | XMLSERIALIZE
       '(' (DOCUMENT | CONTENT) concatenation (AS type_spec)?
       xmlserialize_param_enconding_part? xmlserialize_param_version_part? xmlserialize_param_ident_part? ((HIDE | SHOW) DEFAULTS)? ')'

--- a/sql/plsql/examples/xml_function.sql
+++ b/sql/plsql/examples/xml_function.sql
@@ -1,0 +1,43 @@
+SELECT
+    XMLAGG(XMLELEMENT(X,first_name, ',')
+        ORDER BY FIRST_NAME).extract('//text()').getClobVal() AS "NAMES"
+FROM STUDENTS;
+
+SELECT
+    XMLCOLATTVAL(first_name,first_name, first_name).extract('//text()').getClobVal()
+FROM STUDENTS;
+
+SELECT
+    XMLFOREST(first_name,first_name, first_name).extract('//text()').getClobVal()
+FROM STUDENTS;
+
+SELECT
+    XMLELEMENT(TEST,first_name , ',').extract('//text()').getClobVal()
+FROM STUDENTS;
+
+SELECT XMLPARSE(CONTENT '124 <purchaseOrder poNo="12435">
+   <customerName> Acme Enterprises</customerName>
+   <itemNo>32987457</itemNo>
+   </purchaseOrder>'
+WELLFORMED).extract('//text()').getClobVal() AS PO FROM DUAL;
+
+SELECT XMLPI(NAME "Order analysisComp", 'imported, reconfigured, disassembled').extract('//text()').getClobVal()
+           AS "XMLPI" FROM DUAL;
+
+SELECT warehouse_name,
+       EXTRACTVALUE(warehouse_spec, '/Warehouse/Area'),
+       XMLQuery(
+               'for $i in /Warehouse
+               where $i/Area > 50000
+               return <Details>
+                         <Docks num="{$i/Docks}"/>
+                         <Rail>
+                           {
+                           if ($i/RailAccess = "Y") then "true" else "false"
+                           }
+                         </Rail>
+                      </Details>' PASSING warehouse_spec RETURNING CONTENT).extract('//text()').getClobVal() "Big_warehouses"
+FROM warehouses;
+
+SELECT XMLROOT ( XMLType('<poid>143598</poid>'), VERSION '1.0', STANDALONE YES).extract('//text()').getClobVal()
+           AS "XMLROOT" FROM DUAL;


### PR DESCRIPTION
XML functions may have more than one chain calls.
An example is as follows:
```sql
SELECT
    XMLELEMENT(TEST,first_name , ',').extract('//text()').getClobVal()
FROM STUDENTS;
```
There are two chain calls in the statement. so I changed '?' to '*' to support  chain calls.