### PR TITLE
Remove backslash from JSON exponential notation

### DIFF
--- a/json/JSON.g4
+++ b/json/JSON.g4
@@ -69,10 +69,8 @@ fragment INT
 
 fragment EXP
     // exponent number permits leading 0s (e.g. `1e01`)
-    : [Ee] [+\-]? [0-9]+
+    : [Ee] [+-]? [0-9]+
     ;
-
-// \- since - means "range" inside [...]
 
 WS
     : [ \t\n\r]+ -> skip


### PR DESCRIPTION
The JSON grammar accepts the input `1e\1`, since the character set of the `EXP` lexer rule contains a superfluous backslash. The `-` character [does not need to be escaped if it is the first or last character in a character set](https://github.com/antlr/antlr4/blob/master/doc/lexer-rules.md#lexer-rule-elements). This removes that backslash.