### PR TITLE
PL/SQL: fix rules for CREATE TRIGGER (compound form) statement

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -778,7 +778,7 @@ non_dml_trigger
     ;
 
 trigger_body
-    : COMPOUND TRIGGER
+    : compound_trigger_block
     | CALL identifier
     | trigger_block
     ;
@@ -788,14 +788,14 @@ routine_clause
     ;
 
 compound_trigger_block
-    : COMPOUND TRIGGER seq_of_declare_specs? timing_point_section+ END trigger_name
+    : COMPOUND TRIGGER seq_of_declare_specs? timing_point_section+ END trigger_name?
     ;
 
 timing_point_section
-    : bk=BEFORE STATEMENT IS trigger_block BEFORE STATEMENT
-    | bk=BEFORE EACH ROW IS trigger_block BEFORE EACH ROW
-    | ak=AFTER STATEMENT IS trigger_block AFTER STATEMENT
-    | ak=AFTER EACH ROW IS trigger_block AFTER EACH ROW
+    : bk=BEFORE STATEMENT IS BEGIN tps_body END BEFORE STATEMENT ';'
+    | bk=BEFORE EACH ROW IS BEGIN tps_body END BEFORE EACH ROW ';'
+    | ak=AFTER STATEMENT IS BEGIN tps_body END AFTER STATEMENT ';'
+    | ak=AFTER EACH ROW IS BEGIN tps_body END AFTER EACH ROW ';'
     ;
 
 non_dml_event
@@ -5481,6 +5481,10 @@ exception_handler
 
 trigger_block
     : (DECLARE declare_spec*)? body
+    ;
+
+tps_body
+    : seq_of_statements (EXCEPTION exception_handler+)?
     ;
 
 block

--- a/sql/plsql/examples/create_trigger.sql
+++ b/sql/plsql/examples/create_trigger.sql
@@ -1,0 +1,40 @@
+CREATE TRIGGER my_schema.my_table_trg
+FOR INSERT OR UPDATE OR DELETE ON my_schema.my_table
+COMPOUND TRIGGER
+  v_ts        TIMESTAMP(6) := SYSTIMESTAMP;
+  v_cnt        NUMBER      := 0;
+BEFORE EACH ROW IS
+BEGIN
+
+  IF updating THEN
+    SELECT COUNT(*)
+      INTO v_cnt 
+      FROM (SELECT :new.id FROM dual UNION
+            SELECT :old.id FROM dual
+           );
+
+    IF v_cnt > 1 THEN
+      raise_application_error(-20000, 'You can''t change primary key.');
+    END IF;
+
+    SELECT COUNT(*)
+      INTO v_cnt 
+      FROM (SELECT :new.id, :new.col_a, :new.col_b, :new.col_c, :new.col_d FROM dual UNION
+            SELECT :old.id, :old.col_a, :old.col_b, :old.col_c, :old.col_d FROM dual
+           );
+  END IF;
+
+  IF v_cnt = 2 OR inserting THEN :new.col_ts :=    v_ts;
+  ELSIF updating            THEN :new.col_ts := :old.col_ts;
+  END IF;
+
+  IF v_cnt = 2 OR deleting  THEN
+    INSERT INTO my_schema.h$_hub_lnk_source_l
+      (id, col_a, col_b, col_c, col_d )
+    VALUES
+      (:old.id, :old.col_a, :old.col_b, :old.col_c, :old.col_d )
+    ;
+  END IF;
+
+END BEFORE EACH ROW;
+END;


### PR DESCRIPTION
I've made some minimal changes to fix parsing of CREATE TRIGGER compound form statement. New `tps_body` rule is exact copy of the same rule in [Oracle doc](https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/CREATE-TRIGGER-statement.html#GUID-AF9E33F1-64D1-4382-A6A4-EC33C36F237B).