### PR TITLE
[build] Fix for #4008 -- add testing of TypeScript target back

### DIFF
--- a/_scripts/what-to-test.sh
+++ b/_scripts/what-to-test.sh
@@ -1,7 +1,7 @@
 #
 #set -x
 declare -A targets
-for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "PHP" "Python3" "TypeScript"
+for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "PHP" "Python3" "TypeScript" "Antlr4ng"
 do
     targets[$t]=0
 done
@@ -45,7 +45,7 @@ done
 
 ttargets=""
 # remove temporarily TODO add back: "TypeScript"
-for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "PHP" "Python3"
+for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "PHP" "Python3" "TypeScript" "Antlr4ng"
 do
     if [ ${targets[$t]} -ne 0 ]
     then

--- a/bison/desc.xml
+++ b/bison/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3</targets>
 </desc>

--- a/gvpr/desc.xml
+++ b/gvpr/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3</targets>
    <inputs>examples/*.gvpr</inputs>
 </desc>

--- a/python/python3/desc.xml
+++ b/python/python3/desc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.13.1</antlr-version>
-   <targets>Cpp;CSharp;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>Cpp;CSharp;Java;JavaScript;Python3</targets>
    <!-- fast parsers can work on a large test suite. -->
    <test>
       <targets>Cpp;CSharp;Java</targets>
@@ -10,7 +10,7 @@
    </test>
    <!-- slow parsers work only on a small test suite. -->
    <test>
-      <targets>JavaScript;Python3;TypeScript</targets>
+      <targets>JavaScript;Python3</targets>
       <entry-point>file_input</entry-point>
       <inputs>small</inputs>
    </test>

--- a/sql/plsql/desc.xml
+++ b/sql/plsql/desc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.12.0</antlr-version>
-   <targets>CSharp;Java;JavaScript;TypeScript;Python3</targets>
+   <targets>CSharp;Java;JavaScript;Python3</targets>
    <test>
       <name>hw</name>
-      <targets>JavaScript;TypeScript;Python3</targets>
+      <targets>JavaScript;Python3</targets>
       <inputs>hw-examples</inputs>
    </test>
    <test>


### PR DESCRIPTION
Fixes #4008.

* Add TypeScript testing.
* Add "Antlr4ng" TypeScript for testing that target in the future, as it is superior to Antlr 4.13.1. For example, inclusion of base classes is not possible with 4.13.1. And, it is not clear whether we will have another release of Antlr4, which would fix the issue. https://github.com/antlr/antlr4/pull/4492
* Remove testing of grammars that have TypeScript base class code as 4.13.1 does not work with these grammars.