### PR TITLE
[PlSql] Generate parser and lexer in non-default package

### DIFF
--- a/sql/plsql/Java/org/antlr/grammars/plsql/PlSqlLexerBase.java
+++ b/sql/plsql/Java/org/antlr/grammars/plsql/PlSqlLexerBase.java
@@ -1,3 +1,5 @@
+package org.antlr.grammars.plsql;
+
 import org.antlr.v4.runtime.*;
 
 public abstract class PlSqlLexerBase extends Lexer

--- a/sql/plsql/Java/org/antlr/grammars/plsql/PlSqlParserBase.java
+++ b/sql/plsql/Java/org/antlr/grammars/plsql/PlSqlParserBase.java
@@ -1,3 +1,5 @@
+package org.antlr.grammars.plsql;
+
 import org.antlr.v4.runtime.*;
 
 public abstract class PlSqlParserBase extends Parser

--- a/sql/plsql/pom.xml
+++ b/sql/plsql/pom.xml
@@ -46,7 +46,7 @@
 					<showTree>false</showTree>
 					<entryPoint>sql_script</entryPoint>
 					<grammarName>PlSql</grammarName>
-					<packageName></packageName>
+					<packageName>org.antlr.grammars.plsql</packageName>
 					<exampleFiles>examples/</exampleFiles>
 				</configuration>
 				<executions>
@@ -65,7 +65,7 @@
 							<showTree>false</showTree>
 							<entryPoint>sql_script</entryPoint>
 							<grammarName>PlSql</grammarName>
-							<packageName></packageName>
+							<packageName>org.antlr.grammars.plsql</packageName>
 							<exampleFiles>examples-sql-script/</exampleFiles>
 						</configuration>
 					</execution>

--- a/sql/plsql/pom.xml
+++ b/sql/plsql/pom.xml
@@ -24,6 +24,10 @@
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
+                    <arguments>
+                        <argument>-package</argument>
+                        <argument>org.antlr.grammars.plsql</argument>
+                    </arguments>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
When building a jar, the generated code should appear in a named Java package. Otherwise the classes cannot be imported from a named package.