### PR TITLE
[cool] Fix for #3747 -- fix start rule

### DIFF
--- a/esolang/cool/COOL.g4
+++ b/esolang/cool/COOL.g4
@@ -29,12 +29,9 @@ http://sist.shanghaitech.edu.cn/faculty/songfu/course/spring2017/cs131/COOL/COOL
 grammar COOL;
 
 program
-   : (programBlocks | ) EOF
+   : (classDefine ';')+ EOF
    ;
 
-programBlocks
-   : classDefine ';' programBlocks
-   ;
 
 classDefine
    : CLASS TYPEID (INHERITS TYPEID)? '{' (feature ';')* '}'

--- a/esolang/cool/COOL.g4
+++ b/esolang/cool/COOL.g4
@@ -29,12 +29,11 @@ http://sist.shanghaitech.edu.cn/faculty/songfu/course/spring2017/cs131/COOL/COOL
 grammar COOL;
 
 program
-   : programBlocks EOF
+   : (programBlocks | ) EOF
    ;
 
 programBlocks
-   : classDefine ';' programBlocks # classes
-   | EOF # eof
+   : classDefine ';' programBlocks
    ;
 
 classDefine

--- a/esolang/cool/README.md
+++ b/esolang/cool/README.md
@@ -1,7 +1,15 @@
-# COOL
+# COOL grammar
 
 Classroom Object Oriented Language is a widely used language in CS classes.
 
-This Grammar defination comes from [COOL manual](http://sist.shanghaitech.edu.cn/faculty/songfu/course/spring2017/cs131/COOL/COOLAid.pdf).
+## Author
 
-This is a byproduct from a COOL-to-javascript compiler.
+https://github.com/teverett
+
+Aiken, Alexander. “Cool: a portable project for teaching compiler construction.” ACM SIGPLAN Notices 31 (1996): 19-24.
+
+## Links
+
+http://theory.stanford.edu/~aiken/software/cool/cool.html
+
+https://www.semanticscholar.org/paper/Cool%3A-a-portable-project-for-teaching-compiler-Aiken/c31ab5485ca8efb466f4e48cdc596f8def3aafee


### PR DESCRIPTION
This is a fix for #3747 -- the grammar has a malformed start rule. The rule `programBlocks` should not have an EOF reference.--it only causes confusion as to what the start rule should be. I changed the grammar to reflect the start rule in the original SIGPLAN paper.