### PR TITLE
plsql: fix call statement grammar bug.

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -72,6 +72,7 @@ unit_statement
     | alter_user
     | alter_view
 
+    | call_statement
     | create_analytic_view
     | create_attribute_dimension
     | create_audit_policy
@@ -167,7 +168,6 @@ unit_statement
     | flashback_table
     | grant_statement
     | noaudit_statement
-    | procedure_call
     | purge_statement
     | rename_object
     | revoke_statement
@@ -5361,9 +5361,8 @@ statement
     | return_statement
     | case_statement
     | sql_statement
-    | function_call
+    | call_statement
     | pipe_row_statement
-    | procedure_call
     ;
 
 swallow_to_semi
@@ -5443,12 +5442,8 @@ return_statement
     : RETURN expression?
     ;
 
-function_call
-    : CALL? routine_name function_argument?
-    ;
-
-procedure_call
-    : routine_name function_argument?
+call_statement
+    : CALL? routine_name function_argument? (INTO bind_variable)?
     ;
 
 pipe_row_statement

--- a/sql/plsql/examples/call.sql
+++ b/sql/plsql/examples/call.sql
@@ -1,0 +1,9 @@
+CALL my_procedure(arg1 => 3, arg2 => 4) ;
+
+CALL my_procedure(3, 4) ;
+
+CALL my_procedure(3, arg2 => 4) ;
+
+CALL emp_mgmt.remove_dept(162);
+
+CALL warehouse_typ(456, 'Warehouse 456', 2236).ret_name() INTO :x;


### PR DESCRIPTION
1.support of call stmt not support call ... into ... https://github.com/antlr/grammars-v4/issues/3306
2.rewrite the "function_call" and "procedure_call" to "call_statement". https://github.com/antlr/grammars-v4/issues/3305