### PR TITLE
[PlSql] Properly support multiple out_of_line_constraints

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -5260,8 +5260,8 @@ object_type_col_properties
     ;
 
 constraint_clauses
-    : ADD '(' (out_of_line_constraint* | out_of_line_ref_constraint) ')'
-    | ADD (out_of_line_constraint* | out_of_line_ref_constraint)
+    : ADD '(' (out_of_line_constraint (',' out_of_line_constraint)* | out_of_line_ref_constraint) ')'
+    | ADD (out_of_line_constraint | out_of_line_ref_constraint)
     | MODIFY (
         CONSTRAINT constraint_name
         | PRIMARY KEY

--- a/sql/plsql/examples/alter_table.sql
+++ b/sql/plsql/examples/alter_table.sql
@@ -111,6 +111,11 @@ ALTER TABLE employees MODIFY LOB (resume) (NOCACHE);
 
 alter TABLE employee add ( constraint employee_pk UNique ( a , b ) ) ;
 
+alter table employee add (
+    constraint emp_fk foreign key (col1, col2) references other,
+    constraint emp_fk2 foreign key (col1, col2) references another
+);
+
 alter table employee
     add constraint emp_fk foreign key (col1, col2) references other;
 


### PR DESCRIPTION
Multiple `out_of_line_constraints` in a single `ALTER TABLE ADD ...` must be surrounded by parentheses and separated by comma.

See
https://stackoverflow.com/questions/58284256/incorrect-railroad-diagram-for-alter-table-with-multiple-out-of-line-constraints for further context.