### PR TITLE
Fix for #3123: sort and unique the list of grammars to test

### DIFF
--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -229,10 +229,10 @@ then
             do
                 if [ -f `pwd`/desc.xml ]
                 then
-                break
+                    break
                 elif [ `pwd` == "$prefix" ]
                 then
-                break
+                    break
                 fi
                 cd ..
             done
@@ -267,30 +267,9 @@ then
     exit 1
 fi
 
-if [ "${#grammars[@]}" -eq 0 ]
-then
-    grammars=( "." )
-fi
-new_grammars=()
-for d in ${grammars[@]}
-do
-    if [ ! -d "$prefix/$d" ]
-    then
-        continue
-    fi
-    desc=`find "$prefix/$d" -name desc.xml`
-    for i in $desc
-    do
-        if [ "$i" == "desc.xml" ]; then i='.'; fi
-        directory=${i%/*}
-        pushd $directory > /dev/null
-        directory=${directory##*$prefix/}
-        testname=$directory
-        new_grammars+=( "$testname" )
-        popd > /dev/null
-    done
-done
-grammars=("${new_grammars[@]}")
+echo "Number of grammars before sorting and making unique: ${#grammars[@]}"
+grammars=($(echo "${grammars[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+echo "Number of grammars after sorting and making unique: ${#grammars[@]}"
 
 if [ "${#grammars[@]}" -eq 0 ]
 then


### PR DESCRIPTION
This PR fixes a minor problem with the builds using the Bash script [test.sh](https://github.com/antlr/grammars-v4/blob/8b00eaf4b4eab17bfe5493e96260ee89b6f05efa/_scripts/test.sh), where the array of strings [grammars](https://github.com/antlr/grammars-v4/blob/8b00eaf4b4eab17bfe5493e96260ee89b6f05efa/_scripts/test.sh#L88) contained the same grammar twice. https://github.com/antlr/grammars-v4/issues/3123. This should not happen because it is a waste of resources, and slows the build down because the grammar is tested more than once. The Powershell code [already checks for this](https://github.com/antlr/grammars-v4/blob/8b00eaf4b4eab17bfe5493e96260ee89b6f05efa/_scripts/test.ps1#L181).