### PR TITLE
[java9] Fix for #3748 -- fix start rule

### DIFF
--- a/java/java9/Java9Parser.g4
+++ b/java/java9/Java9Parser.g4
@@ -254,7 +254,7 @@ compilationUnit
 	;
 
 ordinaryCompilation
-	:	packageDeclaration? importDeclaration* typeDeclaration* EOF
+	:	packageDeclaration? importDeclaration* typeDeclaration*
 	;
 
 modularCompilation


### PR DESCRIPTION
This is a fix for #3748 -- ordinaryCompilation is not a start symbol. See the Java Language Spec, version 9. https://docs.oracle.com/javase/specs/jls/se9/html/jls-2.html#jls-2.1