### PR TITLE
Updated type hinting

### DIFF
--- a/vba/examples/example09_typeHints.bas
+++ b/vba/examples/example09_typeHints.bas
@@ -1,0 +1,7 @@
+Sub TypehintsDemo() 
+Dim Number
+ Number = #1
+ OtherNumber = &10
+ Debug.Print Number
+ Debug.Print OtherNumber
+End Sub

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -418,7 +418,7 @@ killStmt
     ;
 
 letStmt
-    : (LET WS)? implicitCallStmt_InStmt WS? (EQ | PLUS_EQ | MINUS_EQ) WS? typeHint? valueStmt
+    : (LET WS)? implicitCallStmt_InStmt WS? (EQ | PLUS_EQ | MINUS_EQ) WS? typeHint? valueStmt typeHint?
     ;
 
 lineInputStmt

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -1877,7 +1877,7 @@ HEXLITERAL
     ;
 
 SHORTLITERAL
-    : (PLUS | MINUS)? DIGIT+ ('#' | '&' | '@')?
+    : (PLUS | MINUS)? DIGIT+
     ;
 
 INTEGERLITERAL

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -418,7 +418,7 @@ killStmt
     ;
 
 letStmt
-    : (LET WS)? implicitCallStmt_InStmt WS? (EQ | PLUS_EQ | MINUS_EQ) WS? valueStmt
+    : (LET WS)? implicitCallStmt_InStmt WS? (EQ | PLUS_EQ | MINUS_EQ) WS? typeHint? valueStmt
     ;
 
 lineInputStmt

--- a/vba/vba.g4
+++ b/vba/vba.g4
@@ -810,7 +810,7 @@ subscripts
     ;
 
 subscript_
-    : (valueStmt WS TO WS)? valueStmt
+    : (valueStmt WS TO WS)? typeHint? valueStmt typeHint?
     ;
 
 // atomic rules ----------------------------------


### PR DESCRIPTION
Type hinting in VBA should work when its placed after the digit as well.

Documentation here.

https://learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/data-types/type-characters

