### PR TITLE
[PlSql] allow '\r' '\n' in quotedIdentifier

### DIFF
--- a/sql/plsql/PlSqlLexer.g4
+++ b/sql/plsql/PlSqlLexer.g4
@@ -2412,7 +2412,7 @@ fragment QS_SHARP  : '#' .*? '#';
 fragment QS_QUOTE  : '\'' .*? '\'';
 fragment QS_DQUOTE : '"' .*? '"';
 
-DELIMITED_ID: '"' (~('"' | '\r' | '\n') | '"' '"')+ '"';
+DELIMITED_ID: '"' (~ [\u0000"] | '"' '"')+ '"';
 
 PERCENT         : '%';
 AMPERSAND       : '&';

--- a/sql/plsql/examples/create_table.sql
+++ b/sql/plsql/examples/create_table.sql
@@ -401,6 +401,10 @@ CREATE TABLE T (
     data xmltype
 );
 
+CREATE TABLE "D1
+"
+("c1" INTEGER, "C2" INTEGER);
+
 create TABLE PROCESSED AS (
 select * FROM T_ORDER_PROCESSED f)
        --     WHERE


### PR DESCRIPTION
```sql
CREATE TABLE "D1
"  
("c1" INTEGER, "C2" INTEGER)
```
I tried this SQL in [offical](https://livesql.oracle.com/). This table can be created.
So, the quotedIdentifier should allow '\r' '\n'