### PR TITLE
[fortran77] Fix for #3526--add targets to fortran77 grammar.

### DIFF
--- a/fortran/fortran77/CSharp/Fortrans77LexerBase.cs
+++ b/fortran/fortran77/CSharp/Fortrans77LexerBase.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+
+public class Fortran77LexerBase : Lexer
+{
+    protected Fortran77LexerBase(ICharStream input, TextWriter output, TextWriter errorOutput)
+        : base(input, output, errorOutput)
+    {
+    }
+
+    public Fortran77LexerBase(ICharStream input)
+        : base(input)
+    {
+    }
+
+    public override string[] RuleNames => throw new NotImplementedException();
+
+    public override IVocabulary Vocabulary => throw new NotImplementedException();
+
+    public override string GrammarFileName => throw new NotImplementedException();
+
+    public bool IsColumnZero()
+    {
+        return this.Column == 0;
+    }
+}

--- a/fortran/fortran77/Cpp/Fortran77LexerBase.h
+++ b/fortran/fortran77/Cpp/Fortran77LexerBase.h
@@ -1,0 +1,21 @@
+#ifndef PLSQLLEXERBASE_H
+#define PLSQLLEXERBASE_H
+
+#include "antlr4-runtime.h"
+
+class Fortran77LexerBase : public antlr4::Lexer
+{
+public:
+    Fortran77LexerBase(antlr4::CharStream *input) : Lexer(input), self(*this) { }
+
+public:
+    Fortran77LexerBase & self;
+
+public:
+    bool IsColumnZero()
+    {
+        return this->getCharPositionInLine() == 0;
+    }
+};
+
+#endif

--- a/fortran/fortran77/Cpp/transformGrammar.py
+++ b/fortran/fortran77/Cpp/transformGrammar.py
@@ -1,0 +1,33 @@
+import sys, os, re, shutil
+from glob import glob
+from pathlib import Path
+
+def main(argv):
+    for file in glob("./*.g4"):
+        fix(file)
+
+def fix(file_path):
+    print("Altering " + file_path)
+    if not os.path.exists(file_path):
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    parts = os.path.split(file_path)
+    file_name = parts[-1]
+
+    shutil.move(file_path, file_path + ".bak")
+    input_file = open(file_path + ".bak",'r')
+    output_file = open(file_path, 'w')
+    for x in input_file:
+        if '// Insert here @header for C++ lexer.' in x:
+            x = x.replace('// Insert here @header for C++ lexer.', '@header {#include "Fortran77LexerBase.h"}')
+        if 'this.' in x:
+            x = x.replace('this.', 'this->')
+        output_file.write(x)
+        output_file.flush()
+
+    print("Writing ...")
+    input_file.close()
+    output_file.close()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/fortran/fortran77/Dart/Fortran77LexerBase.dart
+++ b/fortran/fortran77/Dart/Fortran77LexerBase.dart
@@ -1,0 +1,15 @@
+import 'package:antlr4/antlr4.dart';
+import 'dart:io';
+import 'dart:convert';
+
+abstract class Fortran77LexerBase extends Lexer
+{
+    Fortran77LexerBase(CharStream input) : super(input)
+    {
+    }
+
+    bool IsColumnZero()
+    {
+        return charPositionInLine == 0;
+    }
+}

--- a/fortran/fortran77/Fortran77Lexer.g4
+++ b/fortran/fortran77/Fortran77Lexer.g4
@@ -28,6 +28,9 @@
  */
 lexer grammar Fortran77Lexer;
 
+options { superClass = Fortran77LexerBase; } 
+
+// Insert here @header for C++ lexer.
 
 PROGRAM
    : 'program' | 'PROGRAM'
@@ -650,7 +653,7 @@ NAME
 
 
 COMMENT
-   : {getCharPositionInLine() == 0}? ('c' | STARCHAR) (~ [\r\n])* EOL -> channel(HIDDEN)
+   : {this.IsColumnZero()}? ('c' | STARCHAR) (~ [\r\n])* EOL -> channel(HIDDEN)
    ;
 
 STAR

--- a/fortran/fortran77/Go/fortran77_lexer_base.go
+++ b/fortran/fortran77/Go/fortran77_lexer_base.go
@@ -1,0 +1,14 @@
+package parser
+
+import (
+    "github.com/antlr4-go/antlr/v4"
+)
+
+type Fortran77LexerBase struct {
+    *antlr.BaseLexer
+    lastToken antlr.Token
+}
+
+func (l *Fortran77LexerBase) IsColumnZero() bool {
+    return l.GetCharPositionInLine() == 0;
+}

--- a/fortran/fortran77/Go/transformGrammar.py
+++ b/fortran/fortran77/Go/transformGrammar.py
@@ -1,0 +1,31 @@
+import sys, os, re, shutil
+from glob import glob
+from pathlib import Path
+
+def main(argv):
+    for file in glob("./parser/*.g4"):
+        fix(file)
+
+def fix(file_path):
+    print("Altering " + file_path)
+    if not os.path.exists(file_path):
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    parts = os.path.split(file_path)
+    file_name = parts[-1]
+
+    shutil.move(file_path, file_path + ".bak")
+    input_file = open(file_path + ".bak",'r')
+    output_file = open(file_path, 'w')
+    for x in input_file:
+        if 'this.' in x:
+            x = x.replace('this.', 'p.')
+        output_file.write(x)
+        output_file.flush()
+
+    print("Writing ...")
+    input_file.close()
+    output_file.close()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/fortran/fortran77/Java/Fortran77LexerBase.java
+++ b/fortran/fortran77/Java/Fortran77LexerBase.java
@@ -1,0 +1,14 @@
+import org.antlr.v4.runtime.*;
+
+public abstract class Fortran77LexerBase extends Lexer
+{
+    public Fortran77LexerBase(CharStream input)
+    {
+        super(input);
+    }
+
+    protected boolean IsColumnZero()
+    {
+	return this.getCharPositionInLine() == 0;
+    }
+}

--- a/fortran/fortran77/JavaScript/Fortran77LexerBase.js
+++ b/fortran/fortran77/JavaScript/Fortran77LexerBase.js
@@ -1,0 +1,8 @@
+import antlr4 from 'antlr4';
+import Fortran77Lexer from './Fortran77Lexer.js';
+
+export default class Fortran77LexerBase extends antlr4.Lexer {
+	IsColumnZero(pos) {
+		return this.column == 0;
+	}
+}

--- a/fortran/fortran77/PHP/Fortran77LexerBase.php
+++ b/fortran/fortran77/PHP/Fortran77LexerBase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace {
+	use Antlr\Antlr4\Runtime\Atn\ATNDeserializer;
+	use Antlr\Antlr4\Runtime\Atn\LexerATNSimulator;
+	use Antlr\Antlr4\Runtime\Lexer;
+	use Antlr\Antlr4\Runtime\CharStream;
+	use Antlr\Antlr4\Runtime\PredictionContexts\PredictionContextCache;
+	use Antlr\Antlr4\Runtime\RuleContext;
+	use Antlr\Antlr4\Runtime\Atn\ATN;
+	use Antlr\Antlr4\Runtime\Dfa\DFA;
+	use Antlr\Antlr4\Runtime\Vocabulary;
+	use Antlr\Antlr4\Runtime\RuntimeMetaData;
+	use Antlr\Antlr4\Runtime\VocabularyImpl;
+
+	class Fortran77LexerBase extends Lexer
+	{
+		public function __construct(CharStream $input)
+		{
+			parent::__construct($input);
+		}
+
+		public function IsColumnZero(): bool
+		{
+			return $this->getCharPositionInLine() == 0;
+		}
+
+		public function getVocabulary(): Vocabulary {
+			return null;
+		}
+
+		 public function getRuleNames(): array {
+			return null;
+		 }
+
+		 public function getATN(): ATN {
+			return null;
+		 }
+	}
+}

--- a/fortran/fortran77/PHP/transformGrammar.py
+++ b/fortran/fortran77/PHP/transformGrammar.py
@@ -1,0 +1,33 @@
+import sys, os, re, shutil
+from glob import glob
+from pathlib import Path
+
+def main(argv):
+    for file in glob("./*.g4"):
+        fix(file)
+
+def fix(file_path):
+    print("Altering " + file_path)
+    if not os.path.exists(file_path):
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    parts = os.path.split(file_path)
+    file_name = parts[-1]
+
+    shutil.move(file_path, file_path + ".bak")
+    input_file = open(file_path + ".bak",'r')
+    output_file = open(file_path, 'w')
+    for x in input_file:
+        if '// Insert here @header for C++ lexer.' in x:
+            x = x.replace('// Insert here @header for C++ lexer.', '@header {require "Fortran77LexerBase.php";}')
+        if 'this.' in x:
+            x = x.replace('this.', 'self::')
+        output_file.write(x)
+        output_file.flush()
+
+    print("Writing ...")
+    input_file.close()
+    output_file.close()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/fortran/fortran77/Python3/Fortran77LexerBase.py
+++ b/fortran/fortran77/Python3/Fortran77LexerBase.py
@@ -1,0 +1,5 @@
+from antlr4 import *
+
+class Fortran77LexerBase(Lexer):
+    def IsColumnZero(self):
+        return self.column == 0

--- a/fortran/fortran77/Python3/transformGrammar.py
+++ b/fortran/fortran77/Python3/transformGrammar.py
@@ -1,0 +1,31 @@
+import sys, os, re, shutil
+from glob import glob
+from pathlib import Path
+
+def main(argv):
+    for file in glob("./*.g4"):
+        fix(file)
+
+def fix(file_path):
+    print("Altering " + file_path)
+    if not os.path.exists(file_path):
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    parts = os.path.split(file_path)
+    file_name = parts[-1]
+
+    shutil.move(file_path, file_path + ".bak")
+    input_file = open(file_path + ".bak",'r')
+    output_file = open(file_path, 'w')
+    for x in input_file:
+        if 'this.' in x:
+            x = x.replace('this.', 'self.')
+        output_file.write(x)
+        output_file.flush()
+
+    print("Writing ...")
+    input_file.close()
+    output_file.close()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/fortran/fortran77/TypeScript/Fortran77LexerBase.ts
+++ b/fortran/fortran77/TypeScript/Fortran77LexerBase.ts
@@ -1,0 +1,11 @@
+import {Lexer, Token, CharStream} from "antlr4";
+
+export default class Fortran77LexerBase extends Lexer {
+    constructor(input: CharStream) {
+        super(input);
+    }
+
+    IsColumnZero(): boolean {
+	return this.column == 0;
+    }
+}

--- a/fortran/fortran77/desc.xml
+++ b/fortran/fortran77/desc.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;Java</targets>
+   <antlr-version>^4.13.0</antlr-version>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
 </desc>


### PR DESCRIPTION
This is a fix for https://github.com/antlr/grammars-v4/issues/3526.

The changes in this PR were readily available from the fortran90 grammar, which I added in the last week. All I had to do was copy the files over to [fortran77](https://github.com/antlr/grammars-v4/tree/8d58426f64b98637d55f6e49a51544bac5106b5a/fortran/fortran77), rename a few files, change "90" to "77", and fix up the grammar in target agnostic format.

All targets pass the tests.

That said, I cannot attest to the quality of the grammar since I did not write it. And, there are only [5 test inputs](https://github.com/antlr/grammars-v4/tree/2a4a265a490eca03cd8c8ba87788386c2757c816/fortran/fortran77/examples), which covers only 26% of the parser rules.