### PR TITLE
[gdscript] Fix #3613 -- add reset() method

### DIFF
--- a/gdscript/CSharp/GDScriptLexerBase.cs
+++ b/gdscript/CSharp/GDScriptLexerBase.cs
@@ -165,4 +165,13 @@ public abstract class GDScriptLexerBase : Lexer {
 			}
 		}
 	}
+
+	public override void Reset()
+	{
+		Tokens = new LinkedList<IToken>();
+		Indents = new Stack<int>();
+		Opened = 0;
+		LastToken = null;
+		base.Reset();
+	}
 }

--- a/gdscript/Java/GDScriptLexerBase.java
+++ b/gdscript/Java/GDScriptLexerBase.java
@@ -12,7 +12,7 @@ abstract class GDScriptLexerBase extends Lexer {
     // A queue where extra tokens are pushed on (see the NEWLINE lexer rule).
     private java.util.LinkedList<Token> tokens = new java.util.LinkedList<>();
     // The stack that keeps track of the indentation level.
-    private final Deque<Integer> indents = new ArrayDeque<>();
+    private Deque<Integer> indents = new ArrayDeque<>();
     // The amount of opened braces, brackets and parenthesis.
     private int opened = 0;
     // The most recently produced token.
@@ -142,5 +142,15 @@ abstract class GDScriptLexerBase extends Lexer {
                 }
             }
         }
+    }
+    
+    @Override
+    public void reset()
+    {
+        tokens = new java.util.LinkedList<>();
+        indents = new ArrayDeque<>();
+        opened = 0;
+        lastToken = null;
+        super.reset();
     }
 }


### PR DESCRIPTION
This PR fixes #3613.

The change added the reset() method in Java, Reset() method in CSharp. This PR is required for https://github.com/antlr/grammars-v4/pull/3598