### PR TITLE
Added modify range_partitions to modify_table_partition rule

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -4695,7 +4695,9 @@ merge_table_partition
     ;
 
 modify_table_partition
-    : MODIFY PARTITION partition_name ((ADD | DROP) list_values_clause)? (ADD range_subpartition_desc)? (REBUILD? UNUSABLE LOCAL INDEXES)?
+    : MODIFY (PARTITION partition_name ((ADD | DROP) list_values_clause)? (ADD range_subpartition_desc)? (REBUILD? UNUSABLE LOCAL INDEXES)?
+             | range_partitions
+             )
     ;
 
 split_table_partition

--- a/sql/plsql/examples/alter_table_modify_partition_by_range.sql
+++ b/sql/plsql/examples/alter_table_modify_partition_by_range.sql
@@ -1,0 +1,9 @@
+ALTER TABLE table_name
+    MODIFY
+        PARTITION BY RANGE (date_column)
+            INTERVAL ( NUMTODSINTERVAL (1, 'DAY') )
+            (
+                PARTITION
+                    VALUES LESS THAN
+                        (TO_DATE('2024-01-01', 'YYYY-MM-DD'))
+            );


### PR DESCRIPTION
This rule change allows ALTER TABLE MODIFY Statements similar to the one bellow to be parsed successfully:
```
ALTER TABLE table_name
    MODIFY
        PARTITION BY RANGE (date_column)
            INTERVAL ( NUMTODSINTERVAL (1, 'DAY') )
            (
                PARTITION
                    VALUES LESS THAN
                        (DATE' 2024-01-01')
            )
```
