### PR TITLE
[bnf] Fix #3779

### DIFF
--- a/bnf/bnf.g4
+++ b/bnf/bnf.g4
@@ -45,7 +45,7 @@ rhs
     ;
 
 alternatives
-    : alternative (BAR alternative)*
+    : alternative ('|' alternative)*
     ;
 
 alternative
@@ -61,15 +61,15 @@ element
     ;
 
 optional_
-    : REND alternatives LEND
+    : '[' alternatives ']'
     ;
 
 zeroormore
-    : RBRACE alternatives LBRACE
+    : '{' alternatives '}'
     ;
 
 oneormore
-    : RPAREN alternatives LPAREN
+    : '(' alternatives ')'
     ;
 
 text_
@@ -77,7 +77,7 @@ text_
     ;
 
 id_
-    : LT ruleid GT
+    : '<' ruleid '>'
     ;
 
 ruleid
@@ -88,39 +88,39 @@ ASSIGN
     : '::='
     ;
 
-LPAREN
+Right_Parenthesis
     : ')'
     ;
 
-RPAREN
+Left_Parenthesis
     : '('
     ;
 
-LBRACE
+Right_Curly_Bracket
     : '}'
     ;
 
-RBRACE
+Left_Curly_Bracket
     : '{'
     ;
 
-LEND
+Right_Square_Bracket
     : ']'
     ;
 
-REND
+Left_Square_Bracket
     : '['
     ;
 
-BAR
+Vertical_Line
     : '|'
     ;
 
-GT
+Greater_Than_Sign
     : '>'
     ;
 
-LT
+Less_Than_Sign
     : '<'
     ;
 


### PR DESCRIPTION
This is a fix for #3779 -- the names of the string literals are reversed in meaning.

In this PR, I substituted string literals for the lexer symbols in parser rules. There is no requirement that lexer rule names have to be used in a parser rule, and it is clearer when reading the parser rules to just use the string literals, even if the grammar is later split. The lexer rule names for these single-character string literals are now just the official Unicode character names (e.g., "[Greater_Than_Sign](https://www.compart.com/en/unicode/U+003E)"), with underscores substituted for dashes and spaces in the name. This is tidier, cleaner, more standardized than trying to invent one's own name.

I am planning to reorganize and rename this grammar as "ebnf", and introduce a "bnf" grammar that takes different versions of BNF derived from the original papers in the '50s and '60s on BNF. Some of those papers have hand-written symbols, but the plan is to use Unicode for recognizing these, as well as incorporating the more contemporary versions of BNF that throw away the less-than and greater-than signs, and use quotes around terminals. There seems to be a lot of confusion as to what is BNF.