### PR TITLE
[MariaDB] Allow whitespace in user name specification

### DIFF
--- a/sql/mariadb/MariaDBLexer.g4
+++ b/sql/mariadb/MariaDBLexer.g4
@@ -1332,35 +1332,15 @@ DOT_ID:                              '.' ID_LITERAL;
 ID:                                  ID_LITERAL;
 // DOUBLE_QUOTE_ID:                  '"' ~'"'+ '"';
 REVERSE_QUOTE_ID:                    BQUOTA_STRING;
-STRING_USER_NAME:                    (
-                                       SQUOTA_STRING | DQUOTA_STRING
-                                       | BQUOTA_STRING | ID_LITERAL
-                                     ) '@'
+HOST_IP_ADDRESS:                     (AT_SIGN IP_ADDRESS);
+LOCAL_ID:                            AT_SIGN
                                      (
-                                       SQUOTA_STRING | DQUOTA_STRING
-                                       | BQUOTA_STRING | ID_LITERAL
-                                       | IP_ADDRESS
+                                       STRING_LITERAL | [A-Z0-9._$\u0080-\uFFFF]+
                                      );
-IP_ADDRESS:                          (
-                                       [0-9]+ '.' [0-9.]+
-                                       | [0-9A-F:]+ ':' [0-9A-F:]+
-                                     );
-STRING_USER_NAME_MARIADB:            (
-                                        SQUOTA_STRING | DQUOTA_STRING
-                                        | BQUOTA_STRING | ID_LITERAL
-                                     )  '@';
-LOCAL_ID:                               '@'
+GLOBAL_ID:                           AT_SIGN AT_SIGN
                                      (
-                                        [A-Z0-9._$\u0080-\uFFFF]+
-                                        | SQUOTA_STRING
-                                        | DQUOTA_STRING
-                                        | BQUOTA_STRING
-                                    );
-GLOBAL_ID:                              '@' '@'
-                                    (
-                                        [A-Z0-9._$\u0080-\uFFFF]+
-                                        | BQUOTA_STRING
-                                    );
+                                       [A-Z0-9._$\u0080-\uFFFF]+ | BQUOTA_STRING
+                                     );
 
 
 // Fragments for Literal primitives
@@ -1383,7 +1363,7 @@ fragment BQUOTA_STRING:              '`' ( ~'`' | '``' )* '`';
 fragment HEX_DIGIT:                  [0-9A-F];
 fragment DEC_DIGIT:                  [0-9];
 fragment BIT_STRING_L:               'B' '\'' [01]+ '\'';
-
+fragment IP_ADDRESS:                 [0-9]+ '.' [0-9.]+ | [0-9A-F:]+ ':' [0-9A-F:]+;
 
 
 // Last tokens must generate Errors

--- a/sql/mariadb/MariaDBParser.g4
+++ b/sql/mariadb/MariaDBParser.g4
@@ -2147,8 +2147,16 @@ indexColumnName
     : ((uid | STRING_LITERAL) ('(' decimalLiteral ')')? | expression) sortType=(ASC | DESC)?
     ;
 
+simpleUserName
+    : STRING_LITERAL
+    | ID
+    | ADMIN
+    | keywordsCanBeId;
+hostName: (LOCAL_ID | HOST_IP_ADDRESS | '@' );
 userName
-    : STRING_USER_NAME | STRING_USER_NAME_MARIADB | ID | STRING_LITERAL | ADMIN | keywordsCanBeId | currentUserExpression;
+    : simpleUserName
+    | simpleUserName hostName
+    | currentUserExpression;
 
 mysqlVariable
     : LOCAL_ID

--- a/sql/mariadb/examples/fast/admin.sql
+++ b/sql/mariadb/examples/fast/admin.sql
@@ -1,0 +1,5 @@
+--- https://mariadb.com/kb/en/set/
+SET GLOBAL v1=1;
+SET @@global.v2=2;
+SET SESSION v1=1;
+SET @@session.v2=2;

--- a/sql/mariadb/examples/fast/ddl_create.sql
+++ b/sql/mariadb/examples/fast/ddl_create.sql
@@ -13,6 +13,8 @@ GET CURRENT DIAGNOSTICS errcount = NUMBER;
 -- Create User
 CREATE USER 'test_crm_debezium'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9' PASSWORD EXPIRE NEVER COMMENT '-';
 CREATE USER 'jim'@'localhost' ATTRIBUTE '{"fname": "James", "lname": "Scott", "phone": "123-456-7890"}';
+CREATE USER 'jim' @'localhost' IDENTIFIED BY '123';
+CREATE USER 'jim' @localhost IDENTIFIED BY '123';
 -- Create Table
 create table new_t  (like t1);
 create table log_table(row varchar(512));

--- a/sql/mariadb/examples/fast/grant.sql
+++ b/sql/mariadb/examples/fast/grant.sql
@@ -1,3 +1,6 @@
+GRANT ALL ON *.* TO `foo2` @`%`;
+GRANT ALL ON *.* TO `foo2` @test;
+GRANT ALL ON *.* TO foo2 @test IDENTIFIED BY 'mariadb';
 GRANT ALL ON tbl TO admin@localhost;
 GRANT ALL ON tbl TO admin;
 GRANT ALL ON tbl TO audit_admin;


### PR DESCRIPTION
The user name specification in MariaDB (and MySQL) allows for a whitespace character between the local user name and the host name (incl. the '@' character) afterwards.

This means that the following strings are valid user name specifications which can be used in CREATE and GRANT statements:
```
`user`@`hostname`
`user` @'hostname'
"user"         @'example.com'
userfoo @localhost
```
References:

- https://mariadb.com/kb/en/grant/
- https://mariadb.com/kb/en/create-user/#account-names
- https://github.com/antlr/grammars-v4/pull/3737