### PR TITLE
add LSHIFT, RSHIFT, and URSHIFT

### DIFF
--- a/java/java8/Java8Lexer.g4
+++ b/java/java8/Java8Lexer.g4
@@ -426,6 +426,9 @@ BITAND : '&';
 BITOR : '|';
 CARET : '^';
 MOD : '%';
+LSHIFT : '<<';
+RSHIFT : '>>';
+URSHIFT : '>>>';
 ARROW : '->';
 COLONCOLON : '::';
 

--- a/java/java8/Java8Parser.g4
+++ b/java/java8/Java8Parser.g4
@@ -1268,9 +1268,9 @@ relationalExpression
 
 shiftExpression
 	:	additiveExpression
-	|	shiftExpression '<' '<' additiveExpression
-	|	shiftExpression '>' '>' additiveExpression
-	|	shiftExpression '>' '>' '>' additiveExpression
+	|	shiftExpression '<<' additiveExpression
+	|	shiftExpression '>>' additiveExpression
+	|	shiftExpression '>>>' additiveExpression
 	;
 
 additiveExpression


### PR DESCRIPTION
Hi! I created this pull request because when I am using the Lexer generated by Java8Lexer.g4, shift operations are not correctly tokenized in my opinion (for example, '>>' is tokenized as two '>'). But I might be wrong because it seems you do this deliberately. I'd like to hear your opinions anyway.