### PR TITLE
Fix PostgreSQL set operation precedence

### DIFF
--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -2907,6 +2907,14 @@ select_clause
    ;
 
 simple_select
+   : simple_select_intersect ((UNION | EXCEPT) all_or_distinct simple_select_intersect)*
+   ;
+
+simple_select_intersect
+    : simple_select_pramary ((INTERSECT) all_or_distinct simple_select_pramary)*
+    ;
+
+simple_select_pramary
    : ( SELECT (opt_all_clause into_clause opt_target_list | distinct_clause target_list)
            into_clause
            from_clause
@@ -2916,19 +2924,8 @@ simple_select
            window_clause
        | values_clause
        | TABLE relation_expr
-       | select_with_parens set_operator_with_all_or_distinct (simple_select | select_with_parens)
+       | select_with_parens
      )
-        (set_operator_with_all_or_distinct (simple_select | select_with_parens))*
-   ;
-
-set_operator
-   : UNION # union
-   | INTERSECT # intersect
-   | EXCEPT # except
-   ;
-
-set_operator_with_all_or_distinct
-   : set_operator all_or_distinct
    ;
 
 with_clause

--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -2906,7 +2906,7 @@ select_clause
    ;
 
 simple_select_intersect
-    : simple_select_pramary ((INTERSECT) all_or_distinct simple_select_pramary)*
+    : simple_select_pramary (INTERSECT all_or_distinct simple_select_pramary)*
     ;
 
 simple_select_pramary

--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -2902,11 +2902,6 @@ select_no_parens
    ;
 
 select_clause
-   : simple_select
-   | select_with_parens
-   ;
-
-simple_select
    : simple_select_intersect ((UNION | EXCEPT) all_or_distinct simple_select_intersect)*
    ;
 
@@ -2922,10 +2917,10 @@ simple_select_pramary
            group_clause
            having_clause
            window_clause
-       | values_clause
-       | TABLE relation_expr
-       | select_with_parens
-     )
+    )
+   | values_clause
+   | TABLE relation_expr
+   | select_with_parens
    ;
 
 with_clause


### PR DESCRIPTION
Comes from https://github.com/antlr/grammars-v4/pull/2378#discussion_r1246216426.

PG treats set ops in different precedence - INTERSECT is tighter than UNION and EXCEPT.