### PR TITLE
Extend REINDEX support in PostgresSql

### DIFF
--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -2134,6 +2134,9 @@ reindexstmt
 reindex_target_type
    : INDEX
    | TABLE
+   | SCHEMA
+   | DATABASE
+   | SYSTEM_P
    ;
 
 reindex_target_multitable
@@ -2148,6 +2151,8 @@ reindex_option_list
 
 reindex_option_elem
    : VERBOSE
+   | TABLESPACE
+   | CONCURRENTLY
    ;
 
 altertblspcstmt

--- a/sql/postgresql/examples/reindex.sql
+++ b/sql/postgresql/examples/reindex.sql
@@ -1,3 +1,15 @@
 REINDEX SCHEMA CONCURRENTLY :temp_schema_name;
 
-SELECT pg_my_temp_schema()::regnamespace as temp_schema_name \gset
+SELECT pg_my_temp_schema()::regnamespace as :temp_schema_name;
+
+REINDEX (CONCURRENTLY) TABLE concur_reindex_tab; -- notice
+
+REINDEX (TABLESPACE, VERBOSE) SYSTEM concur_reindex_tab;
+
+REINDEX (CONCURRENTLY, TABLESPACE, VERBOSE) SYSTEM concur_reindex_tab;
+
+REINDEX (VERBOSE) TABLE :temp_schema_name;
+
+REINDEX (VERBOSE) DATABASE :temp_schema_name;
+
+REINDEX (VERBOSE) SYSTEM :temp_schema_name;


### PR DESCRIPTION
Add support for `SCHEMA,DATABASE,SYSTEM` as `REINDEX` target types and `TABLESPACE, CONCURRENTLY` as options. See https://www.postgresql.org/docs/14/sql-reindex.html.