### PR TITLE
with sql parser

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -68,7 +68,7 @@ dmlStatement
     : selectStatement | insertStatement | updateStatement
     | deleteStatement | replaceStatement | callStatement
     | loadDataStatement | loadXmlStatement | doStatement
-    | handlerStatement | valuesStatement
+    | handlerStatement | valuesStatement | withStatement
     ;
 
 transactionStatement
@@ -2023,6 +2023,10 @@ signalConditionInformation
           | CURSOR_NAME
         ) '=' ( stringLiteral | DECIMAL_LITERAL | mysqlVariable | simpleId )
     ;
+
+withStatement
+  : 'WITH' commonTableExpressions (',' commonTableExpressions)*
+  ;
 
 diagnosticsStatement
     : GET ( CURRENT | STACKED )? DIAGNOSTICS (

--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -2025,7 +2025,7 @@ signalConditionInformation
     ;
 
 withStatement
-  : 'WITH' commonTableExpressions (',' commonTableExpressions)*
+  : WITH commonTableExpressions (',' commonTableExpressions)*
   ;
 
 diagnosticsStatement

--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -2025,7 +2025,7 @@ signalConditionInformation
     ;
 
 withStatement
-  : WITH commonTableExpressions (',' commonTableExpressions)*
+  : WITH RECURSIVE? commonTableExpressions (',' commonTableExpressions)*
   ;
 
 diagnosticsStatement

--- a/sql/mysql/Positive-Technologies/examples/dml_with.sql
+++ b/sql/mysql/Positive-Technologies/examples/dml_with.sql
@@ -1,0 +1,42 @@
+#begin
+-- Recursive CTE
+WITH RECURSIVE cte (n) AS (
+  SELECT 1
+  UNION ALL
+  SELECT n + 1 FROM cte WHERE n < 10
+)
+SELECT n FROM cte;
+
+WITH RECURSIVE cte AS (
+  SELECT id, name, manager_id
+  FROM employees
+  WHERE id = 1 
+  UNION ALL
+  SELECT e.id, e.name, e.manager_id
+  FROM employees e
+  JOIN cte ON e.manager_id = cte.id
+)
+SELECT * FROM cte;
+
+WITH RECURSIVE cte AS (
+  SELECT id, name, parent_id
+  FROM departments
+  WHERE id = 1
+  UNION ALL
+  SELECT d.id, d.name, d.parent_id
+  FROM departments d
+  JOIN cte ON d.parent_id = cte.id
+)
+SELECT * FROM cte;
+#end
+#begin
+--Non-recursive Ctes
+WITH cte1 AS (
+  SELECT * FROM table1 WHERE col1 = 'value'
+),
+cte2 AS (
+  SELECT * FROM table2 WHERE col2 = 'value'
+)
+SELECT cte1.col1, cte2.col2 FROM cte1 JOIN cte2 ON cte1.id = cte2.id;
+#end
+


### PR DESCRIPTION
Common Table Expression (CTE) was introduced in MySQL 5.7 WITH the WITH statement to support the syntax of CTE. CTE is a general syntax used to improve the readability, maintainability, and reuse of SQL statements. It can define one or more expressions using simple syntax and use them to build more complex expressions into the query, making the query easier to understand and debug. In this sense, Ctes are important for data integration in MySQL 5.7.