### PR TITLE
[bibtex] Fix for #3284 -- standardize the grammar to work in build.

### DIFF
--- a/bibtex/BibTeXParser.g4
+++ b/bibtex/BibTeXParser.g4
@@ -1,9 +1,9 @@
-parser grammar BibTeX;
+parser grammar BibTeXParser;
 
 options { tokenVocab=BibTeXLexer; }
 
 bibTex
-    : entry*
+    : entry* EOF
     ;
 
 // Entries

--- a/bibtex/desc.xml
+++ b/bibtex/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Java;JavaScript;TypeScript;PHP;Python3;Dart</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
 </desc>


### PR DESCRIPTION
Fix for https://github.com/antlr/grammars-v4/issues/3284
* Rename parser grammar BibTex.g4 to BibTexParser.g4.
* Add EOF to the start rule.
* Add Cpp and CSharp targets.