### PR TITLE
Remove ambiguity in the url grammar

### DIFF
--- a/url/examples/example30.txt
+++ b/url/examples/example30.txt
@@ -1,0 +1,1 @@
+http://www.example.com:8080

--- a/url/url.g4
+++ b/url/url.g4
@@ -52,7 +52,7 @@ host
    ;
 
 hostname
-   : string ('.' string)*   #DomainNameOrIPv4Host
+   : string                 #DomainNameOrIPv4Host
    | '[' v6host ']'         #IPv6Host
    ;
 


### PR DESCRIPTION
This is to solve an [open issue](https://github.com/antlr/grammars-v4/issues/3715).

The dot character is allowed in strings. So there should not be a dot delimiter between strings. Otherwise, the parser would incorrectly parse the delimiter as part of the first string.