### PR TITLE
[build] Fix for #3902--Updated Github Actions badge link according to the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/antlr/grammars-v4/workflows/CI/badge.svg)
+![CI](https://github.com/antlr/grammars-v4/actions/workflows/main.yml/badge.svg)
 
 # Grammars-v4
 


### PR DESCRIPTION
Updated Github Actions badge link according to the doc. The old link was saying "ok" for some reason.