### PR TITLE
[VB6] Fix two corner cases

### DIFF
--- a/vb6/VisualBasic6Parser.g4
+++ b/vb6/VisualBasic6Parser.g4
@@ -286,7 +286,7 @@ deleteSettingStmt
 doLoopStmt
     : DO NEWLINE+ (block NEWLINE+)? LOOP
     | DO WS (WHILE | UNTIL) WS valueStmt NEWLINE+ ( block NEWLINE+)? LOOP
-    | DO NEWLINE+ (block NEWLINE+) LOOP WS (WHILE | UNTIL) WS valueStmt
+    | DO NEWLINE+ (block NEWLINE+)? LOOP WS (WHILE | UNTIL) WS valueStmt
     ;
 
 endStmt
@@ -369,7 +369,7 @@ ifConditionStmt
     ;
 
 ifElseIfBlockStmt
-    : ELSEIF WS ifConditionStmt WS THEN NEWLINE+ (block NEWLINE+)?
+    : ELSEIF WS ifConditionStmt WS THEN (WS | NEWLINE)+ (block NEWLINE+)?
     ;
 
 ifElseBlockStmt

--- a/vb6/examples/test1.bas
+++ b/vb6/examples/test1.bas
@@ -1,0 +1,12 @@
+Public Sub Test1()
+    If i = 1 Then
+        Statment
+    ElseIf i = 2 Then Statment
+    ElseIf i = 3 Then Statment
+    End If
+End Sub
+
+Public Sub Test2()
+    Do
+    Loop Until i >= 1
+End Sub


### PR DESCRIPTION
In some VB6 code I was dealing with I found two corner cases that are apparently valid in real VB6 that didn't parse successfully in this grammar.

1) A "DO .... LOOP WHILE" type of loop wasn't allowed to be empty, when it should be
2) ELSEIF lines don't require a newline before the block, whitespace will do.

A simple example file is included.