### PR TITLE
[pcre] fix quoting bug

### DIFF
--- a/pcre/PCRE.g4
+++ b/pcre/PCRE.g4
@@ -264,8 +264,8 @@ match_point_reset
  ;
 
 quoting
- : '\\' .
- | '\\' 'Q' .*? '\\' 'E'
+ : '\\' 'Q' .*? '\\' 'E'
+ | '\\' .
  ;
 
 // Helper rules

--- a/pcre/PCRE.g4
+++ b/pcre/PCRE.g4
@@ -264,8 +264,7 @@ match_point_reset
  ;
 
 quoting
- : '\\' 'Q' .*? '\\' 'E'
- | '\\' .
+ : '\\' ('Q' .*? '\\' 'E' | .)
  ;
 
 // Helper rules


### PR DESCRIPTION
I have fixed a bug in the current implementation of PCRE syntax parsing where quoting in the format \Q...\E was not being parsed correctly. The issue was due to the order of the grammar, which I have now corrected. Regarding examples, I have decided not to add any as the existing ones are sufficient (see [here](https://github.com/antlr/grammars-v4/blob/master/pcre/examples/quoting.txt#L3)).

The original bug was as follows:

1. Bug

Only the `\Q` part of `\Q.\E` was being parsed as `'\\' .` , resulting in the following parse output:

```bash
$ grun PCRE pcre -tree
\Q.\E
(pcre (alternation (expr (element (atom (quoting \ Q))) (element (atom (character_type .))) (element (atom (quoting \ E))) (element (atom (other \n))))) <EOF>)
```

2. Expected Behavior

```bash
$ grun PCRE pcre -tree
\Q.\E
(pcre (alternation (expr (element (atom (quoting \ Q . \ E))) (element (atom (other \n))))) <EOF>)
```