### PR TITLE
Prerequisite for PR3740

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,67 +3,67 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trcaret"
       ]
     },
     "trcover": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trcover"
       ]
     },
     "trgen": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trgen"
       ]
     },
     "trglob": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trglob"
       ]
     },
     "triconv": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "triconv"
       ]
     },
     "trparse": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trparse"
       ]
     },
     "trtext": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trtext"
       ]
     },
     "trwdog": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trwdog"
       ]
     },
     "trxgrep": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trxgrep"
       ]
     },
     "trxml": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trxml"
       ]
     },
     "trxml2": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trxml2"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,61 +3,67 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trcaret"
       ]
     },
     "trcover": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trcover"
       ]
     },
     "trgen": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trgen"
       ]
     },
+    "trglob": {
+      "version": "0.21.15",
+      "commands": [
+        "trglob"
+      ]
+    },
     "triconv": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "triconv"
       ]
     },
     "trparse": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trparse"
       ]
     },
     "trtext": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trtext"
       ]
     },
     "trwdog": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trwdog"
       ]
     },
     "trxgrep": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trxgrep"
       ]
     },
     "trxml": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trxml"
       ]
     },
     "trxml2": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trxml2"
       ]

--- a/.config/dotnet-tools.json.save
+++ b/.config/dotnet-tools.json.save
@@ -3,67 +3,67 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trcaret"
       ]
     },
     "trcover": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trcover"
       ]
     },
     "trgen": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trgen"
       ]
     },
     "trglob": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trglob"
       ]
     },
     "triconv": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "triconv"
       ]
     },
     "trparse": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trparse"
       ]
     },
     "trtext": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trtext"
       ]
     },
     "trwdog": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trwdog"
       ]
     },
     "trxgrep": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trxgrep"
       ]
     },
     "trxml": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trxml"
       ]
     },
     "trxml2": {
-      "version": "0.21.15",
+      "version": "0.21.16",
       "commands": [
         "trxml2"
       ]

--- a/.config/dotnet-tools.json.save
+++ b/.config/dotnet-tools.json.save
@@ -3,61 +3,67 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trcaret"
       ]
     },
     "trcover": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trcover"
       ]
     },
     "trgen": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trgen"
       ]
     },
+    "trglob": {
+      "version": "0.21.15",
+      "commands": [
+        "trglob"
+      ]
+    },
     "triconv": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "triconv"
       ]
     },
     "trparse": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trparse"
       ]
     },
     "trtext": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trtext"
       ]
     },
     "trwdog": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trwdog"
       ]
     },
     "trxgrep": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trxgrep"
       ]
     },
     "trxml": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trxml"
       ]
     },
     "trxml2": {
-      "version": "0.21.9",
+      "version": "0.21.15",
       "commands": [
         "trxml2"
       ]

--- a/_scripts/templates/CSharp/Other.csproj
+++ b/_scripts/templates/CSharp/Other.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version ="4.13.1" />
-    <PackageReference Include="Antlr4BuildTasks" Version="12.4.0" PrivateAssets="all" />
+    <PackageReference Include="Antlr4BuildTasks" Version="12.4" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/_scripts/templates/CSharp/st.ErrorListener.cs
+++ b/_scripts/templates/CSharp/st.ErrorListener.cs
@@ -6,6 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using Antlr4.Runtime.Atn;
+using Antlr4.Runtime.Dfa;
+using Antlr4.Runtime.Sharpen;
 
 <if(has_name_space)>namespace <name_space>
 {<endif>
@@ -37,4 +41,81 @@ public class ErrorListener\<S> : IAntlrErrorListener\< S>
         }
     }
 }
+
+public class MyDiagnosticErrorListener : DiagnosticErrorListener
+{
+    public override void ReportAmbiguity​(Parser recognizer, DFA dfa, int startIndex, int stopIndex,
+        bool exact, BitSet ambigAlts, ATNConfigSet configs)
+    {
+        NewMethod(recognizer, dfa, startIndex, stopIndex, configs);
+    }
+
+    private void NewMethod(Parser recognizer, DFA dfa, int startIndex, int stopIndex, ATNConfigSet configs)
+    {
+        try
+        {
+            string decisionDescription = GetDecisionDescription(recognizer, dfa);
+            string text = ((ITokenStream)recognizer.InputStream).GetText(Interval.Of(startIndex, stopIndex));
+            int line = recognizer.CurrentToken.Line;
+            int col = recognizer.CurrentToken.Column;
+            System.Console.WriteLine(line + ":" + col + " " + decisionDescription + " " + text);
+            System.Console.WriteLine(configs);
+            foreach (var e in configs.Elements)
+            {
+                ATNState s = e.state;
+                PredictionContext c = e.context;
+                System.Console.WriteLine(OutIt(recognizer, e, c));
+            }
+        }
+        catch (RecognitionException e)
+        {
+            System.Console.WriteLine("catch " + e);
+        }
+    }
+
+    public override void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts,
+        ATNConfigSet configs)
+    {
+        string decisionDescription = GetDecisionDescription(recognizer, dfa);
+        string text = ((ITokenStream)recognizer.InputStream).GetText(Interval.Of(startIndex, stopIndex));
+        string msg = $"reportAttemptingFullContext d={decisionDescription}, input='{text}'";
+        System.Console.WriteLine(msg);
+        NewMethod(recognizer, dfa, startIndex, stopIndex, configs);
+    }
+
+    public override void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction,
+        ATNConfigSet configs)
+    {
+        string decisionDescription = GetDecisionDescription(recognizer, dfa);
+        string text = ((ITokenStream)recognizer.InputStream).GetText(Interval.Of(startIndex, stopIndex));
+        string msg = $"reportContextSensitivity d={decisionDescription}, input='{text}'";
+        System.Console.WriteLine(msg);
+        NewMethod(recognizer, dfa, startIndex, stopIndex, configs);
+    }
+
+    string OutIt(Parser recognizer, ATNConfig c, PredictionContext p)
+    {
+        if (p == null) return "";
+        var str = OutIt(recognizer, null, p.GetParent(0));
+        int rs = p.GetReturnState(0);
+        if (rs != PredictionContext.EMPTY_RETURN_STATE)
+        {
+            var a = recognizer.Atn;
+            var ss = a.states[rs];
+            var riss = ss.ruleIndex;
+            if (riss \< 0) return "";
+            var rnss = recognizer.RuleNames[riss];
+            if (str != "") str = str + " -> ";
+            str = str + rnss;
+            if (c != null)
+            {
+                var k = c.state.ruleIndex;
+                str = str + " -> " + recognizer.RuleNames[k];
+            }
+            return str;
+        }
+        return "";
+    }
+}
+
 <if(has_name_space)>}<endif>

--- a/_scripts/templates/CSharp/st.Test.cs
+++ b/_scripts/templates/CSharp/st.Test.cs
@@ -254,9 +254,9 @@ public class Program
         parser.RemoveErrorListeners();
         lexer.AddErrorListener(listener_lexer);
         parser.AddErrorListener(listener_parser);
-	    if (show_diagnostic)
+        if (show_diagnostic)
         {
-            //parser.AddErrorListener(new MyDiagnosticErrorListener());
+            parser.AddErrorListener(new MyDiagnosticErrorListener());
         }
         if (show_profile)
         {

--- a/_scripts/templates/CSharp/st.test.ps1
+++ b/_scripts/templates/CSharp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/CSharp/st.test.ps1
+++ b/_scripts/templates/CSharp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/CSharp/st.test.ps1
+++ b/_scripts/templates/CSharp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/CSharp/st.test.ps1
+++ b/_scripts/templates/CSharp/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/CSharp/st.test.sh
+++ b/_scripts/templates/CSharp/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/CSharp/st.test.sh
+++ b/_scripts/templates/CSharp/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/Cpp/st.test.ps1
+++ b/_scripts/templates/Cpp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Cpp/st.test.ps1
+++ b/_scripts/templates/Cpp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Cpp/st.test.ps1
+++ b/_scripts/templates/Cpp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Cpp/st.test.ps1
+++ b/_scripts/templates/Cpp/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/Cpp/st.test.sh
+++ b/_scripts/templates/Cpp/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/Cpp/st.test.sh
+++ b/_scripts/templates/Cpp/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/Dart/st.test.ps1
+++ b/_scripts/templates/Dart/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Dart/st.test.ps1
+++ b/_scripts/templates/Dart/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Dart/st.test.ps1
+++ b/_scripts/templates/Dart/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Dart/st.test.ps1
+++ b/_scripts/templates/Dart/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/Dart/st.test.sh
+++ b/_scripts/templates/Dart/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/Dart/st.test.sh
+++ b/_scripts/templates/Dart/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/Go/st.test.ps1
+++ b/_scripts/templates/Go/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Go/st.test.ps1
+++ b/_scripts/templates/Go/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Go/st.test.ps1
+++ b/_scripts/templates/Go/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Go/st.test.ps1
+++ b/_scripts/templates/Go/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/Go/st.test.sh
+++ b/_scripts/templates/Go/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/Go/st.test.sh
+++ b/_scripts/templates/Go/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/Java/st.test.ps1
+++ b/_scripts/templates/Java/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Java/st.test.ps1
+++ b/_scripts/templates/Java/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Java/st.test.ps1
+++ b/_scripts/templates/Java/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Java/st.test.ps1
+++ b/_scripts/templates/Java/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/Java/st.test.sh
+++ b/_scripts/templates/Java/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/Java/st.test.sh
+++ b/_scripts/templates/Java/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/JavaScript/st.test.ps1
+++ b/_scripts/templates/JavaScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/JavaScript/st.test.ps1
+++ b/_scripts/templates/JavaScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/JavaScript/st.test.ps1
+++ b/_scripts/templates/JavaScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/JavaScript/st.test.ps1
+++ b/_scripts/templates/JavaScript/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/JavaScript/st.test.sh
+++ b/_scripts/templates/JavaScript/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/JavaScript/st.test.sh
+++ b/_scripts/templates/JavaScript/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/PHP/st.test.sh
+++ b/_scripts/templates/PHP/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/PHP/st.test.sh
+++ b/_scripts/templates/PHP/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/Python3/st.test.sh
+++ b/_scripts/templates/Python3/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/Python3/st.test.sh
+++ b/_scripts/templates/Python3/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/_scripts/templates/TypeScript/st.run.sh
+++ b/_scripts/templates/TypeScript/st.run.sh
@@ -12,8 +12,8 @@ case `uname` in
 esac
 
 if [ -x "$basedir/node" ]; then
-  exec dotnet trwdog -- "$basedir/node" "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
+  exec "$basedir/node" "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
 else 
-  exec dotnet trwdog -- node "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
+  exec node "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
 fi
 exit $?

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- $Tests ; $last = $LASTEXITCODE ) | Out-Null
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -10,9 +10,9 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-foreach ($item in Get-ChildItem $Tests -Recurse) {
-    $file = $item.fullname
-    $ext = $item.Extension
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
         continue
     } elseif ($ext -eq ".errors") {
@@ -25,8 +25,8 @@ foreach ($item in Get-ChildItem $Tests -Recurse) {
         {
             continue
         }
-        $files.Add($item)
-        Write-Host "Test case: $item"
+        $files.Add($file)
+        Write-Host "Test case: $file"
     }
 }
 foreach ($file in $files) {

--- a/_scripts/templates/TypeScript/st.test.sh
+++ b/_scripts/templates/TypeScript/st.test.sh
@@ -12,7 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+if [ "$global" == "" ]
+then
+    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+else
+    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+fi
 
 files=()
 for f in $files2

--- a/_scripts/templates/TypeScript/st.test.sh
+++ b/_scripts/templates/TypeScript/st.test.sh
@@ -12,11 +12,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     if [ "$global" == "" ]
     then
         dotnet triconv -- -f utf-8 $f > /dev/null 2>&1

--- a/dart2/desc.xml
+++ b/dart2/desc.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <targets>CSharp;Dart;Java</targets>
+   <test>
+      <name>quick</name>
+      <targets>CSharp;Dart</targets>
+      <inputs>examples/*.dart</inputs>
+   </test>
+   <!-- For Java, do a deeper test. -->
+   <test>
+      <name>full</name>
+      <targets>Java</targets>
+      <inputs>examples/**/*.dart</inputs>
+   </test>
 </desc>


### PR DESCRIPTION
This change alters some template scripts for testing. It is a prerequisite for [PR3740](https://github.com/antlr/grammars-v4/pull/3740).

The change specifically replaces the ["find" in Bash scripts](https://github.com/antlr/grammars-v4/blob/09c559937a745759279ecf73c740c67755a4bd30/_scripts/templates/Java/st.test.sh#L15) and the ["foreach ... Get-ChildItem ... -Recurse" in Powershell scripts](https://github.com/antlr/grammars-v4/blob/09c559937a745759279ecf73c740c67755a4bd30/_scripts/templates/CSharp/st.test.ps1#L13) with an OS- and shell-independent "globstar" tool called trglob.

We would like to specify the files to test thus: `examples/**/*.dart` (for fast targets like Java), and `examples/*.dart` (for targets that are slower).

Currently, if we wanted to test targets with different tests, we would have to partition the tests into several directories. With this change, we can have one directory but now test different inputs depending on a globstar path pattern.

The tool inputs Bash "globstar" patterns. In addition, for backward compatibility, any pattern that specifies a directory implies the contents of the directory and any sub-directories recursively are provided. So, the pattern `examples` or `examples/` or `examples/*` all imply all files recursively in the `examples/` directory. But, `examples/*.txt` does not recurse (assuming there is no directory named with extension `.txt`).

### Changes
* The tool was added to the local ".config/" set of tools for testing. Since the tool was only updated recently, I updated all the version numbers for the testing toolset.
* The templates for testing were updated to use the new tool "trglob".
* The dart2 grammar "desc.xml" was updated to test the new tool with the patterns I describe above.