### PR TITLE
[Snowflake]Add keyword and fix priority for sequence in table creation

### DIFF
--- a/sql/snowflake/SnowflakeParser.g4
+++ b/sql/snowflake/SnowflakeParser.g4
@@ -3687,7 +3687,8 @@ expr_list_sorted
     ;
 
 expr
-    : primitive_expression
+    : object_name DOT NEXTVAL
+    | primitive_expression
     | function_call
     | expr COLLATE string
     | case_expression
@@ -3714,7 +3715,6 @@ expr
     | ternary_builtin_function LR_BRACKET expr COMMA expr COMMA expr RR_BRACKET
     | subquery
     | try_cast_expr
-    | object_name DOT NEXTVAL
     | trim_expression
     | expr comparison_operator expr
     | expr IS null_not_null

--- a/sql/snowflake/SnowflakeParser.g4
+++ b/sql/snowflake/SnowflakeParser.g4
@@ -3549,6 +3549,7 @@ keyword
     | TIMESTAMP
     | IF
     | COPY_OPTIONS_
+    | COMMENT
     // etc
     ;
 
@@ -3586,6 +3587,7 @@ non_reserved_words
     | DOWNSTREAM
     | DYNAMIC
     | TARGET_LAG
+    | EMAIL
     ;
 
 builtin_function

--- a/sql/snowflake/examples/create_table.sql
+++ b/sql/snowflake/examples/create_table.sql
@@ -47,6 +47,7 @@ create table t1 if not exists (v varchar(16777216));
 create table if not exists t2(i int) as select(v) from t1;
 create table t2 if not exists (i int) as select(v) from t1;
 CREATE OR REPLACE TABLE TESTSEED (IDENT int DEFAULT SEQID.NEXTVAL,mycol string);
+CREATE OR REPLACE TABLE TESTSEED (IDENT int DEFAULT SCHEM.SEQID.NEXTVAL,mycol string);
 CREATE OR REPLACE TABLE TESTSEED2 (ident int IDENTITY START 2);
 CREATE OR REPLACE TABLE TESTSEED2 (ident int IDENTITY START WITH = 2);
 CREATE OR REPLACE TABLE TESTSEED2 (ident int IDENTITY START = 2 INCREMENT BY 1);


### PR DESCRIPTION
In a statement like : CREATE OR REPLACE TABLE TESTSEED (IDENT int DEFAULT SCHEM.SEQID.NEXTVAL,mycol string);

SCHEM.SEQID.NEXTVAL should match first object_name DOT NEXTVAL instead of primitive_expression DOT (object_name DOT NEXTVAL)

We could also replace _id by object_name in primitive_expression but it's could lead to a lot of issue.