### PR TITLE
Fix #4115 -- _scripts/mkindex.py does not work on Windows Powershell

### DIFF
--- a/_scripts/mkindex.py
+++ b/_scripts/mkindex.py
@@ -114,15 +114,15 @@ def index_grammars(root : str) -> Sequence[dict]:
                 parser = grammars[0] if 'Parser' in grammars[0] else grammars[1]
                 gdir = path[len(root)+1:]
                 if lexer:
-                    lexer = f'https://raw.githubusercontent.com/antlr/grammars-v4/master/{gdir}/{lexer}'
+                    lexer = f'https://raw.githubusercontent.com/antlr/grammars-v4/master/{gdir}/{lexer}'.replace('\\','/')
                 if parser:
-                    parser = f'https://raw.githubusercontent.com/antlr/grammars-v4/master/{gdir}/{parser}'
+                    parser = f'https://raw.githubusercontent.com/antlr/grammars-v4/master/{gdir}/{parser}'.replace('\\','/')
             else:
                 lexer = ""
                 parser = grammars[0]
                 gdir = path[len(root)+1:]
                 if parser:
-                    parser = f'https://raw.githubusercontent.com/antlr/grammars-v4/master/{gdir}/{parser}'
+                    parser = f'https://raw.githubusercontent.com/antlr/grammars-v4/master/{gdir}/{parser}'.replace('\\','/')
 
             exampleFilesDir = get_single_value("exampleFiles", pom)
             if exampleFilesDir is None:


### PR DESCRIPTION
This PR fixes #4115. The problem was that on Windows Powershell, file paths use backslashes, not forward slashes. To set the URL for the location of the grammar file, it must use forward slashes.

https://github.com/antlr/grammars-v4/pull/4112 is a companion PR that fixes the grammars.json file itself. This file is used by the lab.antlr.org.
