### PR TITLE
[fortran90] Fix for #3509--TypeScript target.

### DIFF
--- a/fortran/fortran90/TypeScript/Fortran90LexerBase.ts
+++ b/fortran/fortran90/TypeScript/Fortran90LexerBase.ts
@@ -1,6 +1,6 @@
 import {Lexer, Token, CharStream} from "antlr4";
 
-export abstract class Fortran90LexerBase extends Lexer {
+export default class Fortran90LexerBase extends Lexer {
 
     constructor(input: CharStream) {
         super(input);

--- a/fortran/fortran90/TypeScript/Fortran90LexerBase.ts
+++ b/fortran/fortran90/TypeScript/Fortran90LexerBase.ts
@@ -1,7 +1,6 @@
 import {Lexer, Token, CharStream} from "antlr4";
 
 export default class Fortran90LexerBase extends Lexer {
-
     constructor(input: CharStream) {
         super(input);
     }

--- a/fortran/fortran90/desc.xml
+++ b/fortran/fortran90/desc.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <!-- Antlr 4.13.0 Typescript does not work: -->
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
    <test>
-      <targets>JavaScript;PHP;Python3</targets>
+      <targets>JavaScript;PHP;Python3;TypeScript</targets>
       <inputs>slow</inputs>
    </test>
    <test>


### PR DESCRIPTION
This PR is a fix for #3509.

This was an easy fix, thanks to the comment from @ericvergnaud [here](https://github.com/antlr/antlr4/issues/4302#issuecomment-1576442166). It's just a change to the declaration for the base class. With it, we now have a grammar that is split and superClass'ed for the lexer working for 8 targets, the first of its kind.