### PR TITLE
[MySQL][MariaDB] Dbz crashes on DDL statement (non Latin chars in variables)

### DIFF
--- a/sql/mariadb/MariaDBLexer.g4
+++ b/sql/mariadb/MariaDBLexer.g4
@@ -1351,14 +1351,14 @@ STRING_USER_NAME_MARIADB:            (
                                      )  '@';
 LOCAL_ID:                               '@'
                                      (
-                                        [A-Z0-9._$]+
+                                        [A-Z0-9._$\u0080-\uFFFF]+
                                         | SQUOTA_STRING
                                         | DQUOTA_STRING
                                         | BQUOTA_STRING
                                     );
 GLOBAL_ID:                              '@' '@'
                                     (
-                                        [A-Z0-9._$]+
+                                        [A-Z0-9._$\u0080-\uFFFF]+
                                         | BQUOTA_STRING
                                     );
 

--- a/sql/mariadb/examples/fast/ddl_create.sql
+++ b/sql/mariadb/examples/fast/ddl_create.sql
@@ -628,3 +628,13 @@ WITH my_values(val1, val2) AS (
 )
 SELECT v.val1, v.val2 FROM my_values v;
 #end
+
+#begin
+CREATE DEFINER=`peuser`@`%` PROCEDURE `test_utf`()
+BEGIN
+    SET @Ν_greece := 1, @N_latin := 'test';
+SELECT
+    @Ν_greece
+     ,@N_latin;
+END
+#end

--- a/sql/mysql/Positive-Technologies/MySqlLexer.g4
+++ b/sql/mysql/Positive-Technologies/MySqlLexer.g4
@@ -1324,14 +1324,14 @@ IP_ADDRESS:                          (
                                      );
 LOCAL_ID:                               '@'
                                      (
-                                        [A-Z0-9._$]+
+                                        [A-Z0-9._$\u0080-\uFFFF]+
                                         | SQUOTA_STRING
                                         | DQUOTA_STRING
                                         | BQUOTA_STRING
                                     );
 GLOBAL_ID:                              '@' '@'
                                     (
-                                        [A-Z0-9._$]+
+                                        [A-Z0-9._$\u0080-\uFFFF]+
                                         | BQUOTA_STRING
                                     );
 

--- a/sql/mysql/Positive-Technologies/examples/ddl_create.sql
+++ b/sql/mysql/Positive-Technologies/examples/ddl_create.sql
@@ -672,3 +672,13 @@ SELECT 1;
 
 END
 #end
+
+#begin
+CREATE DEFINER=`peuser`@`%` PROCEDURE `test_utf`()
+BEGIN
+    SET @Ν_greece := 1, @N_latin := 'test';
+SELECT
+    @Ν_greece
+     ,@N_latin;
+END
+#end


### PR DESCRIPTION
Refer: https://issues.redhat.com/browse/DBZ-6821