### PR TITLE
Modified: allow for editionable functions in PLSQL grammar.

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -482,7 +482,7 @@ match_string
     ;
 
 create_function_body
-    : CREATE (OR REPLACE)? FUNCTION function_name ('(' parameter (',' parameter)* ')')?
+    : CREATE (OR REPLACE)? (EDITIONABLE | NONEDITIONABLE)? FUNCTION function_name ('(' parameter (',' parameter)* ')')?
       RETURN type_spec (invoker_rights_clause | parallel_enable_clause | result_cache_clause | DETERMINISTIC)*
       ((PIPELINED? (IS | AS) (DECLARE? seq_of_declare_specs? body | call_spec))
         | (PIPELINED | AGGREGATE) USING implementation_type_name

--- a/sql/plsql/examples/editionable_function.sql
+++ b/sql/plsql/examples/editionable_function.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE EDITIONABLE FUNCTION "TEST"."TRIM_FUNC" (vField in varchar2) return varchar2 is
+    vTemp varchar2(100);
+begin
+    vTemp:=rtrim(ltrim(vField));
+    return vTemp;
+end;


### PR DESCRIPTION
Similar to this pull request: https://github.com/antlr/grammars-v4/pull/3591

The Oracle specification for [Create Function Statements](https://docs.oracle.com/en/database/oracle/oracle-database/21/lnpls/CREATE-FUNCTION-statement.html#GUID-B71BC5BD-B87C-4054-AAA5-213E856651F2)

Now allows for Editionable or NonEditionable keywords in function creation. The change to the grammar is to add this support.