### PR TITLE
rename the module name to ptx-isa-2.1

### DIFF
--- a/asm/ptx/pom.xml
+++ b/asm/ptx/pom.xml
@@ -13,6 +13,6 @@
 
 	<modules>
 		<module>ptx-isa-1.0</module>
-		<module>ptx-isa-3.1</module>
+		<module>ptx-isa-2.1</module>
 	</modules>
 </project>

--- a/asm/ptx/ptx-isa-2.1/pom.xml
+++ b/asm/ptx/ptx-isa-2.1/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>ptx-1.0</artifactId>
+	<artifactId>ptx-2.1</artifactId>
 	<packaging>jar</packaging>
-	<name>CUDA PTX ISA 3.1 grammar</name>
+	<name>CUDA PTX ISA 2.1 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>ptx-parent</artifactId>


### PR DESCRIPTION
rename the module name to ptx-isa-2.1, solve the maven module's error tip problem.

the module's directory name is 'ptx-isa-2.1'.
![image](https://github.com/antlr/grammars-v4/assets/12250931/7d287f48-4c1a-4353-9aae-42b726d92427)

The go target CI failures has been solved in #3454 