### PR TITLE
[abb] Remove useless parentheses.

### DIFF
--- a/abb/abbParser.g4
+++ b/abb/abbParser.g4
@@ -82,7 +82,7 @@ declaration
     ;
 
 type_
-    : ( TOOLDATA | WOBJDATA | SPEEDDATA | ZONEDATA | CLOCK | BOOL )
+    : TOOLDATA | WOBJDATA | SPEEDDATA | ZONEDATA | CLOCK | BOOL
     ;
 
 init_


### PR DESCRIPTION
Removing useless parentheses in the abb grammar.