### PR TITLE
[PlSql] Various fixes

### DIFF
--- a/sql/plsql/PlSqlLexer.g4
+++ b/sql/plsql/PlSqlLexer.g4
@@ -418,6 +418,7 @@ DELETEXML                      : 'DELETEXML';
 DEMAND                         : 'DEMAND';
 DENSE_RANKM                    : 'DENSE_RANKM';
 DEPENDENT                      : 'DEPENDENT';
+DEPRECATE                      : 'DEPRECATE';
 DEPTH                          : 'DEPTH';
 DEQUEUE                        : 'DEQUEUE';
 DEREF                          : 'DEREF';

--- a/sql/plsql/PlSqlLexer.g4
+++ b/sql/plsql/PlSqlLexer.g4
@@ -2511,7 +2511,7 @@ SPACES: [ \t\r\n]+ -> channel(HIDDEN);
 
 fragment NEWLINE_EOF    : NEWLINE | EOF;
 fragment QUESTION_MARK  : '?';
-fragment SIMPLE_LETTER  : [A-Z];
+fragment SIMPLE_LETTER  : [\p{Alpha}\p{General_Category=Other_Letter}];
 fragment FLOAT_FRAGMENT : UNSIGNED_INTEGER* '.'? UNSIGNED_INTEGER+;
 fragment NEWLINE        : '\r'? '\n';
 fragment SPACE          : [ \t];

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6814,6 +6814,7 @@ string_delimiter
     | string_function
     | string_delimiter BAR BAR string_delimiter
     | '(' string_delimiter ')'
+    | id_expression
     ;
 
 cost_matrix_clause

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -5505,7 +5505,7 @@ type_declaration
     ;
 
 table_type_def
-    : TABLE OF type_spec table_indexed_by_part? (NOT NULL_)?
+    : TABLE OF type_spec (NOT NULL_)? table_indexed_by_part?
     ;
 
 table_indexed_by_part

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6491,7 +6491,7 @@ searched_case_statement
     ;
 
 searched_case_when_part
-    : WHEN expression THEN (/*TODO{$case_statement::isStatement}?*/ seq_of_statements | expression)
+    : WHEN condition THEN (/*TODO{$case_statement::isStatement}?*/ seq_of_statements | expression)
     ;
 
 case_else_part

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -5481,6 +5481,7 @@ pragma_declaration
         | EXCEPTION_INIT '(' exception_name ',' numeric_negative ')'
         | INLINE '(' id1 = identifier ',' expression ')'
         | RESTRICT_REFERENCES '(' (identifier | DEFAULT) (',' identifier)+ ')'
+        | DEPRECATE '(' identifier ( ',' CHAR_STRING)? ')'
     ) ';'
     ;
 
@@ -7465,6 +7466,7 @@ regular_id
     | CASESENSITIVE
     | DECIMAL
     | DELETE
+    | DEPRECATE
     | DETERMINISTIC
     | DSINTERVAL_UNCONSTRAINED
     | DURATION

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6405,6 +6405,7 @@ concatenation
     | concatenation op = (ASTERISK | SOLIDUS | MOD) concatenation
     | concatenation op = (PLUS_SIGN | MINUS_SIGN) concatenation
     | concatenation BAR BAR concatenation
+    | concatenation COLLATE column_collation_name
     ;
 
 interval_expression

--- a/sql/plsql/examples/analytic_query.sql
+++ b/sql/plsql/examples/analytic_query.sql
@@ -46,6 +46,12 @@ select deptno
      , listagg(UNIQUE ename, (',') || TO_CHAR(13) ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as employees
 from emp;
 
+select deptno
+     , ename
+     , hiredate
+     , listagg(UNIQUE ename, d ON OVERFLOW TRUNCATE) within group (order by hiredate) over (partition by deptno) as employees
+from emp;
+
  select metric_id ,bsln_guid ,timegroup ,obs_value as obs_value 
  , cume_dist () over (partition by metric_id, bsln_guid, timegroup order by obs_value ) as cume_dist 
  , count(1) over (partition by metric_id, bsln_guid, timegroup ) as n 

--- a/sql/plsql/examples/case_when08.sql
+++ b/sql/plsql/examples/case_when08.sql
@@ -1,0 +1,5 @@
+select
+    case when doc is JSON then 'valid' else 'invalid' end
+    from persons p;
+
+       

--- a/sql/plsql/examples/create_package03.sql
+++ b/sql/plsql/examples/create_package03.sql
@@ -1,6 +1,8 @@
 CREATE OR REPLACE PACKAGE pkg_prc_with_properties AS
   PROCEDURE access_prc_with_properties;
 
+  PRAGMA DEPRECATE(prc_with_properties, 'no more supported');
+
   PROCEDURE prc_with_properties
     PARALLEL_ENABLE
     ACCESSIBLE BY (PROCEDURE access_prc_with_properties);

--- a/sql/plsql/examples/create_package05.sql
+++ b/sql/plsql/examples/create_package05.sql
@@ -11,7 +11,7 @@ create or replace package pkg_fun_with_streaming is
 
   type t_change_cur is ref cursor return t_change;
 
-  type t_message_tab is table of t_message;
+  type t_message_tab is table of t_message not null index by int;
 
 
   function prep_messages(p_changes t_change_cur)

--- a/sql/plsql/examples/lexer02.sql
+++ b/sql/plsql/examples/lexer02.sql
@@ -1,2 +1,3 @@
-select 'A' | | 'B'  from dual
+select 'A' | | 'B'  from dual;
 
+select a ä, b Ḅ from dual;

--- a/sql/plsql/examples/order_by04.sql
+++ b/sql/plsql/examples/order_by04.sql
@@ -1,1 +1,1 @@
-select * from dual order by a nulls first,  b nulls last
+select * from dual order by a nulls first,  b nulls last, substr(c, 1) collate generic_m


### PR DESCRIPTION
Submitting several small fixes in one PR. I hope it's ok.

- [PlSql] Use condition in CASE WHEN clause instead of expression
In the "search form", the WHEN clause evaluates a condition.
- [PlSql] Identifier as LISTAGG delimiter
Although undocumented, variables or other identifiers can be used as delimiter
- [PlSql] DEPRECATE Pragma
Was missing
- [PlSql] Add COLLATE as operator
Was missing
- [PlSql] Fix NOT NULL position in associative array declaration
Was at wrong place
- [PlSql] Allow unicode letters in identifiers
User-defined identifiers character set is actually the [database character set](https://docs.oracle.com/en/database/oracle/oracle-database/18/lnpls/plsql-language-fundamentals.html#GUID-321084DE-3BDD-484B-AE85-7A991B67C51A). It is probably a safe guess to accept only letter symbols.

With these last fixes, I am able to parse three decade-old application codebases summing up 600k lines code!