### PR TITLE
[tsql] Support for "create or replace trigger"-syntax observed working on Sybase ASE 16.

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -2192,7 +2192,7 @@ create_or_alter_trigger
     ;
 
 create_or_alter_dml_trigger
-    : ((CREATE (OR ALTER)?) | ALTER) TRIGGER simple_name
+    : ((CREATE (OR (ALTER | REPLACE))?) | ALTER) TRIGGER simple_name
       ON table_name
       (WITH dml_trigger_option (',' dml_trigger_option)* )?
       (FOR | AFTER | INSTEAD OF)
@@ -2212,7 +2212,7 @@ dml_trigger_operation
     ;
 
 create_or_alter_ddl_trigger
-    : ((CREATE (OR ALTER)?) | ALTER) TRIGGER simple_name
+    : ((CREATE (OR (ALTER | REPLACE))?) | ALTER) TRIGGER simple_name
       ON (ALL SERVER | DATABASE)
       (WITH dml_trigger_option (',' dml_trigger_option)* )?
       (FOR | AFTER) ddl_trigger_operation (',' ddl_trigger_operation)*

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -2192,7 +2192,7 @@ create_or_alter_trigger
     ;
 
 create_or_alter_dml_trigger
-    : ((CREATE (OR (ALTER | REPLACE))?) | ALTER) TRIGGER simple_name
+    : (CREATE (OR (ALTER | REPLACE))? | ALTER) TRIGGER simple_name
       ON table_name
       (WITH dml_trigger_option (',' dml_trigger_option)* )?
       (FOR | AFTER | INSTEAD OF)
@@ -2212,7 +2212,7 @@ dml_trigger_operation
     ;
 
 create_or_alter_ddl_trigger
-    : ((CREATE (OR (ALTER | REPLACE))?) | ALTER) TRIGGER simple_name
+    : (CREATE (OR (ALTER | REPLACE))? | ALTER) TRIGGER simple_name
       ON (ALL SERVER | DATABASE)
       (WITH dml_trigger_option (',' dml_trigger_option)* )?
       (FOR | AFTER) ddl_trigger_operation (',' ddl_trigger_operation)*

--- a/sql/tsql/examples/triggers.sql
+++ b/sql/tsql/examples/triggers.sql
@@ -87,3 +87,19 @@ DISABLE TRIGGER safety ON DATABASE;
 GO
 DISABLE Trigger ALL ON ALL SERVER;
 GO
+
+
+CREATE OR REPLACE TRIGGER triggerOnDatabase
+    ON DATABASE
+    FOR create_procedure
+AS
+BEGIN
+    declare @variable int
+END
+GO
+
+CREATE OR REPLACE TRIGGER myTrigger ON myTable
+FOR UPDATE
+AS
+   PRINT 'This is the trigger from create-or-replace'
+GO

--- a/sql/tsql/examples/triggers.sql
+++ b/sql/tsql/examples/triggers.sql
@@ -90,8 +90,8 @@ GO
 
 
 CREATE OR REPLACE TRIGGER triggerOnDatabase
-    ON DATABASE
-    FOR create_procedure
+ON DATABASE
+FOR create_procedure
 AS
 BEGIN
     declare @variable int


### PR DESCRIPTION
This is a resubmission of one of the the changes from cancelled PR https://github.com/antlr/grammars-v4/pull/3196, adding more support for Sybase. This should not require the rework suggested for the other change included in that PR.