### PR TITLE
[TSql] remove OR REPLACE from T-SQL grammar

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -2385,7 +2385,7 @@ xml_index_option
 
 // https://msdn.microsoft.com/en-us/library/ms187926(v=sql.120).aspx
 create_or_alter_procedure
-    : ((CREATE (OR (ALTER | REPLACE))?) | ALTER) proc = (PROC | PROCEDURE) procName = func_proc_name_schema (
+    : ((CREATE (OR ALTER)?) | ALTER) proc = (PROC | PROCEDURE) procName = func_proc_name_schema (
         ';' DECIMAL
     )? ('('? procedure_param (',' procedure_param)* ')'?)? (
         WITH procedure_option (',' procedure_option)*
@@ -2403,7 +2403,7 @@ create_or_alter_trigger
     ;
 
 create_or_alter_dml_trigger
-    : (CREATE (OR (ALTER | REPLACE))? | ALTER) TRIGGER simple_name ON table_name (
+    : (CREATE (OR ALTER)? | ALTER) TRIGGER simple_name ON table_name (
         WITH dml_trigger_option (',' dml_trigger_option)*
     )? (FOR | AFTER | INSTEAD OF) dml_trigger_operation (',' dml_trigger_operation)* (WITH APPEND)? (
         NOT FOR REPLICATION
@@ -2420,7 +2420,7 @@ dml_trigger_operation
     ;
 
 create_or_alter_ddl_trigger
-    : (CREATE (OR (ALTER | REPLACE))? | ALTER) TRIGGER simple_name ON (ALL SERVER | DATABASE) (
+    : (CREATE (OR ALTER)? | ALTER) TRIGGER simple_name ON (ALL SERVER | DATABASE) (
         WITH dml_trigger_option (',' dml_trigger_option)*
     )? (FOR | AFTER) ddl_trigger_operation (',' ddl_trigger_operation)* AS sql_clauses+
     ;
@@ -2568,7 +2568,7 @@ create_table_index_option
 
 // https://msdn.microsoft.com/en-us/library/ms187956.aspx
 create_view
-    : (CREATE (OR (ALTER | REPLACE))? | ALTER) VIEW simple_name ('(' column_name_list ')')? (
+    : (CREATE (OR ALTER)? | ALTER) VIEW simple_name ('(' column_name_list ')')? (
         WITH view_attribute (',' view_attribute)*
     )? AS select_statement_standalone (WITH CHECK OPTION)? ';'?
     ;

--- a/sql/tsql/examples/ddl_create_view.sql
+++ b/sql/tsql/examples/ddl_create_view.sql
@@ -10,7 +10,7 @@ FROM xyz
 ;
 GO
 
-CREATE OR REPLACE VIEW xyz_view
+CREATE VIEW xyz_view
 AS
 SELECT
     ccc,

--- a/sql/tsql/examples/ddl_procedures.sql
+++ b/sql/tsql/examples/ddl_procedures.sql
@@ -54,9 +54,3 @@ CREATE PROCEDURE [DBO].[EXECUTEOLAP] @MY_PARAM NVARCHAR(MAX)
 WITH EXECUTE AS OWNER
 AS EXTERNAL NAME [MY_ASSEMBLY_NAME].[MY_NAMESPACE.MY_CLASS].[MY_METHOD]
 go
-
-create or replace procedure dbo.a_procedure
-as
-select * from a_table t
-go
-

--- a/sql/tsql/examples/triggers.sql
+++ b/sql/tsql/examples/triggers.sql
@@ -87,19 +87,3 @@ DISABLE TRIGGER safety ON DATABASE;
 GO
 DISABLE Trigger ALL ON ALL SERVER;
 GO
-
-
-CREATE OR REPLACE TRIGGER triggerOnDatabase
-ON DATABASE
-FOR create_procedure
-AS
-BEGIN
-    declare @variable int
-END
-GO
-
-CREATE OR REPLACE TRIGGER myTrigger ON myTable
-FOR UPDATE
-AS
-   PRINT 'This is the trigger from create-or-replace'
-GO


### PR DESCRIPTION
`CREATE OR REPLACE` is not valid T-SQL for DDL statements in triggers, procedures, and views. This PR removes support for that and removes any of the examples that used that syntax.