### PR TITLE
Consolidated the ANTLR4 grammar

### DIFF
--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -35,39 +35,54 @@
  *	-- update for compatibility with Antlr v4.5
  */
 
+// $antlr-format alignTrailingComments on, columnLimit 130, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments off
+// $antlr-format useTab off, allowShortRulesOnASingleLine off, allowShortBlocksOnASingleLine on, alignSemicolons hanging
+// $antlr-format alignColons hanging
+
 // ======================================================
 // Lexer specification
 // ======================================================
 
 lexer grammar ANTLRv4Lexer;
 
-options { superClass = LexerAdaptor; }
+options {
+    superClass = LexerAdaptor;
+}
+
 import LexBasic;
 
 // Standard set of fragments
-tokens { TOKEN_REF , RULE_REF , LEXER_CHAR_SET }
-channels { OFF_CHANNEL , COMMENT }
+tokens {
+    TOKEN_REF,
+    RULE_REF,
+    LEXER_CHAR_SET
+}
+
+channels {
+    OFF_CHANNEL,
+    COMMENT
+}
 
 // -------------------------
 // Comments
 DOC_COMMENT
-   : DocComment -> channel (COMMENT)
-   ;
+    : DocComment -> channel (COMMENT)
+    ;
 
 BLOCK_COMMENT
-   : BlockComment -> channel (COMMENT)
-   ;
+    : BlockComment -> channel (COMMENT)
+    ;
 
 LINE_COMMENT
-   : LineComment -> channel (COMMENT)
-   ;
+    : LineComment -> channel (COMMENT)
+    ;
 
 // -------------------------
 // Integer
 
 INT
-   : DecimalNumeral
-   ;
+    : DecimalNumeral
+    ;
 
 // -------------------------
 // Literal string
@@ -77,12 +92,12 @@ INT
 // may contain unicode escape sequences of the form \uxxxx, where x
 // is a valid hexadecimal number (per Unicode standard).
 STRING_LITERAL
-   : SQuoteLiteral
-   ;
+    : SQuoteLiteral
+    ;
 
 UNTERMINATED_STRING_LITERAL
-   : USQuoteLiteral
-   ;
+    : USQuoteLiteral
+    ;
 
 // -------------------------
 // Arguments
@@ -91,15 +106,14 @@ UNTERMINATED_STRING_LITERAL
 // to a rule invocation, or input parameters to a rule specification
 // are contained within square brackets.
 BEGIN_ARGUMENT
-   : LBrack
-   { this.handleBeginArgument(); }
-   ;
+    : LBrack { this.handleBeginArgument(); }
+    ;
 
 // -------------------------
 // Target Language Actions
 BEGIN_ACTION
-   : LBrace -> pushMode (TargetLanguageAction)
-   ;
+    : LBrace -> pushMode (TargetLanguageAction)
+    ;
 
 // -------------------------
 // Keywords
@@ -108,173 +122,190 @@ BEGIN_ACTION
 // but only when followed by '{', and considered as a single token.
 // Otherwise, the symbols are tokenized as RULE_REF and allowed as
 // an identifier in a labeledElement.
-OPTIONS      : 'options'  WSNLCHARS* '{'  ;
-TOKENS       : 'tokens'   WSNLCHARS* '{'  ;
-CHANNELS     : 'channels' WSNLCHARS* '{'  ;
+OPTIONS
+    : 'options' WSNLCHARS* '{'
+    ;
 
-fragment WSNLCHARS : ' ' | '\t' | '\f' | '\n' | '\r' ;
+TOKENS
+    : 'tokens' WSNLCHARS* '{'
+    ;
+
+CHANNELS
+    : 'channels' WSNLCHARS* '{'
+    ;
+
+fragment WSNLCHARS
+    : ' '
+    | '\t'
+    | '\f'
+    | '\n'
+    | '\r'
+    ;
 
 IMPORT
-   : 'import'
-   ;
+    : 'import'
+    ;
 
 FRAGMENT
-   : 'fragment'
-   ;
+    : 'fragment'
+    ;
 
 LEXER
-   : 'lexer'
-   ;
+    : 'lexer'
+    ;
 
 PARSER
-   : 'parser'
-   ;
+    : 'parser'
+    ;
 
 GRAMMAR
-   : 'grammar'
-   ;
+    : 'grammar'
+    ;
 
 PROTECTED
-   : 'protected'
-   ;
+    : 'protected'
+    ;
 
 PUBLIC
-   : 'public'
-   ;
+    : 'public'
+    ;
 
 PRIVATE
-   : 'private'
-   ;
+    : 'private'
+    ;
 
 RETURNS
-   : 'returns'
-   ;
+    : 'returns'
+    ;
 
 LOCALS
-   : 'locals'
-   ;
+    : 'locals'
+    ;
 
 THROWS
-   : 'throws'
-   ;
+    : 'throws'
+    ;
 
 CATCH
-   : 'catch'
-   ;
+    : 'catch'
+    ;
 
 FINALLY
-   : 'finally'
-   ;
+    : 'finally'
+    ;
 
 MODE
-   : 'mode'
-   ;
-   // -------------------------
-   // Punctuation
+    : 'mode'
+    ;
+
+// -------------------------
+// Punctuation
 
 COLON
-   : Colon
-   ;
+    : Colon
+    ;
 
 COLONCOLON
-   : DColon
-   ;
+    : DColon
+    ;
 
 COMMA
-   : Comma
-   ;
+    : Comma
+    ;
 
 SEMI
-   : Semi
-   ;
+    : Semi
+    ;
 
 LPAREN
-   : LParen
-   ;
+    : LParen
+    ;
 
 RPAREN
-   : RParen
-   ;
+    : RParen
+    ;
 
 LBRACE
-   : LBrace
-   ;
+    : LBrace
+    ;
 
 RBRACE
-   : RBrace
-   ;
+    : RBrace
+    ;
 
 RARROW
-   : RArrow
-   ;
+    : RArrow
+    ;
 
 LT
-   : Lt
-   ;
+    : Lt
+    ;
 
 GT
-   : Gt
-   ;
+    : Gt
+    ;
 
 ASSIGN
-   : Equal
-   ;
+    : Equal
+    ;
 
 QUESTION
-   : Question
-   ;
+    : Question
+    ;
 
 STAR
-   : Star
-   ;
+    : Star
+    ;
 
 PLUS_ASSIGN
-   : PlusAssign
-   ;
+    : PlusAssign
+    ;
 
 PLUS
-   : Plus
-   ;
+    : Plus
+    ;
 
 OR
-   : Pipe
-   ;
+    : Pipe
+    ;
 
 DOLLAR
-   : Dollar
-   ;
+    : Dollar
+    ;
 
 RANGE
-   : Range
-   ;
+    : Range
+    ;
 
 DOT
-   : Dot
-   ;
+    : Dot
+    ;
 
 AT
-   : At
-   ;
+    : At
+    ;
 
 POUND
-   : Pound
-   ;
+    : Pound
+    ;
 
 NOT
-   : Tilde
-   ;
-   // -------------------------
-   // Identifiers - allows unicode rule/token names
+    : Tilde
+    ;
+
+// -------------------------
+// Identifiers - allows unicode rule/token names
 
 ID
-   : Id
-   ;
-   // -------------------------
-   // Whitespace
+    : Id
+    ;
+
+// -------------------------
+// Whitespace
 
 WS
-   : Ws+ -> channel (OFF_CHANNEL)
-   ;
+    : Ws+ -> channel (OFF_CHANNEL)
+    ;
 
 // -------------------------
 // Illegal Characters
@@ -289,44 +320,44 @@ WS
 
 // Comment this rule out to allow the error to be propagated to the parser
 ERRCHAR
-   : . -> channel (HIDDEN)
-   ;
+    : . -> channel (HIDDEN)
+    ;
 
 // ======================================================
 // Lexer modes
 // -------------------------
 // Arguments
 mode Argument;
+
 // E.g., [int x, List<String> a[]]
 NESTED_ARGUMENT
-   : LBrack -> type (ARGUMENT_CONTENT) , pushMode (Argument)
-   ;
+    : LBrack -> type (ARGUMENT_CONTENT), pushMode (Argument)
+    ;
 
 ARGUMENT_ESCAPE
-   : EscAny -> type (ARGUMENT_CONTENT)
-   ;
+    : EscAny -> type (ARGUMENT_CONTENT)
+    ;
 
 ARGUMENT_STRING_LITERAL
-   : DQuoteLiteral -> type (ARGUMENT_CONTENT)
-   ;
+    : DQuoteLiteral -> type (ARGUMENT_CONTENT)
+    ;
 
 ARGUMENT_CHAR_LITERAL
-   : SQuoteLiteral -> type (ARGUMENT_CONTENT)
-   ;
+    : SQuoteLiteral -> type (ARGUMENT_CONTENT)
+    ;
 
 END_ARGUMENT
-   : RBrack
-   { this.handleEndArgument(); }
-   ;
+    : RBrack { this.handleEndArgument(); }
+    ;
 
 // added this to return non-EOF token type here. EOF does something weird
 UNTERMINATED_ARGUMENT
-   : EOF -> popMode
-   ;
+    : EOF -> popMode
+    ;
 
 ARGUMENT_CONTENT
-   : .
-   ;
+    : .
+    ;
 
 // TODO: This grammar and the one used in the Intellij Antlr4 plugin differ
 // for "actions". This needs to be resolved at some point.
@@ -343,64 +374,64 @@ ARGUMENT_CONTENT
 // that they are delimited by ' or " and so consume these
 // in their own alts so as not to inadvertantly match {}.
 mode TargetLanguageAction;
+
 NESTED_ACTION
-   : LBrace -> type (ACTION_CONTENT) , pushMode (TargetLanguageAction)
-   ;
+    : LBrace -> type (ACTION_CONTENT), pushMode (TargetLanguageAction)
+    ;
 
 ACTION_ESCAPE
-   : EscAny -> type (ACTION_CONTENT)
-   ;
+    : EscAny -> type (ACTION_CONTENT)
+    ;
 
 ACTION_STRING_LITERAL
-   : DQuoteLiteral -> type (ACTION_CONTENT)
-   ;
+    : DQuoteLiteral -> type (ACTION_CONTENT)
+    ;
 
 ACTION_CHAR_LITERAL
-   : SQuoteLiteral -> type (ACTION_CONTENT)
-   ;
+    : SQuoteLiteral -> type (ACTION_CONTENT)
+    ;
 
 ACTION_DOC_COMMENT
-   : DocComment -> type (ACTION_CONTENT)
-   ;
+    : DocComment -> type (ACTION_CONTENT)
+    ;
 
 ACTION_BLOCK_COMMENT
-   : BlockComment -> type (ACTION_CONTENT)
-   ;
+    : BlockComment -> type (ACTION_CONTENT)
+    ;
 
 ACTION_LINE_COMMENT
-   : LineComment -> type (ACTION_CONTENT)
-   ;
+    : LineComment -> type (ACTION_CONTENT)
+    ;
 
 END_ACTION
-   : RBrace
-   { this.handleEndAction(); }
-   ;
+    : RBrace { this.handleEndAction(); }
+    ;
 
 UNTERMINATED_ACTION
-   : EOF -> popMode
-   ;
+    : EOF -> popMode
+    ;
 
 ACTION_CONTENT
-   : .
-   ;
+    : .
+    ;
 
 // -------------------------
 mode LexerCharSet;
+
 LEXER_CHAR_SET_BODY
-   : (~ [\]\\] | EscAny)+ -> more
-   ;
+    : (~ [\]\\] | EscAny)+ -> more
+    ;
 
 LEXER_CHAR_SET
-   : RBrack -> popMode
-   ;
+    : RBrack -> popMode
+    ;
 
 UNTERMINATED_CHAR_SET
-   : EOF -> popMode
-   ;
+    : EOF -> popMode
+    ;
 
 // ------------------------------------------------------------------------------
 // Grammar specific Keywords, Punctuation, etc.
 fragment Id
-   : NameStartChar NameChar*
-   ;
-   
+    : NameStartChar NameChar*
+    ;

--- a/antlr/antlr4/ANTLRv4Parser.g4
+++ b/antlr/antlr4/ANTLRv4Parser.g4
@@ -37,342 +37,363 @@
  *	-- moved members to LexerAdaptor
  * 	-- move fragments to imports
  */
+
+// $antlr-format alignTrailingComments on, columnLimit 130, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments off
+// $antlr-format useTab off, allowShortRulesOnASingleLine off, allowShortBlocksOnASingleLine on, alignSemicolons hanging
+// $antlr-format alignColons hanging
+
 parser grammar ANTLRv4Parser;
 
+options {
+    tokenVocab = ANTLRv4Lexer;
+}
 
-options { tokenVocab = ANTLRv4Lexer; }
 // The main entry point for parsing a v4 grammar.
 grammarSpec
-   : grammarDecl prequelConstruct* rules modeSpec* EOF
-   ;
+    : grammarDecl prequelConstruct* rules modeSpec* EOF
+    ;
 
 grammarDecl
-   : grammarType identifier SEMI
-   ;
+    : grammarType identifier SEMI
+    ;
 
 grammarType
-   : LEXER GRAMMAR | PARSER GRAMMAR | GRAMMAR
-   ;
-   // This is the list of all constructs that can be declared before
-   // the set of rules that compose the grammar, and is invoked 0..n
-   // times by the grammarPrequel rule.
+    : LEXER GRAMMAR
+    | PARSER GRAMMAR
+    | GRAMMAR
+    ;
+
+// This is the list of all constructs that can be declared before
+// the set of rules that compose the grammar, and is invoked 0..n
+// times by the grammarPrequel rule.
 
 prequelConstruct
-   : optionsSpec
-   | delegateGrammars
-   | tokensSpec
-   | channelsSpec
-   | action_
-   ;
-   // ------------
-   // Options - things that affect analysis and/or code generation
+    : optionsSpec
+    | delegateGrammars
+    | tokensSpec
+    | channelsSpec
+    | action_
+    ;
+
+// ------------
+// Options - things that affect analysis and/or code generation
 
 optionsSpec
-   : OPTIONS (option SEMI)* RBRACE
-   ;
+    : OPTIONS (option SEMI)* RBRACE
+    ;
 
 option
-   : identifier ASSIGN optionValue
-   ;
+    : identifier ASSIGN optionValue
+    ;
 
 optionValue
-   : identifier (DOT identifier)*
-   | STRING_LITERAL
-   | actionBlock
-   | INT
-   ;
-   // ------------
-   // Delegates
+    : identifier (DOT identifier)*
+    | STRING_LITERAL
+    | actionBlock
+    | INT
+    ;
+
+// ------------
+// Delegates
 
 delegateGrammars
-   : IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
-   ;
+    : IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
+    ;
 
 delegateGrammar
-   : identifier ASSIGN identifier
-   | identifier
-   ;
-   // ------------
-   // Tokens & Channels
+    : identifier ASSIGN identifier
+    | identifier
+    ;
+
+// ------------
+// Tokens & Channels
 
 tokensSpec
-   : TOKENS idList? RBRACE
-   ;
+    : TOKENS idList? RBRACE
+    ;
 
 channelsSpec
-   : CHANNELS idList? RBRACE
-   ;
+    : CHANNELS idList? RBRACE
+    ;
 
 idList
-   : identifier (COMMA identifier)* COMMA?
-   ;
-   // Match stuff like @parser::members {int i;}
+    : identifier (COMMA identifier)* COMMA?
+    ;
+
+// Match stuff like @parser::members {int i;}
 
 action_
-   : AT (actionScopeName COLONCOLON)? identifier actionBlock
-   ;
-   // Scope names could collide with keywords; allow them as ids for action scopes
+    : AT (actionScopeName COLONCOLON)? identifier actionBlock
+    ;
+
+// Scope names could collide with keywords; allow them as ids for action scopes
 
 actionScopeName
-   : identifier
-   | LEXER
-   | PARSER
-   ;
+    : identifier
+    | LEXER
+    | PARSER
+    ;
 
 actionBlock
-   : BEGIN_ACTION ACTION_CONTENT* END_ACTION
-   ;
+    : BEGIN_ACTION ACTION_CONTENT* END_ACTION
+    ;
 
 argActionBlock
-   : BEGIN_ARGUMENT ARGUMENT_CONTENT* END_ARGUMENT
-   ;
+    : BEGIN_ARGUMENT ARGUMENT_CONTENT* END_ARGUMENT
+    ;
 
 modeSpec
-   : MODE identifier SEMI lexerRuleSpec*
-   ;
+    : MODE identifier SEMI lexerRuleSpec*
+    ;
 
 rules
-   : ruleSpec*
-   ;
+    : ruleSpec*
+    ;
 
 ruleSpec
-   : parserRuleSpec
-   | lexerRuleSpec
-   ;
+    : parserRuleSpec
+    | lexerRuleSpec
+    ;
 
 parserRuleSpec
-   : ruleModifiers? RULE_REF argActionBlock? ruleReturns? throwsSpec? localsSpec? rulePrequel* COLON ruleBlock SEMI exceptionGroup
-   ;
+    : ruleModifiers? RULE_REF argActionBlock? ruleReturns? throwsSpec? localsSpec? rulePrequel* COLON ruleBlock SEMI
+        exceptionGroup
+    ;
 
 exceptionGroup
-   : exceptionHandler* finallyClause?
-   ;
+    : exceptionHandler* finallyClause?
+    ;
 
 exceptionHandler
-   : CATCH argActionBlock actionBlock
-   ;
+    : CATCH argActionBlock actionBlock
+    ;
 
 finallyClause
-   : FINALLY actionBlock
-   ;
+    : FINALLY actionBlock
+    ;
 
 rulePrequel
-   : optionsSpec
-   | ruleAction
-   ;
+    : optionsSpec
+    | ruleAction
+    ;
 
 ruleReturns
-   : RETURNS argActionBlock
-   ;
+    : RETURNS argActionBlock
+    ;
 
 // --------------
 // Exception spec
 throwsSpec
-   : THROWS identifier (COMMA identifier)*
-   ;
+    : THROWS identifier (COMMA identifier)*
+    ;
 
 localsSpec
-   : LOCALS argActionBlock
-   ;
+    : LOCALS argActionBlock
+    ;
 
 /** Match stuff like @init {int i;} */
 ruleAction
-   : AT identifier actionBlock
-   ;
+    : AT identifier actionBlock
+    ;
 
 ruleModifiers
-   : ruleModifier+
-   ;
-   // An individual access modifier for a rule. The 'fragment' modifier
-   // is an internal indication for lexer rules that they do not match
-   // from the input but are like subroutines for other lexer rules to
-   // reuse for certain lexical patterns. The other modifiers are passed
-   // to the code generation templates and may be ignored by the template
-   // if they are of no use in that language.
+    : ruleModifier+
+    ;
+
+// An individual access modifier for a rule. The 'fragment' modifier
+// is an internal indication for lexer rules that they do not match
+// from the input but are like subroutines for other lexer rules to
+// reuse for certain lexical patterns. The other modifiers are passed
+// to the code generation templates and may be ignored by the template
+// if they are of no use in that language.
 
 ruleModifier
-   : PUBLIC
-   | PRIVATE
-   | PROTECTED
-   | FRAGMENT
-   ;
+    : PUBLIC
+    | PRIVATE
+    | PROTECTED
+    | FRAGMENT
+    ;
 
 ruleBlock
-   : ruleAltList
-   ;
+    : ruleAltList
+    ;
 
 ruleAltList
-   : labeledAlt (OR labeledAlt)*
-   ;
+    : labeledAlt (OR labeledAlt)*
+    ;
 
 labeledAlt
-   : alternative (POUND identifier)?
-   ;
-   // --------------------
-   // Lexer rules
+    : alternative (POUND identifier)?
+    ;
+
+// --------------------
+// Lexer rules
 
 lexerRuleSpec
-   : FRAGMENT? TOKEN_REF optionsSpec? COLON lexerRuleBlock SEMI
-   ;
+    : FRAGMENT? TOKEN_REF optionsSpec? COLON lexerRuleBlock SEMI
+    ;
 
 lexerRuleBlock
-   : lexerAltList
-   ;
+    : lexerAltList
+    ;
 
 lexerAltList
-   : lexerAlt (OR lexerAlt)*
-   ;
+    : lexerAlt (OR lexerAlt)*
+    ;
 
 lexerAlt
-   : lexerElements lexerCommands?
-   |
-   // explicitly allow empty alts
-   ;
+    : lexerElements lexerCommands?
+    |
+    // explicitly allow empty alts
+    ;
 
 lexerElements
-   : lexerElement+
-   |
-   ;
+    : lexerElement+
+    |
+    ;
 
 lexerElement
-   : lexerAtom ebnfSuffix?
-   | lexerBlock ebnfSuffix?
-   | actionBlock QUESTION?
-   ;
-   // but preds can be anywhere
+    : lexerAtom ebnfSuffix?
+    | lexerBlock ebnfSuffix?
+    | actionBlock QUESTION?
+    ;
+
+// but preds can be anywhere
 
 lexerBlock
-   : LPAREN lexerAltList RPAREN
-   ;
-   // E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop
+    : LPAREN lexerAltList RPAREN
+    ;
+
+// E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop
 
 lexerCommands
-   : RARROW lexerCommand (COMMA lexerCommand)*
-   ;
+    : RARROW lexerCommand (COMMA lexerCommand)*
+    ;
 
 lexerCommand
-   : lexerCommandName LPAREN lexerCommandExpr RPAREN
-   | lexerCommandName
-   ;
+    : lexerCommandName LPAREN lexerCommandExpr RPAREN
+    | lexerCommandName
+    ;
 
 lexerCommandName
-   : identifier
-   | MODE
-   ;
+    : identifier
+    | MODE
+    ;
 
 lexerCommandExpr
-   : identifier
-   | INT
-   ;
-   // --------------------
-   // Rule Alts
+    : identifier
+    | INT
+    ;
+
+// --------------------
+// Rule Alts
 
 altList
-   : alternative (OR alternative)*
-   ;
+    : alternative (OR alternative)*
+    ;
 
 alternative
-   : elementOptions? element+
-   |
-   // explicitly allow empty alts
-   ;
+    : elementOptions? element+
+    |
+    // explicitly allow empty alts
+    ;
 
 element
-   : labeledElement (ebnfSuffix |)
-   | atom (ebnfSuffix |)
-   | ebnf
-   | actionBlock QUESTION?
-   ;
+    : labeledElement (ebnfSuffix |)
+    | atom (ebnfSuffix |)
+    | ebnf
+    | actionBlock (QUESTION elementOptions?)?
+    ;
 
 labeledElement
-   : identifier (ASSIGN | PLUS_ASSIGN) (atom | block)
-   ;
-   // --------------------
-   // EBNF and blocks
+    : identifier (ASSIGN | PLUS_ASSIGN) (atom | block)
+    ;
+
+// --------------------
+// EBNF and blocks
 
 ebnf
-   : block blockSuffix?
-   ;
+    : block blockSuffix?
+    ;
 
 blockSuffix
-   : ebnfSuffix
-   ;
+    : ebnfSuffix
+    ;
 
 ebnfSuffix
-   : QUESTION QUESTION?
-   | STAR QUESTION?
-   | PLUS QUESTION?
-   ;
+    : QUESTION QUESTION?
+    | STAR QUESTION?
+    | PLUS QUESTION?
+    ;
 
 lexerAtom
-   : characterRange
-   | terminal
-   | notSet
-   | LEXER_CHAR_SET
-   | DOT elementOptions?
-   ;
+    : characterRange
+    | terminalDef
+    | notSet
+    | LEXER_CHAR_SET
+    | DOT elementOptions?
+    ;
 
 atom
-   : terminal
-   | ruleref
-   | notSet
-   | DOT elementOptions?
-   ;
+    : terminalDef
+    | ruleref
+    | notSet
+    | DOT elementOptions?
+    ;
 
 // --------------------
 // Inverted element set
 notSet
-   : NOT setElement
-   | NOT blockSet
-   ;
+    : NOT setElement
+    | NOT blockSet
+    ;
 
 blockSet
-   : LPAREN setElement (OR setElement)* RPAREN
-   ;
+    : LPAREN setElement (OR setElement)* RPAREN
+    ;
 
 setElement
-   : TOKEN_REF elementOptions?
-   | STRING_LITERAL elementOptions?
-   | characterRange
-   | LEXER_CHAR_SET
-   ;
+    : TOKEN_REF elementOptions?
+    | STRING_LITERAL elementOptions?
+    | characterRange
+    | LEXER_CHAR_SET
+    ;
 
 // -------------
 // Grammar Block
 block
-   : LPAREN (optionsSpec? ruleAction* COLON)? altList RPAREN
-   ;
+    : LPAREN (optionsSpec? ruleAction* COLON)? altList RPAREN
+    ;
 
 // ----------------
 // Parser rule ref
 ruleref
-   : RULE_REF argActionBlock? elementOptions?
-   ;
+    : RULE_REF argActionBlock? elementOptions?
+    ;
 
 // ---------------
 // Character Range
 characterRange
-   : STRING_LITERAL RANGE STRING_LITERAL
-   ;
+    : STRING_LITERAL RANGE STRING_LITERAL
+    ;
 
-terminal
-   : TOKEN_REF elementOptions?
-   | STRING_LITERAL elementOptions?
-   ;
+terminalDef
+    : TOKEN_REF elementOptions?
+    | STRING_LITERAL elementOptions?
+    ;
 
 // Terminals may be adorned with certain options when
 // reference in the grammar: TOK<,,,>
 elementOptions
-   : LT elementOption (COMMA elementOption)* GT
-   ;
+    : LT elementOption (COMMA elementOption)* GT
+    ;
 
 elementOption
-   : identifier
-   | identifier ASSIGN (identifier | STRING_LITERAL)
-   ;
+    : identifier
+    | identifier ASSIGN (identifier | STRING_LITERAL)
+    ;
 
 identifier
-   : RULE_REF
-   | TOKEN_REF
-   ;
-   
+    : RULE_REF
+    | TOKEN_REF
+    ;

--- a/antlr/antlr4/ANTLRv4Parser.g4
+++ b/antlr/antlr4/ANTLRv4Parser.g4
@@ -302,7 +302,16 @@ element
     : labeledElement (ebnfSuffix |)
     | atom (ebnfSuffix |)
     | ebnf
-    | actionBlock (QUESTION elementOptions?)?
+    | actionBlock (QUESTION predicateOptions?)?
+    ;
+
+predicateOptions
+    : LT predicateOption (COMMA predicateOption)* GT
+    ;
+
+predicateOption
+    : elementOption
+    | identifier ASSIGN actionBlock
     ;
 
 labeledElement

--- a/antlr/antlr4/LexBasic.g4
+++ b/antlr/antlr4/LexBasic.g4
@@ -26,14 +26,20 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-/** 
+/**
  * A generally reusable set of fragments for import in to Lexer grammars.
  *
- *	Modified 2015.06.16 gbr - 
+ *	Modified 2015.06.16 gbr -
  *	-- generalized for inclusion into the ANTLRv4 grammar distribution
- * 
+ *
  */
+
+// $antlr-format alignTrailingComments on, columnLimit 130, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments off
+// $antlr-format useTab off, allowShortRulesOnASingleLine off, allowShortBlocksOnASingleLine on, alignSemicolons hanging
+// $antlr-format alignColons hanging
+
 lexer grammar LexBasic;
+
 // ======================================================
 // Lexer fragments
 //
@@ -41,234 +47,240 @@ lexer grammar LexBasic;
 // Whitespace & Comments
 
 fragment Ws
-   : Hws
-   | Vws
-   ;
+    : Hws
+    | Vws
+    ;
 
 fragment Hws
-   : [ \t]
-   ;
+    : [ \t]
+    ;
 
 fragment Vws
-   : [\r\n\f]
-   ;
+    : [\r\n\f]
+    ;
 
 fragment BlockComment
-   : '/*' .*? ('*/' | EOF)
-   ;
+    : '/*' .*? ('*/' | EOF)
+    ;
 
 fragment DocComment
-   : '/**' .*? ('*/' | EOF)
-   ;
+    : '/**' .*? ('*/' | EOF)
+    ;
 
 fragment LineComment
-   : '//' ~ [\r\n]*
-   ;
-   // -----------------------------------
-   // Escapes
-   // Any kind of escaped character that we can embed within ANTLR literal strings.
+    : '//' ~ [\r\n]*
+    ;
+
+// -----------------------------------
+// Escapes
+// Any kind of escaped character that we can embed within ANTLR literal strings.
 
 fragment EscSeq
-   : Esc ([btnfr"'\\] | UnicodeEsc | . | EOF)
-   ;
+    : Esc ([btnfr"'\\] | UnicodeEsc | . | EOF)
+    ;
 
 fragment EscAny
-   : Esc .
-   ;
+    : Esc .
+    ;
 
 fragment UnicodeEsc
-   : 'u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?
-   ;
-   // -----------------------------------
-   // Numerals
+    : 'u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?
+    ;
+
+// -----------------------------------
+// Numerals
 
 fragment DecimalNumeral
-   : '0'
-   | [1-9] DecDigit*
-   ;
-   // -----------------------------------
-   // Digits
+    : '0'
+    | [1-9] DecDigit*
+    ;
+
+// -----------------------------------
+// Digits
 
 fragment HexDigit
-   : [0-9a-fA-F]
-   ;
+    : [0-9a-fA-F]
+    ;
 
 fragment DecDigit
-   : [0-9]
-   ;
-   // -----------------------------------
-   // Literals
+    : [0-9]
+    ;
+
+// -----------------------------------
+// Literals
 
 fragment BoolLiteral
-   : 'true'
-   | 'false'
-   ;
+    : 'true'
+    | 'false'
+    ;
 
 fragment CharLiteral
-   : SQuote (EscSeq | ~ ['\r\n\\]) SQuote
-   ;
+    : SQuote (EscSeq | ~ ['\r\n\\]) SQuote
+    ;
 
 fragment SQuoteLiteral
-   : SQuote (EscSeq | ~ ['\r\n\\])* SQuote
-   ;
+    : SQuote (EscSeq | ~ ['\r\n\\])* SQuote
+    ;
 
 fragment DQuoteLiteral
-   : DQuote (EscSeq | ~ ["\r\n\\])* DQuote
-   ;
+    : DQuote (EscSeq | ~ ["\r\n\\])* DQuote
+    ;
 
 fragment USQuoteLiteral
-   : SQuote (EscSeq | ~ ['\r\n\\])*
-   ;
-   // -----------------------------------
-   // Character ranges
+    : SQuote (EscSeq | ~ ['\r\n\\])*
+    ;
+
+// -----------------------------------
+// Character ranges
 
 fragment NameChar
-   : NameStartChar
-   | '0' .. '9'
-   | Underscore
-   | '\u00B7'
-   | '\u0300' .. '\u036F'
-   | '\u203F' .. '\u2040'
-   ;
+    : NameStartChar
+    | '0' .. '9'
+    | Underscore
+    | '\u00B7'
+    | '\u0300' .. '\u036F'
+    | '\u203F' .. '\u2040'
+    ;
 
 fragment NameStartChar
-   : 'A' .. 'Z'
-   | 'a' .. 'z'
-   | '\u00C0' .. '\u00D6'
-   | '\u00D8' .. '\u00F6'
-   | '\u00F8' .. '\u02FF'
-   | '\u0370' .. '\u037D'
-   | '\u037F' .. '\u1FFF'
-   | '\u200C' .. '\u200D'
-   | '\u2070' .. '\u218F'
-   | '\u2C00' .. '\u2FEF'
-   | '\u3001' .. '\uD7FF'
-   | '\uF900' .. '\uFDCF'
-   | '\uFDF0' .. '\uFFFD'
-   ;
-   // ignores | ['\u10000-'\uEFFFF] ;
-   // -----------------------------------
-   // Types
+    : 'A' .. 'Z'
+    | 'a' .. 'z'
+    | '\u00C0' .. '\u00D6'
+    | '\u00D8' .. '\u00F6'
+    | '\u00F8' .. '\u02FF'
+    | '\u0370' .. '\u037D'
+    | '\u037F' .. '\u1FFF'
+    | '\u200C' .. '\u200D'
+    | '\u2070' .. '\u218F'
+    | '\u2C00' .. '\u2FEF'
+    | '\u3001' .. '\uD7FF'
+    | '\uF900' .. '\uFDCF'
+    | '\uFDF0' .. '\uFFFD'
+    // ignores | ['\u10000-'\uEFFFF]
+    ;
+
+// -----------------------------------
+// Types
 
 fragment Int
-   : 'int'
-   ;
-   // -----------------------------------
-   // Symbols
+    : 'int'
+    ;
+
+// -----------------------------------
+// Symbols
 
 fragment Esc
-   : '\\'
-   ;
+    : '\\'
+    ;
 
 fragment Colon
-   : ':'
-   ;
+    : ':'
+    ;
 
 fragment DColon
-   : '::'
-   ;
+    : '::'
+    ;
 
 fragment SQuote
-   : '\''
-   ;
+    : '\''
+    ;
 
 fragment DQuote
-   : '"'
-   ;
+    : '"'
+    ;
 
 fragment LParen
-   : '('
-   ;
+    : '('
+    ;
 
 fragment RParen
-   : ')'
-   ;
+    : ')'
+    ;
 
 fragment LBrace
-   : '{'
-   ;
+    : '{'
+    ;
 
 fragment RBrace
-   : '}'
-   ;
+    : '}'
+    ;
 
 fragment LBrack
-   : '['
-   ;
+    : '['
+    ;
 
 fragment RBrack
-   : ']'
-   ;
+    : ']'
+    ;
 
 fragment RArrow
-   : '->'
-   ;
+    : '->'
+    ;
 
 fragment Lt
-   : '<'
-   ;
+    : '<'
+    ;
 
 fragment Gt
-   : '>'
-   ;
+    : '>'
+    ;
 
 fragment Equal
-   : '='
-   ;
+    : '='
+    ;
 
 fragment Question
-   : '?'
-   ;
+    : '?'
+    ;
 
 fragment Star
-   : '*'
-   ;
+    : '*'
+    ;
 
 fragment Plus
-   : '+'
-   ;
+    : '+'
+    ;
 
 fragment PlusAssign
-   : '+='
-   ;
+    : '+='
+    ;
 
 fragment Underscore
-   : '_'
-   ;
+    : '_'
+    ;
 
 fragment Pipe
-   : '|'
-   ;
+    : '|'
+    ;
 
 fragment Dollar
-   : '$'
-   ;
+    : '$'
+    ;
 
 fragment Comma
-   : ','
-   ;
+    : ','
+    ;
 
 fragment Semi
-   : ';'
-   ;
+    : ';'
+    ;
 
 fragment Dot
-   : '.'
-   ;
+    : '.'
+    ;
 
 fragment Range
-   : '..'
-   ;
+    : '..'
+    ;
 
 fragment At
-   : '@'
-   ;
+    : '@'
+    ;
 
 fragment Pound
-   : '#'
-   ;
+    : '#'
+    ;
 
 fragment Tilde
-   : '~'
-   ;
-   
+    : '~'
+    ;


### PR DESCRIPTION
- Consistent formatting (4 spaces indentation).
- Added `elementOptions` after predicates, which is supported by ANTLR4.
- Renamed `terminal` to `terminalDef` as it conflicts otherwise with the `visitTerminal` standard visitor method.

I left in the formatter rules, as used by my VS Code ANTLR4 extension. May I suggest to establish a consistent formatting in the entire grammar repository using these rules? I'll open a [discussion](https://github.com/antlr/grammars-v4/discussions/3816) for this question.