### PR TITLE
[asn_3gpp] Remove useless parentheses.

### DIFF
--- a/acme/acme.g4
+++ b/acme/acme.g4
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 grammar acme;
 
 acmeCompUnit
-   : (acmeImportDeclaration)* (acmeSystemDeclaration | acmeFamilyDeclaration | acmeDesignDeclaration)+ EOF
+   : acmeImportDeclaration* (acmeSystemDeclaration | acmeFamilyDeclaration | acmeDesignDeclaration)+ EOF
    ;
 
 acmeImportDeclaration
@@ -164,7 +164,7 @@ acmeGroupBody
    ;
 
 acmeMembersBlock
-   : MEMBERS LBRACE (acmeInstanceRef (COMMA acmeInstanceRef)*)? RBRACE (SEMICOLON)?
+   : MEMBERS LBRACE (acmeInstanceRef (COMMA acmeInstanceRef)*)? RBRACE SEMICOLON?
    ;
 
 acmePortTypeDeclaration
@@ -216,11 +216,11 @@ acmeConnectorBody
    ;
 
 acmeRepresentationDeclaration
-   : REPRESENTATION (IDENTIFIER ASSIGN)? LBRACE acmeSystemDeclaration (acmeBindingsMapDeclaration)? RBRACE (SEMICOLON)?
+   : REPRESENTATION (IDENTIFIER ASSIGN)? LBRACE acmeSystemDeclaration acmeBindingsMapDeclaration? RBRACE SEMICOLON?
    ;
 
 acmeBindingsMapDeclaration
-   : BINDINGS LBRACE (acmeBindingDeclaration)* RBRACE (SEMICOLON)?
+   : BINDINGS LBRACE acmeBindingDeclaration* RBRACE SEMICOLON?
    ;
 
 acmeBindingDeclaration
@@ -271,7 +271,7 @@ acmePropertyRecordEntry
    ;
 
 acmePropertyRecord
-   : LBRACKET (acmePropertyRecordEntry (SEMICOLON acmePropertyRecordEntry)* (SEMICOLON)?)? RBRACKET
+   : LBRACKET (acmePropertyRecordEntry (SEMICOLON acmePropertyRecordEntry)* SEMICOLON?)? RBRACKET
    ;
 
 acmePropertySequence
@@ -279,15 +279,15 @@ acmePropertySequence
    ;
 
 acmePropertyTypeRecord
-   : RECORD LBRACKET (acmePropertyRecordFieldDescription)* RBRACKET
+   : RECORD LBRACKET acmePropertyRecordFieldDescription* RBRACKET
    ;
 
 acmePropertyTypeSet
-   : SET LBRACE (acmeTypeRef)? RBRACE
+   : SET LBRACE acmeTypeRef? RBRACE
    ;
 
 acmePropertyTypeSequence
-   : SEQUENCE LANGLE (acmePropertyTypeRef)? RANGLE
+   : SEQUENCE LANGLE acmePropertyTypeRef? RANGLE
    ;
 
 acmePropertyTypeEnum
@@ -325,7 +325,7 @@ acmePropertyBlockEntry
    ;
 
 acmePropertyBlock
-   : PROPBEGIN (acmePropertyBlockEntry)+ PROPEND
+   : PROPBEGIN acmePropertyBlockEntry+ PROPEND
    ;
 
 acmePropertyTypeInt
@@ -493,7 +493,7 @@ literalRecordEntry
    ;
 
 literalRecord
-   : LBRACKET (literalRecordEntry (SEMICOLON literalRecordEntry)* (SEMICOLON)?)? RBRACKET
+   : LBRACKET (literalRecordEntry (SEMICOLON literalRecordEntry)* SEMICOLON?)? RBRACKET
    ;
 
 setConstructor
@@ -673,8 +673,8 @@ IN
    ;
 
 INT
-   : (I N T)
-   | (I N T E G E R)
+   : I N T
+   | I N T E G E R
    ;
 
 INVARIANT
@@ -742,7 +742,7 @@ OR
    ;
 
 PATHSEPARATOR
-   : ('.' | ':' | '-' | '+' | '\\' | '\\\\' | '/' | '$' | '%')
+   : '.' | ':' | '-' | '+' | '\\' | '\\\\' | '/' | '$' | '%'
    ;
 
 PUBLIC
@@ -814,8 +814,8 @@ ROLES
    ;
 
 SEQUENCE
-   : (S E Q U E N C E)
-   | (S E Q)
+   : S E Q U E N C E
+   | S E Q
    ;
 
 SELECT

--- a/asn/asn_3gpp/ASN_3gpp.g4
+++ b/asn/asn_3gpp/ASN_3gpp.g4
@@ -73,17 +73,17 @@ exports :   (EXPORTS_LITERAL symbolsExported SEMI_COLON
  |    EXPORTS_LITERAL ALL_LITERAL SEMI_COLON )?
 ;
 
-symbolsExported : ( symbolList )?
+symbolsExported : symbolList?
 ;
 
 imports :   (IMPORTS_LITERAL symbolsImported SEMI_COLON )?
 ;
 
-symbolsImported : (symbolsFromModuleList )?
+symbolsImported : symbolsFromModuleList?
 ;
 
 symbolsFromModuleList :
-     (symbolsFromModule) (symbolsFromModule)*
+     symbolsFromModule symbolsFromModule*
 ;
 
 symbolsFromModule : symbolList FROM_LITERAL globalModuleReference
@@ -95,10 +95,10 @@ globalModuleReference : IDENTIFIER assignedIdentifier
 assignedIdentifier :
 ;
 
-symbolList   : (symbol) (COMMA symbol)*
+symbolList   : symbol (COMMA symbol)*
 ;
 
-symbol  : IDENTIFIER ((L_BRACE  R_BRACE))?
+symbol  : IDENTIFIER (L_BRACE  R_BRACE)?
 ;
 
 //parameterizedReference :
@@ -110,18 +110,17 @@ symbol  : IDENTIFIER ((L_BRACE  R_BRACE))?
 //  identifier
 //;
 
-assignmentList :  (assignment) (assignment)*
+assignmentList :  assignment assignment*
 ;
 
 
 assignment :
- (IDENTIFIER
+ IDENTIFIER
 	(  valueAssignment
 	 | typeAssignment
 	 | parameterizedAssignment
 	 | objectClassAssignment
 	)
- )
 	;
 
 sequenceType :SEQUENCE_LITERAL L_BRACE (extensionAndException  optionalExtensionMarker | componentTypeLists )? R_BRACE
@@ -132,15 +131,15 @@ optionalExtensionMarker :  ( COMMA  ELLIPSIS )?
 ;
 
 componentTypeLists :
-   rootComponentTypeList (tag | (COMMA tag? extensionAndException  extensionAdditions   (optionalExtensionMarker|(EXTENSTIONENDMARKER  COMMA  rootComponentTypeList tag?))))?
+   rootComponentTypeList (tag | COMMA tag? extensionAndException  extensionAdditions   (optionalExtensionMarker| EXTENSTIONENDMARKER  COMMA  rootComponentTypeList tag?))?
 //  |  rootComponentTypeList  COMMA  extensionAndException  extensionAdditions    optionalExtensionMarker
 //  |  rootComponentTypeList  COMMA  extensionAndException  extensionAdditions     EXTENSTIONENDMARKER  COMMA  rootComponentTypeList
-  |  extensionAndException  extensionAdditions  (optionalExtensionMarker | (EXTENSTIONENDMARKER  COMMA    rootComponentTypeList tag?))
+  |  extensionAndException  extensionAdditions  (optionalExtensionMarker | EXTENSTIONENDMARKER  COMMA    rootComponentTypeList tag?)
 //  |  extensionAndException  extensionAdditions  optionalExtensionMarker
 ;
 rootComponentTypeList  : componentTypeList
 ;
-componentTypeList  : (componentType) (COMMA tag? componentType)*
+componentTypeList  : componentType (COMMA tag? componentType)*
 ;
 componentType  :
   namedType (OPTIONAL_LITERAL | DEFAULT_LITERAL value )?
@@ -175,7 +174,7 @@ INVALID_TAG
 
 extensionAdditions  :  (COMMA  extensionAdditionList)?
 ;
-extensionAdditionList  :  (extensionAddition) (COMMA  extensionAddition)*
+extensionAdditionList  :  extensionAddition (COMMA  extensionAddition)*
 ;
 extensionAddition  : componentType  |  extensionAdditionGroup
 ;
@@ -191,19 +190,18 @@ sizeConstraint : SIZE_LITERAL constraint
 
 parameterizedAssignment :
  parameterList
-(ASSIGN_OP
+ ASSIGN_OP
 	(asnType
 		|	value
 		|	valueSet
 	)
-)
-|( definedObjectClass ASSIGN_OP
+
+| definedObjectClass ASSIGN_OP
 	( object_
 		|	objectClass
 		|	objectSet
 	)
 
-)
 // parameterizedTypeAssignment
 //| parameterizedValueAssignment
 //| parameterizedValueSetTypeAssignment
@@ -252,7 +250,7 @@ syntaxList : L_BRACE tokenOrGroupSpec+ R_BRACE
 tokenOrGroupSpec : requiredToken | optionalGroup
 ;
 
-optionalGroup : L_BRACKET (tokenOrGroupSpec)+ R_BRACKET
+optionalGroup : L_BRACKET tokenOrGroupSpec+ R_BRACKET
 ;
 
 requiredToken : literal | primitiveFieldName
@@ -268,8 +266,8 @@ fieldSpec :
 	(
 	  typeOptionalitySpec?
   	| asnType (valueSetOptionalitySpec?  | UNIQUE_LITERAL? valueOptionalitySpec? )
-	| fieldName (OPTIONAL_LITERAL | (DEFAULT_LITERAL (valueSet | value)))?
-	| definedObjectClass (OPTIONAL_LITERAL | (DEFAULT_LITERAL (objectSet | object_)))?
+	| fieldName (OPTIONAL_LITERAL | DEFAULT_LITERAL (valueSet | value))?
+	| definedObjectClass (OPTIONAL_LITERAL | DEFAULT_LITERAL (objectSet | object_))?
 
 	)
 
@@ -284,11 +282,11 @@ fieldSpec :
 
 typeFieldSpec : AMPERSAND IDENTIFIER typeOptionalitySpec?
 ;
-typeOptionalitySpec : OPTIONAL_LITERAL | (DEFAULT_LITERAL asnType)
+typeOptionalitySpec : OPTIONAL_LITERAL | DEFAULT_LITERAL asnType
 ;
 fixedTypeValueFieldSpec : AMPERSAND IDENTIFIER asnType UNIQUE_LITERAL? valueOptionalitySpec ?
 ;
-valueOptionalitySpec : OPTIONAL_LITERAL | (DEFAULT_LITERAL value)
+valueOptionalitySpec : OPTIONAL_LITERAL | DEFAULT_LITERAL value
 ;
 
 variableTypeValueFieldSpec : AMPERSAND IDENTIFIER  fieldName valueOptionalitySpec ?
@@ -307,7 +305,7 @@ parameterizedObject : definedObject actualParameterList
 
 
 definedObject
-	:	IDENTIFIER (DOT)?
+	:	IDENTIFIER DOT?
 	;
 objectSet : L_BRACE objectSetSpec R_BRACE
 ;
@@ -317,7 +315,7 @@ objectSetSpec :
 ;
 
 
-fieldName :(AMPERSAND IDENTIFIER)(AMPERSAND IDENTIFIER DOT)*
+fieldName : AMPERSAND IDENTIFIER (AMPERSAND IDENTIFIER DOT)*
 ;
 valueSet : L_BRACE elementSetSpecs R_BRACE
 ;
@@ -330,11 +328,11 @@ additionalElementSetSpec : elementSetSpec
 ;
 elementSetSpec : unions | ALL_LITERAL exclusions
 ;
-unions :   (intersections) (unionMark intersections)*
+unions :   intersections (unionMark intersections)*
 ;
 exclusions : EXCEPT_LITERAL elements
 ;
-intersections : (intersectionElements) (intersectionMark intersectionElements)*
+intersections : intersectionElements (intersectionMark intersectionElements)*
 ;
 unionMark  :  PIPE  |  UNION_LITERAL
 ;
@@ -351,12 +349,12 @@ objectSetElements :
 ;
 
 
-intersectionElements : elements (exclusions)?
+intersectionElements : elements exclusions?
 ;
 subtypeElements :
-  ((value | MIN_LITERAL) LESS_THAN?  DOUBLE_DOT LESS_THAN?  (value | MAX_LITERAL) )
+  (value | MIN_LITERAL) LESS_THAN?  DOUBLE_DOT LESS_THAN?  (value | MAX_LITERAL)
   |sizeConstraint
- | (PATTERN_LITERAL value)
+ | PATTERN_LITERAL value
  | value
 ;
 
@@ -382,7 +380,7 @@ valueAssignment :
 	  ASSIGN_OP
        value
 ;
-asnType : (builtinType | referencedType) (constraint)*
+asnType : (builtinType | referencedType) constraint*
 ;
 builtinType :
    octetStringType
@@ -460,7 +458,7 @@ componentPresenceLists:
   |  ELLIPSIS (COMMA componentPresenceList)?
 ;
 
-componentPresenceList: (componentPresence) (COMMA componentPresence)*
+componentPresenceList: componentPresence (COMMA componentPresence)*
 ;
 
 componentPresence: IDENTIFIER (ABSENT_LITERAL | PRESENT_LITERAL)
@@ -488,7 +486,7 @@ builtinValue :
 objectIdentifierValue : L_BRACE /*(definedValue)?*/ objIdComponentsList R_BRACE
 ;
 objIdComponentsList
-	: 	(objIdComponents) (objIdComponents)*
+	: 	objIdComponents objIdComponents*
 ;
 objIdComponents  :
 	    	NUMBER
@@ -505,7 +503,7 @@ choiceValue  :    IDENTIFIER COLON value
 enumeratedValue  : IDENTIFIER
 ;
 
-signedNumber :  (MINUS)? NUMBER
+signedNumber :  MINUS? NUMBER
 ;
 choiceType    : CHOICE_LITERAL L_BRACE alternativeTypeLists R_BRACE
 ;
@@ -514,7 +512,7 @@ alternativeTypeLists :   rootAlternativeTypeList (COMMA
 	;
 extensionAdditionAlternatives  : (COMMA  extensionAdditionAlternativesList )?
 ;
-extensionAdditionAlternativesList  : (extensionAdditionAlternative) (COMMA  extensionAdditionAlternative)*
+extensionAdditionAlternativesList  : extensionAdditionAlternative (COMMA  extensionAdditionAlternative)*
 ;
 extensionAdditionAlternative  :  extensionAdditionAlternativesGroup | namedType
 ;
@@ -523,7 +521,7 @@ extensionAdditionAlternativesGroup  :  DOUBLE_L_BRACKET  versionNumber  alternat
 
 rootAlternativeTypeList  : alternativeTypeList
 ;
-alternativeTypeList : (namedType) (COMMA namedType)*
+alternativeTypeList : namedType (COMMA namedType)*
 ;
 namedType : IDENTIFIER   asnType
 ;
@@ -544,7 +542,7 @@ definedValue :
  //| valuereference
   parameterizedValue
 ;
-parameterizedValue : simpleDefinedValue (actualParameterList)?
+parameterizedValue : simpleDefinedValue actualParameterList?
 ;
 simpleDefinedValue : IDENTIFIER (DOT IDENTIFIER)?
 ;
@@ -563,14 +561,14 @@ additionalEnumeration : enumeration
 ;
 integerType:INTEGER_LITERAL  (L_BRACE namedNumberList R_BRACE)?
 ;
-namedNumberList : (namedNumber) (COMMA namedNumber)*
+namedNumberList : namedNumber (COMMA namedNumber)*
 ;
 objectidentifiertype  :  OBJECT_LITERAL IDENTIFIER_LITERAL
 ;
-componentRelationConstraint : L_BRACE (IDENTIFIER (DOT IDENTIFIER)?) R_BRACE
+componentRelationConstraint : L_BRACE IDENTIFIER (DOT IDENTIFIER)? R_BRACE
 			     (L_BRACE atNotation (COMMA atNotation)* R_BRACE)?
 ;
-atNotation :  (A_ROND | (A_ROND_DOT level)) componentIdList
+atNotation :  (A_ROND | A_ROND_DOT level) componentIdList
 ;
 level : (DOT level)?
 ;
@@ -579,9 +577,9 @@ componentIdList : IDENTIFIER (DOT IDENTIFIER)*  //?????
 ;
 octetStringType  :  OCTET_LITERAL STRING_LITERAL
 ;
-bitStringType    : (BIT_LITERAL STRING_LITERAL) (L_BRACE namedBitList R_BRACE)?
+bitStringType    : BIT_LITERAL STRING_LITERAL (L_BRACE namedBitList R_BRACE)?
 ;
-namedBitList: (namedBit) (COMMA namedBit)*
+namedBitList: namedBit (COMMA namedBit)*
 ;
 namedBit      : IDENTIFIER L_PARAN (NUMBER | definedValue) R_PARAN
 	;
@@ -980,11 +978,11 @@ fragment DIGIT
     ;
 
 fragment UPPER
-    : ('A'..'Z')
+    : 'A'..'Z'
     ;
 
 fragment LOWER
-    : ('a'..'z')
+    : 'a'..'z'
     ;
 
 NUMBER
@@ -1008,7 +1006,7 @@ BSTRING
     ;
 
 fragment HEXDIGIT
-    : (DIGIT|'a'..'f'|'A'..'F')
+    : DIGIT | 'a'..'f' | 'A'..'F'
     ;
 
 HSTRING


### PR DESCRIPTION
Again, this grammar could use a serious reformat.