### PR TITLE
Move ':' to COLON

### DIFF
--- a/pascal/pascal.g4
+++ b/pascal/pascal.g4
@@ -401,7 +401,7 @@ actualParameter
    ;
 
 parameterwidth
-   : ':' expression
+   : COLON expression
    ;
 
 gotoStatement


### PR DESCRIPTION
It makes sense when you want to separate the lexer and parser rules.