### PR TITLE
[PlSql] Some updates

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -520,6 +520,7 @@ create_function_body
         | default_collation_clause
         | parallel_enable_clause
         | result_cache_clause
+        | PIPELINED
         | DETERMINISTIC
     )* (
         (PIPELINED? (IS | AS) (DECLARE? seq_of_declare_specs? body | call_spec))

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -7143,7 +7143,7 @@ paren_column_list
 
 // NOTE: In reality this applies to aggregate functions only
 keep_clause
-    : KEEP '(' DENSE_RANK (FIRST | LAST) order_by_clause ')' over_clause?
+    : KEEP '(' DENSE_RANK (FIRST | LAST) (query_partition_clause | order_by_clause) ')' over_clause?
     ;
 
 function_argument

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -523,7 +523,7 @@ create_function_body
         | PIPELINED
         | DETERMINISTIC
     )* (
-        (PIPELINED? (IS | AS) (DECLARE? seq_of_declare_specs? body | call_spec))
+        ((IS | AS) (DECLARE? seq_of_declare_specs? body | call_spec))
         | aggregate_clause
         | pipelined_using_clause
         | sql_macro_body

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -5915,7 +5915,7 @@ query_block
     : SELECT (DISTINCT | UNIQUE | ALL)? selected_list into_clause? from_clause? where_clause? (
         hierarchical_query_clause
         | group_by_clause
-    )* model_clause? order_by_clause? fetch_clause?
+    )* model_clause? order_by_clause? offset_clause? fetch_clause?
     ;
 
 selected_list

--- a/sql/plsql/examples/create_function06.sql
+++ b/sql/plsql/examples/create_function06.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE TYPE DUMMY_TAB
+AS TABLE OF INTEGER;
+
+-- https://docs.oracle.com/cd/B10501_01/appdev.920/a96624/08_subs.htm#19845
+CREATE OR REPLACE FUNCTION fun_pipelined (i INTEGER)
+RETURN dummy_tab PIPELINED PARALLEL_ENABLE
+AS
+BEGIN
+       FOR rec1 in (SELECT i AS outrec from dual)
+       LOOP
+         PIPE ROW (rec1.outrec);
+       END LOOP;
+
+ RETURN;
+END;

--- a/sql/plsql/examples/select_cte.sql
+++ b/sql/plsql/examples/select_cte.sql
@@ -1,0 +1,10 @@
+-- offset, fetch and order by is acceptable in with clause subquery
+WITH t AS (SELECT dummy
+             FROM dual
+             ORDER BY dummy ASC NULLS LAST
+             OFFSET 0 ROWS
+             FETCH FIRST ROW ONLY)
+SELECT dummy FROM t
+ORDER BY dummy ASC NULLS LAST
+OFFSET 0 ROWS
+FETCH FIRST ROW ONLY;

--- a/sql/plsql/examples/select_dense_rank.sql
+++ b/sql/plsql/examples/select_dense_rank.sql
@@ -1,0 +1,4 @@
+-- undocumented (?) feature of first/last: you could replace mandatory "order by" clause by "partition by" clause
+select max(dummy) keep(dense_rank first partition by dummy)
+     , max(dummy) keep(dense_rank last partition by dummy)
+from dual;


### PR DESCRIPTION
All of the following changes come with simple examples to prove non-obvious features of PL/SQL (tested in Oracle 19c).

[13b9b49](https://github.com/antlr/grammars-v4/pull/4040/commits/13b9b49f4d1ad4a0a5e882114f778e5f1a0f63af) Support `OFFSET` clause in `WITH` clause subquery (right between `ORDER BY` and `FETCH`).
[c323d0d](https://github.com/antlr/grammars-v4/pull/4040/commits/c323d0d1cb1a738958a990e560cc2f53fc0855a3) Support undocumented use of `PARTITION BY` clause instead of `ORDER BY` in [`LAST/FIRST`](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/FIRST.html#GUID-85AB9246-0E0A-44A1-A7E6-4E57502E9238) function invocation (`keep_clause`).
[18aa126](https://github.com/antlr/grammars-v4/pull/4040/commits/18aa126ee2f618739850b13bce6a525185029655) Support standalone [`PIPELINED` clause (without `USING` part) ](https://docs.oracle.com/cd/B10501_01/appdev.920/a96624/08_subs.htm#19845)in `CREATE/REPLACE FUNCTION`. 