### PR TITLE
update SQLiteLexer.g4 to support both 0x and 0X for hexadecimal value

### DIFF
--- a/sql/sqlite/SQLiteLexer.g4
+++ b/sql/sqlite/SQLiteLexer.g4
@@ -225,7 +225,7 @@ IDENTIFIER:
     | [A-Z_] [A-Z_0-9]*
 ; // TODO check: needs more chars in set
 
-NUMERIC_LITERAL: ((DIGIT+ ('.' DIGIT*)?) | ('.' DIGIT+)) ('E' [-+]? DIGIT+)? | '0x' HEX_DIGIT+;
+NUMERIC_LITERAL: ((DIGIT+ ('.' DIGIT*)?) | ('.' DIGIT+)) ('E' [-+]? DIGIT+)? | ('0x' | '0X') HEX_DIGIT+;
 
 BIND_PARAMETER: '?' DIGIT* | [:@$] IDENTIFIER;
 


### PR DESCRIPTION
Update the SQLiteLexer.g4 to support parsing hexadecimal integers beginning with either '0x' or '0X'.