### PR TITLE
Improved support for computed arguments in both JavaScript and TypeScript.

### DIFF
--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -412,6 +412,7 @@ initializer
 
 assignable
     : identifier
+    | keyword
     | arrayLiteral
     | objectLiteral
     ;
@@ -427,7 +428,7 @@ anonymousFunction
     ;
 
 arrowFunctionParameters
-    : identifier
+    : propertyName
     | '(' formalParameterList? ')'
     ;
 

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -565,7 +565,7 @@ debuggerStatement
     ;
 
 functionDeclaration
-    : Async? Function_ identifier callSignature (('{' functionBody '}') | SemiColon)
+    : Async? Function_ '*'? identifier callSignature (('{' functionBody '}') | SemiColon)
     ;
 
 //Ovveride ECMA
@@ -613,7 +613,7 @@ indexMemberDeclaration
     ;
 
 generatorMethod
-    : (Async {this.notLineTerminator()}?)? '*'? identifier '(' formalParameterList? ')' '{' functionBody '}'
+    : (Async {this.notLineTerminator()}?)? '*'? propertyName '(' formalParameterList? ')' '{' functionBody '}'
     ;
 
 generatorFunctionDeclaration
@@ -653,7 +653,7 @@ formalParameterList
     ;
 
 formalParameterArg
-    : decorator? accessibilityModifier? identifierOrKeyWord '?'? typeAnnotation? (
+    : decorator? accessibilityModifier? assignable '?'? typeAnnotation? (
         '=' singleExpression
     )? // ECMAScript 6: Initialization
     ;
@@ -704,7 +704,7 @@ getAccessor
     ;
 
 setAccessor
-    : setter '(' (identifier | bindingPattern) typeAnnotation? ')' '{' functionBody '}'
+    : setter '(' formalParameterList? ')' '{' functionBody '}'
     ;
 
 propertyName
@@ -793,6 +793,13 @@ asExpression
     | singleExpression
     ;
 
+assignable
+    : identifier
+    | keyword
+    | arrayLiteral
+    | objectLiteral
+    ;
+
 anonymousFunction
     : functionDeclaration 
     | Async? Function_ '*'? '(' formalParameterList? ')' typeAnnotation? '{' functionBody '}'
@@ -804,7 +811,7 @@ arrowFunctionDeclaration
     ;
 
 arrowFunctionParameters
-    : identifier
+    : propertyName
     | '(' formalParameterList? ')'
     ;
 

--- a/javascript/typescript/examples/JavaScriptClass.js
+++ b/javascript/typescript/examples/JavaScriptClass.js
@@ -189,11 +189,12 @@ class B {
 }
 // extended object
 let Obj = {
-  // [asdfg](a){}, // @todo Support this...
+  [asdfg](a){},
+  y = ([x]: any) => x;
   * foo () {},
   f(){},
   get a(){},
-  // set a([aa]=123){}, @todo ... and this
+  set a([aa]=123){},
   ...anotherObj,
   ...{
     speradObjectLiteral

--- a/javascript/typescript/examples/JavaScriptClass.js
+++ b/javascript/typescript/examples/JavaScriptClass.js
@@ -190,7 +190,6 @@ class B {
 // extended object
 let Obj = {
   [asdfg](a){},
-  y = ([x]: any) => x;
   * foo () {},
   f(){},
   get a(){},

--- a/javascript/typescript/examples/Variable.ts
+++ b/javascript/typescript/examples/Variable.ts
@@ -57,3 +57,5 @@ const codesByType = Joi.object()
 
 const post = (...args: any[]) => {
 };
+
+const function = ([x]: any) => x;


### PR DESCRIPTION
Improved support for computed arguments in both JavaScript and TypeScript:

```
let reference = "...";
let object = {
  [reference](a){},
}
```
and
```
let y = ([reference]: any) => x;
```
and
```
let object = {
  set a([reference]=123){},
};
```

Can now use keywords as function parameter names, e.g 'this' here:

```
let a = {
   get: function(this: SVGElement) {
   }
}
```