### PR TITLE
[plsql] Fix #4131 -- removed Antlr4 Tool warnings from grammar

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -3657,7 +3657,7 @@ system_partitioning
     ;
 
 range_partition_desc
-    : PARTITION partition_name? range_values_clause? table_partition_description? (
+    : PARTITION partition_name? range_values_clause? table_partition_description (
         (
             '(' (
                 range_subpartition_desc (',' range_subpartition_desc)*
@@ -3670,7 +3670,7 @@ range_partition_desc
     ;
 
 list_partition_desc
-    : PARTITION partition_name? list_values_clause? table_partition_description? (
+    : PARTITION partition_name? list_values_clause? table_partition_description (
         (
             '(' (
                 range_subpartition_desc (',' range_subpartition_desc)*


### PR DESCRIPTION
This PR fixes #4131. There were two warnings from the Antlr Tool that occurred because the `?`-operator was applied to a non-terminal that can derive empty.