### PR TITLE
Apex 4

### DIFF
--- a/apex/apex.g4
+++ b/apex/apex.g4
@@ -338,7 +338,7 @@ annotation
 annotationName : qualifiedName ;
 
 elementValuePairs
-    :   elementValuePair (',' elementValuePair)*
+    :   elementValuePair (','? elementValuePair)*
     ;
 
 elementValuePair

--- a/apex/examples/ExampleInvocableMethod.cls
+++ b/apex/examples/ExampleInvocableMethod.cls
@@ -1,0 +1,11 @@
+public class ExampleInvocableMethod {
+    @InvocableMethod(label='Get Account Names' description='Returns the list of account names corresponding to the specified account IDs.' category='Account')
+    public static List<String> getAccountNames(List<ID> ids) {
+      List<String> accountNames = new List<String>();
+      List<Account> accounts = [SELECT Name FROM Account WHERE Id in :ids];
+      for (Account account : accounts) {
+        accountNames.add(account.Name);
+      }
+      return accountNames;
+    }
+  }


### PR DESCRIPTION
The `@InvocableMethod` annotation allows a list of parameters separated by space (no comma required). To account for that scenario, a coma in `elementValuePair`, consumed by the annotation rule, was made optional. Appropriate example called ExampleInvocableMethod has been uploaded as well.