### PR TITLE
[build] Fix for #3480 -- Add Dependabot processing of CSharp.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Install trgen
       shell: bash
       run: |
-        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.19; done
+        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.23; done
     - name: Test
       shell: pwsh
       run: |
@@ -191,7 +191,7 @@ jobs:
     - name: Install trgen
       shell: bash
       run: |
-        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.19; done
+        for i in trgen triconv trwdog trxml trxml2; do dotnet tool install -g $i --version 0.20.23; done
     - name: Test
       shell: bash
       run: |

--- a/_scripts/templates/CSharp/Other.csproj
+++ b/_scripts/templates/CSharp/Other.csproj
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Antlr4.Runtime.Standard" Version ="4.12.0" />
+    <PackageReference Include="Antlr4BuildTasks" Version="12.2" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/_scripts/templates/CSharp/Other.csproj.meta
+++ b/_scripts/templates/CSharp/Other.csproj.meta
@@ -1,0 +1,3 @@
+<StringTemplateOptions>
+   <Process>False</Process>
+</StringTemplateOptions>

--- a/_scripts/templates/CSharp/Test.csproj
+++ b/_scripts/templates/CSharp/Test.csproj
@@ -9,10 +9,7 @@
 <tool_grammar_files:{x |    \<Antlr4 Include="<x>">
 <if(name_space)>\<Package><name_space>\</Package><endif>\</Antlr4>
 } >  \</ItemGroup>
-  \<ItemGroup>
-    \<PackageReference Include="Antlr4.Runtime.Standard" Version ="4.13.0" />
-    \<PackageReference Include="Antlr4BuildTasks" Version="12.2" PrivateAssets="all" />
-  \</ItemGroup>
+  \<Import Project="Other.csproj">\</Import>
   \<PropertyGroup>
     \<RestoreProjectStyle>PackageReference\</RestoreProjectStyle>
   \</PropertyGroup>

--- a/_scripts/templates/CSharp/build.ps1
+++ b/_scripts/templates/CSharp/build.ps1
@@ -3,5 +3,5 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
-$(& dotnet build; $compile_exit_code = $LASTEXITCODE) | Write-Host
+$(& dotnet build Test.csproj; $compile_exit_code = $LASTEXITCODE) | Write-Host
 exit $compile_exit_code

--- a/_scripts/templates/CSharp/build.sh
+++ b/_scripts/templates/CSharp/build.sh
@@ -1,6 +1,6 @@
 # Generated from trgen <version>
 set -e
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
-dotnet restore
-dotnet build
+dotnet restore Test.csproj
+dotnet build Test.csproj
 exit 0

--- a/_scripts/templates/CSharp/clean.ps1
+++ b/_scripts/templates/CSharp/clean.ps1
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-$(& dotnet clean; $status = $LASTEXITCODE) | Write-Host
+$(& dotnet clean Test.csproj; $status = $LASTEXITCODE) | Write-Host
 $(& Remove-Item bin -Recurse -Force ) 2>&1 | Out-Null
 $(& Remove-Item obj -Recurse -Force ) 2>&1 | Out-Null
 exit 0

--- a/_scripts/templates/CSharp/clean.sh
+++ b/_scripts/templates/CSharp/clean.sh
@@ -1,4 +1,4 @@
 # Generated from trgen <version>
-dotnet clean
+dotnet clean Test.csproj
 rm -rf bin obj
 rm -f <tool_grammar_tuples:{x|<x.GeneratedFileName> }>

--- a/_scripts/templates/CSharp/test.ps1
+++ b/_scripts/templates/CSharp/test.ps1
@@ -52,10 +52,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { trwdog trwdog dotnet run -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { trwdog ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | trwdog dotnet run -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | trwdog ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/files
+++ b/_scripts/templates/files
@@ -26,6 +26,8 @@
 ./CSharp/Encodings.cs
 ./CSharp/ErrorListener.cs
 ./CSharp/makefile
+./CSharp/Other.csproj
+./CSharp/Other.meta
 ./CSharp/run.ps1
 ./CSharp/run.sh
 ./CSharp/Test.cs


### PR DESCRIPTION
This fixes #3480, where .csproj files were not recognized and updated by Dependabot. In this implementation, file Other.csproj is added, along with Other.csproj.meta. The Other.csproj file is in MSBuild format, not StringTemplate format, as there is a .meta file that turns off StringTemplate processing. With ST turned off, trgen just copies the file "as is" to the generated driver directory. The Test.csproj file now contains an "Import" statement, where it includes Other.csproj. Because there are two csproj files, the rest of the changes clear up the ambiguity with dotnet builds.

When this is merged, there will be a Dependabot PR created for upgrading 4.12.0 to 4.13.0 of antlr4.runtime.standard. This, too, should be merged. I purposefully downgraded the version in this PR so that there is proof that the implementation works.

NB. As noted [in the comments](https://github.com/antlr/grammars-v4/issues/3480#issuecomment-1570155253), the plan will be to update the templates to .stg files, and replace this hack.

@teverett  All set.