### PR TITLE
[sql/derby and sql/tsql] Fix #4047

### DIFF
--- a/sql/derby/DerbyLexer.g4
+++ b/sql/derby/DerbyLexer.g4
@@ -428,4 +428,6 @@ fragment FullWidthLetter options {
     | '\ua000' ..'\ud7ff'
     | '\uf900' ..'\ufaff'
     | '\uff00' ..'\ufff0'
-; // | '\u20000'..'\u2FA1F'
+    // | '\u10000'..'\u1F9FF'  //not support four bytes chars
+    // | '\u20000'..'\u2FA1F'
+;

--- a/sql/tsql/TSqlLexer.g4
+++ b/sql/tsql/TSqlLexer.g4
@@ -1289,4 +1289,6 @@ fragment FullWidthLetter options {
     | '\ua000' ..'\ud7ff'
     | '\uf900' ..'\ufaff'
     | '\uff00' ..'\ufff0'
-; // | '\u20000'..'\u2FA1F'
+    // | '\u10000'..'\u1F9FF'  //not support four bytes chars
+    // | '\u20000'..'\u2FA1F'
+;


### PR DESCRIPTION
Fixes for #4047 

The comments that were deleted by the formatter were recovered, and the updated grammars were reformatted.

The haskell grammar, which [I mentioned in the Issue](https://github.com/antlr/grammars-v4/issues/4047#issuecomment-2054331635), did not need to be changed.

I noticed that the comment `not support[ed] four bytes chars` is actually incorrect. [Indeed, Antlr4 does handle 4-byte Unicode](https://github.com/antlr/antlr4/blob/master/doc/unicode.md#unicode-code-points-in-lexer-grammars). At the time of [the change](https://github.com/antlr/grammars-v4/commit/1914b0561b6295d20eb3595169edc45bfc0dbcb8), in 2016, Unicode for Antlr was not yet implemented. I don't know whether the grammar should contain the Unicode ranges mentioned in the comments.  I am not familiar enough with the language to decide without reading the specs.