### PR TITLE
[TSql] Simplify grammar

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -2869,17 +2869,8 @@ execute_body_batch
 
 //https://docs.microsoft.com/it-it/sql/t-sql/language-elements/execute-transact-sql?view=sql-server-ver15
 execute_body
-    : (return_status=LOCAL_ID '=')? (database_engine_stored_procedures | func_proc_name_server_database_schema | execute_var_string)  execute_statement_arg?
+    : (return_status=LOCAL_ID '=')? (func_proc_name_server_database_schema | execute_var_string)  execute_statement_arg?
     | '(' execute_var_string (',' execute_var_string)* ')' (AS? (LOGIN | USER) '=' STRING)? (AT_KEYWORD linkedServer=id_)?
-    ;
-
-// https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/database-engine-stored-procedures-transact-sql?view=sql-server-ver16
-database_engine_stored_procedures
-    : (server=id_ '.')? (database=id_ '.')? (schema=id_ '.')? procedure=database_engine_stored_procedures_names
-    ;
-
-database_engine_stored_procedures_names
-    : SP_EXECUTESQL
     ;
 
 execute_statement_arg

--- a/sql/tsql/examples/database_engine_stored_procedures.sql
+++ b/sql/tsql/examples/database_engine_stored_procedures.sql
@@ -19,3 +19,18 @@ EXECUTE sp_executesql @SQLString, @ParmDefinition,
                       @BusinessEntityID = @IntVariable;
 
 GO
+
+DECLARE @IntVariable INT;
+DECLARE @SQLString NVARCHAR(500);
+DECLARE @ParmDefinition NVARCHAR(500);
+DECLARE @max_title VARCHAR(30);
+
+SET @IntVariable = 197;
+SET @SQLString = N'SELECT @max_titleOUT = max(JobTitle)
+   FROM AdventureWorks2012.HumanResources.Employee
+   WHERE BusinessEntityID = @level';
+SET @ParmDefinition = N'@level TINYINT, @max_titleOUT VARCHAR(30) OUTPUT';
+
+EXECUTE sp_executesql @SQLString, @ParmDefinition, @level = @IntVariable, @max_titleOUT=@max_title OUTPUT;
+SELECT @max_title;
+GO


### PR DESCRIPTION
Database engine store procedures and in particular sp_executesql are just like regular store procedures and do not need to be parsed differently. Fix redundancy in grammar.