### PR TITLE
[build] Remove Go target testing for now until 4.13.0 is fully out.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        language: [ CSharp, Dart, Java, JavaScript, Go, Python3, TypeScript ]
+        language: [ CSharp, Dart, Java, JavaScript, Python3, TypeScript ]
     steps:
     - name: Info
       shell: bash
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        language: [ CSharp, Dart, Java, JavaScript, Go, Python3, TypeScript ]
+        language: [ CSharp, Dart, Java, JavaScript, Python3, TypeScript ]
     steps:
     - name: Info
       shell: bash


### PR DESCRIPTION
This is a fix for #3460, which is a blocking problem for testing cleanly any PRs. The Go target testing is removed for now until 4.13.0 is fully out.