### PR TITLE
Vba updates

### DIFF
--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -116,11 +116,11 @@ moduleHeader
     ;
 
 moduleConfig
-    : BEGIN endOfLine* moduleConfigElement+ END
+    : BEGIN (WS GUID WS ambiguousIdentifier)? endOfLine* moduleConfigElement+ END
     ;
 
 moduleConfigElement
-    : ambiguousIdentifier WS? EQ WS? literal endOfLine*
+    : ambiguousIdentifier WS? EQ WS? literal (COLON literal)? endOfLine*
     ;
 
 moduleAttributes
@@ -1856,6 +1856,14 @@ R_SQUARE_BRACKET
     ;
 
 // literals
+fragment BLOCK
+    : HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
+    ;
+
+GUID
+    : '{' BLOCK BLOCK MINUS BLOCK MINUS BLOCK MINUS BLOCK MINUS BLOCK BLOCK BLOCK '}'
+    ;
+
 STRINGLITERAL
     : '"' (~["\r\n] | '""')* '"'
     ;
@@ -1994,6 +2002,10 @@ fragment LETTER
 
 fragment DIGIT
     : [0-9]
+    ;
+
+fragment HEXDIGIT
+    : [A-F0-9]
     ;
 
 fragment LETTERORDIGIT

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -112,7 +112,7 @@ module
     ;
 
 moduleHeader
-    : VERSION WS DOUBLELITERAL WS (CLASS)?
+    : VERSION WS DOUBLELITERAL WS CLASS?
     ;
 
 moduleConfig

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -112,7 +112,7 @@ module
     ;
 
 moduleHeader
-    : VERSION WS DOUBLELITERAL WS CLASS
+    : VERSION WS DOUBLELITERAL WS (CLASS)?
     ;
 
 moduleConfig


### PR DESCRIPTION
The following module header is valid VBA

```vba
VERSION 5.00
Begin {C62A69F0-16DC-11CE-9E98-00AA00574A4F} Login 
   Caption         =   "Please Log In"
   ClientHeight    =   1920
   ClientLeft      =   120
   ClientTop       =   465
   ClientWidth     =   2295
   OleObjectBlob   =   "Login.frx":0000
   StartUpPosition =   1  'CenterOwner
End
```

I changed the file to make the `CLASS` optional, allowed for an optional `GUID` after Begin, and allowed the attribute to have colon followed by a literal. It might be better to create a filename literal that is a string literal, followed by a colon and literal, and then add the new literal to the list allowed for the attribute.