### PR TITLE
Update MySqlParser.g4

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -2625,7 +2625,8 @@ expressionAtom
     | '(' selectStatement ')'                                       #subqueryExpressionAtom
     | INTERVAL expression intervalType                              #intervalExpressionAtom
     | left=expressionAtom bitOperator right=expressionAtom          #bitExpressionAtom
-    | left=expressionAtom mathOperator right=expressionAtom         #mathExpressionAtom
+    | left=expressionAtom mathPriorOperator right=expressionAtom    #mathPriorExpressionAtom
+    | left=expressionAtom mathAfterOperator right=expressionAtom    #mathAfterExpressionAtom
     | left=expressionAtom jsonOperator right=expressionAtom         #jsonExpressionAtom
     ;
 
@@ -2646,9 +2647,14 @@ bitOperator
     : '<' '<' | '>' '>' | '&' | '^' | '|'
     ;
 
-mathOperator
-    : '*' | '/' | '%' | DIV | MOD | '+' | '-'
+mathPriorOperator
+    : '*' | '/' | '%' | DIV | MOD
     ;
+
+mathAfterOperator
+    : '+' | '-'
+    ;
+
 
 jsonOperator
     : '-' '>' | '-' '>' '>'


### PR DESCRIPTION
The origin mathExpression has bugs when we preprocess  complex expressons.  for example:
if we calculate a expression  "100 + 100/2", the result is (100+100)/2. so the mathOperator should have priority.
firstly, we should calculate Mul/Div/Mod;
finally, we should calculate Add/Sub;