### PR TITLE
[build] Fixes for https://github.com/antlr/grammars-v4/issues/3468

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,9 @@ jobs:
       if: ${{ matrix.language == 'Python3' }}
       run: |
         python --version
+    - name: Install Antlr tool
+      run: |
+         pip install antlr4-tools
     - name: Install JavaScript
       if: ${{ matrix.language == 'JavaScript' }}
       uses: actions/setup-node@v3.6.0
@@ -78,16 +81,6 @@ jobs:
       if: ${{ matrix.language == 'JavaScript' }}
       run: |
         node --version
-    - name: Download ANTLR
-      shell: pwsh
-      run: |
-        $antlrPath = _scripts/get-antlr.ps1 "4.12.0"
-        echo "$antlrPath" | Write-Host
-        echo "antlr_path=$antlrPath" >> $env:GITHUB_ENV
-        If(!(test-path -PathType container /tmp)) {
-           New-Item -Path '/tmp' -ItemType Directory
-        }
-        copy $antlrPath /tmp/antlr4-complete.jar
     - name: Update paths
       shell: pwsh
       run: |
@@ -175,6 +168,9 @@ jobs:
       if: ${{ matrix.language == 'Python3' }}
       run: |
         python --version
+    - name: Install Antlr tool
+      run: |
+         pip install antlr4-tools
     - name: Install JavaScript
       if: ${{ matrix.language == 'JavaScript' }}
       uses: actions/setup-node@v3.6.0
@@ -184,16 +180,6 @@ jobs:
       if: ${{ matrix.language == 'JavaScript' }}
       run: |
         node --version
-    - name: Download ANTLR
-      shell: pwsh
-      run: |
-        $antlrPath = _scripts/get-antlr.ps1 "4.12.0"
-        echo "$antlrPath" | Write-Host
-        echo "antlr_path=$antlrPath" >> $env:GITHUB_ENV
-        If(!(test-path -PathType container /tmp)) {
-           New-Item -Path '/tmp' -ItemType Directory
-        }
-        copy $antlrPath /tmp/antlr4-complete.jar
     - name: Install trgen
       shell: bash
       run: |

--- a/_scripts/templates/CSharp/Test.csproj
+++ b/_scripts/templates/CSharp/Test.csproj
@@ -7,9 +7,7 @@
   \</PropertyGroup>
   \<ItemGroup>
 <tool_grammar_files:{x |    \<Antlr4 Include="<x>">
-<if(name_space)>\<Package><name_space>\</Package><endif>
-\<!-- AntlrRuntime><antlr_tool_path>\</AntlrRuntime -->
-\</Antlr4>
+<if(name_space)>\<Package><name_space>\</Package><endif>\</Antlr4>
 } >  \</ItemGroup>
   \<ItemGroup>
     \<PackageReference Include="Antlr4.Runtime.Standard" Version ="4.12.0" />

--- a/_scripts/templates/Dart/build.ps1
+++ b/_scripts/templates/Dart/build.ps1
@@ -3,8 +3,14 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
+# Because there is no integrated build script for Dart targets, we need
+# to manually look at the version in pubspec.yaml and extract the
+# version number. We can then use this with antlr4 to generate the
+# parser and lexer.
+$version = Select-String -Path "pubspec.yaml" -Pattern "antlr4" | ForEach-Object {$_.Line.Split(" ")[3]}
+
 <tool_grammar_files:{x |
-$(& java -jar <antlr_tool_path> <x> -encoding <antlr_encoding> -Dlanguage=Dart <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+$(& antlr4 -v $version <x> -encoding <antlr_encoding> -Dlanguage=Dart <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 if($compile_exit_code -ne 0){
     exit $compile_exit_code
 \}

--- a/_scripts/templates/Dart/build.sh
+++ b/_scripts/templates/Dart/build.sh
@@ -3,8 +3,14 @@ set -e
 
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 
+# Because there is no integrated build script for Dart targets, we need
+# to manually look at the version in pubspec.yaml and extract the
+# version number. We can then use this with antlr4 to generate the
+# parser and lexer.
+version=`grep antlr4 pubspec.yaml | awk '{print $2}'`
+
 <tool_grammar_tuples:{x |
-java -jar "<antlr_tool_path>" -encoding <antlr_encoding> -Dlanguage=Dart <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
+antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=Dart <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
 } >
 
 dart pub get


### PR DESCRIPTION
Remove all mention of tool version in workflows/main.yml, because the version is per-target so dependabot updates don't crash the build. Instead install antlr4 tool and start "greppin'" for the version of the tool to use.