### PR TITLE
add support for Cpp target to swift5

### DIFF
--- a/swift/swift5/Cpp/SwiftSupport.cpp
+++ b/swift/swift5/Cpp/SwiftSupport.cpp
@@ -1,0 +1,355 @@
+#include "SwiftSupport.h"
+#include "Swift5Parser.h"
+#include "Swift5Lexer.h"
+#include "antlr4-runtime.h"
+
+using namespace antlr4;
+
+static int utf8_first_char_len(const char *s, int len) {
+    int i = 0;
+    for(; i < len; i++) {
+        if((s[i] & 0xc0) != 0x80) {
+            i += 1;
+            break;
+        }
+    }
+    return i;
+}
+
+template<typename BITSET>
+static bool isCharacterFromSet(std::unique_ptr<antlr4::Token>& token, const BITSET& bitSet) {
+    if (token->getType() == Token::EOF) {
+        return false;
+    } else {
+        String text = token->getText();
+        if (utf8_first_char_len(text.data(), text.size()) != text.size()) {
+            // not a single character
+            return false;
+        } else {
+            return bitSet.get(text.data()[0]);
+        }
+    }
+}
+
+const SwiftSupport::OperatorHead SwiftSupport::operatorHead;
+const SwiftSupport::OperatorCharacter SwiftSupport::operatorCharacter;
+const SwiftSupport::LeftWS SwiftSupport::leftWS;
+const SwiftSupport::RightWS SwiftSupport::rightWS;
+
+SwiftSupport::OperatorHead::OperatorHead() {
+    // operator-head → /  =­  -­  +­  !­  *­  %­  <­  >­  &­  |­  ^­  ~­  ?­
+    set('/');
+    set('=');
+    set('-');
+    set('+');
+    set('!');
+    set('*');
+    set('%');
+    set('&');
+    set('|');
+    set('<');
+    set('>');
+    set('^');
+    set('~');
+    set('?');
+
+    // operator-head → U+00A1–U+00A7
+    set(0x00A1, 0x00A7 + 1);
+
+    // operator-head → U+00A9 or U+00AB
+    set(0x00A9);
+    set(0x00AB);
+
+    // operator-head → U+00AC or U+00AE
+    set(0x00AC);
+    set(0x00AE);
+
+    // operator-head → U+00B0–U+00B1, U+00B6, U+00BB, U+00BF, U+00D7, or U+00F7
+    set(0x00B0, 0x00B1 + 1);
+    set(0x00B6);
+    set(0x00BB);
+    set(0x00BF);
+    set(0x00D7);
+    set(0x00F7);
+
+    // operator-head → U+2016–U+2017 or U+2020–U+2027
+    set(0x2016, 0x2017 + 1);
+    set(0x2020, 0x2027 + 1);
+
+    // operator-head → U+2030–U+203E
+    set(0x2030, 0x203E + 1);
+
+    // operator-head → U+2041–U+2053
+    set(0x2041, 0x2053 + 1);
+
+    // operator-head → U+2055–U+205E
+    set(0x2055, 0x205E + 1);
+
+    // operator-head → U+2190–U+23FF
+    set(0x2190, 0x23FF + 1);
+
+    // operator-head → U+2500–U+2775
+    set(0x2500, 0x2775 + 1);
+
+    // operator-head → U+2794–U+2BFF
+    set(0x2794, 0x2BFF + 1);
+
+    // operator-head → U+2E00–U+2E7F
+    set(0x2E00, 0x2E7F + 1);
+
+    // operator-head → U+3001–U+3003
+    set(0x3001, 0x3003 + 1);
+
+    // operator-head → U+3008–U+3030
+    set(0x3008, 0x3020 + 1);
+
+    set(0x3030);
+}
+
+SwiftSupport::OperatorCharacter::OperatorCharacter()
+    : OperatorHead() {
+    // operator-character → operator-head­
+
+    // operator-character → U+0300–U+036F
+    set(0x0300, 0x036F + 1);
+    // operator-character → U+1DC0–U+1DFF
+    set(0x1DC0, 0x1DFF + 1);
+    // operator-character → U+20D0–U+20FF
+    set(0x20D0, 0x20FF + 1);
+    // operator-character → U+FE00–U+FE0F
+    set(0xFE00, 0xFE0F + 1);
+    // operator-character → U+FE20–U+FE2F
+    set(0xFE20, 0xFE2F + 1);
+
+    // operator-character → U+E0100–U+E01EF
+    // Java works with 16-bit unicode chars. However, it can work for targets in other languages, e.g. in Swift
+    set(0xE0100,0xE01EF+1);
+}
+
+SwiftSupport::LeftWS::LeftWS() {
+    set(Swift5Parser::WS);
+    set(Swift5Parser::LPAREN);
+    set(Swift5Parser::Interpolataion_multi_line);
+    set(Swift5Parser::Interpolataion_single_line);
+    set(Swift5Parser::LBRACK);
+    set(Swift5Parser::LCURLY);
+    set(Swift5Parser::COMMA);
+    set(Swift5Parser::COLON);
+    set(Swift5Parser::SEMI);
+}
+
+
+SwiftSupport::RightWS::RightWS() {
+    set(Swift5Parser::WS);
+    set(Swift5Parser::RPAREN);
+    set(Swift5Parser::RBRACK);
+    set(Swift5Parser::RCURLY);
+    set(Swift5Parser::COMMA);
+    set(Swift5Parser::COLON);
+    set(Swift5Parser::SEMI);
+    set(Swift5Parser::Line_comment);
+    set(Swift5Parser::Block_comment);
+}
+
+bool SwiftSupport::isOperatorHead(std::unique_ptr<antlr4::Token>& token) {
+    return isCharacterFromSet(token, operatorHead);
+}
+
+bool SwiftSupport::isOperatorCharacter(std::unique_ptr<antlr4::Token>& token) {
+    return isCharacterFromSet(token, operatorCharacter);
+}
+
+bool SwiftSupport::isOpNext(antlr4::TokenStream* tokens) {
+    return getLastOpTokenIndex(tokens) != -1;
+}
+
+/**
+* Find stop token index of next operator; return -1 if not operator.
+*/
+int SwiftSupport::getLastOpTokenIndex(antlr4::TokenStream* tokens) {
+    fillUp(tokens);
+    int currentTokenIndex = tokens->index(); // current on-channel lookahead token index
+    unowned_unique_ptr<Token> currentToken = tokens->get(currentTokenIndex);
+
+    //System.out.println("getLastOpTokenIndex: "+currentToken.getText());
+
+
+    // operator → dot-operator-head­ dot-operator-characters
+    if (currentToken->getType() == Swift5Parser::DOT && tokens->get(currentTokenIndex + 1)->getType() == Swift5Parser::DOT) {
+        //System.out.println("DOT");
+
+
+        // dot-operator
+        currentTokenIndex += 2; // point at token after ".."
+        currentToken = tokens->get(currentTokenIndex);
+
+        // dot-operator-character → .­ | operator-character­
+        while (currentToken->getType() == Swift5Parser::DOT || isOperatorCharacter(currentToken)) {
+            //System.out.println("DOT");
+            currentTokenIndex++;
+            currentToken = tokens->get(currentTokenIndex);
+        }
+
+        //System.out.println("result: "+(currentTokenIndex - 1));
+        return currentTokenIndex - 1;
+    }
+
+    // operator → operator-head­ operator-characters­?
+
+    if (isOperatorHead(currentToken)) {
+        //System.out.println("isOperatorHead");
+
+        currentToken = tokens->get(currentTokenIndex);
+        while (isOperatorCharacter(currentToken)) {
+            //System.out.println("isOperatorCharacter");
+            currentTokenIndex++;
+            currentToken = tokens->get(currentTokenIndex);
+        }
+        //System.out.println("result: "+(currentTokenIndex - 1));
+        return currentTokenIndex - 1;
+    } else {
+        //System.out.println("result: "+(-1));
+        return -1;
+    }
+}
+
+/**
+* "If an operator has whitespace around both sides or around neither side,
+* it is treated as a binary operator. As an example, the + operator in a+b
+* and a + b is treated as a binary operator."
+*/
+bool SwiftSupport::isBinaryOp(antlr4::TokenStream* tokens) {
+    fillUp(tokens);
+    int stop = getLastOpTokenIndex(tokens);
+    if (stop == -1) return false;
+
+    int start = tokens->index();
+    unowned_unique_ptr<Token> currentToken = tokens->get(start);
+    unowned_unique_ptr<Token> prevToken = tokens->get(start - 1); // includes hidden-channel tokens
+    unowned_unique_ptr<Token> nextToken = tokens->get(stop + 1);
+    bool prevIsWS = isLeftOperatorWS(prevToken);
+    bool nextIsWS = isRightOperatorWS(nextToken);
+    //String text = tokens.getText(Interval.of(start, stop));
+    //System.out.println("isBinaryOp: '"+prevToken+"','"+text+"','"+nextToken+"' is "+result);
+    if (prevIsWS) {
+        return nextIsWS;
+    } else {
+        if (currentToken->getType() == Swift5Lexer::BANG || currentToken->getType() == Swift5Lexer::QUESTION) {
+            return false;
+        } else {
+            if (!nextIsWS) return nextToken->getType() != Swift5Lexer::DOT;
+        }
+    }
+    return false;
+}
+
+/**
+* "If an operator has whitespace on the left side only, it is treated as a
+* prefix unary operator. As an example, the ++ operator in a ++b is treated
+* as a prefix unary operator."
+*/
+bool SwiftSupport::isPrefixOp(antlr4::TokenStream* tokens) {
+    fillUp(tokens);
+    int stop = getLastOpTokenIndex(tokens);
+    if (stop == -1) return false;
+
+    int start = tokens->index();
+    unowned_unique_ptr<Token> prevToken = tokens->get(start - 1); // includes hidden-channel tokens
+    unowned_unique_ptr<Token> nextToken = tokens->get(stop + 1);
+    bool prevIsWS = isLeftOperatorWS(prevToken);
+    bool nextIsWS = isRightOperatorWS(nextToken);
+    //String text = tokens.getText(Interval.of(start, stop));
+    // System.out.println("isPrefixOp: '"+prevToken+"','"+text+"','"+nextToken+"' is "+result);
+    return prevIsWS && !nextIsWS;
+}
+
+/**
+* "If an operator has whitespace on the right side only, it is treated as a
+* postfix unary operator. As an example, the ++ operator in a++ b is treated
+* as a postfix unary operator."
+* <p>
+* "If an operator has no whitespace on the left but is followed immediately
+* by a dot (.), it is treated as a postfix unary operator. As an example,
+* the ++ operator in a++.b is treated as a postfix unary operator (a++ .b
+* rather than a ++ .b)."
+*/
+bool SwiftSupport::isPostfixOp(antlr4::TokenStream* tokens) {
+    fillUp(tokens);
+    int stop = getLastOpTokenIndex(tokens);
+    if (stop == -1) return false;
+
+    int start = tokens->index();
+    unowned_unique_ptr<Token> prevToken = tokens->get(start - 1); // includes hidden-channel tokens
+    unowned_unique_ptr<Token> nextToken = tokens->get(stop + 1);
+    bool prevIsWS = isLeftOperatorWS(prevToken);
+    bool nextIsWS = isRightOperatorWS(nextToken);
+    //String text = tokens.getText(Interval.of(start, stop));
+    // System.out.println("isPostfixOp: '"+prevToken+"','"+text+"','"+nextToken+"' is "+result);
+    return !prevIsWS && nextIsWS ||
+            !prevIsWS && nextToken->getType() == Swift5Parser::DOT;
+}
+
+bool SwiftSupport::isOperator(antlr4::TokenStream* tokens, const char* op) {
+    fillUp(tokens);
+    ssize_t stop = getLastOpTokenIndex(tokens);
+    if (stop == -1) return false;
+
+    ssize_t start = tokens->index();
+    String text = tokens->getText(misc::Interval(start, stop));
+    // System.out.println("text: '"+text+"', op: '"+op+"', text.equals(op): '"+text.equals(op)+"'");
+
+    // for (int i = 0; i <= stop; i++) {
+    //     System.out.println("token["+i+"] = '"+tokens.getText(Interval.of(i, i))+"'");
+    // }
+
+    return text.equals(op);
+}
+
+bool SwiftSupport::isLeftOperatorWS(std::unique_ptr<antlr4::Token>& t) {
+    return leftWS.get(t->getType());
+}
+
+bool SwiftSupport::isRightOperatorWS(std::unique_ptr<antlr4::Token>& t) {
+    return rightWS.get(t->getType()) || t->getType() == Token::EOF;
+}
+
+bool SwiftSupport::isSeparatedStatement(antlr4::TokenStream* tokens, int indexOfPreviousStatement) {
+    fillUp(tokens);
+    //System.out.println("------");
+    //System.out.println("indexOfPreviousStatement: " + indexOfPreviousStatement);
+
+    int indexFrom = indexOfPreviousStatement - 1;
+    int indexTo = tokens->index() - 1;
+
+    if (indexFrom >= 0) {
+        // Stupid check for new line and semicolon, can be optimized
+        while (indexFrom >= 0 && tokens->get(indexFrom)->getChannel() == Token::HIDDEN_CHANNEL) {
+            indexFrom--;
+        }
+
+        //System.out.println("from: '" + tokens.getText(Interval.of(indexFrom, indexFrom))+"', "+tokens.get(indexFrom));
+        //System.out.println("to: '" + tokens.getText(Interval.of(indexTo, indexTo))+"', "+tokens.get(indexTo));
+        //System.out.println("in_between: '" + tokens.getText(Interval.of(indexFrom, indexTo)));
+
+        //for (int i = previousIndex; i < currentIndex; i++)
+        for(int i =indexTo;i>= indexFrom;i--){
+            String t = tokens->get(i)->getText();
+            if(t.contains("\n") || t.contains(";")){
+                return true;
+            }
+        }
+        return false;
+        //String text = tokens.getText(Interval.of(indexFrom, indexTo));
+        //return text.contains("\n") || text.contains(";");
+    } else {
+        return true;
+    }
+}
+
+void SwiftSupport::fillUp(antlr4::TokenStream* tokens) {
+    for (int jj = 1;;++jj)
+    {
+        int t = tokens->LA(jj);
+        if (t == -1) break;
+    }
+}

--- a/swift/swift5/Cpp/SwiftSupport.h
+++ b/swift/swift5/Cpp/SwiftSupport.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include "antlr4-runtime.h"
+#include <memory>
+
+template<typename CLS>
+class unowned_unique_ptr  {
+public:
+    unowned_unique_ptr(CLS* cls) {
+        ptr.reset(cls);
+    }
+    ~unowned_unique_ptr()
+    {
+        ptr.release();
+    }
+
+    operator std::unique_ptr<CLS>&() {
+        return ptr;
+    }
+
+    CLS* operator ->() {
+        return ptr.get();
+    }
+
+    unowned_unique_ptr& operator =(CLS* cls) {
+        ptr.release();
+        ptr.reset(cls);
+        return *this;
+    }
+private:
+    std::unique_ptr<CLS> ptr;
+};
+
+class String {
+public:
+    String(const std::string&& str)
+        : str(std::move(str))
+    {
+
+    }
+
+    const char* data() const {
+        return str.data();
+    }
+
+    size_t size() const {
+        return str.size();
+    }
+
+    bool contains(const char* sub) const {
+        return str.find(sub) != std::string::npos;
+    }
+
+    bool equals(const char* other) const {
+        return str == std::string(other);
+    }
+private:
+    const std::string str;
+};
+
+class SwiftSupport : public antlr4::Parser {
+
+    class OperatorHead : public std::bitset<0xE0101> {
+    public:
+        OperatorHead();
+
+        bool get(std::size_t pos) const {
+            return bitset::test(pos);
+        }
+    };
+
+    class OperatorCharacter : public OperatorHead {
+    public:
+        OperatorCharacter();
+    };
+
+    class LeftWS : public std::bitset<255> {
+    public:
+        LeftWS();
+
+        bool get(std::size_t pos) const {
+            return bitset::test(pos);
+        }
+    };
+
+    class RightWS : public std::bitset<255> {
+    public:
+        RightWS();
+
+        bool get(std::size_t pos) const {
+            return bitset::test(pos);
+        }
+    };
+
+public:
+    SwiftSupport(antlr4::TokenStream* input) : Parser(input) { }
+
+    static const OperatorHead operatorHead;
+    static const OperatorCharacter operatorCharacter;
+    static const LeftWS leftWS;
+    static const RightWS rightWS;
+
+    static bool isOperatorHead(std::unique_ptr<antlr4::Token>& token);
+    static bool isOperatorCharacter(std::unique_ptr<antlr4::Token>& token);
+    static bool isOpNext(antlr4::TokenStream*);
+    static int getLastOpTokenIndex(antlr4::TokenStream*);
+    static bool isBinaryOp(antlr4::TokenStream*);
+    static bool isPrefixOp(antlr4::TokenStream*);
+    static bool isPostfixOp(antlr4::TokenStream*);
+    static bool isOperator(antlr4::TokenStream* tokens, const char* op);
+    static bool isLeftOperatorWS(std::unique_ptr<antlr4::Token>& t);
+    static bool isRightOperatorWS(std::unique_ptr<antlr4::Token>& t);
+    static bool isSeparatedStatement(antlr4::TokenStream* tokens, int indexOfPreviousStatement);
+    static void fillUp(antlr4::TokenStream* tokens);
+};

--- a/swift/swift5/Cpp/SwiftSupportLexer.cpp
+++ b/swift/swift5/Cpp/SwiftSupportLexer.cpp
@@ -1,0 +1,4 @@
+#include "SwiftSupportLexer.h"
+
+using namespace antlr4;
+

--- a/swift/swift5/Cpp/SwiftSupportLexer.h
+++ b/swift/swift5/Cpp/SwiftSupportLexer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "antlr4-runtime.h"
+
+class SwiftSupportLexer : public antlr4::Lexer {
+    class Stack : protected std::stack<unsigned long> {
+    public:
+        void push(unsigned long v) {
+            stack::push(v);
+        }
+
+        unsigned long pop() {
+            unsigned long val = stack::top();
+            stack::pop();
+            return val;
+        }
+
+        bool isEmpty() {
+            return stack::empty();
+        }
+
+        unsigned long peek() {
+            return stack::top();
+        }
+
+        void clear() {
+            Stack empty;
+            stack::swap(empty);
+        }
+    };
+public:
+    SwiftSupportLexer(antlr4::CharStream *input) : Lexer(input) { }
+
+    Stack parenthesis;
+
+    void reset() override
+    {
+        Lexer::reset();
+        parenthesis.clear();
+    }
+};

--- a/swift/swift5/Cpp/transformGrammar.py
+++ b/swift/swift5/Cpp/transformGrammar.py
@@ -1,0 +1,36 @@
+"""The script transforms the grammar to fit for the c++ target """
+import sys
+import re
+import shutil
+from glob import glob
+from pathlib import Path
+
+def main():
+    """Executes the script."""
+    for file in glob("./*.g4"):
+        transform_grammar(file)
+
+def transform_grammar(file_path):
+    """Transforms the grammar to fit for the c++ target"""
+    print("Altering " + file_path)
+    if not Path(file_path).is_file:
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+
+    shutil.move(file_path, file_path + ".bak")
+    with open(file_path + ".bak",'r', encoding="utf-8") as input_file:
+        with open(file_path, 'w', encoding="utf-8") as output_file:
+            for line in input_file:
+                line = re.sub(r"(\/\/ Insert here @header for C\+\+ parser\.)",\
+                    '@header {#include "SwiftSupport.h"}', line)
+                line = re.sub(r"(\/\/ Insert here @header for C\+\+ lexer\.)",\
+                    '@header {#include "SwiftSupportLexer.h"}', line)
+                line = re.sub(r"(this\.)", 'this->', line)
+                line = re.sub(r"(_input\.)", '_input->', line)
+                line = re.sub(r"(\.getType\(\))", '->getType()', line)
+                output_file.write(line)
+
+    print("Writing ...")
+
+if __name__ == '__main__':
+    main()

--- a/swift/swift5/Java/SwiftSupport.java
+++ b/swift/swift5/Java/SwiftSupport.java
@@ -1,10 +1,15 @@
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.Interval;
 
 import java.util.BitSet;
 
-public class SwiftSupport {
+public abstract class SwiftSupport extends Parser
+{
+    protected SwiftSupport(TokenStream input)
+    {
+        super(input);
+    }
+
     /* TODO
     There is one caveat to the rules above. If the ! or ? predefined operator
      has no whitespace on the left, it is treated as a postfix operator,
@@ -183,7 +188,7 @@ public class SwiftSupport {
      * Find stop token index of next operator; return -1 if not operator.
      */
     public static int getLastOpTokenIndex(TokenStream tokens) {
-	SwiftSupport.fillUp(tokens);
+        SwiftSupport.fillUp(tokens);
         int currentTokenIndex = tokens.index(); // current on-channel lookahead token index
         Token currentToken = tokens.get(currentTokenIndex);
 
@@ -235,7 +240,7 @@ public class SwiftSupport {
      * and a + b is treated as a binary operator."
      */
     public static boolean isBinaryOp(TokenStream tokens) {
-	SwiftSupport.fillUp(tokens);
+        SwiftSupport.fillUp(tokens);
         int stop = getLastOpTokenIndex(tokens);
         if (stop == -1) return false;
 
@@ -265,7 +270,7 @@ public class SwiftSupport {
      * as a prefix unary operator."
      */
     public static boolean isPrefixOp(TokenStream tokens) {
-	SwiftSupport.fillUp(tokens);
+        SwiftSupport.fillUp(tokens);
         int stop = getLastOpTokenIndex(tokens);
         if (stop == -1) return false;
 
@@ -290,7 +295,7 @@ public class SwiftSupport {
      * rather than a ++ .b)."
      */
     public static boolean isPostfixOp(TokenStream tokens) {
-	SwiftSupport.fillUp(tokens);
+        SwiftSupport.fillUp(tokens);
         int stop = getLastOpTokenIndex(tokens);
         if (stop == -1) return false;
 
@@ -306,7 +311,7 @@ public class SwiftSupport {
     }
 
     public static boolean isOperator(TokenStream tokens, String op) {
-	SwiftSupport.fillUp(tokens);
+        SwiftSupport.fillUp(tokens);
         int stop = getLastOpTokenIndex(tokens);
         if (stop == -1) return false;
 
@@ -330,7 +335,7 @@ public class SwiftSupport {
     }
 
     public static boolean isSeparatedStatement(TokenStream tokens, int indexOfPreviousStatement) {
-	SwiftSupport.fillUp(tokens);
+        SwiftSupport.fillUp(tokens);
         //System.out.println("------");
         //System.out.println("indexOfPreviousStatement: " + indexOfPreviousStatement);
 
@@ -363,10 +368,10 @@ public class SwiftSupport {
     }
     public static void fillUp(TokenStream tokens)
     {
-	for (int jj = 1;;++jj)
-	{
-	    int t = tokens.LA(jj);
-	    if (t == -1) break;
-	}
+        for (int jj = 1;;++jj)
+        {
+            int t = tokens.LA(jj);
+            if (t == -1) break;
+        }
     }
 }

--- a/swift/swift5/Java/SwiftSupportLexer.java
+++ b/swift/swift5/Java/SwiftSupportLexer.java
@@ -1,0 +1,19 @@
+import org.antlr.v4.runtime.*;
+
+import java.util.Stack;
+
+public abstract class SwiftSupportLexer extends Lexer
+{
+    protected SwiftSupportLexer(CharStream input)
+    {
+        super(input);
+    }
+
+	public Stack<Integer> parenthesis = new Stack<Integer>();
+
+    @Override
+	public void reset(){
+		super.reset();
+		parenthesis.clear();
+	}
+}

--- a/swift/swift5/Swift5Lexer.g4
+++ b/swift/swift5/Swift5Lexer.g4
@@ -1,17 +1,9 @@
 lexer grammar Swift5Lexer;
-@lexer::header {
-	import java.util.Stack;
-}
-@lexer::members {
-	Stack<Integer> parenthesis = new Stack<Integer>();
+// Insert here @header for C++ lexer.
 
-	@Override
-	public void reset(){
-		super.reset();
-		parenthesis.clear();
-	}
+options {
+	superClass = SwiftSupportLexer;
 }
-
 AS: 'as';
 ALPHA: 'alpha';
 BREAK: 'break';
@@ -235,11 +227,11 @@ LPAREN:
 LBRACK: '[';
 RCURLY: '}';
 RPAREN:
-	')' { if(!parenthesis.isEmpty()) 
+	')' { if(!parenthesis.isEmpty())
 		{
-			parenthesis.push(parenthesis.pop()-1); 
-			if(parenthesis.peek() == 0) 
-			{ 
+			parenthesis.push(parenthesis.pop()-1);
+			if(parenthesis.peek() == 0)
+			{
 				parenthesis.pop();
 				popMode();
 			}

--- a/swift/swift5/Swift5Parser.g4
+++ b/swift/swift5/Swift5Parser.g4
@@ -1,6 +1,9 @@
 parser grammar Swift5Parser;
 
+// Insert here @header for C++ parser.
+
 options {
+	superClass = SwiftSupport;
 	tokenVocab = Swift5Lexer;
 }
 
@@ -22,7 +25,7 @@ statement:
 
 statements
 	locals[int indexBefore = -1]: (
-		{SwiftSupport.isSeparatedStatement(_input, $indexBefore)}? statement {$indexBefore = _input.index();
+		{this.isSeparatedStatement(_input, $indexBefore)}? statement {$indexBefore = _input.index();
 			}
 	)+;
 
@@ -679,8 +682,8 @@ balanced_token_punctuation:
 		| QUESTION
 	)
 	| arrow_operator
-	| {SwiftSupport.isPrefixOp(_input)}? AND
-	| {SwiftSupport.isPostfixOp(_input)}? BANG;
+	| {this.isPrefixOp(_input)}? AND
+	| {this.isPostfixOp(_input)}? BANG;
 
 // Expressions
 expression: try_operator? prefix_expression binary_expressions?;
@@ -900,9 +903,9 @@ postfix_self_suffix: DOT SELF;
 
 subscript_suffix: LBRACK function_call_argument_list RBRACK;
 
-forced_value_suffix: {!SwiftSupport.isBinaryOp(_input)}? BANG;
+forced_value_suffix: {!this.isBinaryOp(_input)}? BANG;
 optional_chaining_suffix:
-	{!SwiftSupport.isBinaryOp(_input)}? QUESTION;
+	{!this.isBinaryOp(_input)}? QUESTION;
 
 // Function Call Expression
 
@@ -941,8 +944,8 @@ type:
 	| tuple_type
 	| opaque_type
 	| type (
-		{!SwiftSupport.isBinaryOp(_input)}? QUESTION //optional_type
-		| {!SwiftSupport.isBinaryOp(_input)}? BANG //implicitly_unwrapped_optional_type
+		{!this.isBinaryOp(_input)}? QUESTION //optional_type
+		| {!this.isBinaryOp(_input)}? BANG //implicitly_unwrapped_optional_type
 		| DOT TYPE
 		| DOT PROTOCOL
 	) //metatype_type
@@ -996,7 +999,7 @@ protocol_composition_type:
 	type_identifier (AND type_identifier)* trailing_composition_and?;
 
 trailing_composition_and:
-	{!SwiftSupport.isBinaryOp(_input)}? AND;
+	{!this.isBinaryOp(_input)}? AND;
 
 // Opaque Type
 opaque_type: SOME type;
@@ -1190,27 +1193,27 @@ keyword:
 // Operators
 
 // Assignment Operator
-assignment_operator: {SwiftSupport.isBinaryOp(_input)}? EQUAL;
+assignment_operator: {this.isBinaryOp(_input)}? EQUAL;
 
-negate_prefix_operator: {SwiftSupport.isPrefixOp(_input)}? SUB;
+negate_prefix_operator: {this.isPrefixOp(_input)}? SUB;
 
 compilation_condition_AND:
-	{SwiftSupport.isOperator(_input,"&&")}? AND AND;
+	{this.isOperator(_input,"&&")}? AND AND;
 compilation_condition_OR:
-	{SwiftSupport.isOperator(_input,"||")}? OR OR;
+	{this.isOperator(_input,"||")}? OR OR;
 compilation_condition_GE:
-	{SwiftSupport.isOperator(_input,">=")}? GT EQUAL;
-compilation_condition_L: {SwiftSupport.isOperator(_input,"<")}? LT;
-arrow_operator: {SwiftSupport.isOperator(_input,"->")}? SUB GT;
-range_operator: {SwiftSupport.isOperator(_input,"...")}? DOT DOT DOT;
+	{this.isOperator(_input,">=")}? GT EQUAL;
+compilation_condition_L: {this.isOperator(_input,"<")}? LT;
+arrow_operator: {this.isOperator(_input,"->")}? SUB GT;
+range_operator: {this.isOperator(_input,"...")}? DOT DOT DOT;
 same_type_equals:
-	{SwiftSupport.isOperator(_input,"==")}? EQUAL EQUAL;
+	{this.isOperator(_input,"==")}? EQUAL EQUAL;
 
-binary_operator: {SwiftSupport.isBinaryOp(_input)}? operator;
+binary_operator: {this.isBinaryOp(_input)}? operator;
 
-prefix_operator: {SwiftSupport.isPrefixOp(_input)}? operator;
+prefix_operator: {this.isPrefixOp(_input)}? operator;
 
-postfix_operator: {SwiftSupport.isPostfixOp(_input)}? operator;
+postfix_operator: {this.isPostfixOp(_input)}? operator;
 
 operator:
 	operator_head operator_characters?

--- a/swift/swift5/desc.xml
+++ b/swift/swift5/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
-   <targets>Java</targets>
+   <targets>Cpp;Java</targets>
 </desc>


### PR DESCRIPTION
Modify the helper classes and add experimental C++ support. It  is not very well  tested yet and the existing tests do not necessarily catch memory errors.