### PR TITLE
Update vba.g4

### DIFF
--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -143,6 +143,7 @@ moduleDeclarationsElement :
 	| variableStmt
 	| moduleOption
 	| typeStmt
+    | deftypeStmt
 	| macroStmt
 ;
 
@@ -180,7 +181,6 @@ blockStmt :
 	| constStmt
 	| dateStmt
 	| deleteSettingStmt
-	| deftypeStmt
 	| doLoopStmt
 	| endStmt
 	| eraseStmt


### PR DESCRIPTION
Moved deftypeStmt to module elements not block statements, this keyword must be used outside of a sub as it is a module level declaration.