### PR TITLE
[MariaDB] Add variant of ALTER TABLE ADD UNIQUE IF NOT EXISTS

### DIFF
--- a/sql/mariadb/MariaDBParser.g4
+++ b/sql/mariadb/MariaDBParser.g4
@@ -679,7 +679,7 @@ alterSpecification
       indexColumnNames indexOption*                                 #alterByAddIndex
     | ADD (CONSTRAINT name=uid?)? PRIMARY KEY index=uid?
       indexType? indexColumnNames indexOption*                      #alterByAddPrimaryKey
-    | ADD (CONSTRAINT name=uid?)? UNIQUE
+    | ADD (CONSTRAINT name=uid?)? UNIQUE ifNotExists?
       indexFormat=(INDEX | KEY)? indexName=uid?
       indexType? indexColumnNames indexOption*                      #alterByAddUniqueKey
     | ADD keyType=(FULLTEXT | SPATIAL)

--- a/sql/mariadb/examples/ddl_alter.sql
+++ b/sql/mariadb/examples/ddl_alter.sql
@@ -44,6 +44,7 @@ alter table add_test drop foreign key if exists fk;
 alter table add_test drop constraint if exists cons;
 alter table add_test wait 100 add column col1 int not null;
 alter table default.task add column xxxx varchar(200) comment 'cdc test';
+alter table `some_table` add unique if not exists `id_unique` (`id`)
 #end
 #begin
 -- Alter database
@@ -91,7 +92,7 @@ alter tablespace tblsp_2 drop datafile 'deletedfilename' wait engine ndb;
 alter view my_view1 as select 1 union select 2 limit 0,5;
 alter algorithm = merge view my_view2(col1, col2) as select * from t2 with check option;
 alter definer = 'ivan'@'%' view my_view3 as select count(*) from t3;
-alter definer = current_user sql security invoker view my_view4(c1, 1c, _, c1_2) 
+alter definer = current_user sql security invoker view my_view4(c1, 1c, _, c1_2)
 	as select * from  (t1 as tt1, t2 as tt2) inner join t1 on t1.col1 = tt1.col1;
 #end
 #begin


### PR DESCRIPTION
While this syntax isn't covered by the documentation of MariaDB, the SQL parser accepts the following query and performs the intended action:

```sql
ALTER TABLE `some_table` ADD UNIQUE IF NOT EXISTS `id_unique` (`id`)
```

Example:
```
MariaDB [test]> DESCRIBE some_table;
+-------+---------+------+-----+---------+-------+
| Field | Type    | Null | Key | Default | Extra |
+-------+---------+------+-----+---------+-------+
| id    | int(11) | YES  |     | NULL    |       |
+-------+---------+------+-----+---------+-------+
1 row in set (0.002 sec)

MariaDB [test]> alter table `some_table` add unique if not exists `id_unique` (`id`)
Query OK, 0 rows affected (0.022 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [test]> DESCRIBE some_table;
+-------+---------+------+-----+---------+-------+
| Field | Type    | Null | Key | Default | Extra |
+-------+---------+------+-----+---------+-------+
| id    | int(11) | YES  | UNI | NULL    |       |
+-------+---------+------+-----+---------+-------+
1 row in set (0.012 sec)
```

Funny enough, MySQL 8.x does _NOT_ accept the DDL statement:

```
mysql> DESCRIBE `some_table`;
+-------+------+------+-----+---------+-------+
| Field | Type | Null | Key | Default | Extra |
+-------+------+------+-----+---------+-------+
| id    | int  | YES  |     | NULL    |       |
+-------+------+------+-----+---------+-------+
1 row in set (0.02 sec)

mysql> alter table `some_table` add unique if not exists `id_unique` (`id`)
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'if not exists `id_unique` (`id`), ALGORITHM=INPLACE, LOCK=NONE' at line 1
```

https://mariadb.com/kb/en/alter-table/