### PR TITLE
Update SQLiteParser.g4 by allowing order_by_expr_asc_desc to be empty.

### DIFF
--- a/sql/sqlite/SQLiteParser.g4
+++ b/sql/sqlite/SQLiteParser.g4
@@ -587,6 +587,7 @@ order_by_expr
 
 order_by_expr_asc_desc
     : ORDER_ BY_ expr_asc_desc
+    |
 ;
 
 expr_asc_desc


### PR DESCRIPTION
The current definition of order_by_expr_asc_desc is right recursive and does not terminate.