### PR TITLE
[build] Add java package in Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
 		<antlr.version>4.11.1</antlr.version>
 
 		<junit.version>4.13.2</junit.version>
+
+        <packageName>org.antlr.grammars.${project.artifactId}</packageName>
+        <packagePath>org/antlr/grammars/${project.artifactId}</packagePath>
+        <packageLine>package ${packageName};</packageLine>
 	</properties>
 	<prerequisites>
 		<maven>3.1.0</maven>
@@ -52,6 +56,7 @@
 			<version>${junit.version}</version>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -62,6 +67,52 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/generated-sources/copy/${packagePath}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/Java</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <delimiters>
+                                <delimiter>///{*}</delimiter>
+                            </delimiters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${basedir}/target/generated-sources/copy/${packagePath}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
 	</build>
 	<profiles>
 		<profile>

--- a/sql/plsql/Java/PlSqlLexerBase.java
+++ b/sql/plsql/Java/PlSqlLexerBase.java
@@ -1,3 +1,5 @@
+///{packageLine}
+
 import org.antlr.v4.runtime.*;
 
 public abstract class PlSqlLexerBase extends Lexer

--- a/sql/plsql/Java/PlSqlParserBase.java
+++ b/sql/plsql/Java/PlSqlParserBase.java
@@ -1,3 +1,5 @@
+///{packageLine}
+
 import org.antlr.v4.runtime.*;
 
 public abstract class PlSqlParserBase extends Parser

--- a/sql/plsql/pom.xml
+++ b/sql/plsql/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>
@@ -22,6 +21,10 @@
 						<include>PlSqlLexer.g4</include>
 						<include>PlSqlParser.g4</include>
 					</includes>
+					<arguments>
+						<argument>-package</argument>
+						<argument>${packageName}</argument>
+					</arguments>
 					<visitor>true</visitor>
 					<listener>true</listener>
 				</configuration>
@@ -42,7 +45,7 @@
 					<showTree>false</showTree>
 					<entryPoint>sql_script</entryPoint>
 					<grammarName>PlSql</grammarName>
-					<packageName></packageName>
+					<packageName>${packageName}</packageName>
 					<exampleFiles>examples/</exampleFiles>
 				</configuration>
 				<executions>
@@ -61,7 +64,7 @@
 							<showTree>false</showTree>
 							<entryPoint>sql_script</entryPoint>
 							<grammarName>PlSql</grammarName>
-							<packageName></packageName>
+							<packageName>${packageName}</packageName>
 							<exampleFiles>examples-sql-script/</exampleFiles>
 						</configuration>
 					</execution>


### PR DESCRIPTION
As alternative to #4002.
This moves the generated classes into a Java package (and not keep them in the unnamed package) without disturbing the trgen process. This way, one can build a reusable JAR containing the lexer and parser.

The plugin configuration is done globally in the root POM. 
To benefit from it, grammar sub-projects have to adapt their POM and base classes. This PR includes the adaptation for the plsql grammar to illustrate what has to be done.
