### PR TITLE
Fix 'here' method

### DIFF
--- a/javascript/javascript/CSharp/JavaScriptParserBase.cs
+++ b/javascript/javascript/CSharp/JavaScriptParserBase.cs
@@ -72,14 +72,19 @@ public abstract class JavaScriptParserBase : Parser
     /// </param>
     protected bool here(int type)
     {
-        // Get the token ahead of the current index.
-        int possibleIndexEosToken = CurrentToken.TokenIndex - 1;
-        if (possibleIndexEosToken < 0) return false;
-        IToken ahead = ((ITokenStream)this.InputStream).Get(possibleIndexEosToken);
+        // Get the most recently emitted token.
+        IToken currentToken = ((ITokenStream)this.InputStream).LT(-1);
 
-        // Check if the token resides on the Hidden channel and if it's of the
+        // Get the next token index.
+        int nextTokenIndex = currentToken == null ? 0 : currentToken.TokenIndex + 1;
+
+        // Get the token after the `currentToken`. By using `_input.get(index)`,
+        // we also grab a token that is (possibly) on the HIDDEN channel.
+        IToken nextToken = ((ITokenStream)this.InputStream).Get(nextTokenIndex);
+
+        // Check if the token resides on the HIDDEN channel and if it's of the
         // provided type.
-        return ahead.Channel == Lexer.Hidden && ahead.Type == type;
+        return (nextToken.Channel == Lexer.Hidden) && (nextToken.Type == type);
     }
 
     /// <summary>

--- a/javascript/javascript/Cpp/JavaScriptParserBase.cpp
+++ b/javascript/javascript/Cpp/JavaScriptParserBase.cpp
@@ -41,14 +41,19 @@ bool JavaScriptParserBase::closeBrace()
 
 bool JavaScriptParserBase::here(int type)
 {
-    // Get the token ahead of the current index.
-    int possibleIndexEosToken = this->getCurrentToken()->getTokenIndex() - 1;
-    if (possibleIndexEosToken < 0) return false;
-    auto ahead = _input->get(possibleIndexEosToken);
+    // Get the most recently emitted token.
+    auto currentToken = _input->LT(-1);
+
+    // Get the next token index.
+    int nextTokenIndex = currentToken == null ? 0 : currentToken->getTokenIndex() + 1;
+
+    // Get the token after the `currentToken`. By using `_input.get(index)`,
+    // we also grab a token that is (possibly) on the HIDDEN channel.
+    auto nextToken = _input->get(nextTokenIndex);
 
     // Check if the token resides on the HIDDEN channel and if it's of the
     // provided type.
-    return (ahead->getChannel() == Lexer::HIDDEN) && (ahead->getType() == type);
+    return (nextToken->getChannel() == Lexer::HIDDEN) && (nextToken->getType() == type);
 }
 
 bool JavaScriptParserBase::lineTerminatorAhead()

--- a/javascript/javascript/Cpp/JavaScriptParserBase.cpp
+++ b/javascript/javascript/Cpp/JavaScriptParserBase.cpp
@@ -45,7 +45,7 @@ bool JavaScriptParserBase::here(int type)
     auto currentToken = _input->LT(-1);
 
     // Get the next token index.
-    int nextTokenIndex = currentToken == null ? 0 : currentToken->getTokenIndex() + 1;
+    int nextTokenIndex = currentToken == nullptr ? 0 : currentToken->getTokenIndex() + 1;
 
     // Get the token after the `currentToken`. By using `_input.get(index)`,
     // we also grab a token that is (possibly) on the HIDDEN channel.

--- a/javascript/javascript/Go/javascript_parser_base.go
+++ b/javascript/javascript/Go/javascript_parser_base.go
@@ -48,13 +48,23 @@ func (p *JavaScriptParserBase) closeBrace() bool {
 // token stream a token of the given type exists on the
 // Hidden channel.
 func (p *JavaScriptParserBase) here(_type int) bool {
-	// Get the token ahead of the current index.
-	possibleIndexEosToken := p.GetCurrentToken().GetTokenIndex() - 1
-	ahead := p.GetTokenStream().Get(possibleIndexEosToken)
+	// Get the most recently emitted token.
+	currentToken := p.GetTokenStream().LT(-1)
+
+	// Get the next token index.
+	nextTokenIndex := 0
+
+	if currentToken != nil {
+		nextTokenIndex := currentToken.GetTokenIndex() + 1
+	}
+
+	// Get the token after the `currentToken`. By using `_input.get(index)`,
+	// we also grab a token that is (possibly) on the HIDDEN channel.
+	nextToken := p.GetTokenStream().Get(nextTokenIndex);
 
 	// Check if the token resides on the HIDDEN channel and if it's of the
 	// provided type.
-	return ahead.GetChannel() == antlr.LexerHidden && ahead.GetTokenType() == _type
+	return nextToken.GetChannel() == antlr.LexerHidden && nextToken.GetTokenType() == _type
 }
 
 // Returns true if on the current index of the parser's

--- a/javascript/javascript/Go/javascript_parser_base.go
+++ b/javascript/javascript/Go/javascript_parser_base.go
@@ -55,7 +55,7 @@ func (p *JavaScriptParserBase) here(_type int) bool {
 	nextTokenIndex := 0
 
 	if currentToken != nil {
-		nextTokenIndex := currentToken.GetTokenIndex() + 1
+		nextTokenIndex = currentToken.GetTokenIndex() + 1
 	}
 
 	// Get the token after the `currentToken`. By using `_input.get(index)`,

--- a/javascript/javascript/Java/JavaScriptParserBase.java
+++ b/javascript/javascript/Java/JavaScriptParserBase.java
@@ -66,14 +66,19 @@ public abstract class JavaScriptParserBase extends Parser
      */
     private boolean here(final int type) {
 
-        // Get the token ahead of the current index.
-        int possibleIndexEosToken = this.getCurrentToken().getTokenIndex() - 1;
-        if (possibleIndexEosToken < 0) return false;
-        Token ahead = _input.get(possibleIndexEosToken);
+        // Get the most recently emitted token.
+        Token currentToken = _input.LT(-1);
+
+        // Get the next token index.
+        int nextTokenIndex = currentToken == null ? 0 : currentToken.getTokenIndex() + 1;
+
+        // Get the token after the `currentToken`. By using `_input.get(index)`,
+        // we also grab a token that is (possibly) on the HIDDEN channel.
+        Token nextToken = _input.get(nextTokenIndex);
 
         // Check if the token resides on the HIDDEN channel and if it's of the
         // provided type.
-        return (ahead.getChannel() == Lexer.HIDDEN) && (ahead.getType() == type);
+        return (nextToken.getChannel() == Lexer.HIDDEN) && (nextToken.getType() == type);
     }
 
     /**

--- a/javascript/javascript/JavaScript/JavaScriptParserBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptParserBase.js
@@ -44,10 +44,19 @@ export default class JavaScriptParserBase extends antlr4.Parser {
     }
 
     here(type) {
-        const possibleIndexEosToken = this.getCurrentToken().tokenIndex - 1;
-        if (possibleIndexEosToken < 0) return false;
-        const ahead = this._input.get(possibleIndexEosToken);
-        return ahead.channel === antlr4.Lexer.HIDDEN && ahead.type === type;
+        // Get the most recently emitted token.
+        const currentToken = this._input.LT(-1);
+
+        // Get the next token index.
+        const nextTokenIndex = currentToken == null ? 0 : currentToken.tokenIndex + 1;
+
+        // Get the token after the `currentToken`. By using `_input.get(index)`,
+        // we also grab a token that is (possibly) on the HIDDEN channel.
+        const nextToken = this._input.get(nextTokenIndex);
+
+        // Check if the token resides on the HIDDEN channel and if it's of the
+        // provided type.
+        return nextToken.channel === antlr4.Lexer.HIDDEN && nextToken.type === type;
     }
 
     lineTerminatorAhead() {

--- a/javascript/javascript/Python3/JavaScriptParserBase.py
+++ b/javascript/javascript/Python3/JavaScriptParserBase.py
@@ -56,14 +56,20 @@ class JavaScriptParserBase(Parser):
         """
         # Get the token ahead of the current index.
         assert isinstance(self.getCurrentToken(), Token)
-        possibleIndexEosToken: Token = self.getCurrentToken().tokenIndex - 1
-        if (possibleIndexEosToken < 0):
-            return False
-        ahead = self._input.get(possibleIndexEosToken)
+
+        # Get the most recently emitted token.
+        currentToken: Token = self._input.LT(-1)
+
+        # Get the next token index.
+        nextTokenIndex = 0 if currentToken is None else currentToken.tokenIndex + 1
+
+        # Get the token after the `currentToken`. By using `_input.get(index)`,
+        # we also grab a token that is (possibly) on the HIDDEN channel.
+        nextToken: Token = self._input.get(nextTokenIndex)
 
         # Check if the token resides on the HIDDEN channel and if it's of the
         # provided type.
-        return (ahead.channel == Lexer.HIDDEN) and (ahead.type == tokenType)
+        return (nextToken.channel == Lexer.HIDDEN) and (nextToken.type == tokenType)
 
     def lineTerminatorAhead(self) -> bool:
         """

--- a/javascript/javascript/examples/Continue.js
+++ b/javascript/javascript/examples/Continue.js
@@ -1,0 +1,6 @@
+// https://github.com/antlr/grammars-v4/issues/3772
+for (var i = 0; i < [].length; i++) {
+    var o = {}
+    if (false) continue
+    o[test]
+}


### PR DESCRIPTION
Fixes #3772 

There is a bug in the `here` method. If you add a `println` to the method:

```java
protected boolean notLineTerminator() {
    return !here(JavaScriptParser.LineTerminator);
}

private boolean here(final int type) {

    // Get the token ahead of the current index.
    int possibleIndexEosToken = this.getCurrentToken().getTokenIndex() - 1;
    if (possibleIndexEosToken < 0) return false;
    Token ahead = _input.get(possibleIndexEosToken);

    boolean result = (ahead.getChannel() == Lexer.HIDDEN) && (ahead.getType() == type); // <-- Added
    System.out.printf("ahead='%s', result=%s%n", ahead.getText().replace("\n", "\\n"), result); // <-- Added

    // Check if the token resides on the HIDDEN channel and if it's of the
    // provided type.
    return (ahead.getChannel() == Lexer.HIDDEN) && (ahead.getType() == type);
}
```

and then test what the parser rule `continueStatement`:

```
continueStatement
    : Continue ({this.notLineTerminator()}? identifier)? eos
    ;
```

using the Java code:

```java
JavaScriptLexer lexer = new JavaScriptLexer(CharStreams.fromString("{\n  continue\n  a\n}"));
JavaScriptParser parser = new JavaScriptParser(new CommonTokenStream(lexer));
parser.block();
```

then the following is printed:

```
ahead='  ', result=false
ahead='  ', result=false
ahead='  ', result=false
```

Which is incorrect: after the `continue` _is_ a line break,so there should have been printed `ahead='\n', result=true` to the console.

With the provided fix, this is printed (when adding a `println`), and the unit test shows it now works (which failed before this PR).