### PR TITLE
Update to dotnet version 8 (released in November '23).

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Dotnet
       uses: actions/setup-dotnet@v4.0.0
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Install Trash
       shell: bash
       run: |
@@ -73,7 +73,7 @@ jobs:
     - name: Install Dotnet
       uses: actions/setup-dotnet@v4.0.0
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Test Dotnet
       run: |
         dotnet --version
@@ -180,7 +180,7 @@ jobs:
     - name: Install Dotnet
       uses: actions/setup-dotnet@v4.0.0
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Test Dotnet
       run: |
         dotnet --version


### PR DESCRIPTION
Fix for https://github.com/antlr/grammars-v4/issues/3979. This change updates the version of dotnet to version 8. This will be required for new Trash tools.