### PR TITLE
[plsql] Fix for 3660 -- clean up readme

### DIFF
--- a/sql/plsql/README.md
+++ b/sql/plsql/README.md
@@ -1,1 +1,22 @@
-Oracle SQL Language Reference: https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Introduction-to-Oracle-SQL.html
+# PL/SQL grammar
+
+This grammar is for recognizing the latest version of PL/SQL. It does not recognize
+SQL *Plus, which a superset of PL/SQL.
+
+
+## Authors
+
+Various
+
+## Links
+
+Oracle® Database; Database PL/SQL Language Reference [pdf](https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/database-pl-sql-language-reference.pdf)
+
+Oracle® Database; Database PL/SQL Language Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/index.html)
+
+Oracle's SQL*Plus®
+User's Guide and Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqpug/index.html#SQL*Plus%C2%AE)
+
+[wikipedia](https://en.wikipedia.org/wiki/PL/SQL)
+
+[pldb](https://pldb.pub/concepts/pl-sql.html)


### PR DESCRIPTION
This is a fix for #3660.

In this PR, I changed the readme.md file to clarify the links to the PL/SQL Language Reference. I added a few other links and standardized the format.