### PR TITLE
[MariaDB] Add support for Table Value Constructors

### DIFF
--- a/sql/mariadb/MariaDBParser.g4
+++ b/sql/mariadb/MariaDBParser.g4
@@ -70,7 +70,7 @@ dmlStatement
     : selectStatement | insertStatement | updateStatement
     | deleteStatement | replaceStatement | callStatement
     | loadDataStatement | loadXmlStatement | doStatement
-    | handlerStatement
+    | handlerStatement | valuesStatement
     ;
 
 transactionStatement
@@ -942,6 +942,13 @@ selectStatement
 
 updateStatement
     : singleUpdateStatement | multipleUpdateStatement
+    ;
+
+// https://mariadb.com/kb/en/table-value-constructors/
+valuesStatement
+    : VALUES
+    '(' expressionsWithDefaults? ')'
+    (',' '(' expressionsWithDefaults? ')')*
     ;
 
 // details

--- a/sql/mariadb/examples/ddl_create.sql
+++ b/sql/mariadb/examples/ddl_create.sql
@@ -304,7 +304,7 @@ create or replace trigger trg_my1 before delete on test.t1 for each row begin in
 create or replace view my_view1 as select 1 union select 2 limit 0,5;
 create algorithm = merge view my_view2(col1, col2) as select * from t2 with check option;
 create or replace definer = 'ivan'@'%' view my_view3 as select count(*) from t3;
-create or replace definer = current_user sql security invoker view my_view4(c1, 1c, _, c1_2) 
+create or replace definer = current_user sql security invoker view my_view4(c1, 1c, _, c1_2)
 	as select * from  (t1 as tt1, t2 as tt2) inner join t1 on t1.col1 = tt1.col1;
 create view v_some_table as (with a as (select * from some_table) select * from a);
 
@@ -613,4 +613,13 @@ CREATE SEQUENCE `seq_8b4d1cdf-377e-4021-aef3-f7c9846903fc` INCREMENT BY 1 START 
 -- From MariaDB 10.1.2, pre-query variables are supported
 -- src: https://mariadb.com/kb/en/set-statement/
 SET STATEMENT max_statement_time=60 FOR CREATE TABLE some_table (val int);
+#end
+
+#begin
+CREATE OR REPLACE VIEW view_name AS
+WITH my_values(val1, val2) AS (
+    VALUES (1, 'One'),
+           (2, 'Two')
+)
+SELECT v.val1, v.val2 FROM my_values v;
 #end


### PR DESCRIPTION
```
MariaDB [test]> CREATE OR REPLACE VIEW view_name AS
    -> WITH my_values(val1, val2) AS (
    ->     VALUES (1, 'One'),
    ->            (2, 'Two')
    -> )
    -> SELECT v.val1, v.val2 FROM my_values v;
Query OK, 0 rows affected (0.008 sec)

MariaDB [test]> SELECT * FROM view_name;
+------+------+
| val1 | val2 |
+------+------+
|    1 | One  |
|    2 | Two  |
+------+------+
2 rows in set (0.002 sec)
```