### PR TITLE
Upgraded supported TypeScript version to v2.7.

### DIFF
--- a/javascript/javascript/JavaScriptLexer.g4
+++ b/javascript/javascript/JavaScriptLexer.g4
@@ -169,6 +169,8 @@ Try        : 'try';
 As         : 'as';
 From       : 'from';
 Of         : 'of';
+Yield      : 'yield';
+YieldStar  : 'yield*';
 
 /// Future Reserved Words
 
@@ -182,7 +184,6 @@ Import  : 'import';
 
 Async : 'async';
 Await : 'await';
-Yield : 'yield';
 
 /// The following tokens are also considered to be FutureReservedWords
 /// when parsing strict mode

--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -200,7 +200,7 @@ returnStatement
     ;
 
 yieldStatement
-    : Yield ({this.notLineTerminator()}? expressionSequence)? eos
+    : (Yield | YieldStar) ({this.notLineTerminator()}? expressionSequence)? eos
     ;
 
 withStatement
@@ -314,8 +314,9 @@ arrayLiteral
     : ('[' elementList ']')
     ;
 
+// JavaScript supports arrasys like [,,1,2,,].
 elementList
-    : ','* arrayElement? (','+ arrayElement)* ','* // Yes, everything is optional
+    : ','* arrayElement? (','+ arrayElement) * ','* // Yes, everything is optional
     ;
 
 arrayElement
@@ -420,7 +421,8 @@ objectLiteral
     ;
 
 anonymousFunction
-    : Async? Function_ '*'? '(' formalParameterList? ')' functionBody # AnonymousFunctionDecl
+    : functionDeclaration                                             # NamedFunction
+    | Async? Function_ '*'? '(' formalParameterList? ')' functionBody # AnonymousFunctionDecl
     | Async? arrowFunctionParameters '=>' arrowFunctionBody           # ArrowFunction
     ;
 
@@ -556,6 +558,7 @@ keyword
     | Protected
     | Static
     | Yield
+    | YieldStar    
     | Async
     | Await
     | From

--- a/javascript/javascript/examples/ObjectInitializer.js
+++ b/javascript/javascript/examples/ObjectInitializer.js
@@ -9,4 +9,10 @@
 obj = { };
 obj = { item1: "item1", item2: "item2" };
 obj = { item1: "item1", item2: "item2", };
+obj = { item1: "item1",
+        item2: "item2",
+        item3: function(arg1) { return arg1; },
+        item4: function myFunction(arg1) { return arg1; },
+        item5: (arg1) => { return arg1; }
+      };
 

--- a/javascript/jsx/JavaScriptLexer.g4
+++ b/javascript/jsx/JavaScriptLexer.g4
@@ -161,6 +161,7 @@ In         : 'in';
 Try        : 'try';
 As         : 'as';
 From       : 'from';
+YieldStar  : 'yield*';
 
 /// Future Reserved Words
 

--- a/javascript/jsx/JavaScriptParser.g4
+++ b/javascript/jsx/JavaScriptParser.g4
@@ -177,7 +177,7 @@ returnStatement
     ;
 
 yieldStatement
-    : Yield ({this.notLineTerminator()}? expressionSequence)? eos
+    : (Yield | YieldStar) ({this.notLineTerminator()}? expressionSequence)? eos
     ;
 
 withStatement

--- a/javascript/typescript/TypeScriptLexer.g4
+++ b/javascript/typescript/TypeScriptLexer.g4
@@ -1,3 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 by Bart Kiers (original author) and Alexandre Vitorelli (contributor -> ported to CSharp)
+ * Copyright (c) 2017 by Ivan Kochurkin (Positive Technologies):
+    added ECMAScript 6 support, cleared and transformed to the universal grammar.
+ * Copyright (c) 2018 by Juan Alvarez (contributor -> ported to Go)
+ * Copyright (c) 2019 by Andrii Artiushok (contributor -> added TypeScript support)
+ * Copyright (c) 2024 by Andrew Leppard (www.wegrok.review)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 // $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
 // $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
 // $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
@@ -139,6 +171,8 @@ From       : 'from';
 ReadOnly   : 'readonly';
 Async      : 'async';
 Await      : 'await';
+Yield      : 'yield';
+YieldStar  : 'yield*';
 
 /// Future Reserved Words
 
@@ -161,15 +195,20 @@ Interface  : 'interface';
 Package    : 'package';
 Protected  : 'protected';
 Static     : 'static';
-Yield      : 'yield';
 
 //keywords:
+Any        : 'any';
+Number     : 'number';
+Never      : 'never';
+Boolean    : 'boolean';
+String     : 'string';
+Unique     : 'unique';
+Symbol     : 'symbol';
+Undefined  : 'undefined';
+Object     : 'object';
 
-Any     : 'any';
-Number  : 'number';
-Boolean : 'boolean';
-String  : 'string';
-Symbol  : 'symbol';
+Of      : 'of';
+KeyOf   : 'keyof';
 
 TypeAlias: 'type';
 

--- a/javascript/typescript/examples/Enum.ts
+++ b/javascript/typescript/examples/Enum.ts
@@ -1,0 +1,5 @@
+enum Colors {
+  Red = "RED",
+  Green = "GREEN",
+  Blue = "BLUE"
+}

--- a/javascript/typescript/examples/Export.ts
+++ b/javascript/typescript/examples/Export.ts
@@ -1,6 +1,3 @@
-
-
-
 namespace StringUtility
 {
     function ToCapital(str: string): string {
@@ -17,4 +14,9 @@ namespace StringUtility
     export function Eported2(str: string, length: number = 0): string {
         return str.toUpperCase();
     }
+}
+
+export type MyType = {
+    field: number;
+    field2: string;
 }

--- a/javascript/typescript/examples/Function.ts
+++ b/javascript/typescript/examples/Function.ts
@@ -48,10 +48,16 @@ function buildName(firstName: string, lastName?: string) {
     else return firstName;
   }
 
-// Try passing a nested type to the function. This tests we don't match ">>" and ">>>" symbols.
+// Try passing a nested type to the function. This tests we don't match ">>" and ">>>" operators
+// when closing nested types.
 function nestedType(map: Map<string, Map<string, Set<string>>>) {
     // Check that we can parse these too.
     let a = 12;
     let b = a >> 5;
     let c = b >>> 5;
 }
+
+// Function parameter lists can have a trailing comma.
+// See https://github.com/Microsoft/TypeScript/issues/16152
+function TrailingComma(arg1: string, arg2: number,) {}
+var myFunction = function(arg1: string, arg2: number,) {};

--- a/javascript/typescript/examples/Generic.ts
+++ b/javascript/typescript/examples/Generic.ts
@@ -28,3 +28,8 @@ function displayNames<T>(names:T[]): void {
 function display<T extends Person>(per: T): void {
     console.log(`${ per.firstName} ${per.lastName}` );
 }
+
+function genericWithKeyOf<T, K extends keyof T>(list: T[], field: K): T[] {}
+
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#generic-parameter-defaults
+function genericParameterWithDefault<T = DefaultType>(field: T) {}

--- a/javascript/typescript/examples/Loop.ts
+++ b/javascript/typescript/examples/Loop.ts
@@ -16,3 +16,7 @@ for await (const document of array) {
 for await (const document: string of array) {
 
 };
+
+for (let [field, value] of Object.entries(object) as [string, any]) {
+
+};

--- a/javascript/typescript/examples/NonNullAssertOp.js
+++ b/javascript/typescript/examples/NonNullAssertOp.js
@@ -11,7 +11,9 @@ function processEntity(e?: Entity) {
   let s = e!.name;
   let t = e.name;
   let o = e!.obj!.i;
-  let p = e?.name;  
+  let p = e?.name;
+
+  let i = p!;
 }
 
 var e = null;

--- a/javascript/typescript/examples/ObjectInitializer.ts
+++ b/javascript/typescript/examples/ObjectInitializer.ts
@@ -10,3 +10,10 @@ let obj = { };
 obj = { item1: "item1", item2: "item2" };
 obj = { item1: "item1", item2: "item2", };
 
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#constant-named-properties
+const Foo = "Foo";
+const Bar = "Bar";
+let x = {
+  [Foo]: 100,
+  [Bar]: "hello"
+};

--- a/javascript/typescript/examples/Type.ts
+++ b/javascript/typescript/examples/Type.ts
@@ -1,10 +1,25 @@
 // TypeDefinition
+
+// TypeAlias
 type Employee = {
+     type: "employee" | "manager";
+     typeId: 1 | 2;
      id: string;
      name: string;
      address?: string; // Optional
      phone?: string | null;
-};
+}
+
+// https://github.com/microsoft/TypeScript/pull/12386
+type EmployeeType =
+     | "employee"
+     | "manager";
+
+type EmployeeNameType = Employee["name"];
+
+// keyof
+type EmployeeMap = Map<string, string>;
+type EmployeeMapKey = keyof EmployeeMap;
 
 // TypeAnotation
 var age: number = 32; // number variable
@@ -22,6 +37,8 @@ employee1 = {
 }
 
 var employee2: Employee = {
+    type: "employee",
+    typeId: 1,
     id: 101,
     name: "Steve"
 }


### PR DESCRIPTION
This PR upgrades compatibility to TypeScript v2.7. It also adds the `yield*` operator to JavaScript and JSX.

First some minor parsing improvements:

You can now name anonymous functions, e.g.

```
object = {
     field: function myFunction(arg1) { return arg1; }
}
```

Assertion typing (casting) is now supported in `for` statements, e.g.

```
let object = {"field1":5, "field2:"value"};
for (let [field, value] of Object.entries(object) as [string, any]) {
}
```

You can now export type aliases, e.g.

```
export type MyType = {
    field: number, 
    field2: string, 
}
```

(and they don't need to end with a semi-colon).

Union, intersection type aliases can now start with a leading | or &, e.g.

```
type EmployeeType =
     | "employee"
     | "manager";
```

See https://github.com/microsoft/TypeScript/pull/12386 

Tuples (and function parameter lists) can have a trailing comma:

```
[string, number,]
```

See https://github.com/Microsoft/TypeScript/issues/28893 

Upgrades based on TypeScript versions:

**TypeScript v0.9**

You can now declare namespaces, e.g.

```
declare namespace myLib {
}
```

See https://www.typescriptlang.org/docs/handbook/declaration-files/by-example.html

**TypeScript v1.8**

Boolean, number and string literal types are now supported, e.g.

```
export type CharityStatsJson = {
    type: "single" | "multi"; 
    type: 1 | 2; 
    type: false | 1 | 2; 
```

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#type-parameters-as-constraints

**TypeScript v2.0**

Added non-null assertion operator, e.g.

```
let s = e!.name; // Assert that e is non-null and access name
```

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator 

Added `undefined` type, e.g.

```
let y: number | undefined;
```

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#null--and-undefined-aware-types

Added `never` type, e.g.

```
function error(message: string): never {
  throw new Error(message);
}
```

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#the-never-type

**TypeScript v2.1**

Added `keyof` and indexed access types, e.g.

```
interface Person {
  name: string;
  age: number;
  location: string;
}
type Key = keyof Person; // "name" | "age" | "location"
type Age = Person["age"]; 
```

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html#keyof-and-lookup-types

**TypeScript v2.2**

Added `object` type, e.g.

```
declare function create(o: object | null): void;
```

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type

**TypeScript v2.3**

Added `yield*` operator to JavaScript, TypeScript & JSX.

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#generators

Added generic parameter defaults, e.g.

```
function genericParameterWithDefault<T = DefaultType>(field: T) {}
```

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#generic-parameter-defaults

**TypeScript v2.7**

Added `unique symbol` type, e.g.

`declare const Foo: unique symbol;`

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#unique-symbol