### PR TITLE
Bump antlr.version from 4.9.3 to 4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<maven.compiler.source>1.7</maven.compiler.source>
-		<antlr.version>4.9.3</antlr.version>
+		<antlr.version>4.10</antlr.version>
 		<antlr4test-maven-plugin.version>1.19</antlr4test-maven-plugin.version>
 		<junit.version>4.13.2</junit.version>
 	</properties>


### PR DESCRIPTION
Bumps `antlr.version` from 4.9.3 to 4.10.

Updates `antlr4-runtime` from 4.9.3 to 4.10
- [Release notes](https://github.com/antlr/antlr4/releases)
- [Changelog](https://github.com/antlr/antlr4/blob/master/CHANGES.txt)
- [Commits](https://github.com/antlr/antlr4/compare/4.9.3...4.10)

Updates `antlr4-maven-plugin` from 4.9.3 to 4.10
- [Release notes](https://github.com/antlr/antlr4/releases)
- [Changelog](https://github.com/antlr/antlr4/blob/master/CHANGES.txt)
- [Commits](https://github.com/antlr/antlr4/compare/4.9.3...4.10)

Updates `antlr4` from 4.9.3 to 4.10
- [Release notes](https://github.com/antlr/antlr4/releases)
- [Changelog](https://github.com/antlr/antlr4/blob/master/CHANGES.txt)
- [Commits](https://github.com/antlr/antlr4/compare/4.9.3...4.10)

---
updated-dependencies:
- dependency-name: org.antlr:antlr4-runtime dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.antlr:antlr4-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.antlr:antlr4 dependency-type: direct:production update-type: version-update:semver-minor ...