### PR TITLE
[PlSql] Add domain and qualifier to database links

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -4508,11 +4508,11 @@ security_clause
     ;
 
 domain
-    : regular_id
+    : id_expression
     ;
 
 database
-    : regular_id
+    : id_expression
     ;
 
 edition_name
@@ -4563,7 +4563,7 @@ replay_upgrade_clauses
     ;
 
 alter_database_link
-    : ALTER SHARED? PUBLIC? DATABASE LINK link_name (
+    : ALTER SHARED? PUBLIC? DATABASE LINK local_link_name (
         CONNECT TO user_object_name IDENTIFIED BY password_value link_authentication?
         | link_authentication
     )
@@ -4668,7 +4668,7 @@ drop_database
 
 // https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/CREATE-DATABASE-LINK.html
 create_database_link
-    : CREATE SHARED? PUBLIC? DATABASE LINK dblink (
+    : CREATE SHARED? PUBLIC? DATABASE LINK link_name (
         CONNECT TO (
             CURRENT_USER
             | user_object_name IDENTIFIED BY password_value link_authentication?
@@ -4677,12 +4677,8 @@ create_database_link
     )* (USING CHAR_STRING)?
     ;
 
-dblink
-    : database_name ('.' d = id_expression)* ('@' cq = id_expression)?
-    ;
-
 drop_database_link
-    : DROP PUBLIC? DATABASE LINK dblink
+    : DROP PUBLIC? DATABASE LINK link_name
     ;
 
 // https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ALTER-TABLESPACE-SET.html
@@ -7061,6 +7057,14 @@ collection_name
     ;
 
 link_name
+    : database ('.' domain)* (AT_SIGN connection_qualifier)?
+    ;
+
+local_link_name
+    : identifier
+    ;
+
+connection_qualifier
     : identifier
     ;
 
@@ -7070,7 +7074,7 @@ column_name
 
 tableview_name
     : identifier ('.' id_expression)? (
-        AT_SIGN link_name (PERIOD link_name)*
+        AT_SIGN link_name
         | /*TODO{!(input.LA(2) == BY)}?*/ partition_extension_clause
     )?
     | xmltable outer_join_sign?

--- a/sql/plsql/examples/dblink01.sql
+++ b/sql/plsql/examples/dblink01.sql
@@ -3,3 +3,5 @@ select last_name, department_name
    where employees.department_id = departments.department_id;
 
 SELECT * FROM scott.emp@hq.acme.com;
+
+SELECT * FROM scott.emp@hq.acme.com@dc1;


### PR DESCRIPTION
Database links are more than a single identifier:
![image](https://github.com/antlr/grammars-v4/assets/692124/c558e5c7-1aec-413c-af4d-8ae3a6ca9d10)
(see [Database Link Names](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Syntax-for-Schema-Objects-and-Parts-in-SQL-Statements.html#GUID-3B6E39A1-A538-4A8C-A314-932851A22777))

This was applied only for CREATE and DROP DATABASE LINK, with this PR this rule  applies everywhere where database links are accepted (FROM clause, procedure calls, ...).

Unified the existing `dblink` rule and reformatted it.

Only in ALTER DATABASE LINK, the name must be local, apparently. So `local_link_name` is introduced.