### PR TITLE
[build] Fix for #3477 -- Add Dependabot processing of TypeScript.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,3 +62,12 @@ updates:
       - "infrastructure"
       - "dependencies"
       - "target:python3"
+  # TypeScript
+  - package-ecosystem: "npm"
+    directory: "/_scripts/templates/TypeScript"
+    schedule:
+      interval: "daily"
+    labels:
+      - "infrastructure"
+      - "dependencies"
+      - "target:typescript"


### PR DESCRIPTION
Update dependabot.yml to check the TypeScript templates. Note, Dependabot can have more than one entry for package-ecosystem "npm". I tested it here, and it works. Also, importantly, the package.json file does not contain any open angle brackets (i.e., `<`). Therefore, the npm manager has no problem parsing and updating the package.json file.

@teverett This PR is good to go.