### PR TITLE
Fix for #3103 -- change in ocl/examples didn't kick off correct build…

### DIFF
--- a/_scripts/templates/JavaScript/package.json
+++ b/_scripts/templates/JavaScript/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "^4.11.0",
+    "antlr4": "4.11.0",
     "fs-extra": "^11.1.0",
     "timer-node": "^5.0.6",
     "typescript-string-operations": "^1.4.1"

--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -220,9 +220,25 @@ then
     then
         grammars=()
         # Test grammars for the enclosing directories.
-        directories=`git diff --name-only ${additional[0]} ${additional[1]} 2> /dev/null | sed 's#\(.*\)[/][^/]*$#\1#' | sort -u | grep -v _scripts`
+        directories=`git diff --name-only ${additional[0]} ${additional[1]} . 2> /dev/null | sed 's#\(.*\)[/][^/]*$#\1#' | sort -u | grep -v _scripts`
         for g in $directories
         do
+            pushd $g
+            echo here
+            while true
+            do
+                if [ -f `pwd`/desc.xml ]
+                then
+                break
+                elif [ `pwd` == "$prefix" ]
+                then
+                break
+                fi
+                cd ..
+            done
+            g=`pwd`
+            g=${g##*$prefix/}
+            popd
             echo Adding diff $g
             grammars+=( $g )
         done

--- a/ocl/desc.xml
+++ b/ocl/desc.xml
@@ -1,3 +1,3 @@
 <desc>
-   <targets></targets>
+   <targets>Java</targets>
 </desc>

--- a/ocl/pom.xml
+++ b/ocl/pom.xml
@@ -36,7 +36,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>compilationUnit</entryPoint>
+					<entryPoint>specification</entryPoint>
 					<grammarName>OCL</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>


### PR DESCRIPTION
* Fix to _scripts/test.sh to detect change in ocl/examples/..., then go up the directory to select the grammar to test. Currently, it didn't go up the directory tree and just said "ocl/examples" changed. That's true, but that's not strictly where to find the grammar "ocl"!
* The pom.xml start symbol is wrong; it's not "compilationUnit"!!
* When I ran my script to set up "desc.xml", no targets worked (yes, that's because the start symbol was wrong!). I now set Java as a default target to test.

Fix start symbol and target for ocl grammar.