### PR TITLE
Pulled in previous JavaScript grammar improvements into TypeScript grammar.

### DIFF
--- a/javascript/typescript/TypeScriptLexer.g4
+++ b/javascript/typescript/TypeScriptLexer.g4
@@ -171,9 +171,6 @@ Symbol  : 'symbol';
 
 TypeAlias: 'type';
 
-Get : 'get';
-Set : 'set';
-
 Constructor : 'constructor';
 Namespace   : 'namespace';
 Require     : 'require';

--- a/javascript/typescript/TypeScriptLexer.g4
+++ b/javascript/typescript/TypeScriptLexer.g4
@@ -45,9 +45,11 @@ Modulus                    : '%';
 Power                      : '**';
 NullCoalesce               : '??';
 Hashtag                    : '#';
-RightShiftArithmetic       : '>>';
 LeftShiftArithmetic        : '<<';
-RightShiftLogical          : '>>>';
+// We can't match these in the lexer because it would cause issues when parsing
+// types like Map<string, Map<string, string>>
+// RightShiftArithmetic       : '>>';
+// RightShiftLogical          : '>>>';
 LessThan                   : '<';
 MoreThan                   : '>';
 LessThanEquals             : '<=';

--- a/javascript/typescript/TypeScriptLexer.g4
+++ b/javascript/typescript/TypeScriptLexer.g4
@@ -29,6 +29,7 @@ SemiColon                  : ';';
 Comma                      : ',';
 Assign                     : '=';
 QuestionMark               : '?';
+QuestionMarkDot            : '?.';
 Colon                      : ':';
 Ellipsis                   : '...';
 Dot                        : '.';
@@ -41,6 +42,9 @@ Not                        : '!';
 Multiply                   : '*';
 Divide                     : '/';
 Modulus                    : '%';
+Power                      : '**';
+NullCoalesce               : '??';
+Hashtag                    : '#';
 RightShiftArithmetic       : '>>';
 LeftShiftArithmetic        : '<<';
 RightShiftLogical          : '>>>';
@@ -68,6 +72,8 @@ RightShiftLogicalAssign    : '>>>=';
 BitAndAssign               : '&=';
 BitXorAssign               : '^=';
 BitOrAssign                : '|=';
+PowerAssign                : '**=';
+NullishCoalescingAssign    : '??=';
 ARROW                      : '=>';
 
 /// Null Literals
@@ -81,17 +87,22 @@ BooleanLiteral: 'true' | 'false';
 /// Numeric Literals
 
 DecimalLiteral:
-    DecimalIntegerLiteral '.' [0-9]* ExponentPart?
-    | '.' [0-9]+ ExponentPart?
+    DecimalIntegerLiteral '.' [0-9] [0-9_]* ExponentPart?
+    | '.' [0-9] [0-9_]* ExponentPart?
     | DecimalIntegerLiteral ExponentPart?
 ;
 
 /// Numeric Literals
 
-HexIntegerLiteral    : '0' [xX] HexDigit+;
+HexIntegerLiteral    : '0' [xX] [0-9a-fA-F] HexDigit*;
 OctalIntegerLiteral  : '0' [0-7]+ {!this.IsStrictMode()}?;
-OctalIntegerLiteral2 : '0' [oO] [0-7]+;
-BinaryIntegerLiteral : '0' [bB] [01]+;
+OctalIntegerLiteral2 : '0' [oO] [0-7] [_0-7]*;
+BinaryIntegerLiteral : '0' [bB] [01] [_01]*;
+
+BigHexIntegerLiteral     : '0' [xX] [0-9a-fA-F] HexDigit* 'n';
+BigOctalIntegerLiteral   : '0' [oO] [0-7] [_0-7]* 'n';
+BigBinaryIntegerLiteral  : '0' [bB] [01] [_01]* 'n';
+BigDecimalIntegerLiteral : DecimalIntegerLiteral 'n';
 
 /// Keywords
 
@@ -125,6 +136,7 @@ As         : 'as';
 From       : 'from';
 ReadOnly   : 'readonly';
 Async      : 'async';
+Await      : 'await';
 
 /// Future Reserved Words
 
@@ -223,7 +235,10 @@ fragment CharacterEscapeSequence: SingleEscapeCharacter | NonEscapeCharacter;
 
 fragment HexEscapeSequence: 'x' HexDigit HexDigit;
 
-fragment UnicodeEscapeSequence: 'u' HexDigit HexDigit HexDigit HexDigit;
+fragment UnicodeEscapeSequence:
+    'u' HexDigit HexDigit HexDigit HexDigit
+    | 'u' '{' HexDigit HexDigit+ '}'
+;
 
 fragment ExtendedUnicodeEscapeSequence: 'u' '{' HexDigit+ '}';
 
@@ -233,13 +248,13 @@ fragment NonEscapeCharacter: ~['"\\bfnrtv0-9xu\r\n];
 
 fragment EscapeCharacter: SingleEscapeCharacter | [0-9] | [xu];
 
-fragment LineContinuation: '\\' [\r\n\u2028\u2029];
+fragment LineContinuation: '\\' [\r\n\u2028\u2029]+;
 
-fragment HexDigit: [0-9a-fA-F];
+fragment HexDigit: [_0-9a-fA-F];
 
-fragment DecimalIntegerLiteral: '0' | [1-9] [0-9]*;
+fragment DecimalIntegerLiteral: '0' | [1-9] [0-9_]*;
 
-fragment ExponentPart: [eE] [+-]? [0-9]+;
+fragment ExponentPart: [eE] [+-]? [0-9_]+;
 
 fragment IdentifierPart: IdentifierStart | [\p{Mn}] | [\p{Nd}] | [\p{Pc}] | '\u200C' | '\u200D';
 

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -349,11 +349,14 @@ sourceElement
 
 statement
     : block
+    | variableStatement    
     | importStatement
     | exportStatement
     | emptyStatement_
     | abstractDeclaration //ADDED
     | classDeclaration
+    | functionDeclaration
+    | expressionStatement    
     | interfaceDeclaration //ADDED
     | namespaceDeclaration //ADDED
     | ifStatement
@@ -368,13 +371,10 @@ statement
     | throwStatement
     | tryStatement
     | debuggerStatement
-    | functionDeclaration
     | arrowFunctionDeclaration
     | generatorFunctionDeclaration
-    | variableStatement
     | typeAliasDeclaration //ADDED
     | enumDeclaration      //ADDED
-    | expressionStatement
     | Export statement
     ;
 
@@ -555,7 +555,7 @@ tryStatement
     ;
 
 catchProduction
-    : Catch '(' Identifier typeAnnotation? ')' block
+    : Catch ('(' Identifier typeAnnotation? ')')? block
     ;
 
 finallyProduction
@@ -567,7 +567,7 @@ debuggerStatement
     ;
 
 functionDeclaration
-    : Function_ Identifier callSignature (('{' functionBody '}') | SemiColon)
+    : Async? Function_ Identifier callSignature (('{' functionBody '}') | SemiColon)
     ;
 
 //Ovveride ECMA
@@ -615,11 +615,11 @@ indexMemberDeclaration
     ;
 
 generatorMethod
-    : '*'? Identifier '(' formalParameterList? ')' '{' functionBody '}'
+    : (Async {this.notLineTerminator()}?)? '*'? Identifier '(' formalParameterList? ')' '{' functionBody '}'
     ;
 
 generatorFunctionDeclaration
-    : Function_ '*' Identifier? '(' formalParameterList? ')' '{' functionBody '}'
+    : Async? Function_ '*' Identifier? '(' formalParameterList? ')' '{' functionBody '}'
     ;
 
 generatorBlock
@@ -636,6 +636,15 @@ iteratorBlock
 
 iteratorDefinition
     : '[' singleExpression ']' '(' formalParameterList? ')' '{' functionBody '}'
+    ;
+
+classElementName
+    : propertyName
+    | privateIdentifier
+    ;
+
+privateIdentifier
+    : '#' identifierName
     ;
 
 formalParameterList
@@ -687,6 +696,7 @@ propertyAssignment
     | setAccessor                                   # PropertySetter
     | generatorMethod                               # MethodProperty
     | identifierOrKeyWord                           # PropertyShorthand
+    | Ellipsis? singleExpression                    # SpreadOperator
     | restParameter                                 # RestParameterInObject
     ;
 
@@ -728,6 +738,7 @@ functionExpressionDeclaration
 singleExpression
     : functionExpressionDeclaration                               # FunctionExpression
     | arrowFunctionDeclaration                                    # ArrowFunctionExpression // ECMAScript 6
+    | Class Identifier? typeParameters? classHeritage classTail   # ClassExpression
     | singleExpression '?.'? '[' expressionSequence ']'           # MemberIndexExpression
     | singleExpression '?.' singleExpression                      # OptionalChainExpression
     | singleExpression '!'? '.' '#'? identifierName nestedTypeGeneric? # MemberDotExpression
@@ -852,11 +863,11 @@ bigintLiteral
     ;
 
 getter
-    : Get propertyName
+    : {this.n("get")}? Identifier classElementName
     ;
 
 setter
-    : Set propertyName
+    : {this.n("set")}? Identifier classElementName
     ;
 
 identifierName
@@ -924,8 +935,6 @@ keyword
     | ReadOnly
     | From
     | As
-    | Get
-    | Set
     | Require
     | TypeAlias
     | String

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -476,8 +476,10 @@ iterationStatement
     | While '(' expressionSequence ')' statement                                                                            # WhileStatement
     | For '(' expressionSequence? SemiColon expressionSequence? SemiColon expressionSequence? ')' statement                 # ForStatement
     | For '(' varModifier variableDeclarationList SemiColon expressionSequence? SemiColon expressionSequence? ')' statement # ForVarStatement
-    | For '(' singleExpression (In | Identifier {this.p("of")}?) expressionSequence ')' statement                           # ForInStatement
-    | For '(' varModifier variableDeclaration (In | Identifier {this.p("of")}?) expressionSequence ')' statement            # ForVarInStatement
+    | For '(' singleExpression In expressionSequence ')' statement                                                          # ForInStatement
+    | For '(' varModifier variableDeclaration In expressionSequence ')' statement                                           # ForVarInStatement
+    | For Await? '(' singleExpression Identifier {this.p("of")}? expressionSequence ')' statement                           # ForOfStatement
+    | For Await? '(' varModifier variableDeclaration Identifier {this.p("of")}? expressionSequence ')' statement            # ForVarOfStatement
     ;
 
 varModifier

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -118,27 +118,11 @@ predefinedType
     ;
 
 typeReference
-    : typeName nestedTypeGeneric?
+    : typeName typeGeneric?
     ;
 
-nestedTypeGeneric
-    : typeIncludeGeneric
-    | typeGeneric
-    ;
-
-// I tried recursive include, but it's not working.
-// typeGeneric
-//    : '<' typeArgumentList typeGeneric?'>'
-//    ;
-//
-// TODO: Fix recursive
-//
 typeGeneric
-    : '<' typeArgumentList '>'
-    ;
-
-typeIncludeGeneric
-    : '<' typeArgumentList '<' typeArgumentList ('>' bindingPattern '>' | '>>')
+    : '<' typeArgumentList typeGeneric?'>'
     ;
 
 typeName
@@ -741,8 +725,8 @@ singleExpression
     | Class Identifier? typeParameters? classHeritage classTail   # ClassExpression
     | singleExpression '?.'? '[' expressionSequence ']'           # MemberIndexExpression
     | singleExpression '?.' singleExpression                      # OptionalChainExpression
-    | singleExpression '!'? '.' '#'? identifierName nestedTypeGeneric? # MemberDotExpression
-    | singleExpression '?'? '.' '#'? identifierName nestedTypeGeneric? # MemberDotExpression
+    | singleExpression '!'? '.' '#'? identifierName typeGeneric?  # MemberDotExpression
+    | singleExpression '?'? '.' '#'? identifierName typeGeneric?  # MemberDotExpression
     // Split to try `new Date()` first, then `new Date`.
     | New singleExpression typeArguments? arguments                   # NewExpression
     | New singleExpression typeArguments?                             # NewExpression
@@ -763,7 +747,7 @@ singleExpression
     | singleExpression ('*' | '/' | '%') singleExpression             # MultiplicativeExpression
     | singleExpression ('+' | '-') singleExpression                   # AdditiveExpression
     | singleExpression '??' singleExpression                          # CoalesceExpression    
-    | singleExpression ('<<' | '>>' | '>>>') singleExpression         # BitShiftExpression
+    | singleExpression ('<<' | '>' '>' | '>' '>' '>') singleExpression # BitShiftExpression
     | singleExpression ('<' | '>' | '<=' | '>=') singleExpression     # RelationalExpression
     | singleExpression Instanceof singleExpression                    # InstanceofExpression
     | singleExpression In singleExpression                            # InExpression

--- a/javascript/typescript/examples/Export.js
+++ b/javascript/typescript/examples/Export.js
@@ -1,0 +1,33 @@
+// https://github.com/antlr/grammars-v4/issues/3484
+
+// Exporting declarations
+export let name1, name2/*, … */; // also var
+export const name1 = 1, name2 = 2/*, … */; // also var, let
+export function functionName() { /* … */ }
+export class ClassName { /* … */ }
+export function* generatorFunctionName() { /* … */ }
+export const { name1, name2: bar } = o;
+export const [ name1, name2 ] = array;
+
+// Export list
+export { name1, /* …, */ nameN };
+export { variable1 as name1, variable2 as name2, /* …, */ nameN };
+export { variable1 as "string name" };
+export { name1 as default /*, … */ };
+
+// Default exports
+export default expression;
+export default function functionName() { /* … */ }
+export default class ClassName { /* … */ }
+export default function* generatorFunctionName() { /* … */ }
+export default function () { /* … */ }
+export default class { /* … */ }
+export default function* () { /* … */ }
+
+// Aggregating modules
+export * from "module-name";
+export * as name1 from "module-name";
+export { name1, /* …, */ nameN } from "module-name";
+export { import1 as name1, import2 as name2, /* …, */ nameN } from "module-name";
+export { default, /* …, */ } from "module-name";
+export { default as name1 } from "module-name";

--- a/javascript/typescript/examples/Function.ts
+++ b/javascript/typescript/examples/Function.ts
@@ -39,7 +39,6 @@ function Greet(greeting: string, ...names: string[]) {
     return greeting + " " + names.join(", ") + "!";
 }
 
-
 function Test(value: TestClass | TestClass2): value is TestClass {
     return (<TestClass>value).someFunction !== undefined;
 }
@@ -48,4 +47,11 @@ function buildName(firstName: string, lastName?: string) {
     if (lastName) return firstName + " " + lastName;
     else return firstName;
   }
-  
+
+// Try passing a nested type to the function. This tests we don't match ">>" and ">>>" symbols.
+function nestedType(map: Map<string, Map<string, Set<string>>>) {
+    // Check that we can parse these too.
+    let a = 12;
+    let b = a >> 5;
+    let c = b >>> 5;
+}

--- a/javascript/typescript/examples/Import.js
+++ b/javascript/typescript/examples/Import.js
@@ -1,0 +1,16 @@
+// https://github.com/antlr/grammars-v4/issues/3484
+
+import defaultExport from "module-name";
+import * as name from "module-name";
+import { export1 } from "module-name";
+import { export1 as alias1 } from "module-name";
+import { default as alias } from "module-name";
+import { export1, export2 } from "module-name";
+import { export1, export2 as alias2, /* … */ } from "module-name";
+import { "string name" as alias } from "module-name";
+import defaultExport, { export1, /* … */ } from "module-name";
+import defaultExport, * as name from "module-name";
+import "module-name";
+
+import { "a-b" as yield } from "/modules/my-module.js";
+import { "a-b" as await } from "/modules/my-module.js";

--- a/javascript/typescript/examples/JavaScriptClass.js
+++ b/javascript/typescript/examples/JavaScriptClass.js
@@ -1,0 +1,237 @@
+"use strict";
+//------------------------------------------------------------------------------
+// Class Definition
+// More intuitive, OOP-style and boilerplate-free classes.
+// http://es6-features.org/#ClassDefinition
+//------------------------------------------------------------------------------
+
+class Shape {
+    constructor (id, x, y) {
+        this.id = id
+        this.move(x, y)
+    }
+    move (x, y) {
+        this.x = x
+        this.y = y
+    }
+}
+
+//------------------------------------------------------------------------------
+// Class Inheritance
+// More intuitive, OOP-style and boilerplate-free inheritance.
+// http://es6-features.org/#ClassInheritance
+//------------------------------------------------------------------------------
+
+class Rectangle extends Shape {
+    constructor (id, x, y, width, height) {
+        super(id, x, y)
+        this.width  = width
+        this.height = height
+    }
+}
+class Circle extends Shape {
+    constructor (id, x, y, radius) {
+        super(id, x, y)
+        this.radius = radius
+    }
+}
+
+//------------------------------------------------------------------------------
+// Class Inheritance, From Expressions
+// Support for mixin-style inheritance by extending from expressions yielding
+//   function objects. [Notice: the generic aggregation function is usually
+//   provided by a library like this one, of course]
+// http://es6-features.org/#ClassInheritanceFromExpressions
+//------------------------------------------------------------------------------
+
+var aggregation = (baseClass, ...mixins) => {
+    let base = class _Combined extends baseClass {
+        constructor (...args) {
+            super(...args)
+            mixins.forEach((mixin) => {
+                mixin.prototype.initializer.call(this)
+            })
+        }
+    }
+    let copyProps = (target, source) => {
+        Object.getOwnPropertyNames(source)
+            .concat(Object.getOwnPropertySymbols(source))
+            .forEach((prop) => {
+            if (prop.match(/^(?:constructor|prototype|arguments|caller|name|bind|call|apply|toString|length)$/))
+                return
+            Object.defineProperty(target, prop, Object.getOwnPropertyDescriptor(source, prop))
+        })
+    }
+    mixins.forEach((mixin) => {
+        copyProps(base.prototype, mixin.prototype)
+        copyProps(base, mixin)
+    })
+    return base
+}
+
+class Colored {
+    initializer ()     { this._color = "white" }
+    get color ()       { return this._color }
+    set color (v)      { this._color = v }
+}
+
+class ZCoord {
+    initializer ()     { this._z = 0 }
+    get z ()           { return this._z }
+    set z (v)          { this._z = v }
+}
+
+class Shape {
+    constructor (x, y) { this._x = x; this._y = y }
+    get x ()           { return this._x }
+    set x (v)          { this._x = v }
+    get y ()           { return this._y }
+    set y (v)          { this._y = v }
+}
+
+class Rectangle extends aggregation(Shape, Colored, ZCoord) {}
+
+var rect = new Rectangle(7, 42)
+rect.z     = 1000
+rect.color = "red"
+console.log(rect.x, rect.y, rect.z, rect.color)
+
+//------------------------------------------------------------------------------
+// Base Class Access
+// Intuitive access to base class constructor and methods.
+// http://es6-features.org/#BaseClassAccess
+//------------------------------------------------------------------------------
+
+class Shape {
+    // …
+    toString () {
+        return `Shape(${this.id})`
+    }
+}
+class Rectangle extends Shape {
+    constructor (id, x, y, width, height) {
+        super(id, x, y)
+        // …
+    }
+
+    toString () {
+        return "Rectangle > " + super.toString()
+    }
+}
+class Circle extends Shape {
+    constructor (id, x, y, radius) {
+        super(id, x, y)
+        // …
+    }
+    toString () {
+        return "Circle > " + super.toString()
+    }
+}
+
+//------------------------------------------------------------------------------
+// Static Members
+// Simple support for static class members.
+// http://es6-features.org/#StaticMembers
+//------------------------------------------------------------------------------
+
+class Rectangle extends Shape {
+    // …
+    static contextTypes = {
+        router: PropTypes.object,
+    };
+
+    static defaultRectangle () {
+        return new Rectangle("default", 0, 0, 100, 100)
+    }
+}
+class Circle extends Shape {
+    // …
+    static defaultCircle () {
+        return new Circle("default", 0, 0, 100)
+    }
+}
+var defRectangle = Rectangle.defaultRectangle()
+var defCircle    = Circle.defaultCircle()
+
+//------------------------------------------------------------------------------
+// Getter/Setter
+// Getter/Setter also directly within classes (and not just within object
+//   initializers, as it is possible since ECMAScript 5.1).
+// http://es6-features.org/#GetterSetter
+//------------------------------------------------------------------------------
+
+class Rectangle {
+    constructor (width, height) {
+        this._width  = width
+        this._height = height
+    }
+    set width  (width)  { this._width = width               }
+    get width  ()       { return this._width                }
+    set height (height) { this._height = height             }
+    get height ()       { return this._height               }
+    get area   ()       { return this._width * this._height }
+}
+var r = new Rectangle(50, 20)
+r.area === 1000
+
+//------------------------------------------------------------------------------
+// Class definition with empty statement
+//------------------------------------------------------------------------------
+class A {
+    ;
+}
+
+////
+class B {
+    get [runtimeCalc]() {return 1};
+    set [runtimeCalc](p) {};
+    get 'string as key'() {};
+}
+// extended object
+let Obj = {
+  // [asdfg](a){}, // @todo Support this...
+  * foo () {},
+  f(){},
+  get a(){},
+  // set a([aa]=123){}, @todo ... and this
+  ...anotherObj,
+  ...{
+    speradObjectLiteral
+  },
+  ...functionResult()
+}
+
+//------------------------------------------------------------------------------
+// Public class fields
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
+//------------------------------------------------------------------------------
+const PREFIX = "prefix";
+
+class ClassWithField {
+  field;
+  fieldWithInitializer = "instance field";
+  [`${PREFIX}Field`] = "prefixed field";
+}
+
+const instance = new ClassWithField();
+console.log(Object.hasOwn(instance, "field")); // true
+console.log(instance.field); // undefined
+console.log(instance.fieldWithInitializer); // "instance field"
+console.log(instance.prefixField); // "prefixed field"
+
+//------------------------------------------------------------------------------
+// Static initialization blocks
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks
+//------------------------------------------------------------------------------
+class ClassWithStaticInitializationBlock {
+  static staticProperty1 = 'Property 1';
+  static staticProperty2;
+  static {
+    this.staticProperty2 = 'Property 2';
+  }
+}
+
+console.log(ClassWithStaticInitializationBlock.staticProperty1);
+// Expected output: "Property 1"
+console.log(ClassWithStaticInitializationBlock.staticProperty2);
+// Expected output: "Property 2"

--- a/javascript/typescript/examples/Loop.ts
+++ b/javascript/typescript/examples/Loop.ts
@@ -1,0 +1,18 @@
+let object = {};
+for (let field in object) {
+};
+
+let array = [];
+for (let element of array) {
+};
+
+for (let element: number of array) {
+};
+
+for await (const document of array) {
+
+};
+
+for await (const document: string of array) {
+
+};

--- a/javascript/typescript/examples/NonNullAssertOp.js
+++ b/javascript/typescript/examples/NonNullAssertOp.js
@@ -10,7 +10,8 @@ class Entity{
 function processEntity(e?: Entity) {
   let s = e!.name;
   let t = e.name;
-    let o = e!.obj!.i;
+  let o = e!.obj!.i;
+  let p = e?.name;  
 }
 
 var e = null;

--- a/javascript/typescript/examples/Type.ts
+++ b/javascript/typescript/examples/Type.ts
@@ -1,16 +1,29 @@
+// TypeDefinition
+type Employee = {
+     id: string;
+     name: string;
+     address?: string; // Optional
+     phone?: string | null;
+};
+
 // TypeAnotation
 var age: number = 32; // number variable
 var name: string = "John";// string variable
 var isUpdated: boolean = true;// Boolean variable
 
-var employee : {
+var employee1 : {
     id: number;
     name: string;
 };
 
-employee = {
+employee1 = {
     id: 100,
     name : "John"
+}
+
+var employee2: Employee = {
+    id: 101,
+    name: "Steve"
 }
 
 function display(id:number, name:string)


### PR DESCRIPTION
TypeScript is a (typed) superset of the JavaScript language and there have been many improvements to the JavaScript grammar that haven't made it into the TypeScript grammar. This PR pulls them in, and adds a couple of minor TypeScript only improvements.

Improvements to the TypeScript grammar from the existing JavaScript grammar include:

* Improved import and export support.
* Addition of power (`**`, `**=`) and coalescing (`??`, `??=`) operators.
* Improved support for async.
* Support for using underscore to break up long numbers.
* Support for big numbers.
* Better support for unicode characters.
* Support for class expressions.
* Member chain expressions.
* ... and more

The TypeScript specific improvements are:

* Fixed arbitrary nested generic types, e.g. `Promise<Map<string, Set<string>>>` now works.
* Added the 'null' type.
* The 'get' and 'set' identifiers are not reserved and can be used to create functions - just like in JavaScript grammar.
* catch clauses can now be typed, e.g. `catch (error: MyError) {`

I've copied a couple of the JavaScript examples to the TypeScript example directory to help test the improvements. It would be nice if the TypeScript tests made sure we could parse all of the JavaScript examples. However without copying all the files, I wasn't sure how to do that (and whether the intention was to deliberately decouple each language).

To review it might make sense to look at the diff TypeScriptParser.g4 with JavaScriptParser.g4 (ditto for lexers) as most of the changes are just existing grammar.

There is still more work to be done to bring Typescript up to date.