### PR TITLE
Update CPP14Parser.g4

### DIFF
--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -643,7 +643,7 @@ virtualSpecifier: Override | Final;
  */
 
 pureSpecifier:
-	Assign val = OctalLiteral {if($val.text.compareTo("0")!=0) throw new InputMismatchException(this);
+	Assign val = OctalLiteral {if($val.text.compare("0")!=0) throw new InputMismatchException(this);
 		};
 /*Derived classes*/
 


### PR DESCRIPTION
Fix compareTo function to compare function

While working with antlr, I ran into a problem that it generates parser code where it uses the compareTo function to compare strings, which is not present in c++. I decided to fix this little tank and change it to compare so that there would be no problems.


![image](https://github.com/antlr/grammars-v4/assets/94537822/87b8f63d-d700-45b8-8517-d4e99894358a)
