### PR TITLE
[Antlr4] Rule labels are not supported in lexer rules

### DIFF
--- a/antlr/antlr4/ANTLRv4Parser.g4
+++ b/antlr/antlr4/ANTLRv4Parser.g4
@@ -235,16 +235,11 @@ lexerElements
    ;
 
 lexerElement
-   : labeledLexerElement ebnfSuffix?
-   | lexerAtom ebnfSuffix?
+   : lexerAtom ebnfSuffix?
    | lexerBlock ebnfSuffix?
    | actionBlock QUESTION?
    ;
    // but preds can be anywhere
-
-labeledLexerElement
-   : identifier (ASSIGN | PLUS_ASSIGN) (lexerAtom | lexerBlock)
-   ;
 
 lexerBlock
    : LPAREN lexerAltList RPAREN

--- a/antlr/antlr4/examples/LexerElementLabel.g4
+++ b/antlr/antlr4/examples/LexerElementLabel.g4
@@ -1,0 +1,4 @@
+// Testing that lexer rules must not contain element labels.
+lexer grammar LexerElementLabel;
+
+Token : var='token' ;

--- a/antlr/antlr4/examples/LexerElementLabel.g4.errors
+++ b/antlr/antlr4/examples/LexerElementLabel.g4.errors
@@ -1,0 +1,2 @@
+line 4:8 no viable alternative at input 'var'
+line 4:11 mismatched input '=' expecting {BEGIN_ARGUMENT, OPTIONS, 'returns', 'locals', 'throws', COLON, AT}


### PR DESCRIPTION
The patch updates the grammar accordingly.