### PR TITLE
[cypher] Removed useless parentheses.

### DIFF
--- a/cypher/CypherParser.g4
+++ b/cypher/CypherParser.g4
@@ -327,7 +327,7 @@ invocationName
     ;
 
 functionInvocation
-    : invocationName LPAREN DISTINCT? (expressionChain)? RPAREN
+    : invocationName LPAREN DISTINCT? expressionChain? RPAREN
     ;
 
 parenthesizedExpression
@@ -401,7 +401,7 @@ charLit
     : CHAR_LITERAL
     ;
 listLit
-    : LBRACK (expressionChain)? RBRACK
+    : LBRACK expressionChain? RBRACK
     ;
 
 mapLit


### PR DESCRIPTION
Removed parentheses from cypher grammar that are unnecessary.