### PR TITLE
[abnf] Remove useless parentheses in abnf.

### DIFF
--- a/abnf/Abnf.g4
+++ b/abnf/Abnf.g4
@@ -72,7 +72,7 @@ repetition
    ;
 
 repeat_
-   : INT | ( INT? '*' INT? )
+   : INT | INT? '*' INT?
    ;
 
 element


### PR DESCRIPTION
Removed useless parentheses in abnf repeat_ rule.