### PR TITLE
[build] For the JavaScript target, use npm scripts to call the Antlr tool.

### DIFF
--- a/_scripts/templates/JavaScript/build.sh
+++ b/_scripts/templates/JavaScript/build.sh
@@ -3,9 +3,7 @@ set -e
 
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 
-<tool_grammar_tuples:{x |
-java -jar "<antlr_tool_path>" -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
-} >
-
 npm install
+npm run build
+
 exit 0

--- a/_scripts/templates/JavaScript/package.json
+++ b/_scripts/templates/JavaScript/package.json
@@ -4,16 +4,16 @@
   "description": "",
   "main": "Test.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node runAntlr.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "4.13",
+    "antlr4": "4.13.0",
     "fs-extra": "^11.1.0",
     "timer-node": "^5.0.6",
     "typescript-string-operations": "^1.4.1"
   },
   "type": "module"
 }
-

--- a/_scripts/templates/JavaScript/runAntlr.js
+++ b/_scripts/templates/JavaScript/runAntlr.js
@@ -1,0 +1,16 @@
+import fs from 'fs-extra';
+import exec from 'child_process';
+
+// Read package.json
+const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+
+// Extract the antlr4 version
+const antlrVersion = packageJson.dependencies.antlr4.replace('^', '');
+
+// Run the command with the antlr4 version
+<tool_grammar_tuples:{x |
+exec.execSync(`antlr4 -v ${antlrVersion\} -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>`, (err, stdout, stderr) => {
+    console.log("stdout: " + stdout);
+    console.log("stderr: " + stderr);
+\});
+} >


### PR DESCRIPTION
This PR is a Javascript hack to run Antlr tool using the NPM package manager, which I learned from ChatGPT. This is important so that the versions of the Antlr tool and JavaScript runtime for Antlr are in synch. It also helps keep Dependabot working smoothly, and letting it work without crashing the build.

The hack is a Node javascript script that reads the package.json file and extracts the version of the Antlr runtime dependency. The program then performs an `execSync()` to call the [antlr4 tool](https://github.com/antlr/antlr4-tools). That tool does the actual downloading of the correct version for the Antlr tool .jar. We want the builds to look as much as possible written by a native JavaScript programmer, using the build tools native to JavaScript. Makefiles, Bash, and Powershell scripts are not a natural fit for JS programmers!