### PR TITLE
[MySQL] Allow space in user name specification

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlLexer.g4
+++ b/sql/mysql/Positive-Technologies/MySqlLexer.g4
@@ -1309,31 +1309,15 @@ DOT_ID:                              '.' ID_LITERAL;
 ID:                                  ID_LITERAL;
 // DOUBLE_QUOTE_ID:                  '"' ~'"'+ '"';
 REVERSE_QUOTE_ID:                    BQUOTA_STRING;
-STRING_USER_NAME:                    (
-                                       SQUOTA_STRING | DQUOTA_STRING
-                                       | BQUOTA_STRING | ID_LITERAL
-                                     ) '@'
+HOST_IP_ADDRESS:                     (AT_SIGN IP_ADDRESS);
+LOCAL_ID:                            AT_SIGN
                                      (
-                                       SQUOTA_STRING | DQUOTA_STRING
-                                       | BQUOTA_STRING | ID_LITERAL
-                                       | IP_ADDRESS
+                                       STRING_LITERAL | [A-Z0-9._$\u0080-\uFFFF]+
                                      );
-IP_ADDRESS:                          (
-                                       [0-9]+ '.' [0-9.]+
-                                       | [0-9A-F]* ':' [0-9A-F]* ':' [0-9A-F:]+
-                                     );
-LOCAL_ID:                               '@'
+GLOBAL_ID:                           AT_SIGN AT_SIGN
                                      (
-                                        [A-Z0-9._$\u0080-\uFFFF]+
-                                        | SQUOTA_STRING
-                                        | DQUOTA_STRING
-                                        | BQUOTA_STRING
-                                    );
-GLOBAL_ID:                              '@' '@'
-                                    (
-                                        [A-Z0-9._$\u0080-\uFFFF]+
-                                        | BQUOTA_STRING
-                                    );
+                                       [A-Z0-9._$\u0080-\uFFFF]+ | BQUOTA_STRING
+                                     );
 
 
 // Fragments for Literal primitives
@@ -1356,7 +1340,7 @@ fragment BQUOTA_STRING:              '`' ( ~'`' | '``' )* '`';
 fragment HEX_DIGIT:                  [0-9A-F];
 fragment DEC_DIGIT:                  [0-9];
 fragment BIT_STRING_L:               'B' '\'' [01]+ '\'';
-
+fragment IP_ADDRESS:                 [0-9]+ '.' [0-9.]+ | [0-9A-F]* ':' [0-9A-F]* ':' [0-9A-F:]+;
 
 
 // Last tokens must generate Errors

--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -285,8 +285,12 @@ charSet
     | CHAR SET
     ;
 
+currentUserExpression
+    : CURRENT_USER ( '(' ')')?
+    ;
+
 ownerStatement
-    : DEFINER '=' (userName | CURRENT_USER ( '(' ')')?)
+    : DEFINER '=' (userName | currentUserExpression)
     ;
 
 scheduleExpression
@@ -2099,8 +2103,16 @@ indexColumnName
     : ((uid | STRING_LITERAL) ('(' decimalLiteral ')')? | expression) sortType=(ASC | DESC)?
     ;
 
-userName
-    : STRING_USER_NAME | ID | STRING_LITERAL | ADMIN | keywordsCanBeId;
+simpleUserName
+    : STRING_LITERAL
+    | ID
+    | ADMIN
+    | keywordsCanBeId;
+hostName: (LOCAL_ID | HOST_IP_ADDRESS | '@' );
+ userName
+    : simpleUserName
+    | simpleUserName hostName
+    | currentUserExpression;
 
 mysqlVariable
     : LOCAL_ID
@@ -2391,8 +2403,9 @@ functionCall
 specificFunction
     : (
       CURRENT_DATE | CURRENT_TIME | CURRENT_TIMESTAMP
-      | CURRENT_USER | LOCALTIME | UTC_TIMESTAMP | SCHEMA
+      | LOCALTIME | UTC_TIMESTAMP | SCHEMA
       ) ('(' ')')?                                                  #simpleFunctionCall
+    | currentUserExpression                                         #currentUser
     | CONVERT '(' expression separator=',' convertedDataType ')'    #dataTypeFunctionCall
     | CONVERT '(' expression USING charsetName ')'                  #dataTypeFunctionCall
     | CAST '(' expression AS convertedDataType ')'                  #dataTypeFunctionCall

--- a/sql/mysql/Positive-Technologies/examples/admin.sql
+++ b/sql/mysql/Positive-Technologies/examples/admin.sql
@@ -1,0 +1,7 @@
+-- https://dev.mysql.com/doc/refman/8.0/en/set-statement.html
+SET GLOBAL v1=1;
+SET @@global.v2=2;
+SET LOCAL v1=1;
+SET @@local.v2=2;
+SET SESSION v1=1;
+SET @@session.v2=2;

--- a/sql/mysql/Positive-Technologies/examples/ddl_create.sql
+++ b/sql/mysql/Positive-Technologies/examples/ddl_create.sql
@@ -2,6 +2,7 @@
 -- Create User
 CREATE USER 'test_crm_debezium'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9' PASSWORD EXPIRE NEVER COMMENT '-';
 CREATE USER 'jim'@'localhost' ATTRIBUTE '{"fname": "James", "lname": "Scott", "phone": "123-456-7890"}';
+CREATE USER 'jim' @'localhost' ATTRIBUTE '{"fname": "James", "lname": "Scott", "phone": "123-456-7890"}';
 -- Create Table
 create table new_t  (like t1);
 create table log_table(row varchar(512));

--- a/sql/mysql/Positive-Technologies/examples/grant.sql
+++ b/sql/mysql/Positive-Technologies/examples/grant.sql
@@ -1,3 +1,5 @@
+GRANT ALL ON *.* TO `foo2` @`%`;
+GRANT ALL ON *.* TO `foo2` @test;
 GRANT ALL ON tbl TO admin@localhost;
 GRANT ALL ON tbl TO admin;
 GRANT ALL PRIVILEGES ON tbl TO admin;


### PR DESCRIPTION
The user name specification in MySQL (and MariaDB) allows for a whitespace character between the local user name and the host name (incl. the '@' character) afterwards.

This means that the following strings are valid user name specifications which can be used in CREATE and GRANT statements:
```
`user`@`hostname`
`user` @'hostname'
"user"         @'example.com'
userfoo @localhost
```

References:

- https://dev.mysql.com/doc/refman/8.0/en/account-names.html
- https://github.com/antlr/grammars-v4/pull/3736