### PR TITLE
PromQL: Added missing trigonometric functions 

### DIFF
--- a/promql/PromQLLexer.g4
+++ b/promql/PromQLLexer.g4
@@ -154,6 +154,21 @@ FUNCTION options { caseInsensitive=false; }
     | 'stddev_over_time'
     | 'stdvar_over_time'
     | 'last_over_time'
+    | 'acos'
+    | 'acosh'
+    | 'asin'
+    | 'asinh'
+    | 'atan'
+    | 'atanh'
+    | 'cos'
+    | 'cosh'
+    | 'sin'
+    | 'sinh'
+    | 'tan'
+    | 'tanh'
+    | 'deg'
+    | 'pi'
+    | 'rad'
     ;
 
 LEFT_BRACE:  '{';

--- a/promql/examples/function.txt
+++ b/promql/examples/function.txt
@@ -1,1 +1,2 @@
 day_of_month(timestamp(up{job="prometheus"}))
+sin(rate(http_requests_total[5m]))


### PR DESCRIPTION
This pull request adds the missing trigonometric functions to the promql grammar: acos, acosh, asin, asinh, etc. You can see a list of functions in promql [here](https://prometheus.io/docs/prometheus/latest/querying/functions/#trigonometric-functions).
