### PR TITLE
[PromQL] support preserving comments

### DIFF
--- a/promql/PromQLLexer.g4
+++ b/promql/PromQLLexer.g4
@@ -28,6 +28,8 @@
 
 lexer grammar PromQLLexer;
 
+channels { WHITESPACE, COMMENTS }
+
 // All keywords in PromQL are case insensitive, it is just function,
 // label and metric names that are not.
 options { caseInsensitive=true; }
@@ -178,4 +180,9 @@ DURATION: [0-9]+ [smhdwy];
 METRIC_NAME: [a-z_:] [a-z0-9_:]*;
 LABEL_NAME:  [a-z_] [a-z0-9_]*;
 
-WS: [\r\t\n ]+ -> skip;
+
+
+WS: [\r\t\n ]+ -> channel(WHITESPACE);
+SL_COMMENT
+    : '#' .*? '\n' -> channel(COMMENTS)
+    ;

--- a/promql/examples/comments.txt
+++ b/promql/examples/comments.txt
@@ -1,0 +1,17 @@
+# testing
+# comments
+max by (
+  some_entry,
+  # comment here too
+  another_one
+)
+(
+  max_over_time (
+    a_metric
+    {
+      # another comment here
+      important="thing"
+    }
+  )
+)
+


### PR DESCRIPTION
Send the comments and whitespace to separate channels. This is useful for code formatters etc that want to have access to these.