### PR TITLE
[Tsql] Fix grammar for foreign_key_options

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3639,8 +3639,7 @@ primary_key_options
 foreign_key_options
     :
         REFERENCES table_name '(' pk = column_name_list')'
-        on_delete?
-        on_update?
+        (on_delete | on_update)*
         (NOT FOR REPLICATION)?
     ;
 

--- a/sql/tsql/examples/ddl_alter_table.sql
+++ b/sql/tsql/examples/ddl_alter_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_order_item 
+    ADD PRIMARY KEY (order_id), FOREIGN KEY (order_id) REFERENCES t_order (order_id) 
+    ON UPDATE CASCADE ON DELETE CASCADE ;


### PR DESCRIPTION
Previous syntax does not match the follow statement:
```sql
ALTER TABLE t_order_item ADD PRIMARY KEY (order_id), FOREIGN KEY (order_id) REFERENCES t_order (order_id) ON UPDATE CASCADE  ON DELETE CASCADE
```

**ON UPDATE CASCADE**  and  **ON DELETE CASCADE**  When they appear at the same time, the order is irrelevant