### PR TITLE
[build] Fix for #3900--remove auto reformat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git add --all
         git commit -m "Reformat to coding standard."
+        echo "Committed reformatted code."
     - name: Push changes
       # git push changes to "master" branch.
       # make sure to uncheck "Require a pull request before merging" in gh actions, "Branches" section.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,40 +28,6 @@ jobs:
       shell: bash
       run: |
         dotnet tool restore
-    - name: Check grammar coding standards
-      continue-on-error: false
-      run: |
-        if [ "${{github.event_name}}" == "pull_request" ]; then
-          Before="${{github.event.pull_request.base.sha}}"
-          After="${{github.event.pull_request.head.sha}}"
-        else
-          Before="${{github.event.before}}"
-          After="${{github.event.after}}"
-        fi
-        # check for bad coding standard in grammar by doing a reformat.
-        bash _scripts/reformat.sh -f diff $Before $After
-    - name: Commit changes
-      # git commit reformatting changes if any, but only if on master branch.
-      # If there were no changes, this is a no-op.
-      if: github.ref == 'refs/heads/master'
-      continue-on-error: false
-      shell: bash
-      run: |
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add --all
-        git commit -m "Reformat to coding standard."
-        echo "Committed reformatted code."
-    - name: Push changes
-      # git push changes to "master" branch.
-      # make sure to uncheck "Require a pull request before merging" in gh actions, "Branches" section.
-      uses: ad-m/github-push-action@master
-      if: github.ref == 'refs/heads/master'
-      continue-on-error: false
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.ref }}
-        force_with_lease: true
     - name: Gather targets.
       id: step1
       shell: bash
@@ -199,7 +165,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest]
-        test: [ useless-parens ]
+        test: [ useless-parens, format ]
     steps:
     - name: Info
       shell: bash


### PR DESCRIPTION
@teverett @KvanTTT 

This change is important. It removes the code to reformat grammars and auto check-in those changes. This is what @KvanTTT [wanted](https://github.com/antlr/grammars-v4/discussions/3816#discussioncomment-7911861). Instead antlr-format is run as a check. Aside, the code has a bug [here](https://github.com/antlr/grammars-v4/blob/aff0126d0aff25ecfcdf7d83ca0727f74ee5ce26/.github/workflows/main.yml#L53) in that when "git commit" doesn't contain any changes, the program returns 1, which causes the "setup" job to fail, and all tests for the grammar to not run because [they depend on "setup"](https://github.com/antlr/grammars-v4/blob/aff0126d0aff25ecfcdf7d83ca0727f74ee5ce26/.github/workflows/main.yml#L78).