### PR TITLE
Added `SEQ` to REGULAR_ID list in PLSQL

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -7152,6 +7152,7 @@ regular_id
     | SELF
     | SERIALLY_REUSABLE
     | SET
+    | SEQ
     | SHARDSPACE
     | SIGNTYPE
     | SIMPLE_INTEGER

--- a/sql/plsql/examples/seq_token_error.sql
+++ b/sql/plsql/examples/seq_token_error.sql
@@ -1,0 +1,1 @@
+select seq from employees;


### PR DESCRIPTION
Hey,

We were running into an issue where the parser was failing to continue with the parse because variables had been named 'seq', I figured this was because it was a defined token in the lexer. Removing the token from the lexer broke the parser.

Adding the token to the parsers REGULAR_ID as I have done here works great, however it significantly impacts performance of the parser and was wondering if anyone could offer appropriate guidance on how to improve this PR?

This is my first time using Antlr having worked with TypeScripts AST quite extensively. It is a fantastic tool, thank you for your work on it.