### PR TITLE
added SEMICOLON lexer definition and parser rule for Fortran90(see issue: https://github.com/antlr/grammars-v4/issues/3708)

### DIFF
--- a/fortran/fortran90/Fortran90Lexer.g4
+++ b/fortran/fortran90/Fortran90Lexer.g4
@@ -530,6 +530,11 @@ COLON
    ;
 
 
+SEMICOLON
+   : ';'
+   ;
+
+
 ASSIGN
    : '='
    ;

--- a/fortran/fortran90/Fortran90Parser.g4
+++ b/fortran/fortran90/Fortran90Parser.g4
@@ -875,6 +875,8 @@ variableName : NAME;
 
 commaExpr: COMMA expression;
 
+semicolonStmt : SEMICOLON actionStmt;
+
 actionStmt :
 	arithmeticIfStmt
 	| assignmentStmt
@@ -905,6 +907,7 @@ actionStmt :
     | nullifyStmt 
     | pointerAssignmentStmt  
     | whereStmt
+    | semicolonStmt
     ;
 
 whereStmt : WHERE LPAREN maskExpr RPAREN assignmentStmt;


### PR DESCRIPTION
Given the following Fortran90 program which can be compiled with gfortran for example:
```fortran
program Hello
  logical            :: found_cellarea, found_tocell
  found_cellarea = .FALSE.    ; found_tocell = .FALSE.
  write(*,*) 'Hello'
end program Hello
```

The following parsing error is produced when using the provided grammars:
```text
line 4:30 token recognition error at: ';'
```

The lexer grammar ([fortran/fortran90/Fortran90Lexer.g4](https://github.com/antlr/grammars-v4/blob/master/fortran/fortran90/Fortran90Lexer.g4)) does not contain a semicolon definition.
The parser grammar ([fortran/fortran90/Fortran90Parser.g4](https://github.com/antlr/grammars-v4/blob/master/fortran/fortran90/Fortran90Parser.g4)) does not contain an associated semicolon rule.

In Fortran90 the semicolon ';' was added to allow separate but related statements to be placed on the same line.


This PR contians two edits: 
- The first adds a SEMICOLON definiton to the Fortran90Lexer.g4
- The second adds a "semicolonStmt" rule in the Fortran90Parser.g4
- This is a first cut and needs to be reviewed by an expert.

The following parse tree can be generated with these changes from the previous example program:
![image](https://github.com/antlr/grammars-v4/assets/3452168/23c26da1-bc3e-4236-b69d-4fbb5dab68c1)


## Literature 
Better information on this can be found here: [https://www.nsc.liu.se/~boein/f77to90/a3.html](https://www.nsc.liu.se/~boein/f77to90/a3.html)
Excerpt from that site:
```text
"...several statements can be given on the same line if using the semicolon ; as a separator..."
```

https://www.nccs.nasa.gov/sites/default/docs/tutorials/f90studentnotes.pdf
Excerpt:
```
"The semicolon is used as a statement separator, allowing multiple statements to
appear on one line. The use of multiple-statement lines can, however, produce
unreadable code, and should therefore be used only for simple cases"
```

