### PR TITLE
[PlSql] Accept string concatenation and functions as LISTAGG delimiter

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6684,7 +6684,7 @@ other_function
     | COALESCE '(' table_element (',' (numeric | quoted_string))? ')'
     | COLLECT '(' (DISTINCT | UNIQUE)? concatenation collect_order_by_part? ')'
     | within_or_over_clause_keyword function_argument within_or_over_part+
-    | LISTAGG '(' (ALL | DISTINCT | UNIQUE)? argument (',' CHAR_STRING)? listagg_overflow_clause? ')' (
+    | LISTAGG '(' (ALL | DISTINCT | UNIQUE)? argument (',' string_delimiter)? listagg_overflow_clause? ')' (
         WITHIN GROUP '(' order_by_clause ')'
     )? over_clause?
     | cursor_name (PERCENT_ISOPEN | PERCENT_FOUND | PERCENT_NOTFOUND | PERCENT_ROWCOUNT)
@@ -6802,6 +6802,13 @@ collect_order_by_part
 within_or_over_part
     : WITHIN GROUP '(' order_by_clause ')'
     | over_clause
+    ;
+
+string_delimiter
+    : CHAR_STRING
+    | string_function
+    | string_delimiter BAR BAR string_delimiter
+    | '(' string_delimiter ')'
     ;
 
 cost_matrix_clause

--- a/sql/plsql/examples/analytic_query.sql
+++ b/sql/plsql/examples/analytic_query.sql
@@ -40,6 +40,12 @@ select deptno
      , listagg(UNIQUE edepartment, ',' ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as edepartments
 from emp;
 
+select deptno
+     , ename
+     , hiredate
+     , listagg(UNIQUE ename, (',') || TO_CHAR(13) ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as employees
+from emp;
+
  select metric_id ,bsln_guid ,timegroup ,obs_value as obs_value 
  , cume_dist () over (partition by metric_id, bsln_guid, timegroup order by obs_value ) as cume_dist 
  , count(1) over (partition by metric_id, bsln_guid, timegroup ) as n 


### PR DESCRIPTION
This fixes #3821 for usual string cases. It may still not cover all cases but as the specification is vague, we are in a best effort situation here. 
Common sense suggests that developers don't use very exotic constructs as string delimiters.