### PR TITLE
[csharp] Fix for #4088 (add testing of the CSharp target of csharp grammar)

### DIFF
--- a/csharp/desc.xml
+++ b/csharp/desc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Java</targets>
+   <targets>CSharp;Java</targets>
    <grammar-name>CSharp</grammar-name>
+   <inputs>examples/**/*.cs</inputs>
 </desc>


### PR DESCRIPTION
This PR adds testing of the CSharp port for the [csharp grammar](https://github.com/antlr/grammars-v4/tree/master/csharp), which is a workaround for #4088. The port is fine. The main problem is that the Antlr4 runtime error recovery does not use the same algorithm to report errors, so one of the tests would give a different error message. The solution is to just ignore the file for now. https://github.com/antlr/antlr4/issues/3700#issuecomment-2102551486