### PR TITLE
Add unicode charset to IDENTIFIER

### DIFF
--- a/sql/sqlite/SQLiteLexer.g4
+++ b/sql/sqlite/SQLiteLexer.g4
@@ -222,8 +222,8 @@ IDENTIFIER:
     '"' (~'"' | '""')* '"'
     | '`' (~'`' | '``')* '`'
     | '[' ~']'* ']'
-    | [A-Z_] [A-Z_0-9]*
-; // TODO check: needs more chars in set
+    | [A-Z_\u007F-\uFFFF] [A-Z_0-9\u007F-\uFFFF]*
+;
 
 NUMERIC_LITERAL: ((DIGIT+ ('.' DIGIT*)?) | ('.' DIGIT+)) ('E' [-+]? DIGIT+)? | '0x' HEX_DIGIT+;
 

--- a/sql/sqlite/examples/identifiers.sql
+++ b/sql/sqlite/examples/identifiers.sql
@@ -1,0 +1,7 @@
+SELECT 名, 色 FROM 猫
+
+SELECT * FROM 本
+
+SELECT * FROM msg WHERE data = 'こんにちわ'
+
+SELECT * FROM msg WHERE data = :データ


### PR DESCRIPTION
SQLite supports unicode characters as identifiers and specifically any character larger than `u007f`. This changes adds the unicode range to the `IDENTIFIER` lexer rule. The supported character ranges where documented early in the tokenizer design doc in https://www.sqlite.org/draft/tokenreq.html