### PR TITLE
[PlSql] Correctly parse package init blocks with simple statements

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -667,7 +667,7 @@ create_package_body
     : CREATE (OR REPLACE)? (EDITIONABLE | NONEDITIONABLE)? PACKAGE BODY (schema_object_name '.')? package_name (
         IS
         | AS
-    ) package_obj_body* (BEGIN seq_of_statements (EXCEPTION exception_handler+)?)? END package_name?
+    ) package_obj_body*? (BEGIN seq_of_statements (EXCEPTION exception_handler+)?)? END package_name?
     ;
 
 // Create Package Specific Clauses

--- a/sql/plsql/examples-sql-script/package_with_simple_init_block.pkb
+++ b/sql/plsql/examples-sql-script/package_with_simple_init_block.pkb
@@ -1,0 +1,5 @@
+-- The package init block should not be parsed as a variable declaration
+create package body MyPackage as
+begin
+  OtherPackage.DoSomething;
+end MyPackage;


### PR DESCRIPTION
Before this commit, the following package init block was parsed as a variable declaration:

```
    create or replace package body MyPackage is
    begin
      OtherPackage.DoSomething;
    end;
```

... because variable_declaration is:

`: identifier CONSTANT? type_spec (NOT NULL_)? default_value_part? ';'`

so `identifier` would match "begin" and `type_spec` would match "OtherPackage.DoSomething" (because "BEGIN" is a non-reserved keyword which is allowed as an identifier in some contexts).

Making the package_obj_body match non-greedy fixes this.