### PR TITLE
add CodeQL grammar

### DIFF
--- a/codeql/CodeQLLexer.g4
+++ b/codeql/CodeQLLexer.g4
@@ -34,7 +34,7 @@ ASC:   'asc';
 AVG:   'avg';
 BOOLEAN:   'boolean';
 BY:   'by';
-CLASS:   'class';
+CLASS_:   'class';
 CONCAT:   'concat';
 COUNT:   'count';
 DATE:   'date';

--- a/codeql/CodeQLLexer.g4
+++ b/codeql/CodeQLLexer.g4
@@ -136,22 +136,11 @@ COLONCOLON:         '::';
 
 // Literals
 INT_LITERAL :     [0-9]+;
-
-
-FLOAT_LITERAL:      INT_LITERAL ('.' INT_LITERAL)? ;
-
-BOOL_LITERAL:       TRUE
-            |       FALSE
-            ;
-
+FLOAT_LITERAL:      INT_LITERAL '.' INT_LITERAL;
 STRING_LITERAL:     '"' (~["\\\r\n] | EscapeSequence)* '"';
-
 AT:                 '@';
-// Additional symbols not defined in the lexical specification
-ELLIPSIS:           '...';
 
 // Whitespace and comments
-
 WS:                 [ \t\r\n\u000C]+ -> channel(HIDDEN);
 COMMENT:            '/*' ~[*]*?.*? '*/'    -> channel(HIDDEN);
 QL_DOC:            '/**' .*? '*/'    -> channel(HIDDEN);
@@ -159,12 +148,9 @@ LINE_COMMENT:       '//' ~[\r\n]*    -> channel(HIDDEN);
 
 // Identifiers
 
-// 将 LowerId 和 UpperId 定义为词法规则
-
 LOWERID: [a-z][a-zA-Z0-9_]* ;
 UPPERID: [A-Z][a-zA-Z0-9_]* ;
-// 将 AtLowerId 定义为词法规则
-ATLOWERID: '@' LOWERID ;
+ATLOWERID: AT LOWERID ;
 
 
 

--- a/codeql/CodeQLLexer.g4
+++ b/codeql/CodeQLLexer.g4
@@ -1,0 +1,175 @@
+/*
+ CodeQL grammar
+ The MIT License (MIT).
+ Copyright (c) 2023, Dijun Liu
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ CodeQL grammar built from the CodeQL Specification https://codeql.github.com/docs/ql-language-reference/ql-language-specification
+*/
+
+lexer grammar CodeQLLexer;
+
+// Keywords
+AND:   'and';
+ANY:   'any';
+AS:   'as';
+ASC:   'asc';
+AVG:   'avg';
+BOOLEAN:   'boolean';
+BY:   'by';
+CLASS:   'class';
+CONCAT:   'concat';
+COUNT:   'count';
+DATE:   'date';
+DESC:   'desc';
+ELSE:   'else';
+EXISTS:   'exists';
+EXTENDS:   'extends';
+FALSE:   'false';
+FLOAT:   'float';
+FORALL:   'forall';
+
+FOREX:   'forex';
+FROM:   'from';
+IF:   'if';
+IMPLIES:   'implies';
+IMPORT:   'import';
+IN:   'in';
+INSTANCEOF:   'instanceof';
+INT:   'int';
+MAX:   'max';
+MIN:   'min';
+MODULE:   'module';
+NEWTYPE:   'newtype';
+NONE:   'none';
+NOT:   'not';
+OR:   'or';
+ORDER:   'order';
+PREDICATE:   'predicate';
+RANK:   'rank';
+RESULT:   'result';
+SELECT:   'select';
+STRICTCONCAT:   'strictconcat';
+STRICTCOUNT:   'strictcount';
+STRICTSUM:   'strictsum';
+STRING:   'string';
+SUM:   'sum';
+SUPER:   'super';
+THEN:   'then';
+THIS:   'this';
+TRUE:   'true';
+UNIQUE:   'unique';
+WHERE:   'where';
+
+IMPLEMENTS:            'implements';
+SIGNATURE:             'signature';
+DEFAULT:               'default';
+ABSTRACT:              'abstract';
+CACHED:                'cached';
+EXTERNAL:              'external';
+EXTENSIBLE:            'extensible';
+FINAL:                 'final';
+TRANSIENT:             'transient';
+LIBRARY:               'library';
+PRIVATE:               'private';
+DEPRECATED:            'deprecated';
+OVERRIDE:              'override';
+ADDITIONAL:            'additional';
+QUERY:                 'query';
+PRAGMA:                'pragma';
+INLINE:                'inline';
+INLINE_LATE:           'inline_late';
+NOINLINE:              'noinline';
+NOMAGIC:               'nomagic';
+NOOPT:                 'noopt';
+ASSUME_SMALL_DELTA:    'assume_small_delta';
+LANGUAGE:              'language';
+MONOTONICAGGREGATES:   'monotonicAggregates';
+BINDINGSET:            'bindingset';
+ONLY_BIND_OUT:         'only_bind_out';
+ONLY_BIND_INTO:        'only_bind_into';
+
+//operator
+LT:                 '<';
+LE:                 '<=';
+ASSIGN:             '=';
+GT:                 '>';
+GE:                 '>=';
+SUB:                '-';
+DONTCARE:           '_';
+COMMA:              ',';
+SEMI:               ';';
+NOTEQUAL:           '!=';
+DIV:                '/';
+DOT:                '.';
+DOTDOT:             '..';
+LPAREN:             '(';
+RPAREN:             ')';
+LBRACE:             '{';
+RBRACE:             '}';
+LBRACK:             '[';
+RBRACK:             ']';
+MUL:                '*';
+MOD:                '%';
+ADD:                '+';
+BITOR:              '|';
+COLONCOLON:         '::';
+
+
+
+// Literals
+INT_LITERAL :     [0-9]+;
+
+
+FLOAT_LITERAL:      INT_LITERAL ('.' INT_LITERAL)? ;
+
+BOOL_LITERAL:       TRUE
+            |       FALSE
+            ;
+
+STRING_LITERAL:     '"' (~["\\\r\n] | EscapeSequence)* '"';
+
+AT:                 '@';
+// Additional symbols not defined in the lexical specification
+ELLIPSIS:           '...';
+
+// Whitespace and comments
+
+WS:                 [ \t\r\n\u000C]+ -> channel(HIDDEN);
+COMMENT:            '/*' ~[*]*?.*? '*/'    -> channel(HIDDEN);
+QL_DOC:            '/**' .*? '*/'    -> channel(HIDDEN);
+LINE_COMMENT:       '//' ~[\r\n]*    -> channel(HIDDEN);
+
+// Identifiers
+
+// 将 LowerId 和 UpperId 定义为词法规则
+
+LOWERID: [a-z][a-zA-Z0-9_]* ;
+UPPERID: [A-Z][a-zA-Z0-9_]* ;
+// 将 AtLowerId 定义为词法规则
+ATLOWERID: '@' LOWERID ;
+
+
+
+fragment EscapeSequence
+    : '\\' 'u005c'? [btnfr"'\\]
+    | '\\' 'u005c'? ([0-3]? [0-7])? [0-7]
+    ;
+

--- a/codeql/CodeQLParser.g4
+++ b/codeql/CodeQLParser.g4
@@ -306,7 +306,7 @@ head
 optbody
     : ';'
     |  '{' formula '}'
-    |  '=' literalId '(' (predicateRef '/' INT_LITERAL (',' predicateRef '/' INT_LITERAL)*)? ')' '(' (exprs)? ')'
+    |  '=' literalId '(' (predicateRef '/' INT_LITERAL (',' predicateRef '/' INT_LITERAL)*)? ')' '(' exprs? ')'
     ;
 
 //class ::= QL_DOC? annotations 'class' classname ('extends' type (',' type)*)? ('instanceof' type (',' type)*)?  '{' member* '}'
@@ -490,8 +490,8 @@ inrange
 //call ::= predicateRef (closure)? "(" (exprs)? ")"
 //     |   primary "." predicateName (closure)? "(" (exprs)? ")"
 call
-    : predicateRef (closure)? '(' (exprs)? ')'
-    | primary '.' predicateName (closure)? '(' (exprs)? ')'
+    : predicateRef closure? '(' exprs? ')'
+    | primary '.' predicateName closure? '(' exprs? ')'
     ;
 
 //closure ::= "*" | "+"
@@ -534,16 +534,16 @@ nonOpExpr
 //        |   range
 //        |   setliteral
 primary
-    : primaryBase (primaryPostfixOp)*
+    : primaryBase primaryPostfixOp*
     ;
 
 primaryPostfixOp
      : '.' '(' type ')'
-     | '.' predicateName (closure)? '(' (exprs)? ')'
+     | '.' predicateName closure? '(' exprs? ')'
      ;
 
 callwithresults_nomember
-    : predicateRef (closure)? '(' (exprs)? ')'
+    : predicateRef closure? '(' exprs? ')'
     ;
 
 primaryBase
@@ -622,9 +622,9 @@ cast
 //            |   aggid ("[" expr "]")? "(" as_exprs ("order" "by" aggorderbys)? ")"
 //            |   "unique" "(" var_decls "|" (formula)? ("|" as_exprs)? ")"
 aggregation
-    : aggid ('[' expr ']')? '(' var_decls ('|' (formula)? ('|' as_exprs ('order' 'by' aggorderbys)?)?)? ')'
+    : aggid ('[' expr ']')? '(' var_decls ('|' formula? ('|' as_exprs ('order' 'by' aggorderbys)?)?)? ')'
     | aggid ('[' expr ']')? '(' as_exprs ('order' 'by' aggorderbys)? ')'
-    | 'unique' '(' var_decls '|' (formula)? ('|' as_exprs)? ')'
+    | 'unique' '(' var_decls '|' formula? ('|' as_exprs)? ')'
     ;
 //expression_pragma ::= "pragma" "[" expression_pragma_type "]" "(" expr ")"
 expression_pragma
@@ -649,7 +649,7 @@ aggorderby
     ;
 //any ::= "any" "(" var_decls ("|" (formula)? ("|" expr)?)? ")"
 any
-    :'any' '(' var_decls ('|' (formula)? ('|' expr)?)? ')'
+    :'any' '(' var_decls ('|' formula? ('|' expr)?)? ')'
     ;
 
 //callwithresults ::= predicateRef (closure)? "(" (exprs)? ")"

--- a/codeql/CodeQLParser.g4
+++ b/codeql/CodeQLParser.g4
@@ -104,7 +104,7 @@ implements
 
 //moduleBody ::= (import | predicate | class | module | alias | select)*
 moduleBody
-    : (importDeclaration | predicate | signature | datatype | typeunion | class | module | alias | select)*
+    : (importDeclaration | predicate | signature | datatype | typeunion | class_ | module | alias | select)*
     ;
 
 //import ::= annotations 'import' importModuleExpr ('as' modulename)?
@@ -310,7 +310,7 @@ optbody
     ;
 
 //class ::= QL_DOC? annotations 'class' classname ('extends' type (',' type)*)? ('instanceof' type (',' type)*)?  '{' member* '}'
-class
+class_
     : QL_DOC? annotations 'class' classname ('extends' type (',' type)*)? ('instanceof' type (',' type)*)?  '{' member* '}'
     ;
 

--- a/codeql/CodeQLParser.g4
+++ b/codeql/CodeQLParser.g4
@@ -426,19 +426,19 @@ fparen
     ;
 
 //disjunction ::= formula "or" formula
-disjunction
-    : formula 'or' formula
-    ;
+//disjunction
+//    : formula 'or' formula
+//    ;
 
 //conjunction ::= formula "and" formula
-conjunction
-    : formula 'and' formula
-    ;
+//conjunction
+//    : formula 'and' formula
+//    ;
 
 //implies ::= formula "implies" formula
-implies
-    : formula 'implies' formula
-    ;
+//implies
+//    : formula 'implies' formula
+//    ;
 
 //ifthen ::= "if" formula "then" formula "else" formula
 ifthen
@@ -590,13 +590,13 @@ unop
 //      |   expr "*" expr
 //      |   expr "/" expr
 //      |   expr "%" expr
-binop
-    : expr '+' expr
-    | expr '-' expr
-    | expr '*' expr
-    | expr '/' expr
-    | expr '%' expr
-    ;
+//binop
+//    : expr '+' expr
+//    | expr '-' expr
+//    | expr '*' expr
+//    | expr '/' expr
+//    | expr '%' expr
+//    ;
 
 //variable ::= varname | "this" | "result"
 variable

--- a/codeql/CodeQLParser.g4
+++ b/codeql/CodeQLParser.g4
@@ -1,0 +1,720 @@
+/*
+ CodeQL grammar
+ The MIT License (MIT).
+ Copyright (c) 2023, Dijun Liu
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ CodeQL grammar built from the CodeQL Specification https://codeql.github.com/docs/ql-language-reference/ql-language-specification
+*/
+
+parser grammar CodeQLParser;
+
+options { tokenVocab=CodeQLLexer; }
+
+literalId
+    : LOWERID
+    | ATLOWERID
+    | UPPERID
+    | NONE
+    | ANY
+    | keywordAllowed
+    ;
+
+// keywords allowed named in user variable and user predicate decl
+keywordAllowed
+    : 'unique'
+    | 'implements'
+    | 'signature'
+    | 'default'
+    | 'abstract'
+    | 'cached'
+    | 'external'
+    | 'extensible'
+    | 'final'
+    | 'transient'
+    | 'library'
+    | 'private'
+    | 'deprecated'
+    | 'override'
+    | 'additional'
+    | 'query'
+    | 'pragma'
+    | 'inline'
+    | 'inline_late'
+    | 'noinline'
+    | 'nomagic'
+    | 'noopt'
+    | 'assume_small_delta'
+    | 'language'
+    | 'monotonicAggregates'
+    | 'bindingset'
+    | 'only_bind_out'
+    | 'only_bind_into'
+    ;
+
+// keyword can used in predicate call
+keywordPredCallAllowed
+    : keywordAllowed
+    | 'any'
+    | 'none'
+    ;
+
+// varname ::= lowerId
+varname
+    : LOWERID
+    | keywordAllowed
+    ;
+
+//ql ::= QL_DOC? moduleBody
+ql
+    : QL_DOC? moduleBody EOF
+    ;
+
+//module ::= annotation* 'module' modulename parameters? implements? '{' moduleBody '}'
+module
+    : annotation* 'module' modulename parameters? implements? '{' moduleBody '}'
+    ;
+
+//parameters ::= '<' signatureExpr parameterName (',' signatureExpr parameterName)* '>'
+parameters
+    : '<' signatureExpr parameterName (',' signatureExpr parameterName)* '>'
+    ;
+
+//implements ::= IMPLEMENTS moduleSignatureExpr (',' moduleSignatureExpr)*
+implements
+    : IMPLEMENTS moduleSignatureExpr (',' moduleSignatureExpr)*
+    ;
+
+//moduleBody ::= (import | predicate | class | module | alias | select)*
+moduleBody
+    : (importDeclaration | predicate | signature | datatype | typeunion | class | module | alias | select)*
+    ;
+
+//import ::= annotations 'import' importModuleExpr ('as' modulename)?
+importDeclaration
+    :  annotations 'import' importModuleExpr ('as' modulename)?
+    ;
+
+//qualId ::= SIMPLEID | qualId '.' SIMPLEID
+simpleId
+    : LOWERID
+    | UPPERID
+    ;
+
+qualId
+    : simpleId
+    | qualId '.' simpleId
+    ;
+
+//importModuleExpr ::= qualId | importModuleExpr '::' modulename arguments?
+importModuleExpr
+    : qualId
+    | importModuleExpr '::' modulename arguments?
+    ;
+
+//arguments ::= '<' argument (',' argument)* '>'
+arguments
+    : '<' argument (',' argument)* '>'
+    ;
+
+//argument ::= moduleExpr | type | predicateRef '/' int
+argument
+    : moduleExpr
+    | type
+    | predicateRef '/' INT_LITERAL
+    ;
+
+//signature ::= predicateSignature | typeSignature | moduleSignature
+signature
+    : predicateSignature
+    | typeSignature
+    | moduleSignature
+    ;
+
+//predicateSignature ::= QL_DOC? annotations SIGNATURE head ';'
+predicateSignature
+    : QL_DOC? annotation* SIGNATURE head ';'
+    ;
+
+//typeSignature ::= QL_DOC? annotations SIGNATURE 'class' classname ('extends' type (',' type)*)? (';' | '{' signaturePredicate* '}')
+typeSignature
+    : QL_DOC? annotations SIGNATURE 'class' classname ('extends' type (',' type)*)? (';' | '{' signaturePredicate* '}')
+    ;
+
+//moduleSignature ::= QL_DOC? annotation* SIGNATURE 'module' moduleSignatureName parameters? '{' moduleSignatureBody '}'
+moduleSignature
+    : QL_DOC? annotation* SIGNATURE 'module' moduleSignatureName parameters? '{' moduleSignatureBody '}'
+    ;
+
+//moduleSignatureBody ::= (signaturePredicate | defaultPredicate | signatureType)*
+moduleSignatureBody
+    : (signaturePredicate | defaultPredicate | signatureType)*
+    ;
+
+//signaturePredicate ::= QL_DOC? annotations head ';'
+signaturePredicate
+    : QL_DOC? annotations head ';'
+    ;
+
+//defaultPredicate ::= QL_DOC? annotations DEFAULT head '{' formula '}'
+defaultPredicate
+    : QL_DOC? annotations DEFAULT head '{' formula '}'
+    ;
+
+//signatureType ::= QL_DOC? annotations 'class' classname ('extends' type (',' type)*)? '{' signaturePredicate* '}'
+signatureType
+    : QL_DOC? annotations 'class' classname ('extends' type (',' type)*)? (';' | '{' signaturePredicate* '}')
+    ;
+
+//select ::= ('from' var_decls)? ('where' formula)? 'select' as_exprs ('order' 'by' orderbys)?
+select
+    : ('from' var_decls)? ('where' formula)? 'select' as_exprs ('order' 'by' orderbys)?
+    ;
+
+//as_exprs ::= as_expr (',' as_expr)*
+as_exprs
+    : as_expr (',' as_expr)*
+    ;
+
+//as_expr ::= expr ('as' lowerId)?
+as_expr
+    : expr ('as' LOWERID)?
+    ;
+
+//orderbys ::= orderby (',' orderby)*
+orderbys
+    : orderby (',' orderby)*
+    ;
+
+//orderby ::= lowerId ('asc' | 'desc')?
+orderby
+    : LOWERID ('asc' | 'desc')?
+    ;
+
+dtName
+    : UPPERID
+    ;
+
+dtBranches
+    : dtBranche ('or' dtBranche)*
+    ;
+
+dtBranche
+    : dtBranchName'(' var_decls ')' ('{' formula '}')?
+    ;
+
+dtBranchName
+    : UPPERID
+    ;
+
+datatype
+    : QL_DOC? annotations 'newtype' dtName '=' dtBranches
+    ;
+
+unionBranches
+    : type ('or' type)*
+    ;
+
+typeunion
+    : QL_DOC? annotations 'class' UPPERID '=' unionBranches ';'
+    ;
+
+//predicate ::= QL_DOC? annotations head optbody
+predicate
+    : QL_DOC? annotations head optbody
+    ;
+
+//annotations ::= annotation*
+annotations
+    : annotation*
+    ;
+
+//annotation ::= simpleAnnotation | argsAnnotation
+annotation
+    : simpleAnnotation
+    | argsAnnotation
+    ;
+
+//simpleAnnotation ::= ABSTRACT
+//                 |   CACHED
+//                 |   EXTERNAL
+//                 |   EXTENSIBLE
+//                 |   FINAL
+//                 |   TRANSIENT
+//                 |   LIBRARY
+//                 |   PRIVATE
+//                 |   DEPRECATED
+//                 |   OVERRIDE
+//                 |   ADDITIONAL
+//                 |   QUERY
+simpleAnnotation
+    : ABSTRACT
+    | CACHED
+    | EXTERNAL
+    | EXTENSIBLE
+    | FINAL
+    | TRANSIENT
+    | LIBRARY
+    | PRIVATE
+    | DEPRECATED
+    | OVERRIDE
+    | ADDITIONAL
+    | QUERY
+    ;
+
+//argsAnnotation
+//    : PRAGMA '[' (INLINE | INLINE_LATE | NOINLINE | NOMAGIC | NOOPT | ASSUME_SMALL_DELTA) ']'
+//    | LANGUAGE '[' 'monotonicAggregates' ']'
+//    | BINDINGSET '[' (variable ( ',' variable)*)? ']'
+//    ;
+pragmaArg
+    :INLINE | INLINE_LATE | NOINLINE | NOMAGIC | NOOPT | ASSUME_SMALL_DELTA
+    ;
+
+
+argsAnnotation
+    : PRAGMA '[' pragmaArg (',' pragmaArg)* ']'
+    | LANGUAGE '[' 'monotonicAggregates' ']'
+    | BINDINGSET '[' (variable ( ',' variable)*)? ']'
+    ;
+
+//head ::= ('predicate' | type) predicateName '(' var_decls ')'
+head
+    : ('predicate' | type) predicateName '(' var_decls ')'
+    ;
+
+//optbody ::= ';'
+//        |  '{' formula '}'
+//        |  '=' literalId '(' (predicateRef '/' int (',' predicateRef '/' int)*)? ')' '(' (exprs)? ')'
+optbody
+    : ';'
+    |  '{' formula '}'
+    |  '=' literalId '(' (predicateRef '/' INT_LITERAL (',' predicateRef '/' INT_LITERAL)*)? ')' '(' (exprs)? ')'
+    ;
+
+//class ::= QL_DOC? annotations 'class' classname ('extends' type (',' type)*)? ('instanceof' type (',' type)*)?  '{' member* '}'
+class
+    : QL_DOC? annotations 'class' classname ('extends' type (',' type)*)? ('instanceof' type (',' type)*)?  '{' member* '}'
+    ;
+
+//member ::= character | predicate | field
+member
+    : character
+    | predicate
+    | field
+    ;
+
+//character ::= QL_DOC? annotations classname "(" ")" "{" formula "}"
+character
+    : QL_DOC? annotations classname '(' ')' '{' formula '}'
+    ;
+
+//field ::= QL_DOC? annotations var_decl ";"
+field
+    : QL_DOC? annotations var_decl ';'
+    ;
+
+//moduleExpr ::= modulename arguments? | moduleExpr "::" modulename arguments?
+moduleExpr
+    : modulename arguments?
+    | moduleExpr '::' modulename arguments?
+    ;
+
+//moduleSignatureExpr ::= (moduleExpr "::")? moduleSignatureName arguments?
+moduleSignatureExpr
+    : (moduleExpr '::')? moduleSignatureName arguments?
+    ;
+
+//signatureExpr : (moduleExpr "::")? SIMPLEID ("/" Integer | arguments)?
+signatureExpr
+    : (moduleExpr '::')? simpleId ('/' INT_LITERAL | arguments)?
+    ;
+
+//type ::= (moduleExpr "::")? classname | dbasetype | "boolean" | "date" | "float" | "int" | "string"
+type
+    : (moduleExpr '::')? classname
+    | dbbasetype
+    | 'boolean'
+    | 'date'
+    | 'float'
+    | 'int'
+    | 'string'
+    ;
+
+//exprs ::= expr ("," expr)*
+exprs
+    : expr (',' expr)*
+    ;
+
+//alias ::= QL_DOC? annotations "predicate" literalId "=" predicateRef "/" int ";"
+//      |  QL_DOC? annotations "class" classname "=" type ";"
+//      |  QL_DOC? annotations "module" modulename "=" moduleExpr ";"
+alias
+    : QL_DOC? annotations 'predicate' predicateName '=' predicateRef '/' INT_LITERAL ';'
+    | QL_DOC? annotations 'class' classname '=' type ';'
+    | QL_DOC? annotations 'module' modulename '=' moduleExpr ';'
+    ;
+
+//var_decls ::= (var_decl ("," var_decl)*)?
+var_decls
+    : (var_decl (',' var_decl)*)?
+    ;
+
+//var_decl ::= type lowerId
+var_decl
+    : type varname
+    ;
+
+//formula ::= fparen
+//        |   disjunction
+//        |   conjunction
+//        |   implies
+//        |   ifthen
+//        |   negated
+//        |   quantified
+//        |   comparison
+//        |   instanceof
+//        |   inrange
+//        |   call
+formula
+    : conjunction_formula ('or' formula)*
+    ;
+
+formula_base
+    : fparen
+    | ifthen
+    | negated
+    | quantified
+    | comparison
+    | instanceof
+    | inrange
+    | call
+    ;
+
+//disjunction_formula
+//    : conjunction_formula ('or' formula)*
+//    ;
+
+conjunction_formula
+    : implies_formula ('and' formula)*
+    ;
+
+implies_formula
+    : formula_base ('implies' formula)*
+    ;
+
+//fparen ::= "(" formula ")"
+fparen
+    : '(' formula ')'
+    ;
+
+//disjunction ::= formula "or" formula
+disjunction
+    : formula 'or' formula
+    ;
+
+//conjunction ::= formula "and" formula
+conjunction
+    : formula 'and' formula
+    ;
+
+//implies ::= formula "implies" formula
+implies
+    : formula 'implies' formula
+    ;
+
+//ifthen ::= "if" formula "then" formula "else" formula
+ifthen
+    : 'if' formula 'then' formula 'else' formula
+    ;
+
+//negated ::= "not" formula
+negated
+    : 'not' formula
+    ;
+//
+//quantified ::= "exists" "(" expr ")"
+//           |   "exists" "(" var_decls ("|" formula)? ("|" formula)? ")"
+//           |   "forall" "(" var_decls ("|" formula)? "|" formula ")"
+//           |   "forex"  "(" var_decls ("|" formula)? "|" formula ")"
+quantified
+    : 'exists' '(' expr ')'
+    | 'exists' '(' var_decls ('|' formula)? ('|' formula)? ')'
+    | 'forall' '(' var_decls ('|' formula)? '|' formula ')'
+    | 'forex'  '(' var_decls ('|' formula)? '|' formula ')'
+    ;
+//
+//comparison ::= expr compop expr
+comparison
+    : expr compop expr
+    ;
+
+//compop ::= "=" | "!=" | "<" | ">" | "<=" | ">="
+compop
+    : '='
+    | '!='
+    | '<'
+    | '>'
+    | '<='
+    | '>='
+    ;
+
+//instanceof ::= expr "instanceof" type
+instanceof
+    : expr 'instanceof' type
+    ;
+
+//inrange ::= expr "in" (range | setliteral)
+inrange
+    : expr 'in' (range | setliteral)
+    ;
+
+//
+//call ::= predicateRef (closure)? "(" (exprs)? ")"
+//     |   primary "." predicateName (closure)? "(" (exprs)? ")"
+call
+    : predicateRef (closure)? '(' (exprs)? ')'
+    | primary '.' predicateName (closure)? '(' (exprs)? ')'
+    ;
+
+//closure ::= "*" | "+"
+closure
+    : '*' | '+'
+    ;
+//expr ::= dontcare
+//     |   unop
+//     |   binop
+//     |   cast
+//     |   primary
+expr
+    : multExpr (('+' | '-') multExpr)*
+    ;
+
+multExpr
+    : unaryExpr (('*' | '/' | '%') unaryExpr)*
+    ;
+
+unaryExpr
+    : nonOpExpr
+    | unop
+    ;
+
+nonOpExpr
+    : DONTCARE
+    | cast
+    | primary
+    ;
+
+//primary ::= eparen
+//        |   literal
+//        |   variable
+//        |   super_expr
+//        |   postfix_cast
+//        |   callwithresults
+//        |   aggregation
+//        |   expression_pragma
+//        |   any
+//        |   range
+//        |   setliteral
+primary
+    : primaryBase (primaryPostfixOp)*
+    ;
+
+primaryPostfixOp
+     : '.' '(' type ')'
+     | '.' predicateName (closure)? '(' (exprs)? ')'
+     ;
+
+callwithresults_nomember
+    : predicateRef (closure)? '(' (exprs)? ')'
+    ;
+
+primaryBase
+    : eparen
+    | literal
+    | variable
+    | super_expr
+    | aggregation
+    | expression_pragma
+    | callwithresults_nomember
+    | any
+    | none
+    | range
+    | setliteral
+    ;
+
+none
+    : NONE '(' ')'
+    ;
+
+//eparen ::= "(" expr ")"
+eparen
+    : '(' expr ')'
+    ;
+
+//literal ::= "false" | "true" | int | float | string
+literal
+    : 'false'
+    | 'true'
+    | INT_LITERAL
+    | FLOAT_LITERAL
+    | STRING_LITERAL
+    ;
+
+//unop ::= "+" expr
+//     |   "-" expr
+unop
+    : '+' expr
+    | '-' expr
+    ;
+
+//binop ::= expr "+" expr
+//      |   expr "-" expr
+//      |   expr "*" expr
+//      |   expr "/" expr
+//      |   expr "%" expr
+binop
+    : expr '+' expr
+    | expr '-' expr
+    | expr '*' expr
+    | expr '/' expr
+    | expr '%' expr
+    ;
+
+//variable ::= varname | "this" | "result"
+variable
+    : varname
+    | 'this'
+    | 'result'
+    ;
+
+//super_expr ::= "super" | type "." "super"
+super_expr
+    : 'super'
+    | type '.' 'super'
+    ;
+//cast ::= "(" type ")" expr
+cast
+    : '(' type ')' expr
+    ;
+//postfix_cast ::= primary "." "(" type ")"
+//postfix_cast
+//    : primary '.' '(' type ')'
+//    ;
+//aggregation ::= aggid ("[" expr "]")? "(" var_decls ("|" (formula)? ("|" as_exprs ("order" "by" aggorderbys)?)?)? ")"
+//            |   aggid ("[" expr "]")? "(" as_exprs ("order" "by" aggorderbys)? ")"
+//            |   "unique" "(" var_decls "|" (formula)? ("|" as_exprs)? ")"
+aggregation
+    : aggid ('[' expr ']')? '(' var_decls ('|' (formula)? ('|' as_exprs ('order' 'by' aggorderbys)?)?)? ')'
+    | aggid ('[' expr ']')? '(' as_exprs ('order' 'by' aggorderbys)? ')'
+    | 'unique' '(' var_decls '|' (formula)? ('|' as_exprs)? ')'
+    ;
+//expression_pragma ::= "pragma" "[" expression_pragma_type "]" "(" expr ")"
+expression_pragma
+    :PRAGMA '[' expression_pragma_type ']' '(' expr ')'
+    ;
+//expression_pragma_type ::= "only_bind_out" | "only_bind_into"
+expression_pragma_type
+    : 'only_bind_out' | 'only_bind_into'
+    ;
+//aggid ::= "avg" | "concat" | "count" | "max" | "min" | "rank" | "strictconcat" | "strictcount" | "strictsum" | "sum"
+aggid
+    : 'avg' | 'concat' | 'count' | 'max' | 'min' | 'rank' | 'strictconcat' | 'strictcount' | 'strictsum' | 'sum'
+    ;
+//aggorderbys ::= aggorderby ("," aggorderby)*
+aggorderbys
+     :aggorderby (',' aggorderby)*
+     ;
+
+//aggorderby ::= expr ("asc" | "desc")?
+aggorderby
+    : expr ('asc' | 'desc')?
+    ;
+//any ::= "any" "(" var_decls ("|" (formula)? ("|" expr)?)? ")"
+any
+    :'any' '(' var_decls ('|' (formula)? ('|' expr)?)? ')'
+    ;
+
+//callwithresults ::= predicateRef (closure)? "(" (exprs)? ")"
+//                |   primary "." predicateName (closure)? "(" (exprs)? ")"
+//callwithresults
+//    : predicateRef (closure)? '(' (exprs)? ')'
+//    | primary '.' predicateName (closure)? '(' (exprs)? ')'
+//    ;
+
+//range ::= "[" expr ".." expr "]"
+range
+    : '[' expr '..' expr ']'
+    ;
+//setliteral ::= "[" expr ("," expr)* ","? "]"
+setliteral
+    : '[' expr (',' expr)* ','? ']'
+    ;
+
+//SIMPLEID ::= lowerId | upperId
+//SIMPLEID
+//    :
+//    : LowerId
+//    | UpperId
+//    ;
+
+//modulename ::= SIMPLEID
+modulename
+    : simpleId
+    ;
+
+//moduleSignatureName ::= upperId
+moduleSignatureName
+    : UPPERID
+    ;
+
+//classname ::= upperId
+classname
+    : UPPERID
+    ;
+
+//dbbasetype ::= atLowerId
+dbbasetype
+    : ATLOWERID
+    ;
+
+//predicateRef ::= (moduleExpr "::")? literalId
+predicateRef
+    : (moduleExpr '::')? predicateCallName
+    ;
+
+//predicateName ::= lowerId
+predicateName
+    : LOWERID
+    | keywordAllowed
+    ;
+
+predicateCallName
+    : LOWERID
+    | ATLOWERID
+    | UPPERID
+    | keywordPredCallAllowed
+    ;
+
+//parameterName ::= SIMPLEID
+parameterName
+    : simpleId
+    ;
+

--- a/codeql/README.md
+++ b/codeql/README.md
@@ -1,0 +1,5 @@
+# CodeQL Grammar
+CodeQL grammar built from the [CodeQL Specification](https://codeql.github.com/docs/ql-language-reference/ql-language-specification/).
+
+All test cases have been extracted from the [QL Language Reference](https://codeql.github.com/docs/ql-language-reference/) and slightly modified. It should be noted that some of these cases may contain semantic errors; however, the focus here is solely on verifying the correctness of the lexer and parser.
+

--- a/codeql/desc.xml
+++ b/codeql/desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+</desc>

--- a/codeql/desc.xml
+++ b/codeql/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
 </desc>

--- a/codeql/examples/alias.qll
+++ b/codeql/examples/alias.qll
@@ -1,0 +1,24 @@
+module ModAlias = ModuleName;
+deprecated module OldVersion = NewVersion;
+class TypeAlias = TypeName;
+class Bool = boolean;
+import OneTwoThreeLib
+
+class OT = M::OneTwo;
+
+
+from OT ot
+select ot
+
+int getSuccessor(int i) {
+  result = i + 1 and
+  i in [1 .. 9]
+}
+
+predicate succ = getSuccessor/1;
+
+predicate isSmall(int i) {
+  i in [1 .. 9]
+}
+predicate lessThanTen = isSmall/1;
+

--- a/codeql/examples/annotation.ql
+++ b/codeql/examples/annotation.ql
@@ -1,0 +1,30 @@
+private module M {
+}
+
+module M1 {
+    private int foo() { result = 1 }
+    predicate bar = foo/0;
+}
+
+abstract class Configuration extends string {
+    /** Holds if `source` is a relevant data flow source. */
+    abstract predicate isSource(Node source);
+}
+
+class ConfigA extends Configuration {
+    // provides a concrete definition of `isSource`
+    override predicate isSource(Node source) { any() }
+  }
+  class ConfigB extends ConfigA {
+    // doesn't need to override `isSource`, because it inherits it from ConfigA
+  }
+  deprecated class DataFlowNode extends @dataflownode {
+   
+  }
+
+  class Element extends int {
+    string getName() { result = "" }
+    final predicate hasName(string name) { name = this.getName() }
+  }
+
+select 1

--- a/codeql/examples/expression.ql
+++ b/codeql/examples/expression.ql
@@ -1,0 +1,34 @@
+select 0,42,-2048,2.0,123.456,-100.5
+,"hello"
+,"They said, \"Please escape quotation marks!\""
+,(1)
+, [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+
+
+class A extends int {
+    A() { this = 1 }
+    int getANumber() { result = 2 }
+  }
+
+  class B extends int {
+    B() { this = 1 }
+    int getANumber() { result = 3 }
+  }
+
+  class C extends A, B {
+    // Need to define `int getANumber()`; otherwise it would be ambiguous
+    int getANumber() {
+      result = B.super.getANumber()
+    }
+
+    predicate test() {
+        count(File f | f.getTotalNumberOfLines() > 500 | f) = 1
+        and max(File f | f.getExtension() = "js" | f.getBaseName() order by f.getTotalNumberOfLines(), f.getNumberOfLinesOfCode()) = 1
+        and min(string s | s = "Tarski" or s = "Dedekind" or s = "De Morgan" | s) = ""
+        and avg(int i | i = [0 .. 3] | i)  = 1
+        and sum(int i, int j | i = [0 .. 2] and j = [3 .. 5] | i * j) =  1
+        and concat(int i | i = [0 .. 3] | i.toString() order by i desc) = ""
+        and concat(int i | i = [0 .. 3] | i.toString(), "|") = ""
+        and rank[4](int i | i = [5 .. 15] | i) = 1
+    }
+  }

--- a/codeql/examples/fomula.ql
+++ b/codeql/examples/fomula.ql
@@ -1,0 +1,33 @@
+
+class Person extends string{
+  Person(){
+    this = "asdf"
+  }
+}
+bindingset[a]
+predicate foo(int a) {
+  "Ann" < "Anne"
+  and 5 + 6 >= 11
+  and  4 != 5
+  and not a = 3
+  and 1 != [1 .. 2]
+
+  and a in [2.1 .. 10.5]
+  and (a in [2.1 .. 10.5])
+  and exists(int i | i instanceof SmallInt)
+  and forall(int i | i instanceof SmallInt | i < 5)
+}
+
+string visibility(Class c){
+  if c.isPublic()
+  then result = "public"
+  else result = "private"
+}
+
+class SmallInt extends int {
+  SmallInt() { this = [1 .. 10] }
+}
+
+from SmallInt x
+where x % 2 = 0 implies x % 4 = 0
+select x

--- a/codeql/examples/module.qll
+++ b/codeql/examples/module.qll
@@ -1,0 +1,36 @@
+module Example {
+  class OneTwoThree extends int {
+    OneTwoThree() {
+      this = 1 or this = 2 or this = 3
+    }
+  }
+
+
+}
+
+bindingset[result] bindingset[x]
+int increment(int x) { result = x + 1 }
+
+module IncrementTwice = M<increment/1, increment/1>;
+
+bindingset[x] signature int transformer(int x);
+
+module M<transformer/1 first, transformer/1 second> {
+  bindingset[x]
+  int applyBoth(int x) {
+    result = second(first(x))
+  }
+}
+
+bindingset[this]
+signature class TSig;
+
+module M1<TSig T> {
+  newtype A = B() or C()
+}
+
+string foo(M1<int>::A a) { result  = "1" }
+
+predicate test() {
+  foo(M1<int>::B()) = ""   // valid: repeated identical instantiation of M does not duplicate A, B, C
+}

--- a/codeql/examples/predicates.ql
+++ b/codeql/examples/predicates.ql
@@ -1,0 +1,97 @@
+
+predicate isCountry(string country) {
+  country = "Germany"
+  or
+  country = "Belgium"
+  or
+  country = "France"
+}
+
+predicate hasCapital(string country, string capital) {
+  country = "Belgium" and capital = "Brussels"
+  or
+  country = "Germany" and capital = "Berlin"
+  or
+  country = "France" and capital = "Paris"
+}
+
+string getANeighbor(string country) {
+  country = "France" and result = "Belgium"
+  or
+  country = "France" and result = "Germany"
+  or
+  country = "Germany" and result = "Austria"
+  or
+  country = "Germany" and result = "Belgium"
+  or
+  country = getANeighbor(result)
+}
+
+class FavoriteNumbers extends int {
+  FavoriteNumbers() {  // 2. Characteristic predicate
+    this = 1 or
+    this = 4 or
+    this = 9
+  }
+
+  string getName() {   // 3. Member predicate for the class `FavoriteNumbers`
+    this = 1 and result = "one"
+    or
+    this = 4 and result = "four"
+    or
+    this = 9 and result = "nine"
+  }
+}
+
+bindingset[i]
+int multiplyBy4(int i) {
+  result = i * 4
+}
+
+bindingset[x] bindingset[y]
+predicate plusOne(int x, int y) {
+  x + 1 = y
+}
+
+bindingset[str, len]
+string truncate(string str, int len) {
+  if str.length() > len
+  then result = str.prefix(len)
+  else result = str
+}
+
+from int x, int y
+where x = 3 and y in [0 .. 2]
+select x, y, x * y as product, "product: " + product
+
+
+class OneTwoThree extends int {
+  OneTwoThree() { // characteristic predicate
+    this = 1 or this = 2 or this = 3
+  }
+
+  string getAString() { // member predicate
+    result = "One, two or three: " + this.toString()
+  }
+
+  predicate isEven() { // member predicate
+    this = 2
+  }
+}
+
+
+
+
+
+
+
+
+
+
+           
+
+
+
+     
+
+

--- a/codeql/examples/signature.qll
+++ b/codeql/examples/signature.qll
@@ -1,0 +1,29 @@
+signature int operator(int lhs, int rhs);
+signature class ExtendsInt extends int;
+
+signature class CanBePrinted {
+  string toString();
+}
+signature module MSig {
+  class T;
+  predicate restriction(T t);
+  default string descr(T t) { result = "default" }
+}
+
+module Module implements MSig {
+  newtype T = A() or B()
+
+  predicate restriction(T t) { t = A() }
+}
+
+signature class NodeSig;
+
+signature module EdgeSig<NodeSig Node> {
+  predicate apply(Node src, Node dst);
+}
+
+module Reachability<NodeSig Node, EdgeSig<Node> Edge> {
+  Node reachableFrom(Node src) {
+    Edge::apply+(src, result)
+  }
+}

--- a/codeql/examples/types.ql
+++ b/codeql/examples/types.ql
@@ -1,0 +1,107 @@
+class OneTwoThree extends int {
+  OneTwoThree() { // characteristic predicate
+    this = 1 or this = 2 or this = 3
+  }
+
+  string getAString() { // member predicate
+    result = "One, two or three: " + this.toString()
+  }
+
+  predicate isEven() { // member predicate
+    this = 2
+  }
+}
+
+
+class SmallInt extends int {
+  SmallInt() { this = [1 .. 10] }
+}
+
+class DivisibleInt extends SmallInt {
+  SmallInt divisor;   // declaration of the field `divisor`
+  DivisibleInt() { this % divisor = 0 }
+
+  SmallInt getADivisor() { result = divisor }
+}
+
+class OneTwo extends OneTwoThree {
+  OneTwo() {
+    this = 1 or this = 2
+  }
+
+  override string getAString() {
+    result = "One or two: " + this.toString()
+  }
+}
+
+class TwoThree extends OneTwoThree {
+  TwoThree() {
+    this = 2 or this = 3
+  }
+
+  override string getAString() {
+    result = "Two or three: " + this.toString()
+  }
+}
+final class FinalOneTwoThree = OneTwoThree;
+
+class OneTwoFinalExtension extends FinalOneTwoThree {
+  OneTwoFinalExtension() {
+    this = 1 or this = 2
+  }
+
+  string getAString() {
+    result = "One or two: " + this.toString()
+  }
+}
+
+
+class Interface extends int {
+  Interface() { this in [1 .. 10] }
+  string foo() { result = "" }
+}
+
+class Foo extends int {
+  Foo() { this in [1 .. 5] }
+  string foo() { result = "foo" }
+}
+
+class Bar extends Interface instanceof Foo {
+  override string foo() { result = "bar" }
+}
+
+newtype T =
+  Type1(SmallInt a, SmallInt b) { a = b }
+  or
+  Type2(SmallInt c)
+  or
+  Type3()
+
+  private newtype TTaintType =
+  TExactValue()
+  or
+  TTaintedValue()
+
+/** Describes how data is tainted. */
+class TaintType extends TTaintType {
+  string toString() {
+    this = TExactValue() and result = "exact"
+    or
+    this = TTaintedValue() and result = "tainted"
+  }
+}
+
+/** A taint type where the data is untainted. */
+class Untainted extends TaintType, TExactValue {
+}
+
+/** A taint type where the data is tainted. */
+class Tainted extends TaintType, TTaintedValue {
+}
+
+class  TypeX = Type1 or Type2;
+
+
+
+from DivisibleInt i
+select i, i.getADivisor(), 1.(OneTwoThree).getAString(), 1.(OneTwoThree).getAString().toUpperCase()

--- a/codeql/examples/variable.ql
+++ b/codeql/examples/variable.ql
@@ -1,0 +1,6 @@
+
+from int i
+where i in [0 .. 9] and "hello".indexOf("l") = 1 and 
+min(float f | f in [-3 .. 3]) = (i + 7) * 3   and x.sqrt() = 3
+select i
+

--- a/codeql/pom.xml
+++ b/codeql/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>codeql</artifactId>
+	<packaging>jar</packaging>
+	<name>CodeQL grammar</name>
+	<parent>
+		<groupId>org.antlr.grammars</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<includes>
+					    <include>CodeQLLexer.g4</include>
+						<include>CodeQLParser.g4</include>
+					</includes>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>ql</entryPoint>
+					<grammarName>CodeQL</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
 				<module>clu</module>
 				<module>cmake</module>
 				<module>cobol85</module>
+				<module>codeql</module>
 				<module>cookie</module>
 				<module>cpp</module>
 				<module>cql</module>


### PR DESCRIPTION
add CodeQL grammar

CodeQL grammar built from the [CodeQL Specification](https://codeql.github.com/docs/ql-language-reference/ql-language-specification/).

All test cases have been extracted from the [QL Language Reference](https://codeql.github.com/docs/ql-language-reference/) and slightly modified. It should be noted that some of these cases may contain semantic errors; however, the focus here is solely on verifying the correctness of the lexer and parser.

