### PR TITLE
Fix for #3720 -- Update Go target testing versions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       if: ${{ matrix.language == 'Go' }}
       uses: actions/setup-go@v4
       with:
-        go-version: '^1.20.0'
+        go-version: '^1.21.0'
     - name: Test Go
       if: ${{ matrix.language == 'Go' }}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       if: ${{ matrix.language == 'Go' }}
       uses: actions/setup-go@v4
       with:
-        go-version: '^1.18.0'
+        go-version: '^1.20.0'
     - name: Test Go
       if: ${{ matrix.language == 'Go' }}
       run: |

--- a/_scripts/templates/Go/go.mod
+++ b/_scripts/templates/Go/go.mod
@@ -1,6 +1,6 @@
 module example.com/myparser
 
-go 1.18
+go 1.20
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.6.0</version>
+						<version>3.5.0</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>


### PR DESCRIPTION
* The version of Go in the go.mod files should be 1.20. That's the version referenced in the Go Antlr runtime.
* The version of Go installed should be anything greater than or equal to 1.20. We can certainly use a more recent version of Go, e.g., 1.21 which is the current latest. So, for the Github Actions workflow file, I updated to the latest of Go.
* My repo has a Dependabot update that I mistakenly added in. It shouldn't because only these should be done by an Admin for the github.com/antlr/grammars-v4. I undid the change. Eventually, I will need to refork the entire repo from scratch so I don't see spurious commits.
* For now, we don't touch the version of Antlr for the Go target. Right now, it should be 4.13.0. There is no 4.13.1 for Go yet.
