### PR TITLE
[PromQL] Support trailing commas in labelMatcherList

### DIFF
--- a/promql/PromQLParser.g4
+++ b/promql/PromQLParser.g4
@@ -83,7 +83,7 @@ instantSelector
 
 labelMatcher:         labelName labelMatcherOperator STRING;
 labelMatcherOperator: EQ | NE | RE | NRE;
-labelMatcherList:     labelMatcher (COMMA labelMatcher)*;
+labelMatcherList:     labelMatcher (COMMA labelMatcher)* COMMA?;
 
 matrixSelector: instantSelector TIME_RANGE;
 

--- a/promql/examples/label_matcher_list_trailing_comma.txt
+++ b/promql/examples/label_matcher_list_trailing_comma.txt
@@ -1,0 +1,1 @@
+important_metric{name="testing",service="cassandra", comma="trailing",} > 100000


### PR DESCRIPTION
The Prometheus parser supports trailing commas in this case so support in ANTLR also.