### PR TITLE
Fix for #4035 -- add Antlr4ng port for cpp grammar.

### DIFF
--- a/cpp/Antlr4ng/CPP14ParserBase.ts
+++ b/cpp/Antlr4ng/CPP14ParserBase.ts
@@ -1,0 +1,25 @@
+import {Parser, Lexer, Token, TokenStream, ParserRuleContext} from "antlr4ng";
+import { CPP14Parser } from './CPP14Parser.js';
+import { ParametersAndQualifiersContext } from './CPP14Parser.js';
+
+export default abstract class CPP14ParserBase extends Parser {
+
+    constructor(input: TokenStream) {
+        super(input);
+    }
+
+    protected IsPureSpecifierAllowed() : boolean {
+        try {
+            var x = this.context; // memberDeclarator
+            var c = (x.children[0] as ParserRuleContext).children[0] as ParserRuleContext;
+            var c2 = c.children[0] as ParserRuleContext;
+            var p = c2.children[1] as ParserRuleContext;
+	    if (p == undefined)
+		return false;
+	    var r = p.constructor.name === "ParametersAndQualifiersContext";
+	    return r;
+        } catch (e) {
+        }
+        return false;
+    }
+}

--- a/cpp/Antlr4ng/transformGrammar.py
+++ b/cpp/Antlr4ng/transformGrammar.py
@@ -1,0 +1,31 @@
+"""The script transforms the grammar to fit for the c++ target """
+import sys
+import re
+import shutil
+from glob import glob
+from pathlib import Path
+
+def main():
+    """Executes the script."""
+    for file in glob("./*.g4"):
+        transform_grammar(file)
+
+def transform_grammar(file_path):
+    """Transforms the grammar to fit for the target"""
+    print("Altering " + file_path)
+    if not Path(file_path).is_file:
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+
+    shutil.move(file_path, file_path + ".bak")
+    with open(file_path + ".bak",'r', encoding="utf-8") as input_file:
+        with open(file_path, 'w', encoding="utf-8") as output_file:
+            for line in input_file:
+                line = re.sub(r"(\/\/ Insert here @header for C\+\+ parser\.)",\
+                    '@header {import CPP14ParserBase from "./CPP14ParserBase.js"}', line)
+                output_file.write(line)
+
+    print("Writing ...")
+
+if __name__ == '__main__':
+    main()

--- a/cpp/desc.xml
+++ b/cpp/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
 </desc>

--- a/cpp/desc.xml
+++ b/cpp/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;Antlr4ng</targets>
 </desc>


### PR DESCRIPTION
This is a fix for #4035. It's based on the TypeScript port with a few simple mods specific for Antlr4ng.