### PR TITLE
[Typescript grammer] re-arrange class decorations and declaration grammer entries

### DIFF
--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -338,7 +338,6 @@ statement
     | exportStatement
     | emptyStatement_
     | abstractDeclaration //ADDED
-    | decoratorList
     | classDeclaration
     | interfaceDeclaration //ADDED
     | namespaceDeclaration //ADDED
@@ -505,7 +504,7 @@ functionDeclaration
 
 //Ovveride ECMA
 classDeclaration
-    : Abstract? Class Identifier typeParameters? classHeritage classTail
+    : decoratorList? (Export | Export Default)? Abstract? Class Identifier typeParameters? classHeritage classTail
     ;
 
 classHeritage
@@ -658,7 +657,6 @@ functionExpressionDeclaration
 singleExpression
     : functionExpressionDeclaration                                          # FunctionExpression
     | arrowFunctionDeclaration                                               # ArrowFunctionExpression   // ECMAScript 6
-    | Class Identifier? classTail                                            # ClassExpression
     | singleExpression '[' expressionSequence ']'                            # MemberIndexExpression
     | singleExpression '!'? '.' identifierName nestedTypeGeneric?            # MemberDotExpression
     // Split to try `new Date()` first, then `new Date`.

--- a/javascript/typescript/examples/Class.ts
+++ b/javascript/typescript/examples/Class.ts
@@ -39,3 +39,21 @@ class Employee extends Person {
 }
 
 let emp = new Employee(100,"Steve");
+
+import {Controller, Get, Post} from '@nestjs/common';
+
+export class NotController {
+    @Post()
+    notControllerPost(body) {
+        return 'This is not an api method';
+    }
+}
+
+export default class CustomerModel {
+    constructor(data) {
+        this.cardAccountId = data.cardAccountId;
+        this.accountHolderId = data.accountHolderId;
+        this.firstName = data.firstName;
+        this.lastName = data.lastName;
+    }
+}


### PR DESCRIPTION
This should fix 3 main issues: 
 - a class with which had both `export` in front of it *and* decorators would break the grammer
 - generally, `decoratorsList` appears directly in each allowed context except for class declarations, it's not very convenient to get a class's decorators that way + it's more elegant that way IMO
 - there was a redundancy between `ClassExpression` and `classDeclaration`, on top of that if a class would be parsed as `ClassExpression` it would miss the decorators etc