### PR TITLE
[PlSql] Fix JSON_OBJECT to allow FORMAT JSON for all entry types

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6555,9 +6555,10 @@ json_object_content
     ;
 
 json_object_entry
-    : KEY? expression (VALUE | IS)? expression
-    | expression ':' expression (FORMAT JSON)?
-    | identifier
+    : (KEY? expression (VALUE | IS)? expression
+        | expression ':' expression
+        | identifier
+    ) (FORMAT JSON)?
     ;
 
 json_table_clause

--- a/sql/plsql/examples/json_sql.sql
+++ b/sql/plsql/examples/json_sql.sql
@@ -9,6 +9,8 @@ ORDER BY d.department_id;
 
 SELECT JSON_OBJECT(KEY 'VALUE' VALUE COL), t.*  FROM T t;
 
+SELECT JSON_OBJECT(KEY 'VALUE' VALUE COL FORMAT JSON), t.*  FROM T t;
+
 SELECT JSON_ARRAY (
                JSON_OBJECT('percentage' VALUE .50),
                JSON_ARRAY(1,2,3),


### PR DESCRIPTION
The format clause is allowed for all entry types
![image](https://github.com/antlr/grammars-v4/assets/692124/63a41616-57d7-4354-bb9a-cdd141477aca)
regular_entry ::=
![image](https://github.com/antlr/grammars-v4/assets/692124/1ded8122-e1c9-40d0-83ff-2619ec14f382)

See https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/JSON_OBJECT.html#GUID-1EF347AE-7FDA-4B41-AFE0-DD5A49E8B370