### PR TITLE
Fix for #3851 -- cancel old actions if a commit comes along

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a fix for #3851 -- add cancel-in-progress flag to the Github Actions build. This is already done for the main [antlr4](https://github.com/antlr/antlr4/blob/d25d421780286e3de0714831a5f82eca59234249/.github/workflows/hosted.yml#L3-L5) repo, where build times can be quite lengthy. This allows a build to be canceled if another commit is pushed right away after discovering a build issue, instead of waiting for the rest of the jobs to complete for the PR.