### PR TITLE
Fix #3856 -- add PHP environment setup and test to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Setup PHP
+      id: setup-php
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+        ini-values: xdebug.max_nesting_level=1000
+    - name: Print PHP version
+      run: |
+        echo ${{ steps.setup-php.outputs.php-version }}
+        php --version
     - name: Install Dotnet
       uses: actions/setup-dotnet@v3.2.0
       with:


### PR DESCRIPTION
Fixes problem seen in build for https://github.com/antlr/grammars-v4/pull/3843 seen in [this build](https://github.com/antlr/grammars-v4/actions/runs/7010383029/job/19070929695). The environment for the workflow was not being set up for PHP.