### PR TITLE
[Tsql] Fix grammar for alter_service

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -1569,7 +1569,11 @@ alter_server_role_pdw
 
 // https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-service-transact-sql
 alter_service
-    : ALTER SERVICE modified_service_name=id_ (ON QUEUE (schema_name=id_ DOT)? queue_name=id_)?  ('(' (COMMA? (ADD|DROP) CONTRACT modified_contract_name=id_)* ')')?
+    : ALTER SERVICE modified_service_name=id_ (ON QUEUE (schema_name=id_ DOT)? queue_name=id_)?  ('(' opt_arg_clause (COMMA opt_arg_clause)* ')')?
+    ;
+
+opt_arg_clause
+    : (ADD|DROP) CONTRACT modified_contract_name=id_
     ;
 
 // https://docs.microsoft.com/en-us/sql/t-sql/statements/create-service-transact-sql

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -1569,7 +1569,7 @@ alter_server_role_pdw
 
 // https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-service-transact-sql
 alter_service
-    : ALTER SERVICE modified_service_name=id_ (ON QUEUE (schema_name=id_ DOT) queue_name=id_)? (COMMA? (ADD|DROP) modified_contract_name=id_)*
+    : ALTER SERVICE modified_service_name=id_ (ON QUEUE (schema_name=id_ DOT)? queue_name=id_)?  ('(' (COMMA? (ADD|DROP) CONTRACT modified_contract_name=id_)* ')')?
     ;
 
 // https://docs.microsoft.com/en-us/sql/t-sql/statements/create-service-transact-sql

--- a/sql/tsql/examples/ddl_alter_service.sql
+++ b/sql/tsql/examples/ddl_alter_service.sql
@@ -1,0 +1,9 @@
+ALTER SERVICE [//Adventure-Works.com/Expenses]  
+    ON QUEUE NewQueue ;
+    
+ALTER SERVICE [//Adventure-Works.com/Expenses]  
+    (ADD CONTRACT [//Adventure-Works.com/Expenses/ExpenseSubmission]) ;
+    
+ALTER SERVICE [//Adventure-Works.com/Expenses]  
+    (ADD CONTRACT [//Adventure-Works.com/Expenses/ExpenseProcessing],   
+     DROP CONTRACT [//Adventure-Works.com/Expenses/ExpenseSubmission]) ;


### PR DESCRIPTION
Add parentheses and keyword 'CONTRACT'.

Syntax from the documentation:
```
ALTER SERVICE service_name   
   [ ON QUEUE [ schema_name . ]queue_name ]   
   [ ( < opt_arg > [ , ...n ] ) ]  
[ ; ]  
  
<opt_arg> ::=  
   ADD CONTRACT contract_name | DROP CONTRACT contract_name
```