### PR TITLE
[pcre] Fixed bug in pcre character_class

### DIFF
--- a/pcre/PCRE.g4
+++ b/pcre/PCRE.g4
@@ -253,7 +253,8 @@ character_class_range
 
 character_class_range_atom
     : character
-    | ~']'
+    | '\\' .
+    | ~(']' | '\\')
     ;
 
 posix_character_class

--- a/pcre/examples/character_class.txt
+++ b/pcre/examples/character_class.txt
@@ -1,6 +1,8 @@
 [abc]
 [^abc]
 [x-y]
+[a\-z]
+[\--a]
 [[:alnum:]]
 [[:cntrl:]]
 [[:digit:]]


### PR DESCRIPTION
fixed bug described below:

### `[a\-z]`

it should be set consists of three elements; `a`, `-`, `z`.
However current rule parses like this:

```shell-session
$ grun PCRE pcre -tree
[a\-z]
(pcre (alternation (expr (element (atom (character_class [ (character_class_atom a) (character_class_atom (character_class_range (character_class_range_atom \) - (character_class_range_atom z))) ]))) (element (atom (other \n))))) <EOF>)
```

which means character set of `a` and all characters between `\` and `z`.

### `[\--a]`

this should be parsed as range between `-` and `a`, which means all characters between `-` and `a`, but grun says:

```shell-session
$ grun PCRE pcre -tree
[\--a]
(pcre (alternation (expr (element (atom (character_class [ (character_class_atom (character_class_range (character_class_range_atom \) - (character_class_range_atom -))) (character_class_atom a) ]))) (element (atom (other \n))))) <EOF>)
```

which means all characters between `\` and `-`, and `a`.