### PR TITLE
fix: PostgreSQLParser substr_list cannot be empty

### DIFF
--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -3955,7 +3955,6 @@ substr_list
    | a_expr FOR a_expr
    | a_expr SIMILAR a_expr ESCAPE a_expr
    | expr_list
-   |
    ;
 
 trim_list


### PR DESCRIPTION
```
postgres=# SELECT SUBSTRING();
ERROR:  function substring() does not exist
LINE 1: SELECT SUBSTRING();
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```