### PR TITLE
TS grammer - Add module as reserverd and fix 'propertyMemberBase' order

### DIFF
--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -504,7 +504,7 @@ functionDeclaration
 
 //Ovveride ECMA
 classDeclaration
-    : decoratorList? (Export | Export Default)? Abstract? Class Identifier typeParameters? classHeritage classTail
+    : decoratorList? (Export Default?)? Abstract? Class Identifier typeParameters? classHeritage classTail
     ;
 
 classHeritage

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -504,7 +504,7 @@ functionDeclaration
 
 //Ovveride ECMA
 classDeclaration
-    : decoratorList? (Export Default?)? Abstract? Class Identifier typeParameters? classHeritage classTail
+    : decoratorList? (Export | Export Default)? Abstract? Class Identifier typeParameters? classHeritage classTail
     ;
 
 classHeritage
@@ -539,7 +539,7 @@ propertyMemberDeclaration
     ;
 
 propertyMemberBase
-    : Async? accessibilityModifier? Static? ReadOnly?
+    : accessibilityModifier? Async? Static? ReadOnly?
     ;
 
 indexMemberDeclaration
@@ -835,6 +835,7 @@ keyword
     | String
     | Boolean
     | Number
+    | Module
     ;
 
 getter

--- a/javascript/typescript/examples/Class.ts
+++ b/javascript/typescript/examples/Class.ts
@@ -38,6 +38,13 @@ class Employee extends Person {
     }
 }
 
+
+export class myClass {
+    public async foo(    ): Promise<any> {
+    }
+}
+
+
 let emp = new Employee(100,"Steve");
 
 import {Controller, Get, Post} from '@nestjs/common';

--- a/javascript/typescript/examples/Module.ts
+++ b/javascript/typescript/examples/Module.ts
@@ -11,3 +11,17 @@ export class Employee {
     }
 }
 let companyName:string = "XYZ";
+
+
+module.exports.routes = {
+    "GET /lookup/:lookupId": {
+        controller: "LookupReferenceController"
+    },
+    "POST /lookup": {
+        controller: "LookupReferenceController"
+    },
+
+'/health': function(req, res) {
+    return res.json({status: 'UP', version: sails.config.version});
+}
+}


### PR DESCRIPTION
- expressions of the sort of `module.export...` broke the parsing
- `'public' modifier must precede 'async' modifier.ts(1029)`