### PR TITLE
Fix issue at llvm-ir grammar.

### DIFF
--- a/llvm-ir/LLVMIR.g4
+++ b/llvm-ir/LLVMIR.g4
@@ -114,7 +114,10 @@ gc: 'gc' StringLit;
 prefix: 'prefix' typeConst;
 prologue: 'prologue' typeConst;
 personality: 'personality' typeConst;
-returnAttribute: returnAttr | dereferenceable;
+returnAttribute: 
+    returnAttr 
+    | dereferenceable
+    | align;
 funcBody: '{' basicBlock+ useListOrder* '}';
 basicBlock: LabelIdent? instruction* terminator;
 instruction: // Instructions producing values.

--- a/llvm-ir/examples/returnAttribute_align.ll
+++ b/llvm-ir/examples/returnAttribute_align.ll
@@ -1,0 +1,4 @@
+define void @main() {
+  %0 = call nonnull align 8 i32 @f()
+  ret void
+}


### PR DESCRIPTION
Recently I compiled C++ code to llvmir and experienced issues parsing it.

It seems the grammar is missing the align statement at the returnAttribute rule, which should be a valid returnAttribute according to the [language reference manual](https://releases.llvm.org/15.0.0/docs/LangRef.html#paramattrs).

This also fixed my issue parsing the llvmir code.