### PR TITLE
remove quote arround COMPRESSION keyword

### DIFF
--- a/sql/mysql/Positive-Technologies/MySqlLexer.g4
+++ b/sql/mysql/Positive-Technologies/MySqlLexer.g4
@@ -430,7 +430,7 @@ COMMIT:                              'COMMIT';
 COMPACT:                             'COMPACT';
 COMPLETION:                          'COMPLETION';
 COMPRESSED:                          'COMPRESSED';
-COMPRESSION:                         'COMPRESSION' | QUOTE_SYMB? 'COMPRESSION' QUOTE_SYMB?;
+COMPRESSION:                         'COMPRESSION';
 CONCURRENT:                          'CONCURRENT';
 CONNECT:                             'CONNECT';
 CONNECTION:                          'CONNECTION';


### PR DESCRIPTION
The keyword `COMPRESSION` allows a quoted version like `'COMPRESSION'` (or even `'COMPRESSION"`) since [this commit](https://github.com/antlr/grammars-v4/commit/1079f9ba5fc9b1203da18a38ddb2899708c11d71).

According to [the official documentation](https://dev.mysql.com/doc/refman/5.7/en/create-table.html) this is not permitted. And this break parsing when a STRING_LITERAL is equals to `'COMPRESSION'`, like in the snippet `compression int DEFAULT '100' COMMENT 'compression'`.