### PR TITLE
[abb] Remove useless parentheses in lexer grammar

### DIFF
--- a/abb/abbLexer.g4
+++ b/abb/abbLexer.g4
@@ -72,7 +72,7 @@ STRINGLITERAL
    ;
 
 fragment EscapeSequence
-   : '\\' ('b' | 't' | 'n' | 'f' | 'r' | '"' | '\'' | '\\' | ('0' .. '3') ('0' .. '7') ('0' .. '7') | ('0' .. '7') ('0' .. '7') | ('0' .. '7'))
+   : '\\' ('b' | 't' | 'n' | 'f' | 'r' | '"' | '\'' | '\\' | '0' .. '3' '0' .. '7' '0' .. '7' | '0' .. '7' '0' .. '7' | '0' .. '7')
    ;
 
 FLOATLITERAL
@@ -96,7 +96,7 @@ fragment HexPrefix
 
 
 fragment HexDigit
-   : ('0' .. '9' | 'A' .. 'F')
+   : '0' .. '9' | 'A' .. 'F'
    ;
 
 
@@ -111,7 +111,7 @@ fragment BinPrefix
 
 
 fragment BinDigit
-   : ('0' | '1')
+   : '0' | '1'
    ;
 
 
@@ -130,5 +130,5 @@ fragment IdentifierStart
 
 
 fragment IdentifierPart
-   : (IdentifierStart | '0' .. '9')
+   : IdentifierStart | '0' .. '9'
    ;

--- a/antlr/antlr3/ANTLRv3Parser.g4
+++ b/antlr/antlr3/ANTLRv3Parser.g4
@@ -91,7 +91,7 @@ ruleScopeSpec
    ;
 
 block
-   : LPAREN ((optionsSpec)? COLON)?
+   : LPAREN (optionsSpec? COLON)?
                 alternative rewrite (OR alternative rewrite )*
         RPAREN
    ;
@@ -106,7 +106,7 @@ alternative
    ;
 
 exceptionGroup
-   : (exceptionHandler)+ (finallyClause)?
+   : exceptionHandler+ finallyClause?
    | finallyClause
    ;
 
@@ -152,7 +152,7 @@ notSet
    ;
 
 treeSpec
-   : TREE_BEGIN element (element)+ RPAREN
+   : TREE_BEGIN element element+ RPAREN
    ;
 
 ebnf

--- a/antlr/antlr3/ANTLRv3Parser.g4
+++ b/antlr/antlr3/ANTLRv3Parser.g4
@@ -73,7 +73,7 @@ optionValue
    ;
 
 rule_
-   : DOC_COMMENT? ((PROTECTED | PUBLIC | PRIVATE | FRAGMENT))? id_ BANG? argActionBlock? (RETURNS argActionBlock)? throwsSpec? optionsSpec? ruleScopeSpec? ruleAction* COLON altList SEMI exceptionGroup?
+   : DOC_COMMENT? (PROTECTED | PUBLIC | PRIVATE | FRAGMENT)? id_ BANG? argActionBlock? (RETURNS argActionBlock)? throwsSpec? optionsSpec? ruleScopeSpec? ruleAction* COLON altList SEMI exceptionGroup?
    ;
    
 ruleAction


### PR DESCRIPTION
Updated my script to check for useless parentheses in the lexer rules. This PR includes several more, which I missed.