### PR TITLE
Removed copyrights in the MySQL grammars for generated code.

### DIFF
--- a/sql/mysql/Oracle/MySQLLexer.g4
+++ b/sql/mysql/Oracle/MySQLLexer.g4
@@ -42,11 +42,7 @@ tokens {
 
 //-------------------------------------------------------------------------------------------------
 
-@header {/*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates.
- * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
+@header {
 /* eslint-disable @typescript-eslint/no-unused-vars, no-useless-escape */
 
 import { MySQLBaseLexer, SqlMode } from "../MySQLBaseLexer.js";

--- a/sql/mysql/Oracle/MySQLParser.g4
+++ b/sql/mysql/Oracle/MySQLParser.g4
@@ -31,8 +31,7 @@ options {
     tokenVocab = MySQLLexer;
 }
 
-@header {/* Copyright (c) 2020, 2024, Oracle and/or its affiliates. */
-
+@header {
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-useless-escape, no-lone-blocks */
 


### PR DESCRIPTION
Users of the grammars can of course use whatever they want for their generated code.