### PR TITLE
[build] Fix for #3476 -- Add Dependabot processing of Dart.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,15 @@ updates:
       - "infrastructure"
       - "dependencies"
       - "target:csharp-standard"
-  # dart is not supported by bot
+  # dart
+  - package-ecosystem: "pub"
+    directory: "/_scripts/templates/Dart"
+    schedule:
+      interval: "daily"
+    labels:
+      - "infrastructure"
+      - "dependencies"
+      - "target:dart"
   # go
   # TODO: go runtime need tagged version, may need another repository
   # - package-ecosystem: "gomod"

--- a/_scripts/templates/Dart/pubspec.yaml
+++ b/_scripts/templates/Dart/pubspec.yaml
@@ -2,7 +2,7 @@
 name: cli
 description: A sample command-line application.
 environment:
-  sdk: '>=2.12.0 \<3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
   antlr4: 4.13.0
 dev_dependencies:

--- a/_scripts/templates/Dart/pubspec.yaml.meta
+++ b/_scripts/templates/Dart/pubspec.yaml.meta
@@ -1,0 +1,3 @@
+<StringTemplateOptions>
+   <Process>False</Process>
+</StringTemplateOptions>

--- a/_scripts/templates/files
+++ b/_scripts/templates/files
@@ -40,6 +40,7 @@
 ./Dart/makefile
 ./Dart/MyErrorListener.dart
 ./Dart/pubspec.yaml
+./Dart/pubspec.yaml.meta
 ./Dart/run.ps1
 ./Dart/run.sh
 ./Dart/Test.dart


### PR DESCRIPTION
This PR is a fix for #3476. It adds Dependabot processing of the file _scripts/templates/Dart/pubspec.yml file.

The problem is that Dependabot cannot process the pubspec.yml in template form. The solution removes the escaping, and adds the file _scripts/templates/Dart/pubspec.yml.meta, which means that the file pubspec.yml should not be processed by StringTemplate.