### PR TITLE
[PlSql] Add pragma_declaration to package_obj_body

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -629,7 +629,8 @@ function_spec
     ;
 
 package_obj_body
-    : exception_declaration
+    : pragma_declaration
+    | exception_declaration
     | subtype_declaration
     | cursor_declaration
     | variable_declaration

--- a/sql/plsql/examples-sql-script/pragma_exception_init.pkb
+++ b/sql/plsql/examples-sql-script/pragma_exception_init.pkb
@@ -1,0 +1,8 @@
+create or replace package body pragma_exception_init
+is
+
+  some_exception exception;
+  pragma exception_init (some_exception, -20001);
+
+end pragma_exception_init;
+/


### PR DESCRIPTION
E.g. https://docs.oracle.com/en/database/oracle/oracle-database/21/lnpls/SERIALLY_REUSABLE-pragma.html states that: "The SERIALLY_REUSABLE pragma can appear in the declare_section of the specification of a bodiless package, or in both the specification and body of a package, but not in only the body of a package."

Also, `pragma exception_init (...)` has been verified to work in the declaration section of a package body, although https://docs.oracle.com/en/database/oracle/oracle-database/21/lnpls/EXCEPTION_INIT-pragma.html doesn't mention it.