### PR TITLE
Enable testing of grammars with Antlr4ng

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,12 +124,10 @@ jobs:
       run: |
          pip install antlr4-tools
     - name: Install JavaScript
-      if: ${{ matrix.language == 'JavaScript' }}
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: '16.13.0'
+        node-version: '21.7.1'
     - name: Test JavaScript
-      if: ${{ matrix.language == 'JavaScript' }}
       run: |
         node --version
     - name: Update paths

--- a/_scripts/templates/Antlr4ng/package.json
+++ b/_scripts/templates/Antlr4ng/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "i",
+  "version": "1.0.0",
+  "description": "",
+  "main": "Test.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "antlr4ng": "^3.0.4",
+    "buffer": "^6.0.3",
+    "fs-extra": "^11.1.1",
+    "timer-node": "^5.0.6",
+    "typescript-string-operations": "^1.5.0"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@types/node": "^20.2.5"
+  }
+}

--- a/_scripts/templates/Antlr4ng/package.json
+++ b/_scripts/templates/Antlr4ng/package.json
@@ -9,7 +9,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4ng": "^3.0.4",
+    "antlr4ng": "3.0.4",
+    "antlr4ng-cli": "2.0.0",
     "buffer": "^6.0.3",
     "fs-extra": "^11.1.1",
     "timer-node": "^5.0.6",

--- a/_scripts/templates/Antlr4ng/st.Test.ts
+++ b/_scripts/templates/Antlr4ng/st.Test.ts
@@ -1,0 +1,225 @@
+// Generated from trgen <version>
+
+import { ATNSimulator } from 'antlr4ng';
+import { CharStream } from 'antlr4ng';
+import { CommonTokenStream } from 'antlr4ng';
+import { ConsoleErrorListener } from 'antlr4ng';
+import { BaseErrorListener } from 'antlr4ng';
+//import { InputStream } from 'antlr4ng';
+import { Recognizer } from 'antlr4ng';
+import { RecognitionException } from 'antlr4ng';
+import { Token } from 'antlr4ng';
+import { readFileSync } from 'fs';
+import { writeFileSync } from 'fs';
+import { openSync } from 'fs';
+import { readSync } from 'fs';
+import { writeSync } from 'fs';
+import { closeSync } from 'fs';
+import { readFile } from 'fs/promises'
+
+<tool_grammar_tuples: {x | import { <x.GrammarAutomName> \} from './<x.GrammarAutomName>.js';
+} >
+import { StringBuilder, emptyString, joinString, formatString, isNullOrWhiteSpace } from 'typescript-string-operations';
+import { Timer, Time, TimerOptions } from 'timer-node';
+
+
+function getChar() {
+    let buffer = Buffer.alloc(1);
+    var xx = 0;
+    try {
+        xx = readSync(0, buffer, 0, 1, null);
+    } catch (err) {
+    }
+    if (xx === 0) {
+        return '';
+    }
+    return buffer.toString('utf8');
+}
+
+
+class MyErrorListener\<T  extends ATNSimulator> extends ConsoleErrorListener {
+    _quiet: boolean;
+    _tee: boolean;
+    _output: any;
+    had_error: boolean;
+
+    constructor(quiet: boolean, tee: boolean, output: any) {
+        super();
+        this._quiet = quiet;
+        this._tee = tee;
+        this._output = output;
+        this.had_error = false;
+    }
+
+    syntaxError\<T extends ATNSimulator>(recognizer: Recognizer\<T> | null, offendingSymbol: unknown, line: number, column: number, msg: string | null, e: RecognitionException | null): void {
+        this.had_error = true;
+        if (this._tee) {
+            writeSync(this._output, `line ${line}:${column} ${msg}\n`);
+        }
+        if (!this._quiet) {
+            console.error(`line ${line}:${column} ${msg}`);
+        }
+    }
+}
+
+var tee = false;
+var show_profile = false;
+var show_tree = false;
+var show_tokens = false;
+var show_trace = false;
+var error_code = 0;
+var quiet = false;
+var enc = 'utf8';
+var string_instance = 0;
+var prefix = '';
+var inputs: string[] = [];
+var is_fns: boolean[] = [];
+
+function splitLines(t: string) { return t.split(/\r\n|\r|\n/); }
+
+function main() {
+    for (let i = 2; i \<process.argv.length; ++i)
+    {
+        switch (process.argv[i]) {
+            case '-tokens':
+                show_tokens = true;
+                break;
+            case '-tree':
+                show_tree = true;
+                break;
+            case '-prefix':
+                prefix = process.argv[++i] + ' ';
+                break;
+            case '-input':
+                inputs.push(process.argv[++i]);
+                is_fns.push(false);
+                break;
+            case '-tee':
+                tee = true;
+                break;
+            case '-encoding':
+                enc = process.argv[++i];
+                break;
+            case '-x':
+                var sb = new StringBuilder();
+                var ch;
+                while ((ch = getChar()) != '') {
+                    sb.Append(ch);
+                }
+                var input = sb.ToString();
+                var sp = splitLines(input);
+                for (var ii of sp) {
+                    if (ii == '') continue;
+                    inputs.push(ii);
+                    is_fns.push(true);
+                }
+                break;
+            case '-q':
+                quiet = true;
+                break;
+            case '-trace':
+                show_trace = true;
+                break;
+            default:
+                inputs.push(process.argv[i]);
+                is_fns.push(true);
+                break;
+        }
+    }
+    if (inputs.length == 0) {
+        ParseStdin();
+    }
+    else {
+        const timer = new Timer({ label: 'test-timer' });
+        timer.start();
+        for (var f = 0; f \<inputs.length; ++f)
+        {
+            if (is_fns[f])
+                ParseFilename(inputs[f], f);
+            else
+                ParseString(inputs[f], f);
+        }
+        timer.stop();
+        var t = timer.time().m * 60 + timer.time().s + timer.time().ms / 1000;
+        if (!quiet) console.error('Total Time: ' + t);
+    }
+    process.exitCode = error_code;
+}
+
+function ParseStdin() {
+    var sb = new StringBuilder();
+    var ch;
+    while ((ch = getChar()) != '') {
+        sb.Append(ch);
+    }
+    var input = sb.ToString();
+    var str = CharStream.fromString(input);
+    DoParse(str, "stdin", 0);
+}
+
+function ParseString(input: string, row_number: number) {
+    var str = CharStream.fromString(input);
+    DoParse(str, "string" + string_instance++, row_number);
+}
+
+function ParseFilename(input: string, row_number: number) {
+    var buffer = readFileSync(input, { encoding: enc as BufferEncoding });
+    var str = CharStream.fromString(buffer);
+    DoParse(str, input, row_number);
+}
+
+function DoParse(str: CharStream, input_name: string, row_number: number) {
+    const lexer = new <lexer_name>(str);
+    const tokens = new CommonTokenStream(lexer);
+    const parser = new <parser_name>(tokens);
+    lexer.removeErrorListeners();
+    parser.removeErrorListeners();
+    var output = tee ? openSync(input_name + ".errors", 'w') : 1;
+    var listener_parser = new MyErrorListener(quiet, tee, output);
+    var listener_lexer = new MyErrorListener(quiet, tee, output);
+    parser.addErrorListener(listener_parser);
+    lexer.addErrorListener(listener_lexer);
+    if (show_tokens) {
+        for (var i = 0; ; ++i) {
+            var ro_token = lexer.nextToken();
+            var token = ro_token;
+            token.tokenIndex = i;
+            console.error(token.toString());
+            if (token.type === Token.EOF)
+                break;
+        }
+//        lexer.reset();
+    }
+    if (show_trace) {
+//       parser._interp.trace_atn_sim = true;
+    }
+    const timer = new Timer({ label: 'test-timer2' });
+    timer.start();
+    const tree = parser.<start_symbol>();
+    timer.stop();
+    var result = "";
+    if (listener_parser.had_error || listener_lexer.had_error) {
+        result = 'fail';
+        error_code = 1;
+    }
+    else {
+        result = 'success';
+    }
+    var t = timer.time().m * 60 + timer.time().s + timer.time().ms / 1000;
+    if (show_tree) {
+        if (tee) {
+            writeFileSync(input_name + ".tree", tree.toStringTree(parser.ruleNames, parser));
+        } else {
+            console.error(tree.toStringTree(parser.ruleNames, parser));
+        }
+    }
+    if (!quiet) {
+        console.error(prefix + 'TypeScript ' + row_number + ' ' + input_name + ' ' + result + ' ' + t);
+    }
+    if (tee) {
+        closeSync(output);
+    }
+}
+
+
+main()

--- a/_scripts/templates/Antlr4ng/st.build.ps1
+++ b/_scripts/templates/Antlr4ng/st.build.ps1
@@ -4,19 +4,6 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
-# Because there is no integrated build script for Dart targets, we need
-# to manually look at the version in package.json and extract the
-# version number. We can then use this with antlr4 to generate the
-# parser and lexer.
-$version = (Select-String -Path "package.json" -Pattern "antlr4" | ForEach-Object {$_.Line.Split(" ")[5]}) -replace '"|,|\r|\n'
-
-<tool_grammar_tuples:{x |
-$(& java -jar ./node_modules/antlr4ng-cli/*.jar <x.GrammarFileName> -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
-if($compile_exit_code -ne 0){
-    exit $compile_exit_code
-\}
-}>
-
 $(& npm install -g typescript ts-node ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
 if($compile_exit_code -ne 0){
     exit $compile_exit_code
@@ -26,6 +13,13 @@ $(& npm install ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
 if($compile_exit_code -ne 0){
     exit $compile_exit_code
 \}
+
+<tool_grammar_tuples:{x |
+$(& java -jar ./node_modules/antlr4ng-cli/*.jar <x.GrammarFileName> -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+if($compile_exit_code -ne 0){
+    exit $compile_exit_code
+\}
+}>
 
 $(& tsc -p tsconfig.json --pretty ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
 

--- a/_scripts/templates/Antlr4ng/st.build.ps1
+++ b/_scripts/templates/Antlr4ng/st.build.ps1
@@ -14,8 +14,9 @@ if($compile_exit_code -ne 0){
     exit $compile_exit_code
 \}
 
+$jarFile = Get-ChildItem ./node_modules/antlr4ng-cli/*.jar
 <tool_grammar_tuples:{x |
-$(& java -jar ./node_modules/antlr4ng-cli/*.jar <x.GrammarFileName> -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+$(& java -jar $jarFile.FullName <x.GrammarFileName> -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 if($compile_exit_code -ne 0){
     exit $compile_exit_code
 \}

--- a/_scripts/templates/Antlr4ng/st.build.ps1
+++ b/_scripts/templates/Antlr4ng/st.build.ps1
@@ -1,0 +1,32 @@
+# Generated from trgen <version>
+
+if (Test-Path -Path transformGrammar.py -PathType Leaf) {
+    $(& python3 transformGrammar.py ) 2>&1 | Write-Host
+}
+
+# Because there is no integrated build script for Dart targets, we need
+# to manually look at the version in package.json and extract the
+# version number. We can then use this with antlr4 to generate the
+# parser and lexer.
+$version = (Select-String -Path "package.json" -Pattern "antlr4" | ForEach-Object {$_.Line.Split(" ")[5]}) -replace '"|,|\r|\n'
+
+<tool_grammar_tuples:{x |
+$(& java -jar ./node_modules/antlr4ng-cli/*.jar <x.GrammarFileName> -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+if($compile_exit_code -ne 0){
+    exit $compile_exit_code
+\}
+}>
+
+$(& npm install -g typescript ts-node ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+if($compile_exit_code -ne 0){
+    exit $compile_exit_code
+\}
+
+$(& npm install ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+if($compile_exit_code -ne 0){
+    exit $compile_exit_code
+\}
+
+$(& tsc -p tsconfig.json --pretty ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+
+exit $compile_exit_code

--- a/_scripts/templates/Antlr4ng/st.build.sh
+++ b/_scripts/templates/Antlr4ng/st.build.sh
@@ -1,0 +1,20 @@
+# Generated from trgen <version>
+set -e
+rm -rf node_modules package-lock.json
+npm install -g typescript ts-node
+npm install
+
+if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
+
+# Because there is no integrated build script for Dart targets, we need
+# to manually look at the version in package.json and extract the
+# version number. We can then use this with antlr4 to generate the
+# parser and lexer.
+version=`grep antlr4 package.json | awk '{print $2}' | tr -d '"' | tr -d ',' | tr -d '\r' | tr -d '\n'`
+
+<tool_grammar_tuples:{x |
+java -jar ./node_modules/antlr4ng-cli/*.jar -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
+} >
+
+tsc -p tsconfig.json --pretty
+exit 0

--- a/_scripts/templates/Antlr4ng/st.clean.ps1
+++ b/_scripts/templates/Antlr4ng/st.clean.ps1
@@ -1,0 +1,17 @@
+# Generated from trgen <version>
+$(& Remove-Item *.interp -Recurse -Force ) 2>&1 | Out-Null
+$files = New-Object System.Collections.Generic.List[string]
+<tool_grammar_tuples:{x |
+$f = java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
+foreach ($s in $f) {
+    $j = $s.Split(" ")[0]
+    $files.Add($j)
+\}
+foreach ($f in $files)
+{
+    $(& Remove-Item $f -Force ) 2>&1 | Out-Null
+\}
+} >
+$(& Remove-Item node_modules -Recurse -Force ) 2>&1 | Out-Null
+$(& Remove-Item package-lock.json -Recurse -Force ) 2>&1 | Out-Null
+exit 0

--- a/_scripts/templates/Antlr4ng/st.clean.sh
+++ b/_scripts/templates/Antlr4ng/st.clean.sh
@@ -1,0 +1,12 @@
+# Generated from trgen <version>
+rm -f *.interp
+files=()
+<tool_grammar_tuples:{x |
+files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+} >
+for i in ${files[*]}
+do
+    rm -f $i
+done
+rm -rf node_modules package-lock.json
+exit 0

--- a/_scripts/templates/Antlr4ng/st.makefile
+++ b/_scripts/templates/Antlr4ng/st.makefile
@@ -1,0 +1,8 @@
+# Generated from trgen <version>
+build: FORCE
+	bash build.sh
+clean: FORCE
+	bash clean.sh
+FORCE: ;
+test: FORCE
+	bash test.sh

--- a/_scripts/templates/Antlr4ng/st.perf.sh
+++ b/_scripts/templates/Antlr4ng/st.perf.sh
@@ -1,0 +1,50 @@
+# Generated from trgen <version>
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if the test file directory does not exist, or it is just
+# an empty directory.
+if [ ! -d ../<example_files_unix> ]
+then
+    echo "No test cases provided."
+    exit 0
+elif [ ! "$(ls -A ../<example_files_unix>)" ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
+
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+
+# Get a list of test files from the test directory. Do not include any
+# .errors or .tree files. Pay close attention to remove only file names
+# that end with the suffix .errors or .tree.
+files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files=()
+for f in $files2
+do
+    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ "$?" = "0" ]
+    then
+        files+=( $f )
+    fi
+done
+
+# Parse all input files.
+# Individual parsing.
+rm -f parse.txt
+for f in ${files[*]}
+do
+    trwdog sh -c "ts-node Test.js -prefix individual $f" >> parse.txt 2>&1
+    xxx="$?"
+    if [ "$xxx" -ne 0 ]
+    then
+        status="$xxx"
+    fi
+done
+# Group parsing.
+echo "${files[*]}" | trwdog sh -c "ts-node Test.js -x -prefix group" >> parse.txt 2>&1
+status=$?
+
+exit 0

--- a/_scripts/templates/Antlr4ng/st.run.sh
+++ b/_scripts/templates/Antlr4ng/st.run.sh
@@ -1,0 +1,19 @@
+# Generated from trgen <version>
+set -e
+# set -x
+
+# ts-node is a bash script, so duplicate that code and call node via trwdog.
+tsnode=`which ts-node`
+
+basedir=$(dirname "$(echo "$tsnode" | sed -e 's,\\\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node" "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
+else 
+  exec node "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
+fi
+exit $?

--- a/_scripts/templates/Antlr4ng/st.test.ps1
+++ b/_scripts/templates/Antlr4ng/st.test.ps1
@@ -1,0 +1,180 @@
+# Generated from trgen <version>
+
+$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
+Write-Host "Test cases here: $Tests"
+
+# Get a list of test files from the test directory. Do not include any
+# .errors or .tree files. Pay close attention to remove only file names
+# that end with the suffix .errors or .tree.
+if (Test-Path -Path "tests.txt" -PathType Leaf) {
+    Remove-Item "tests.txt"
+}
+$files = New-Object System.Collections.Generic.List[string]
+$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+foreach ($file in $allFiles) {
+    $ext = $file | Split-Path -Extension
+    if (Test-Path $file -PathType Container) {
+        continue
+    } elseif ($ext -eq ".errors") {
+        continue
+    } elseif ($ext -eq ".tree") {
+        continue
+    } else {
+        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        if ($last -ne 0)
+        {
+            continue
+        }
+        $files.Add($file)
+        Write-Host "Test case: $file"
+    }
+}
+foreach ($file in $files) {
+    Add-Content "tests.txt" $file
+}
+if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+
+# Parse all input files.
+<if(individual_parsing)>
+# Individual parsing.
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- pwsh -command "ts-node Test.js -q -tee -tree $_" *>> parse.txt }
+<else>
+# Group parsing.
+get-content "tests.txt" | dotnet trwdog -- pwsh -command "ts-node Test.js -q -x -tee -tree" *> parse.txt
+$status=$LASTEXITCODE
+<endif>
+
+# trwdog returns 255 if it cannot spawn the process. This could happen
+# if the environment for running the program does not exist, or the
+# program did not build.
+if ( $status -eq 255 ) {
+    Write-Host "Test failed."
+    Get-Content $file | Write-Host
+    exit 1
+}
+
+# Any parse errors will be put in .errors files. But, if there's any
+# output from the program in stdout or stderr, it's all bad news.
+$size = (Get-Item -Path "parse.txt").Length
+if ( $size -eq 0 ) {
+} else {
+    Write-Host "Test failed."
+    Get-Content "parse.txt" | Write-Host
+    exit 1
+}
+
+$old = Get-Location
+Set-Location ..
+
+# Check if any .errors/.tree files have changed. That's not good.
+git config --global pager.diff false
+Remove-Item -Force -Path $old/updated.txt -errorAction ignore 2>&1 | Out-Null
+$updated = 0
+foreach ($item in Get-ChildItem . -Recurse) {
+    $file = $item.fullname
+    $ext = $item.Extension
+    if ($ext -eq ".errors") {
+        git diff --exit-code $file *>> $old/updated.txt
+	$st = $LASTEXITCODE
+        if ($st -ne 0) {
+            $updated = $st
+        }
+    }
+}
+foreach ($item in Get-ChildItem . -Recurse) {
+    $file = $item.fullname
+    $ext = $item.Extension
+    if ($ext -eq ".tree") {
+        git diff --exit-code $file *>> $old/updated.txt
+	$st = $LASTEXITCODE
+        if ($st -ne 0) {
+            $updated = $st
+        }
+    }
+}
+
+# Check if any untracked .errors files are not empty.
+$new_errors_txt = New-Object System.Collections.Generic.List[string]
+$new_errors2_txt = git ls-files --exclude-standard -o $TestDirectory
+$new_errors = $LASTEXITCODE
+
+# Gather up all untracked .errors file output. These are new errors
+# and must be reported as a parse fail.
+if ( ! [String]::IsNullOrWhiteSpace($new_errors2_txt) ) {
+    $new_errors3_txt = $new_errors2_txt.Split("\n\r\t ")
+} else {
+    $new_errors3_txt = [System.Collections.Arraylist]@()
+}
+if (Test-Path -Path "$old/new_errors.txt" -PathType Leaf) {
+    Remove-Item "$old/new_errors.txt"
+}
+New-Item -Path "$old" -Name "new_errors.txt" -ItemType "file" -Value "" | Out-Null
+foreach ($s in $new_errors3_txt) {
+    if ( [String]::IsNullOrWhiteSpace($s) ) {
+        continue
+    }
+    $ext = $item.Extension
+    if (! $s.EndsWith(".errors")) {
+        continue
+    }
+    $file = $s
+    $size = (Get-Item -Path $file).Length
+    if ( $size -eq 0 ) {
+    } else {
+        $new_errors_txt.Add($item)
+        Add-Content -Path "$old/new_errors.txt" -Value "$item"
+        ((Get-Content $file) -join "`n") + "`n" | Add-Content -Path "$old/new_errors.txt"
+    }
+}
+
+# If "git diff" reported an exit code of 129, it is because
+# the directory containing the grammar is not in a repo. In this
+# case, assume parse error code as the defacto result.
+if ( $updated -eq 129 ) {
+    Write-Host "Grammar outside a git repository. Assuming parse exit code."
+    if ( $status -eq 0 ) {
+        Write-Host "Test succeeded."
+    } else {
+        Get-Content "$old/new_errors.txt" | Write-Host
+        Write-Host "Test failed."
+    }
+    Remove-Item -Force -Path $old/updated.txt -errorAction ignore 2>&1 | Out-Null
+    Remove-Item -Force -Path $old/new_errors2.txt -errorAction ignore 2>&1 | Out-Null
+    Remove-Item -Force -Path $old/new_errors.txt -errorAction ignore 2>&1 | Out-Null
+    $err = $status
+    exit 1
+}
+
+# "Git diff" reported a difference. Redo the "git diff" to print out all
+# the differences. Also, output any untracked, non-zero length .errors files.
+if ( $updated -eq 1 ) {
+    Write-Host "Difference in output."
+    git diff . | Write-Host
+    Get-Content "$old/new_errors.txt" | Write-Host
+    Write-Host "Test failed."
+    Remove-Item -Force -Path $old/updated.txt -errorAction ignore 2>&1 | Out-Null
+    Remove-Item -Force -Path $old/new_errors2.txt -errorAction ignore 2>&1 | Out-Null
+    Remove-Item -Force -Path $old/new_errors.txt -errorAction ignore 2>&1 | Out-Null
+    exit 1
+}
+
+# If there's non-zero length .errors flies that are new, report them
+# as errors in the parse.
+if ( $new_errors_txt.Count -gt 0 ) {
+    Write-Host "New errors in output."
+    Get-Content "$old/new_errors.txt" | Write-Host
+    Write-Host "Test failed."
+    Remove-Item -Force -Path $old/updated.txt -errorAction ignore 2>&1 | Out-Null
+    Remove-Item -Force -Path $old/new_errors2.txt -errorAction ignore 2>&1 | Out-Null
+    Remove-Item -Force -Path $old/new_errors.txt -errorAction ignore 2>&1 | Out-Null
+    exit 1
+}
+
+Write-Host "Test succeeded."
+Remove-Item -Force -Path $old/updated.txt -errorAction ignore 2>&1 | Out-Null
+Remove-Item -Force -Path $old/new_errors2.txt -errorAction ignore 2>&1 | Out-Null
+Remove-Item -Force -Path $old/new_errors.txt -errorAction ignore 2>&1 | Out-Null
+exit 0

--- a/_scripts/templates/Antlr4ng/st.test.ps1
+++ b/_scripts/templates/Antlr4ng/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Antlr4ng/st.test.sh
+++ b/_scripts/templates/Antlr4ng/st.test.sh
@@ -1,0 +1,201 @@
+# Generated from trgen <version>
+
+# comment for local dotnet tools.
+global=1
+
+# glob patterns
+shopt -s globstar
+
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+
+# Get a list of test files from the test directory. Do not include any
+# .errors or .tree files. Pay close attention to remove only file names
+# that end with the suffix .errors or .tree.
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+
+files=()
+for f in $files2
+do
+    if [ -d "$f" ]; then continue; fi
+    if [ "$global" == "" ]
+    then
+        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    else
+        triconv -f utf-8 $f > /dev/null 2>&1
+    fi
+    if [ "$?" = "0" ]
+    then
+        files+=( $f )
+    fi
+done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
+
+# Parse all input files.
+<if(individual_parsing)>
+# Individual parsing.
+rm -f parse.txt
+for f in ${files[*]}
+do
+    if [ "$global" == "" ]
+    then
+        dotnet trwdog -- sh -c "ts-node Test.js -q -tee -tree $f" >> parse.txt 2>&1
+    else
+        trwdog sh -c "ts-node Test.js -q -tee -tree $f" >> parse.txt 2>&1
+    fi
+    xxx="$?"
+    if [ "$xxx" -ne 0 ]
+    then
+        status="$xxx"
+    fi
+done
+<else>
+# Group parsing.
+if [ "$global" == "" ]
+then
+    echo "${files[*]}" | dotnet trwdog -- sh -c "ts-node Test.js -q -x -tee -tree" > parse.txt 2>&1
+else
+    echo "${files[*]}" | trwdog sh -c "ts-node Test.js -q -x -tee -tree" > parse.txt 2>&1
+fi
+status="$?"
+<endif>
+
+# trwdog returns 255 if it cannot spawn the process. This could happen
+# if the environment for running the program does not exist, or the
+# program did not build.
+if [ "$status" = "255" ]
+then
+    echo "Test failed."
+    cat parse.txt
+    exit 1
+fi
+
+# Any parse errors will be put in .errors files. But, if there's any
+# output from the program in stdout or stderr, it's all bad news.
+if [ -s parse.txt ]
+then
+    echo "Test failed."
+    cat parse.txt
+    exit 1
+fi
+
+# rm -rf `find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree' -size 0`
+
+# For Unix environments, convert the newline in the .errors and .trees
+# to Unix style.
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     machine=Linux;;
+    Darwin*)    machine=Mac;;
+    CYGWIN*)    machine=Cygwin;;
+    MINGW*)     machine=MinGw;;
+    *)          machine="UNKNOWN:${unameOut}"
+esac
+if [[ "$machine" == "MinGw" || "$machine" == "Msys" || "$machine" == "Cygwin" || "#machine" == "Linux" ]]
+then
+    gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
+    if [ "$gen" != "" ]
+    then
+        dos2unix $gen
+    fi
+fi
+
+old=`pwd`
+cd ..
+
+# Check if any files in the test files directory have changed.
+git config --global pager.diff false
+rm -f $old/updated.txt
+updated=0
+for f in `find . -name '*.errors'`
+do
+    git diff --exit-code $f >> $old/updated.txt 2>&1
+    xxx=$?
+    if [ "$xxx" -ne 0 ]
+    then
+        updated=$xxx
+    fi
+done
+for f in `find . -name '*.tree'`
+do
+    git diff --exit-code $f >> $old/updated.txt 2>&1
+    xxx=$?
+    if [ "$xxx" -ne 0 ]
+    then
+        updated=$xxx
+    fi
+done
+
+# Check if any untracked .errors files.
+git ls-files --exclude-standard -o > $old/new_errors2.txt 2>&1
+new_errors=$?
+
+# Gather up all untracked .errors file output. These are new errors
+# and must be reported as a parse fail.
+rm -f $old/new_errors.txt
+touch $old/new_errors.txt
+for f in `cat $old/new_errors2.txt`
+do
+    ext=${f##*.}
+    ext=".$ext"
+    if [ "$ext" = ".errors" ]
+    then  
+        if [ -s $f ]
+        then
+            echo $f >> $old/new_errors.txt
+            cat $f >> $old/new_errors.txt
+        fi
+    fi
+done
+
+# If "git diff" reported an exit code of 129, it is because
+# the directory containing the grammar is not in a repo. In this
+# case, assume parse error code as the defacto result.
+if [ "$updated" = "129" ]
+then
+    echo "Grammar outside a git repository. Assuming parse exit code."
+    if [ "$status" = 0 ]
+    then
+        echo "Test succeeded."
+    else
+        cat $old/new_errors.txt
+        echo "Test failed."
+    fi
+    rm -f $old/updated.txt $old/new_errors2.txt $old/new_errors.txt
+    exit $status
+fi
+
+# "Git diff" reported a difference. Redo the "git diff" to print out all
+# the differences. Also, output any untracked, non-zero length .errors files.
+if [ "$updated" = "1" ]
+then
+    echo "Difference in output."
+    git diff .
+    cat $old/new_errors.txt
+    echo "Test failed."
+    rm -f $old/updated.txt $old/new_errors2.txt $old/new_errors.txt
+    exit 1
+fi
+
+# If there's non-zero length .errors flies that are new, report them
+# as errors in the parse.
+if [ -s $old/new_errors.txt ]
+then
+    echo "New errors in output."
+    cat $old/new_errors.txt
+    echo "Test failed."
+    rm -f $old/updated.txt $old/new_errors2.txt $old/new_errors.txt
+    exit 1
+fi
+
+echo "Test succeeded."
+rm -f $old/updated.txt $old/new_errors2.txt $old/new_errors.txt
+exit 0

--- a/_scripts/templates/Antlr4ng/tsconfig.json
+++ b/_scripts/templates/Antlr4ng/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ESNext",
+  },
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
+}

--- a/_scripts/templates/CSharp/Other.csproj
+++ b/_scripts/templates/CSharp/Other.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version ="4.13.1" />
-    <PackageReference Include="Antlr4BuildTasks" Version="12.5.0" PrivateAssets="all" />
+    <PackageReference Include="Antlr4BuildTasks" Version="12.5" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/_scripts/templates/CSharp/Test.csproj.st
+++ b/_scripts/templates/CSharp/Test.csproj.st
@@ -1,7 +1,7 @@
 \<!-- Generated from trgen <version> -->
 \<Project Sdk="Microsoft.NET.Sdk" >
   \<PropertyGroup>
-    \<TargetFramework>net7.0\</TargetFramework>
+    \<TargetFramework>net8.0\</TargetFramework>
     \<OutputType>Exe\</OutputType>
     \<ProduceReferenceAssembly>false\</ProduceReferenceAssembly>
   \</PropertyGroup>
@@ -31,7 +31,7 @@ do
   if [ "$x1" != "errors" ]
   then
     echo $file
-    cat $file | bin/Debug/net7.0/Test
+    cat $file | bin/Debug/net8.0/Test
     status="$?"
     if [ -f "$file".errors ]
     then
@@ -67,7 +67,7 @@ for %%G in (..\\<example_files_win>\*) do (
   set X3=%%~pG
   if !X1! neq .errors (
     echo !FILE!
-    cat !FILE! | bin\Debug\net7.0\Test.exe
+    cat !FILE! | bin\Debug\net8.0\Test.exe
     if not exist !FILE!.errors (
       if ERRORLEVEL 1 set ERR=1
     ) else (

--- a/_scripts/templates/CSharp/st.perf.sh
+++ b/_scripts/templates/CSharp/st.perf.sh
@@ -41,7 +41,7 @@ do
     # Loop from 1 to n and execute the body of the loop each time
     for ((i=1; i\<=n; i++))
     do
-        trwdog ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -prefix individual $f >> parse.txt 2>&1
+        trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -prefix individual $f >> parse.txt 2>&1
         xxx="$?"
         if [ "$xxx" -ne 0 ]
         then
@@ -53,7 +53,7 @@ done
 # Loop from 1 to n and execute the body of the loop each time
 for ((i=1; i\<=n; i++))
 do
-    echo "${files[*]}" | trwdog ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -x -prefix group >> parse.txt 2>&1
+    echo "${files[*]}" | trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -x -prefix group >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then

--- a/_scripts/templates/CSharp/st.run.ps1
+++ b/_scripts/templates/CSharp/st.run.ps1
@@ -1,1 +1,1 @@
-./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> $args
+./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> $args

--- a/_scripts/templates/CSharp/st.run.sh
+++ b/_scripts/templates/CSharp/st.run.sh
@@ -1,1 +1,1 @@
-./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> "$@"
+./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> "$@"

--- a/_scripts/templates/CSharp/st.test.ps1
+++ b/_scripts/templates/CSharp/st.test.ps1
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/CSharp/st.test.sh
+++ b/_scripts/templates/CSharp/st.test.sh
@@ -52,9 +52,9 @@ for f in ${files[*]}
 do
     if [ "$global" == "" ]
     then
-        dotnet trwdog -- ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
+        dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
     else
-        trwdog ./bin/Debug/net7.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
+        trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
     fi
     xxx="$?"
     if [ "$xxx" -ne 0 ]

--- a/_scripts/templates/Dart/st.clean.sh
+++ b/_scripts/templates/Dart/st.clean.sh
@@ -1,8 +1,10 @@
 # Generated from trgen <version>
+version=4.13.1
 rm -f *.interp
 files=()
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 <tool_grammar_tuples:{x |
-files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=Dart <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+files+=( `java -jar "$JAR" -depend -encoding <antlr_encoding> -Dlanguage=Dart <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
 } >
 for i in ${files[*]}
 do

--- a/_scripts/templates/Go/st.clean.sh
+++ b/_scripts/templates/Go/st.clean.sh
@@ -1,8 +1,10 @@
 # Generated from trgen <version>
+version=4.13.1
 rm -f *.interp
 files=()
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 <tool_grammar_tuples:{x |
-files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=Go <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+files+=( `java -jar "$JAR" -depend -encoding <antlr_encoding> -Dlanguage=Go <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
 } >
 for i in ${files[*]}
 do

--- a/_scripts/templates/Java/st.clean.sh
+++ b/_scripts/templates/Java/st.clean.sh
@@ -1,8 +1,10 @@
 # Generated from trgen <version>
+version=4.13.1
 rm -f *.interp
 files=()
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 <tool_grammar_tuples:{x |
-files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+files+=( `java -jar "$JAR" -depend -encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
 } >
 for i in ${files[*]}
 do

--- a/_scripts/templates/JavaScript/st.clean.sh
+++ b/_scripts/templates/JavaScript/st.clean.sh
@@ -1,8 +1,10 @@
 # Generated from trgen <version>
+version=4.13.1
 rm -f *.interp
 files=()
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 <tool_grammar_tuples:{x |
-files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+files+=( `java -jar "$JAR" -depend -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
 } >
 for i in ${files[*]}
 do

--- a/_scripts/templates/PHP/st.clean.sh
+++ b/_scripts/templates/PHP/st.clean.sh
@@ -1,8 +1,10 @@
 # Generated from trgen <version>
+version=4.13.1
 rm -f *.interp
 files=()
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 <tool_grammar_tuples:{x |
-files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+files+=( `java -jar "$JAR" -depend -encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
 } >
 for i in ${files[*]}
 do

--- a/_scripts/templates/Python3/st.clean.sh
+++ b/_scripts/templates/Python3/st.clean.sh
@@ -1,8 +1,10 @@
 # Generated from trgen <version>
+version=4.13.1
 rm -f *.interp
 files=()
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 <tool_grammar_tuples:{x |
-files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+files+=( `java -jar "$JAR" -depend -encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
 } >
 for i in ${files[*]}
 do

--- a/_scripts/templates/TypeScript/st.clean.sh
+++ b/_scripts/templates/TypeScript/st.clean.sh
@@ -1,8 +1,10 @@
 # Generated from trgen <version>
+version=4.13.1
 rm -f *.interp
 files=()
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 <tool_grammar_tuples:{x |
-files+=( `java -jar "<antlr_tool_path>" -depend -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
+files+=( `java -jar "$JAR" -depend -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName> | awk '{print $1\}' | grep -v ':'` )
 } >
 for i in ${files[*]}
 do

--- a/abb/desc.xml
+++ b/abb/desc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <inputs>examples/**/*.sys</inputs>
 </desc>

--- a/abnf/desc.xml
+++ b/abnf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/acme/desc.xml
+++ b/acme/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ada/ada2005/desc.xml
+++ b/ada/ada2005/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/ada/ada2012/desc.xml
+++ b/ada/ada2012/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ada/ada83/desc.xml
+++ b/ada/ada83/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/ada/ada95/desc.xml
+++ b/ada/ada95/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/agc/desc.xml
+++ b/agc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/alef/desc.xml
+++ b/alef/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/algol60/desc.xml
+++ b/algol60/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/alloy/desc.xml
+++ b/alloy/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/alpaca/desc.xml
+++ b/alpaca/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/amazon-states-language-intrinsic-functions/desc.xml
+++ b/amazon-states-language-intrinsic-functions/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/amazon-states-language/desc.xml
+++ b/amazon-states-language/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/angelscript/desc.xml
+++ b/angelscript/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/apt/desc.xml
+++ b/apt/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/aql/desc.xml
+++ b/aql/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/argus/desc.xml
+++ b/argus/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/arithmetic/desc.xml
+++ b/arithmetic/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asl/desc.xml
+++ b/asl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/asm6502/desc.xml
+++ b/asm/asm6502/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/asm8080/desc.xml
+++ b/asm/asm8080/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/asm8086/desc.xml
+++ b/asm/asm8086/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/asm/asmMASM/desc.xml
+++ b/asm/asmMASM/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/asmRISCV/desc.xml
+++ b/asm/asmRISCV/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/asm/asmZ80/desc.xml
+++ b/asm/asmZ80/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/masm/desc.xml
+++ b/asm/masm/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/nasm/desc.xml
+++ b/asm/nasm/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/pdp7/desc.xml
+++ b/asm/pdp7/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/ptx/ptx-isa-1.0/desc.xml
+++ b/asm/ptx/ptx-isa-1.0/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/asm/ptx/ptx-isa-2.1/desc.xml
+++ b/asm/ptx/ptx-isa-2.1/desc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <test>
       <name>small</name>
-      <targets>JavaScript;PHP;Python3;TypeScript</targets>
+      <targets>JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
       <inputs>examples-small</inputs>
    </test>
    <test>

--- a/asn/asn/desc.xml
+++ b/asn/asn/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/atl/desc.xml
+++ b/atl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/awk/desc.xml
+++ b/awk/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-	<targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+	<targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/b/desc.xml
+++ b/b/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/basic/desc.xml
+++ b/basic/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/bcl/desc.xml
+++ b/bcl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/bdf/desc.xml
+++ b/bdf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/bibcode/desc.xml
+++ b/bibcode/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/bibtex/desc.xml
+++ b/bibtex/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/bicep/desc.xml
+++ b/bicep/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/bnf/desc.xml
+++ b/bnf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/c/desc.xml
+++ b/c/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/calculator/desc.xml
+++ b/calculator/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/callable/desc.xml
+++ b/callable/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/capnproto/desc.xml
+++ b/capnproto/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/caql/desc.xml
+++ b/caql/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
    <grammar-files>CaQL.g4</grammar-files>
 </desc>

--- a/cayenne/desc.xml
+++ b/cayenne/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/chip8/desc.xml
+++ b/chip8/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/clf/desc.xml
+++ b/clf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/clojure/desc.xml
+++ b/clojure/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cmake/desc.xml
+++ b/cmake/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cobol85/desc.xml
+++ b/cobol85/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/codeql/desc.xml
+++ b/codeql/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cookie/desc.xml
+++ b/cookie/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cql/desc.xml
+++ b/cql/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cql3/desc.xml
+++ b/cql3/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/creole/desc.xml
+++ b/creole/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/css3/desc.xml
+++ b/css3/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/csv/desc.xml
+++ b/csv/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ctl/desc.xml
+++ b/ctl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cto/desc.xml
+++ b/cto/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cypher/desc.xml
+++ b/cypher/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/datalog/desc.xml
+++ b/datalog/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/dcm/desc.xml
+++ b/dcm/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/dice/desc.xml
+++ b/dice/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/dif/desc.xml
+++ b/dif/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/doiurl/desc.xml
+++ b/doiurl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/dot/desc.xml
+++ b/dot/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/edif300/desc.xml
+++ b/edif300/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/edn/desc.xml
+++ b/edn/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/elixir/desc.xml
+++ b/elixir/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
     <!-- Although they work, the Go, PHP, and Python targets are excluded since they are very slow -->
-    <targets>CSharp;Dart;Java;JavaScript;TypeScript</targets>
+    <targets>CSharp;Dart;Java;JavaScript;TypeScript;Antlr4ng</targets>
 </desc>

--- a/erlang/desc.xml
+++ b/erlang/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/brainflak/desc.xml
+++ b/esolang/brainflak/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/brainfuck/desc.xml
+++ b/esolang/brainfuck/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/cool/desc.xml
+++ b/esolang/cool/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/lolcode/desc.xml
+++ b/esolang/lolcode/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/loop/desc.xml
+++ b/esolang/loop/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/nanofuck/desc.xml
+++ b/esolang/nanofuck/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/sickbay/desc.xml
+++ b/esolang/sickbay/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/snowball/desc.xml
+++ b/esolang/snowball/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/esolang/wheel/desc.xml
+++ b/esolang/wheel/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/evm-bytecode/desc.xml
+++ b/evm-bytecode/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/fasta/desc.xml
+++ b/fasta/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/fdo91/desc.xml
+++ b/fdo91/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/fen/desc.xml
+++ b/fen/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/flatbuffers/desc.xml
+++ b/flatbuffers/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/flowmatic/desc.xml
+++ b/flowmatic/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/focal/desc.xml
+++ b/focal/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/fol/desc.xml
+++ b/fol/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/freedesktop/desktop-entry/desc.xml
+++ b/freedesktop/desktop-entry/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/fusion-tables/desc.xml
+++ b/fusion-tables/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/gedcom/desc.xml
+++ b/gedcom/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/glsl/desc.xml
+++ b/glsl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/gml/desc.xml
+++ b/gml/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/graphql/desc.xml
+++ b/graphql/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/graphstream-dgs/desc.xml
+++ b/graphstream-dgs/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/gtin/desc.xml
+++ b/gtin/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/guido/desc.xml
+++ b/guido/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/guitartab/desc.xml
+++ b/guitartab/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/http/desc.xml
+++ b/http/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/hypertalk/desc.xml
+++ b/hypertalk/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/icalendar/desc.xml
+++ b/icalendar/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/icon/desc.xml
+++ b/icon/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/idl/desc.xml
+++ b/idl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/inf/desc.xml
+++ b/inf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/informix/desc.xml
+++ b/informix/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/infosapient/desc.xml
+++ b/infosapient/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/iri/desc.xml
+++ b/iri/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/iso8601/desc.xml
+++ b/iso8601/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/istc/desc.xml
+++ b/istc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/itn/desc.xml
+++ b/itn/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/jam/desc.xml
+++ b/jam/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/janus/desc.xml
+++ b/janus/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/java/java/desc.xml
+++ b/java/java/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/java/java20/desc.xml
+++ b/java/java20/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/java/java8/desc.xml
+++ b/java/java8/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/joss/desc.xml
+++ b/joss/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/jpa/desc.xml
+++ b/jpa/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/json/desc.xml
+++ b/json/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/json5/desc.xml
+++ b/json5/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/karel/desc.xml
+++ b/karel/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/kotlin/kotlin-formal/desc.xml
+++ b/kotlin/kotlin-formal/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Java;JavaScript;TypeScript;Python3</targets>
+   <targets>CSharp;Dart;Java;JavaScript;TypeScript;Antlr4ng;Python3</targets>
 </desc>

--- a/kquery/desc.xml
+++ b/kquery/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/lambda/desc.xml
+++ b/lambda/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/lcc/desc.xml
+++ b/lcc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/less/desc.xml
+++ b/less/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/lisa/desc.xml
+++ b/lisa/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/lisp/desc.xml
+++ b/lisp/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/llvm-ir/desc.xml
+++ b/llvm-ir/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/lrc/desc.xml
+++ b/lrc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ltl/desc.xml
+++ b/ltl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/lucene/desc.xml
+++ b/lucene/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/matlab/desc.xml
+++ b/matlab/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/mckeeman-form/desc.xml
+++ b/mckeeman-form/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/mdx/desc.xml
+++ b/mdx/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/memcached_protocol/desc.xml
+++ b/memcached_protocol/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/metamath/desc.xml
+++ b/metamath/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/metric/desc.xml
+++ b/metric/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/microc/desc.xml
+++ b/microc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/modelica/desc.xml
+++ b/modelica/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/modula2pim4/desc.xml
+++ b/modula2pim4/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/molecule/desc.xml
+++ b/molecule/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/moo/desc.xml
+++ b/moo/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/morsecode/desc.xml
+++ b/morsecode/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/mps/desc.xml
+++ b/mps/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/muddb/desc.xml
+++ b/muddb/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/mumath/desc.xml
+++ b/mumath/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/mumps/desc.xml
+++ b/mumps/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
    <entry-point>program</entry-point>
 </desc>

--- a/muparser/desc.xml
+++ b/muparser/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/newick/desc.xml
+++ b/newick/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/objc/desc.xml
+++ b/objc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/oncrpc/desc.xml
+++ b/oncrpc/desc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <grammar-files>oncrpcv2.g4</grammar-files>
    <grammar-name>oncrpcv2</grammar-name>
 </desc>

--- a/orwell/desc.xml
+++ b/orwell/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/p/desc.xml
+++ b/p/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/parkingsign/desc.xml
+++ b/parkingsign/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pascal/desc.xml
+++ b/pascal/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pbm/desc.xml
+++ b/pbm/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pcre/desc.xml
+++ b/pcre/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pddl/desc.xml
+++ b/pddl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pdn/desc.xml
+++ b/pdn/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/peoplecode/desc.xml
+++ b/peoplecode/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pii/desc.xml
+++ b/pii/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pl0/desc.xml
+++ b/pl0/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/plucid/desc.xml
+++ b/plucid/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ply/desc.xml
+++ b/ply/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/pmmn/desc.xml
+++ b/pmmn/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/postalcode/desc.xml
+++ b/postalcode/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/powerbuilderdw/desc.xml
+++ b/powerbuilderdw/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/powerquery/desc.xml
+++ b/powerquery/desc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
    <entry-point>document</entry-point>
 </desc>

--- a/prolog/desc.xml
+++ b/prolog/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/promql/desc.xml
+++ b/promql/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/propcalc/desc.xml
+++ b/propcalc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/properties/desc.xml
+++ b/properties/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <entry-point>propertiesFile</entry-point>
 </desc>

--- a/protobuf2/desc.xml
+++ b/protobuf2/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/protobuf3/desc.xml
+++ b/protobuf3/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/prov-n/desc.xml
+++ b/prov-n/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/qif/desc.xml
+++ b/qif/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/quakemap/desc.xml
+++ b/quakemap/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/racket-bsl/desc.xml
+++ b/racket-bsl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/racket-isl/desc.xml
+++ b/racket-isl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/rcs/desc.xml
+++ b/rcs/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/recfile/desc.xml
+++ b/recfile/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/redcode/desc.xml
+++ b/redcode/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/refal/desc.xml
+++ b/refal/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/restructuredtext/desc.xml
+++ b/restructuredtext/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/rfc1035/desc.xml
+++ b/rfc1035/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/rfc1960/desc.xml
+++ b/rfc1960/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/rfc3080/desc.xml
+++ b/rfc3080/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/rfc822/rfc822-datetime/desc.xml
+++ b/rfc822/rfc822-datetime/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/rfc822/rfc822-emailaddress/desc.xml
+++ b/rfc822/rfc822-emailaddress/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/robotwars/desc.xml
+++ b/robotwars/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/romannumerals/desc.xml
+++ b/romannumerals/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ron/desc.xml
+++ b/ron/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/rpn/desc.xml
+++ b/rpn/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ruby/desc.xml
+++ b/ruby/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/scala/desc.xml
+++ b/scala/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Java;JavaScript;TypeScript;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Java;JavaScript;TypeScript;Antlr4ng;Python3</targets>
    <entry-point>compilationUnit</entry-point>
 </desc>

--- a/scotty/desc.xml
+++ b/scotty/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/semver/desc.xml
+++ b/semver/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sexpression/desc.xml
+++ b/sexpression/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sgf/desc.xml
+++ b/sgf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sharc/desc.xml
+++ b/sharc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sici/desc.xml
+++ b/sici/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sieve/desc.xml
+++ b/sieve/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/smalltalk/desc.xml
+++ b/smalltalk/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/smiles/desc.xml
+++ b/smiles/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/smtlibv2/desc.xml
+++ b/smtlibv2/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/snobol/desc.xml
+++ b/snobol/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/solidity/desc.xml
+++ b/solidity/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sparql/desc.xml
+++ b/sparql/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sql/athena/desc.xml
+++ b/sql/athena/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sql/derby/desc.xml
+++ b/sql/derby/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sql/drill/desc.xml
+++ b/sql/drill/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;PHP;Python3</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;TypeScript;Antlr4ng;PHP;Python3</targets>
 </desc>

--- a/sql/hive/v2/desc.xml
+++ b/sql/hive/v2/desc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
    <grammar-files>HiveLexer.g4;HintParser.g4;HiveParser.g4</grammar-files>
    <grammar-name>Hive</grammar-name>
    <entry-point>statements</entry-point>

--- a/sql/hive/v3/desc.xml
+++ b/sql/hive/v3/desc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
    <grammar-files>HiveLexer.g4;HintParser.g4;HiveParser.g4</grammar-files>
    <grammar-name>Hive</grammar-name>
    <entry-point>statements</entry-point>

--- a/sql/hive/v4/desc.xml
+++ b/sql/hive/v4/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sql/informix-sql/desc.xml
+++ b/sql/informix-sql/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
 <antlr-version>^4.10</antlr-version>
-<targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+<targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sql/snowflake/desc.xml
+++ b/sql/snowflake/desc.xml
@@ -2,5 +2,5 @@
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
   <antlr-version>^4.10</antlr-version>
   <targets>CSharp;Cpp;Dart;Java;JavaScript</targets>
-  <!--CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript-->
+  <!--CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng-->
 </desc>

--- a/sql/trino/desc.xml
+++ b/sql/trino/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/sql/tsql/desc.xml
+++ b/sql/tsql/desc.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Go;Java;TypeScript</targets>
+   <targets>CSharp;Go;Java;TypeScript;Antlr4ng</targets>
    <test>
-      <targets>TypeScript</targets>
+      <targets>TypeScript;Antlr4ng</targets>
       <inputs>examples-small</inputs>
    </test>
    <test>

--- a/stacktrace/desc.xml
+++ b/stacktrace/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript/targets>
 </desc>

--- a/stacktrace/desc.xml
+++ b/stacktrace/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript/targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
 </desc>

--- a/star/desc.xml
+++ b/star/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/stellaris/desc.xml
+++ b/stellaris/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/stl/desc.xml
+++ b/stl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/suokif/desc.xml
+++ b/suokif/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/swift-fin/desc.xml
+++ b/swift-fin/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/szf/desc.xml
+++ b/szf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tcpheader/desc.xml
+++ b/tcpheader/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Java;JavaScript;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Java;JavaScript;TypeScript;Antlr4ng</targets>
    <entry-point>segmentheader</entry-point>
 </desc>

--- a/teal/desc.xml
+++ b/teal/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/telephone/desc.xml
+++ b/telephone/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/terraform/desc.xml
+++ b/terraform/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tiny/desc.xml
+++ b/tiny/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tinybasic/desc.xml
+++ b/tinybasic/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tinyc/desc.xml
+++ b/tinyc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tinymud/desc.xml
+++ b/tinymud/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tl/desc.xml
+++ b/tl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tnt/desc.xml
+++ b/tnt/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/toml/desc.xml
+++ b/toml/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/trac/desc.xml
+++ b/trac/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/tsv/desc.xml
+++ b/tsv/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/ttm/desc.xml
+++ b/ttm/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/turing/desc.xml
+++ b/turing/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/turtle-doc/desc.xml
+++ b/turtle-doc/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/turtle/desc.xml
+++ b/turtle/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/unicode/unicode16/desc.xml
+++ b/unicode/unicode16/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/unreal_angelscript/desc.xml
+++ b/unreal_angelscript/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/upnp/desc.xml
+++ b/upnp/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/url/desc.xml
+++ b/url/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/useragent/desc.xml
+++ b/useragent/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/vb6/desc.xml
+++ b/vb6/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/vba/desc.xml
+++ b/vba/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/verilog/systemverilog/desc.xml
+++ b/verilog/systemverilog/desc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
    <grammar-name>SystemVerilog</grammar-name>
    <entry-point>source_text</entry-point>
 </desc>

--- a/verilog/verilog/desc.xml
+++ b/verilog/verilog/desc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
    <grammar-name>Verilog</grammar-name>
    <entry-point>source_text</entry-point>
 </desc>

--- a/vhdl/desc.xml
+++ b/vhdl/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/vmf/desc.xml
+++ b/vmf/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/wavefront/desc.xml
+++ b/wavefront/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/wkt-crs-v1/desc.xml
+++ b/wkt-crs-v1/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/wkt/desc.xml
+++ b/wkt/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/wln/desc.xml
+++ b/wln/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/wren/desc.xml
+++ b/wren/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/xml/desc.xml
+++ b/xml/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/xpath/xpath1/desc.xml
+++ b/xpath/xpath1/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
-   <targets>CSharp;Cpp;Dart;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/xsd-regex/desc.xml
+++ b/xsd-regex/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/xyz/desc.xml
+++ b/xyz/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/yara/desc.xml
+++ b/yara/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
 </desc>


### PR DESCRIPTION
This PR updates the grammars and build to test using the Typescript tool and runtime Antlr4ng for certain Antlr4 grammars. The target `Antlr4ng` is added to the grammar's desc.xml where the target works.

[Antlr4ng](https://github.com/mike-lischke/antlr4ng) is @mike-lischke 's updated TypeScript target, improving on many issues with the Antlr4 TypeScript target version 4.13.1. The reason it is added is because there will likely not be any further releases of Antlr4. In fact, for grammars that have TypeScript target-specific support code, Antlr 4.13.1 TypeScript runtime does not work with newer versions of tsc/Node because the generated parser and lexer cannot run ([it cannot find the compiled base class files](https://github.com/antlr/antlr4/issues/4491)). The only hope is to use Antlr4ng.

This PR made the following changes.
* Installed Node 21.7.1 for all OSes for the CI workflow. This is required to run on Mac ([dyld[15293]: Library not loaded: '/usr/local/opt/icu4c/lib/libicui18n.73.dylib'](https://github.com/antlr/grammars-v4/actions/runs/8319594275/job/22763188451#step:24:609)). In addition, I saw a performance gain with the newer node, but I don't see the gain here in the Github Actions.
* Added Antlr4ng templates for trgen. These templates mirror what is done with the Antlr 4.13.1 TypeScript templates, except that here we need to use the Antlr4ng-specific tool and runtime. I have the package.json use specifically version 3.0.4 of the runtime and 2.0.0 of the tool. Note, *the package-lock.json file is NOT checked in because: (1) it is generated from a specification: package.json; (2) when I build a TS application, the package-lock.json gets updated. I do NOT want to check this change as a side-effect from a build. There have been many "answers" on SO that insist to check in package-lock.json. I emphatically reject this idea! Package.json is a specification; package-lock.json is an implementation. Fortunately, in the world of C#, there is no such stupid concept with .csproj's because every one knows you don't check in generated files.*
* Updated the CSharp targets with net8.0. I already updated the Dotnet tool chain with version 8 [here](https://github.com/antlr/grammars-v4/pull/3980). This PR completes the switchover by modifying the trgen templates to use net8.
* Fixed a problem with "clean.sh" in templates. The Antlr .jar is used to tell what files are generated and what should be removed. Note, this script is never used in testing. The change is not perfect because I hardwire the name of the Antlr tool, so I will still need to figure out a more permanent solution.
* Added in `Antlr4ng` into `<targets>` sections in desc.xml. This tells trgen that the grammar works for Antlr4ng. Otherwise, the grammar DOES NOT work for the target. No split grammars with a base class are working yet. The assumption is that it should work. If not, we can ask Mike to make a fix and cut an immediate release. Mike is a much more responsive partner in fixing bugs.