### PR TITLE
[PlSql] Fix compatibility with earlier JDK versions

### DIFF
--- a/sql/plsql/PlSqlLexer.g4
+++ b/sql/plsql/PlSqlLexer.g4
@@ -2512,7 +2512,7 @@ SPACES: [ \t\r\n]+ -> channel(HIDDEN);
 
 fragment NEWLINE_EOF    : NEWLINE | EOF;
 fragment QUESTION_MARK  : '?';
-fragment SIMPLE_LETTER  : [\p{Alpha}\p{General_Category=Other_Letter}];
+fragment SIMPLE_LETTER  : [\p{Alphabetic}\p{General_Category=Other_Letter}];
 fragment FLOAT_FRAGMENT : UNSIGNED_INTEGER* '.'? UNSIGNED_INTEGER+;
 fragment NEWLINE        : '\r'? '\n';
 fragment SPACE          : [ \t];


### PR DESCRIPTION
This fixes a small incompatibility identified with earlier versions of JDK17 where the using of just `\p{Alpha}` was not being recognized as it is on later JDK17 builds such as 17.0.10.

See comments from this discussion:
https://github.com/Naros/grammars-v4/commit/d3ab3347aa42e53643d96ebd5bfcfe5121320dc8#commitcomment-139821784

@lbovet @KvanTTT this is the fix as I showed in the above discussion, feel free to share your opinions.