### PR TITLE
[php] Fix for #3017: crash in Java target

### DIFF
--- a/php/Java/PhpLexerBase.java
+++ b/php/Java/PhpLexerBase.java
@@ -72,7 +72,7 @@ public abstract class PhpLexerBase extends Lexer
                 }
                 else
                 {
-                    token = new CommonToken(PhpLexer.SemiColon);
+                    token.setType(PhpLexer.SemiColon);
                 }
             }
         }

--- a/php/desc.xml
+++ b/php/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Python3</targets>
+   <targets>CSharp;Java;Python3</targets>
 </desc>


### PR DESCRIPTION
The base class for the lexer created a semi-colon token but gave no text to the symbol. Changed it to just mutate the token type to a semicolon, as done in the other targets. https://github.com/antlr/grammars-v4/issues/3017