### PR TITLE
[abnf] Remove useless parentheses.

### DIFF
--- a/abnf/Abnf.g4
+++ b/abnf/Abnf.g4
@@ -94,22 +94,22 @@ NumberValue
 
 
 fragment BinaryValue
-   : 'b' BIT+ ( ( '.' BIT+ )+ | ( '-' BIT+ ) )?
+   : 'b' BIT+ ( ( '.' BIT+ )+ | '-' BIT+ )?
    ;
 
 
 fragment DecimalValue
-   : 'd' DIGIT+ ( ( '.' DIGIT+ )+ | ( '-' DIGIT+ ) )?
+   : 'd' DIGIT+ ( ( '.' DIGIT+ )+ | '-' DIGIT+ )?
    ;
 
 
 fragment HexValue
-   : 'x' HEX_DIGIT+ ( ( '.' HEX_DIGIT+ )+ | ( '-' HEX_DIGIT+ ) )?
+   : 'x' HEX_DIGIT+ ( ( '.' HEX_DIGIT+ )+ | '-' HEX_DIGIT+ )?
    ;
 
 
 ProseValue
-   : '<' ( ~ '>' )* '>'
+   : '<' ~'>'* '>'
    ;
 
 
@@ -134,7 +134,7 @@ WS
 
 
 STRING
-   : ( '%s' | '%i' )? '"' ( ~ '"' )* '"'
+   : ( '%s' | '%i' )? '"' ~'"'* '"'
    ;
 
 fragment LETTER : 'a' .. 'z' | 'A' .. 'Z';
@@ -153,5 +153,5 @@ fragment DIGIT
 // > ABNF strings are case insensitive and the character set for these strings is US-ASCII.
 // > So the definition of HEXDIG already allows for both upper and lower case (or a mixture).
 fragment HEX_DIGIT
-   : ( '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' )
+   : '0' .. '9' | 'a' .. 'f' | 'A' .. 'F'
    ;


### PR DESCRIPTION
Remove the useless parentheses I missed in the lexer rules.

NB: the expression `( ~ '>' )*` is equivalent to the simplified expression `~'>'*`. This works because the tree generated has `~` higher priority than the `*` operator.