### PR TITLE
[PlSql] Fix combination of JSON conditions with logical expressions

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6304,7 +6304,14 @@ seed_part
 // Expression & Condition
 
 condition
-    : expression
+    : condition_part
+    | condition AND condition
+    | condition OR condition
+    | '(' condition ')'
+    ;
+
+condition_part
+    : logical_expression
     | json_condition
     ;
 

--- a/sql/plsql/examples/json_sql.sql
+++ b/sql/plsql/examples/json_sql.sql
@@ -38,3 +38,7 @@ SELECT JSON_VALUE('{a:100}', '$.a') AS value FROM DUAL;
 SELECT JSON_VALUE('{"level": 10}', '$.level' RETURNING NUMBER) FROM DUAL;
 
 SELECT 1 FROM DUAL WHERE '{"a": 1, "b": [1, 2, 3]}' IS JSON;
+
+SELECT * FROM employees WHERE (doc IS JSON);
+
+SELECT * FROM employees WHERE dept = 2 AND (doc IS JSON);


### PR DESCRIPTION
Before this fix, we could not combine correctly logical expressions and JSON conditions with AND/OR operators.

Also, the condition now restricts the expression to be a logical expression. I am pretty sure it is correct since the other branch of `expression` is `cursor_expression` and it is clearly not usable as condition.

It also allows for parentheses around conditions. That was not supported for JSON conditions.
