### PR TITLE
Add RIGHT and FULL join operators

### DIFF
--- a/sql/sqlite/SQLiteParser.g4
+++ b/sql/sqlite/SQLiteParser.g4
@@ -421,7 +421,7 @@ result_column
 
 join_operator
     : COMMA
-    | NATURAL_? (LEFT_ OUTER_? | INNER_ | CROSS_)? JOIN_
+    | NATURAL_? ((LEFT_ | RIGHT_ | FULL_) OUTER_? | INNER_ | CROSS_)? JOIN_
 ;
 
 join_constraint

--- a/sql/sqlite/examples/join-operators.sql
+++ b/sql/sqlite/examples/join-operators.sql
@@ -1,0 +1,19 @@
+SELECT * FROM Song JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song NATURAL JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song LEFT JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song LEFT OUTER JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song RIGHT JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song RIGHT OUTER JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song FULL JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song FULL OUTER JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song INNER JOIN Album ON Song.albumId = Album.id;
+
+SELECT * FROM Song CROSS JOIN Album ON Song.albumId = Album.id;


### PR DESCRIPTION
Add the `RIGHT OUTER JOIN` and `FULL OUTER JOIN` join operators that where added in SQLite [3.39.0](https://www.sqlite.org/changes.html#version_3_39_0). See also the syntax diagram in https://www.sqlite.org/syntax/join-operator.html