### PR TITLE
[build] Fix for #3766 -- install specific version of PHP, set max stack size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.2'
+        ini-values: xdebug.max_nesting_level=1000
     - name: Print PHP version
       run: |
         echo ${{ steps.setup-php.outputs.php-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,15 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Setup PHP
+      id: setup-php
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+    - name: Print PHP version
+      run: |
+        echo ${{ steps.setup-php.outputs.php-version }}
+        php --version
     - name: Install Dotnet
       uses: actions/setup-dotnet@v3.2.0
       with:

--- a/c/desc.xml
+++ b/c/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
 </desc>


### PR DESCRIPTION
This is a fix for #3766, where we weren't setting up a specific version of PHP. In addition, the php.ini settings weren't set up for large stack sizes, which is what the c grammar requires.

This change is simple:
* I added to .github/workflow/main.yml an action to "Setup PHP", and another to print out the version of PHP installed. In the setup, we set `xdebug.max_nesting_level=1000` so that the [c grammar](https://github.com/antlr/grammars-v4/tree/master/c) now runs cleanly on all platforms.
* To test the change, I modified the [c grammar](https://github.com/antlr/grammars-v4/tree/master/c) desc.xml by adding a space. The test now works.