### PR TITLE
[PlSql] Break out unary_logical_operation rule

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6083,7 +6083,7 @@ logical_expression
     ;
 
 unary_logical_expression
-    : NOT? multiset_expression unary_logical_operation*
+    : NOT? multiset_expression unary_logical_operation?
     ;
 
 unary_logical_operation

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6083,7 +6083,11 @@ logical_expression
     ;
 
 unary_logical_expression
-    : NOT? multiset_expression (IS NOT? logical_operation)*
+    : NOT? multiset_expression unary_logical_operation*
+    ;
+
+unary_logical_operation
+    : IS NOT? logical_operation
     ;
 
 logical_operation:

--- a/sql/plsql/examples-sql-script/logical_expressions.sql
+++ b/sql/plsql/examples-sql-script/logical_expressions.sql
@@ -1,0 +1,17 @@
+DECLARE
+    FOO NUMBER := 1;
+    BAR NUMBER := 2;
+BEGIN
+    IF FOO = 1 AND BAR IS NOT NULL THEN
+        RAISE_APPLICATION_ERROR(-20001, 'FOO is 1 and BAR is not null');
+    END IF;
+
+    IF FOO = 1 OR NOT BAR IS NULL THEN
+        RAISE_APPLICATION_ERROR(-20002, 'FOO is 1 or BAR is not null');
+    END IF;
+
+    IF FOO = 1 AND BAR IS NOT NULL AND BAR IS NOT NAN THEN
+        RAISE_APPLICATION_ERROR(-20003, 'FOO is 1 and BAR is not null and BAR is not nan');
+    END IF;
+END;
+/


### PR DESCRIPTION
To simplify processing of multiple unary logical operations within a unary_logical_expression, as well as to avoid ambiguity of NOT tokens within unary_logical_expression.