### PR TITLE
Fix for 3847 -- fix build.

### DIFF
--- a/apt/apt.g4
+++ b/apt/apt.g4
@@ -3,7 +3,7 @@
 grammar apt;
 
 //  productions
-record: commented=commenterR? rType=TypeR WSS options=optionsR? uri=uriR WSS distribution=wordWithDash components=componentsR WSS? EOF;
+record: commented=commenterR? rType=TypeR WSS options_ = optionsR? uri=uriR WSS distribution=wordWithDash components=componentsR WSS? EOF;
 wordWithDashSegment: Word | Dash;
 wordWithDash: wordWithDashSegment+;
 component: WSS cId=wordWithDash;

--- a/asm/ptx/ptx-isa-1.0/PTXLexer.g4
+++ b/asm/ptx/ptx-isa-1.0/PTXLexer.g4
@@ -188,7 +188,7 @@ LEU            : '.leu';
 GTU            : '.gtu';
 GEU            : '.geu';
 NUM            : '.num';
-NAN            : '.nan';
+NAN_            : '.nan';
 HI             : '.hi';
 LO             : '.lo';
 WIDE           : '.wide';

--- a/asm/ptx/ptx-isa-1.0/PTXParser.g4
+++ b/asm/ptx/ptx-isa-1.0/PTXParser.g4
@@ -298,7 +298,7 @@ cmp_op
     | GTU
     | GEU
     | NUM
-    | NAN
+    | NAN_
     ;
 
 bool_op

--- a/elixir/desc.xml
+++ b/elixir/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-    <!-- Although they work, the Go and Python targets are excluded since they are very slow -->
-    <targets>CSharp;Dart;Java;JavaScript;PHP;TypeScript</targets>
+    <!-- Although they work, the Go, PHP, and Python targets are excluded since they are very slow -->
+    <targets>CSharp;Dart;Java;JavaScript;TypeScript</targets>
 </desc>

--- a/icon/icon.g4
+++ b/icon/icon.g4
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 grammar icon;
 
-start
+start_
    : prog EOF
    ;
 

--- a/lark/LarkParser.g4
+++ b/lark/LarkParser.g4
@@ -4,7 +4,7 @@ options {
     tokenVocab = LarkLexer;
 }
 
-start: item* EOF;
+start_: item* EOF;
 
 item: rule_ | token | statement ;
 

--- a/scala/desc.xml
+++ b/scala/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Java;JavaScript;TypeScript;Python3</targets>
    <entry-point>compilationUnit</entry-point>
 </desc>

--- a/sieve/sieve.g4
+++ b/sieve/sieve.g4
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 grammar sieve;
 
-start
+start_
    : commands EOF
    ;
 

--- a/smtlibv2/SMTLIBv2.g4
+++ b/smtlibv2/SMTLIBv2.g4
@@ -485,7 +485,7 @@ UndefinedSymbol:
 
 // Starting rule(s)
 
-start
+start_
     : logic EOF
     | theory_decl EOF
     | script EOF

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -3955,7 +3955,7 @@ group_by_item
 
 option_clause
     // https://msdn.microsoft.com/en-us/library/ms181714.aspx
-    : OPTION '(' options+=option (',' options+=option)* ')'
+    : OPTION '(' options_ += option (',' options_ += option)* ')'
     ;
 
 option

--- a/wavefront/WavefrontOBJ.g4
+++ b/wavefront/WavefrontOBJ.g4
@@ -8,7 +8,7 @@ grammar WavefrontOBJ;
 
 // PARSER RULES
 
-start
+start_
     : NL* (statement (NL+ | EOF))+
     ;
 


### PR DESCRIPTION
The following targets fail the build:

* asm/ptx/ptx-isa-1.0 with Cpp: NAN is a symbol conflict for Cpp--apparently now for MacOS. ./icon ./lark .sieve ./smtlibv2 ./wavefront with Go target--symbol conflict apparently now with "start" as a parser rule.
* ./scala with Go target--timeout. This grammar is super slow. Go target should be removed from desc.xml to indicate it doesn't work.
* elixir with PHP target--stack overflow. The PHP has logical errors in the code. I tried to address some of the problems, but it was too much, and needed to work on other things. Fix for #12 -- Allowed memory size of 134217728 bytes exhausted. antlr-php-runtime#34