### PR TITLE
[apex] Removed useless parentheses.

### DIFF
--- a/apex/apex.g4
+++ b/apex/apex.g4
@@ -63,28 +63,26 @@ typeDeclaration
 
 modifier
     :   classOrInterfaceModifier
-    |   (   NATIVE
-        |   SYNCHRONIZED
-        |   TRANSIENT
-        )
+    |   NATIVE
+    |   SYNCHRONIZED
+    |   TRANSIENT
     ;
 
 classOrInterfaceModifier
     :   annotation       // class or interface
-    |   (   PUBLIC     // class or interface
-        |   PROTECTED  // class or interface
-        |   PRIVATE    // class or interface
-        |   STATIC     // class or interface
-        |   ABSTRACT   // class or interface
-        |   FINAL      // class only -- does not apply to interfaces
-        |   GLOBAL     // class or interface
-        |   WEBSERVICE // class only -- does not apply to interfaces
-        |   OVERRIDE   // method only
-        |   VIRTUAL    // method only
-        |   TESTMETHOD    // method only
-		|	APEX_WITH_SHARING // class only
-		|	APEX_WITHOUT_SHARING //class only
-        )
+    |   PUBLIC     // class or interface
+    |   PROTECTED  // class or interface
+    |   PRIVATE    // class or interface
+    |   STATIC     // class or interface
+    |   ABSTRACT   // class or interface
+    |   FINAL      // class only -- does not apply to interfaces
+    |   GLOBAL     // class or interface
+    |   WEBSERVICE // class only -- does not apply to interfaces
+    |   OVERRIDE   // method only
+    |   VIRTUAL    // method only
+    |   TESTMETHOD    // method only
+    |   APEX_WITH_SHARING // class only
+    |   APEX_WITHOUT_SHARING //class only
     ;
 
 variableModifier
@@ -253,7 +251,7 @@ variableInitializer
     ;
 
 arrayInitializer
-    :   '{' (variableInitializer (',' variableInitializer)* (',')? )? '}'
+    :   '{' (variableInitializer (',' variableInitializer)* ','? )? '}'
     ;
 
 enumConstantName
@@ -352,7 +350,7 @@ elementValue
     ;
 
 elementValueArrayInitializer
-    :   '{' (elementValue (',' elementValue)*)? (',')? '}'
+    :   '{' (elementValue (',' elementValue)*)? ','? '}'
     ;
 
 annotationTypeDeclaration
@@ -360,7 +358,7 @@ annotationTypeDeclaration
     ;
 
 annotationTypeBody
-    :   '{' (annotationTypeElementDeclaration)* '}'
+    :   '{' annotationTypeElementDeclaration* '}'
     ;
 
 annotationTypeElementDeclaration
@@ -506,7 +504,7 @@ constantExpression
     ;
 
 apexDbUpsertExpression
-    :   DB_UPSERT expression (expression)*
+    :   DB_UPSERT expression expression*
     ;
 
 apexDbExpression


### PR DESCRIPTION
Removed useless parentheses in modifier, classOrInterfaceModifier, arrayInitializer, elementValueArrayInitializer, annotationTypeBody, apexDbUpsertExpression. I don't understand why modifier was grouped the way it was. Strange.