### PR TITLE
Fix for #3588 -- Update root pom.xml for testing Antlr 4.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,10 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
 
-		<!-- antlr.version is the version of the tool. But the
-		runtime is tied to the version of antlr4test-maven-plugin.version -->
+		<!-- The Antlr tool version is specified with
+		antlr.version. The Antlr runtime is tied to the
+		version of antlr4test-maven-plugin.version. When Antlr
+		is release, the plugin has to be updated. -->
 		<antlr4test-maven-plugin.version>1.22</antlr4test-maven-plugin.version>
 		<antlr.version>4.11.1</antlr.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+
+		<!-- antlr.version is the version of the tool. But the
+		runtime is tied to the version of antlr4test-maven-plugin.version -->
 		<antlr4test-maven-plugin.version>1.22</antlr4test-maven-plugin.version>
-		<antlr.version>4.13.0</antlr.version>
+		<antlr.version>4.11.1</antlr.version>
+
 		<junit.version>4.13.2</junit.version>
 	</properties>
 	<prerequisites>


### PR DESCRIPTION
This is a fix for https://github.com/antlr/grammars-v4/issues/3588.

The version of the Antlr tool is specified directly in the root pom.xml. But the version of the runtime is specified indirectly with the antlr4test-maven-plugin.version. The plugin links with a version of runtime specified in the plugin [here](https://github.com/antlr/antlr4test-maven-plugin/blob/fbba99e1ecebe03681e1269a0a1fba95f75550c3/pom.xml#L41).

Consequently, when Dependabot updates the pom.xml, e.g., https://github.com/antlr/grammars-v4/pull/3114 and https://github.com/antlr/grammars-v4/pull/3462, it fails to take into consideration updating the version of the plugin, which must be specially released and published. The state for testing using the plugin is then inconsistent.

The newer test framework via [trgen](https://github.com/kaby76/Domemtech.Trash/tree/main/src/trgen) does not have this problem because [it works from the version in the templates for both tool and runtime](https://github.com/kaby76/Domemtech.Trash/blob/e18338d088afb263aaae63f4de2179766a7f1a29/src/trgen/templates/Java/st.build.sh#L9). The [antlr4 tool](https://github.com/antlr/antlr4-tools) is used, which not only downloads the Antlr .jar, but the java runtime. Even when running the compiled java program, [it refers back to the one and only version string](https://github.com/antlr/grammars-v4/blob/8c81d4c7b2dfde7a802d206ac0fae84c2dd9e841/_scripts/templates/Java/st.test.sh#L35).

I am removing a .error file that I created for abb. The test plugin cannot deal with empty .errors files, so it has to be removed.

There's a problem with the XPath grammars. That is being fixed separately. https://github.com/antlr/grammars-v4/pull/3595

The PR updates the support for testing with the plugin, until a time when people stop using it. Grammars that require the new features of Antlr 4.11.2 or more recent must be removed from the root pom.xml.
