### PR TITLE
[build] Fix for #3514 -- "antlr4" tool is not robust.

### DIFF
--- a/_scripts/templates/Cpp/cmake/FindANTLR.cmake
+++ b/_scripts/templates/Cpp/cmake/FindANTLR.cmake
@@ -1,7 +1,7 @@
 find_package(Java QUIET COMPONENTS Runtime)
 
   execute_process(
-      COMMAND antlr4<if(os_win)>.exe<else><endif>
+      COMMAND antlr4<if(os_win)>.exe<else><endif> -v ${ANTLR4_TAG}
       OUTPUT_VARIABLE ANTLR_COMMAND_OUTPUT
       ERROR_VARIABLE ANTLR_COMMAND_ERROR
       RESULT_VARIABLE ANTLR_COMMAND_RESULT
@@ -98,6 +98,7 @@ find_package(Java QUIET COMPONENTS Runtime)
     add_custom_command(
         OUTPUT ${ANTLR_${Name}_OUTPUTS}
         COMMAND antlr4<if(os_win)>.exe<else><endif>
+                -v ${ANTLR4_TAG}
                 ${InputFile}
                 -o ${ANTLR_${Name}_OUTPUT_DIR}
                 -no-listener

--- a/_scripts/templates/Go/build.ps1
+++ b/_scripts/templates/Go/build.ps1
@@ -1,7 +1,7 @@
 # Generated from trgen <version>
 $env:GO111MODULE = "on"
 For ($i=0; $i -le 5; $i++) {
-	$(& go get github.com/antlr4-go/antlr/v4 ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+	$(& go get github.com/antlr4-go/antlr/v4@v4.13.0 ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 	if($compile_exit_code -eq 0){
 		Break
 	}

--- a/_scripts/templates/Go/build.sh
+++ b/_scripts/templates/Go/build.sh
@@ -1,6 +1,6 @@
 # Generated from trgen <version>
 export GO111MODULE=on
-for i in {1..5}; do go get github.com/antlr4-go/antlr/v4; if [ "$?" = "0" ]; then break; fi; done; if [ "$?" != "0" ]; then exit 1; fi
+for i in {1..5}; do go get github.com/antlr4-go/antlr/v4@v4.13.0; if [ "$?" = "0" ]; then break; fi; done; if [ "$?" != "0" ]; then exit 1; fi
 
 set -e
 
@@ -13,7 +13,7 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 # Go has no version, just the latest version.
 
 <tool_grammar_tuples:{x |
-antlr4 -encoding <antlr_encoding> -Dlanguage=Go <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
+antlr4 -v 4.13.0 -encoding <antlr_encoding> -Dlanguage=Go <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
 } >
 
 go build Test.go


### PR DESCRIPTION
This PR fixes #3514. It should address build errors for Go for [PR#3517](https://github.com/antlr/grammars-v4/pull/3517) [build errors](https://github.com/antlr/grammars-v4/actions/runs/5187609698/jobs/9350179996#step:20:54) and [PR#3613](https://github.com/antlr/grammars-v4/pull/3513) [build errors](https://github.com/antlr/grammars-v4/actions/runs/5186830904/jobs/9348436952#step:21:65) and likely other places.

This change brings back the explicit version tags for Antlr to Cpp and Go targets, avoiding the problem with the "antlr4" Python script. I didn't want to do this because now someone will need to manually change those version strings when Antlr is again released. Unfortunately, there is no Dependabot for CMake files. There may be a way to update the Go target with Dependabot, but the [instructions for using the Go target](https://github.com/antlr/antlr4/blob/master/doc/go-target.md#2-get-the-go-antlr-runtime) explicitly say `go get github.com/antlr4-go/antlr`. Dependabot can't modify `go get github.com/antlr4-go/antlr/v4@v4.13.0` in a Bash file.