### PR TITLE
snowflake: Remove `PUBLIC` as a keyword

### DIFF
--- a/sql/snowflake/SnowflakeLexer.g4
+++ b/sql/snowflake/SnowflakeLexer.g4
@@ -636,7 +636,6 @@ PROFILE:                                               'PROFILE';
 PROPERTY:                                              'PROPERTY';
 PROVIDER:                                              'PROVIDER';
 PROVIDER_KEY_NAME:                                     'PROVIDER_KEY_NAME';
-PUBLIC:                                                'PUBLIC';
 PURGE:                                                 'PURGE';
 PUT:                                                   'PUT';
 PYTHON:                                                'PYTHON';

--- a/sql/snowflake/examples/call.sql
+++ b/sql/snowflake/examples/call.sql
@@ -1,0 +1,1 @@
+CALL public.some_store_procedure('some input');

--- a/sql/snowflake/examples/call.sql
+++ b/sql/snowflake/examples/call.sql
@@ -1,1 +1,2 @@
-CALL public.some_store_procedure('some input');
+call my_stored_proc(arg_1);
+call public.some_store_procedure('some input');

--- a/sql/snowflake/examples/other.sql
+++ b/sql/snowflake/examples/other.sql
@@ -22,4 +22,3 @@ truncate materialized view v;
 truncate table t;
 unset i;
 unset (i,j,k);
-call my_stored_proc(arg_1);


### PR DESCRIPTION
As far as I can tell, `PUBLIC` is not actually a keyword.

The reason I wanted to remove this is because we use a schema called `public`. This messes with the parsing of `public` as an identifier (`ID_`).