### PR TITLE
Bugfix for C grammar

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -428,7 +428,7 @@ statement
     ;
 
 labeledStatement
-    :   Identifier ':' statement
+    :   Identifier ':' statement?
     |   'case' constantExpression ':' statement
     |   'default' ':' statement
     ;

--- a/c/examples/label_before_closing_curly_brace.c
+++ b/c/examples/label_before_closing_curly_brace.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]){
+    int i = 0;
+    do {
+        i++;
+        if (i == 5){
+            goto label;
+        }
+        printf("%d\n", i);
+label:
+    } while (i < 10);
+}
+


### PR DESCRIPTION
Hello,

The actual grammar for C has a bug that occurs when a label is placed right before a line starting with }.

With the actual grammar, the following code:
```
#include <stdlib.h>
#include <stdio.h>

int main(int argc, char* argv[]){
    int i = 0;
    do {
        i++;
        if (i == 5){
            goto label;
        }
        printf("%d\n", i);
label:
    } while (i < 10);
}
```

produces the following error:
```
line 13:4 extraneous input '}' expecting {'__extension__', '__builtin_va_arg', '__builtin_offsetof', '__asm', '__asm__', 'break', 'case', 'continue', 'default', 'do', 'for', 'goto', 'if', 'return', 'sizeof', 'switch', 'while', '_Alignof', '_Generic', '(', '{', '+', '++', '-', '--', '*', '&', '&&', '!', '~', ';', Identifier, Constant, DigitSequence, StringLiteral}

line 15:0 mismatched input '<EOF>' expecting {'__extension__', '__builtin_va_arg', '__builtin_offsetof', '__m128', '__m128d', '__m128i', '__typeof__', '__inline__', '__stdcall', '__declspec', '__asm', '__attribute__', '__asm__', 'auto', 'break', 'case', 'char', 'const', 'continue', 'default', 'do', 'double', 'enum', 'extern', 'float', 'for', 'goto', 'if', 'inline', 'int', 'long', 'register', 'restrict', 'return', 'short', 'signed', 'sizeof', 'static', 'struct', 'switch', 'typedef', 'union', 'unsigned', 'void', 'volatile', 'while', '_Alignas', '_Alignof', '_Atomic', '_Bool', '_Complex', '_Generic', '_Noreturn', '_Static_assert', '_Thread_local', '(', '{', '}', '+', '++', '-', '--', '*', '&', '&&', '!', '~', ';', Identifier, Constant, DigitSequence, StringLiteral}
```

This pull request is aimed to fix this bug.

Regards