### PR TITLE
[r] Fix for #4135 -- specify the "R" grammar for testing, skip "RFilter"

### DIFF
--- a/r/desc.xml
+++ b/r/desc.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <targets>Java;Python3</targets>
+   <grammar-name>R</grammar-name>
 </desc>


### PR DESCRIPTION
This is a fix for #4135 where it is unclear which grammar to test. The current version of trgen miraculously picks "R", but that will not be the case in the next version. Using `grammar-name`, the grammar to test is specified, just as it is in the [pom.xml](https://github.com/antlr/grammars-v4/blob/d2d7b89157946345710254cf6e4121f29cfa011f/r/pom.xml#L43).