### PR TITLE
[build] Fix for #3389

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Install trgen
       shell: bash
       run: |
-        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.17; done
+        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.19; done
     - name: Test
       shell: pwsh
       run: |
@@ -197,7 +197,7 @@ jobs:
     - name: Install trgen
       shell: bash
       run: |
-        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.17; done
+        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.19; done
     - name: Test
       shell: bash
       run: |

--- a/_scripts/readme.md
+++ b/_scripts/readme.md
@@ -150,7 +150,7 @@ Trgen will construct and pass to the template evaluator the following attributes
 To generate the driver code from templates for a grammar, you will need
 to have the NET SDK installed. Afterwards, install `trgen`:
 
-    dotnet tool install -g trgen --version 0.20.17
+    dotnet tool install -g trgen --version 0.20.19
 
 To create a driver program:
 

--- a/_scripts/really-run.ps1
+++ b/_scripts/really-run.ps1
@@ -14,9 +14,9 @@ $antlrPath = _scripts/get-antlr.ps1 "4.12.0"
 # Set up env as it is used in test script.
 echo "antlr_path=$antlrPath" >> $env:GITHUB_ENV
 
-dotnet tool install -g trgen --version 0.20.17
-dotnet tool install -g triconv --version 0.20.17
-dotnet tool install -g trwdog --version 0.20.17
+dotnet tool install -g trgen --version 0.20.19
+dotnet tool install -g triconv --version 0.20.19
+dotnet tool install -g trwdog --version 0.20.19
 
 # Call test script.
 $env:ANTLR_JAR_PATH="$antlrPath"


### PR DESCRIPTION
This is a fix for #3389. PR https://github.com/antlr/grammars-v4/pull/3388 is failing because trgen computes the wrong filename for base class files. The fix is to use the latest version of trgen, which fixes the problem.