### PR TITLE
Fix python3 parse error

### DIFF
--- a/python/python3/Python3Parser.g4
+++ b/python/python3/Python3Parser.g4
@@ -68,7 +68,7 @@ varargslist: (vfpdef ('=' test)? (',' vfpdef ('=' test)?)* (',' (
 vfpdef: name;
 
 stmt: simple_stmts | compound_stmt;
-simple_stmts: simple_stmt (';' simple_stmt)* ';'? NEWLINE;
+simple_stmts: simple_stmt (';' simple_stmt)* ';'? NEWLINE?;
 simple_stmt: (expr_stmt | del_stmt | pass_stmt | flow_stmt |
              import_stmt | global_stmt | nonlocal_stmt | assert_stmt);
 expr_stmt: testlist_star_expr (annassign | augassign (yield_expr|testlist) |


### PR DESCRIPTION
fix case like:
```
print(0)
print(1)
```
cause error
Parse error: {
      startLine: 2,
      endLine: 2,
      startCol: 8,
      endCol: 13,
      message: "no viable alternative at input '<EOF>'"
    }