### PR TITLE
VBA Conditional Compilation Grammar

### DIFF
--- a/vba/pom.xml
+++ b/vba/pom.xml
@@ -13,6 +13,7 @@
 
     <modules>
         <module>vba6</module>
+        <module>vba_cc</module>
         <module>vba_like</module>
     </modules>
 </project>

--- a/vba/vba_cc/README.md
+++ b/vba/vba_cc/README.md
@@ -1,0 +1,7 @@
+# Visual Basic Conditional Compilation Grammar for ANTLR4
+
+Derived from the Visual Basic 7.1 language reference
+
+https://msopenspecs.azureedge.net/files/MS-VBAL/%5bMS-VBAL%5d.pdf
+
+The vba_cc grammar can be used against vba files to analyze that portion of the code.

--- a/vba/vba_cc/desc.xml
+++ b/vba/vba_cc/desc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
+   <antlr-version>^4.10</antlr-version>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+</desc>

--- a/vba/vba_cc/desc.xml
+++ b/vba/vba_cc/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
 </desc>

--- a/vba/vba_cc/desc.xml
+++ b/vba/vba_cc/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.10</antlr-version>
-   <targets>CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
 </desc>

--- a/vba/vba_cc/examples/cc.bas
+++ b/vba/vba_cc/examples/cc.bas
@@ -1,0 +1,28 @@
+Attribute VB_Name = "CCTEST"
+#Const conDebug = 1
+
+#If conDebuge = 1 Then 'Run debug code
+    Debug.Print "oops"
+#Elseif conDebug > 1 Then
+    Debug.Print "help"
+#Else
+    #If Cdbl(Abs(conDebug)) < (1 Mod 3) Then
+    
+        foo = 2
+    #Endif
+#End If
+
+Open pth for output as #ff
+    Print #ff, cont
+Close #ff
+
+' The blocks can each be empty.
+#if Win64 Then
+#Elseif Win32 Then
+#Else
+#Endif
+
+' The blocks can each be empty.
+#if 1 / 2 = .5 Then
+    foo = 4
+#Endif

--- a/vba/vba_cc/pom.xml
+++ b/vba/vba_cc/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>vba7_1</artifactId>
+	<packaging>jar</packaging>
+	<name>VBA 7.1 grammar</name>
+	<parent>
+		<groupId>org.antlr.grammars</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<includes>
+					   <include>vbaLexer.g4</include>
+					   <include>vbaParser.g4</include>
+					</includes>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>startRule</entryPoint>
+					<grammarName>vba_cc</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/vba/vba_cc/vba_cc.g4
+++ b/vba/vba_cc/vba_cc.g4
@@ -1,0 +1,362 @@
+grammar vba_cc;
+
+options {
+    caseInsensitive = true;
+}
+
+startRule
+    : (proceduralModuleHeader | classFileHeader) conditionalModuleBody NEWLINE* EOF
+    ;
+
+proceduralModuleHeader
+    : 'ATTRIBUTE VB_NAME = ' STRINGLITERAL
+    ;
+
+classFileHeader
+    : 'VERSION' FLOATLITERAL 'CLASS'?
+    ;
+
+// 3.4 Conditional Compilation
+logicalLine
+    : NEWLINE WS? (~(CONST | IF | ELSEIF | ELSE | NEWLINE) (~(NEWLINE))*)?;
+conditionalModuleBody: ccBlock;
+ccBlock: (ccConst | ccIfBlock | logicalLine)+;
+
+// 3.4.1 Conditional Compilation Const Directive
+ccConst: NEWLINE CONST ccVarLhs '=' ccExpression COMMENT?;
+ccVarLhs: name;
+
+// 3.4.2 Conditional Compilation If Directives
+ccIfBlock
+    : ccIf ccBlock? ccElseifBlock* ccElseBlock? ccEndif;
+ccIf: NEWLINE+ IF ccExpression THEN COMMENT?;
+ccElseifBlock: ccElseif ccBlock?;
+ccElseif: NEWLINE+ ELSEIF ccExpression THEN COMMENT?;
+ccElseBlock: ccElse ccBlock?;
+ccElse: NEWLINE+ ELSE COMMENT?;
+ccEndif: NEWLINE+ ENDIF COMMENT?;
+
+// 5.1
+name
+    : untypedName
+    | typedName
+    ;
+
+untypedName
+    : IDENTIFIER
+    | FOREIGN_NAME
+    ;
+
+// Known as TYPED-NAME in MS-VBAL
+// This probably could be turned into a token
+typedName
+    : IDENTIFIER typeSuffix
+    ;
+
+typeSuffix
+    : '&'
+    | '%'
+    | '#'
+    | '!'
+    | '@'
+    | '$'
+    | '^'
+    ;
+
+// 5.6.16.2 Conditional Compilation Expressions
+ccExpression
+    : literalExpression                                                  # LiteralExpress
+    | reservedKeywords                                                   # IdentifierExpression
+    | IDENTIFIER                                                         # IdentifierExpression
+    | '(' ccExpression ')'                                               # ParenthesizedExpression
+    | ccExpression ('^') ccExpression                                    # ArithmeticExpression
+    | '-' ccExpression                                                   # UnaryMinusExpression
+    | ccExpression ('*' | '/') ccExpression                              # ArithmeticExpression
+    | ccExpression '\\' ccExpression                                     # ArithmeticExpression
+    | ccExpression 'MOD' ccExpression                                    # ArithmeticExpression
+    | ccExpression ('+' | '-') ccExpression                              # ArithmeticExpression
+    | ccExpression '&' ccExpression                                      # ConcatExpression
+    | ccExpression (EQ | NEQ | GT | GEQ | LEQ | LT | LIKE) ccExpression  # RelationExpression
+    | ccFunc '(' ccExpression ')'                                        # IndexExpression
+    | 'NOT' ccExpression                                                 # NotOperatorExpression
+    | ccExpression 'AND' ccExpression                                    # booleanExpression
+    | ccExpression 'OR' ccExpression                                     # booleanExpression
+    | ccExpression 'XOR' ccExpression                                    # booleanExpression
+    | ccExpression 'EQV' ccExpression                                    # booleanExpression
+    | ccExpression 'IMP' ccExpression                                    # booleanExpression
+    ;
+
+literalExpression
+    : BOOLEANLITERAL
+    | FLOATLITERAL
+    | INTEGERLITERAL
+    | STRINGLITERAL
+    | DATELITERAL
+    | EMPTY
+    | NULL_
+    | NOTHING
+    ;
+
+ccFunc
+    : 'INT'
+    | 'FIX'
+    | 'ABS'
+    | 'SGN'
+    | 'LEN'
+    | 'LENB'
+    | 'CBOOL'
+    | 'CBYTE'
+    | 'CCUR'
+    | 'CDATE'
+    | 'CDBL'
+    | 'CINT'
+    | 'CLNG'
+    | 'CLNGLNG'
+    | 'CLNGPTR'
+    | 'CSNG'
+    | 'CSTR'
+    | 'CVAR'
+    ;
+
+reservedKeywords
+    : WIN16
+    | WIN32
+    | WIN64
+    | VBA6
+    | VBA7
+    | MAC
+    ;
+
+CONST
+    : '#CONST'
+    ;
+
+IF
+    : '#IF'
+    ;
+
+ELSEIF
+    : '#ELSEIF'
+    ;
+
+ELSE
+    : '#ELSE'
+    ;
+
+ENDIF
+    : '#END IF'
+    | '#ENDIF'
+    ;
+
+EMPTY
+    : 'EMPTY'
+    ;
+
+LIKE
+    : 'LIKE'
+    ;
+
+NOTHING
+    : 'NOTHING'
+    ;
+
+NULL_
+    : 'NULL'
+    ;
+
+THEN
+    : 'THEN'
+    ;
+
+WIN16
+    : 'WIN16'
+    ;
+
+WIN32
+    : 'WIN32'
+    ;
+
+WIN64
+    : 'WIN64'
+    ;
+
+VBA6
+    : 'VBA6'
+    ;
+
+VBA7
+    : 'VBA7'
+    ;
+
+MAC
+    : 'MAC'
+    ;
+
+EQ
+    : '='
+    ;
+
+GEQ
+    : '>='
+    | '=>'
+    ;
+
+GT
+    : '>'
+    ;
+
+LEQ
+    : '<='
+    | '=<'
+    ;
+
+LT
+    : '<'
+    ;
+
+NEQ
+    : '<>'
+    | '><'
+    ;
+
+BOOLEANLITERAL
+    : 'TRUE'
+    | 'FALSE'
+    ;
+
+MISC
+    : ~[\r\n\u2028\u2029<>&=*+^\-/ \t"()A-Z0-9]+
+    ;
+
+NEWLINE
+    : [\r\n\u2028\u2029]+
+    ;
+
+SINGLEQUOTE
+    : '\''
+    ;
+
+STRINGLITERAL
+    : '"' (~["\r\n] | '""')* '"'
+    ;
+
+OCTLITERAL
+    : '&' [O]? [0-7]+
+    ;
+
+HEXLITERAL
+    : '&H' [0-9A-F]+
+    ;
+
+INTEGERLITERAL
+    : (DIGIT DIGIT*
+    | HEXLITERAL
+    | OCTLITERAL) [%&^]?
+    ;
+
+FLOATLITERAL
+    : FLOATINGPOINTLITERAL [!#@]?
+    | DECIMALLITERAL [!#@]
+    ;
+
+fragment FLOATINGPOINTLITERAL
+    : DECIMALLITERAL [DE] [+-]? DECIMALLITERAL
+    | DECIMALLITERAL '.' DECIMALLITERAL? ([DE] [+-]? DECIMALLITERAL)?
+    | '.' DECIMALLITERAL ([DE] [+-]? DECIMALLITERAL)?
+    ;
+
+fragment DECIMALLITERAL
+    : DIGIT DIGIT*
+    ;
+
+DATELITERAL
+    : '#' DATEORTIME '#'
+    ;
+
+fragment DATEORTIME
+    : DATEVALUE WS+ TIMEVALUE
+    | DATEVALUE
+    | TIMEVALUE
+    ;
+
+fragment DATEVALUE
+    : DATEVALUEPART DATESEPARATOR DATEVALUEPART (DATESEPARATOR DATEVALUEPART)?
+    ;
+
+fragment DATEVALUEPART
+    : DIGIT+
+    | MONTHNAME
+    ;
+
+fragment DATESEPARATOR
+    : WS+
+    | WS? [/,-] WS?
+    ;
+
+fragment MONTHNAME
+    : ENGLISHMONTHNAME
+    | ENGLISHMONTHABBREVIATION
+    ;
+
+fragment ENGLISHMONTHNAME
+    : 'JANUARY'
+    | 'FEBRUARY'
+    | 'MARCH'
+    | 'APRIL'
+    | 'MAY'
+    | 'JUNE'
+    | 'JULY'
+    | 'AUGUST'
+    | 'SEPTEMBER'
+    | 'OCTOBER'
+    | 'NOVEMBER'
+    | 'DECEMBER'
+    ;
+
+// May has intentionally been left out
+fragment ENGLISHMONTHABBREVIATION
+    : 'JAN'
+    | 'FEB'
+    | 'MAR'
+    | 'APR'
+    | 'JUN'
+    | 'JUL'
+    | 'AUG'
+    | 'SEP'
+    | 'OCT'
+    | 'NOV'
+    | 'DEC'
+    ;
+
+fragment TIMEVALUE
+    : DIGIT+ AMPM
+    | DIGIT+ TIMESEPARATOR DIGIT+ (TIMESEPARATOR DIGIT+)? AMPM?
+    ;
+
+fragment TIMESEPARATOR
+    : WS? (':' | '.') WS?
+    ;
+
+fragment AMPM
+    : WS? ('AM' | 'PM' | 'A' | 'P')
+    ;
+
+fragment DIGIT
+    : [0-9]
+    ;
+
+IDENTIFIER
+    : [A-Z][A-Z0-9_]*
+    ;
+
+FOREIGN_NAME
+    : '[' ~[\r\n\u2028\u2029]* ']'
+    ;
+
+COMMENT
+    : SINGLEQUOTE ~[\r\n\u2028\u2029]*
+    ;
+
+WS
+    : ([ \t])+ -> channel(HIDDEN)
+    ;

--- a/vba/vba_cc/vba_cc.g4
+++ b/vba/vba_cc/vba_cc.g4
@@ -92,7 +92,7 @@ literalExpression
     | INTEGERLITERAL
     | STRINGLITERAL
     | DATELITERAL
-    | EMPTY
+    | EMPTY_
     | NULL_
     | NOTHING
     ;
@@ -119,9 +119,9 @@ ccFunc
     ;
 
 reservedKeywords
-    : WIN16
-    | WIN32
-    | WIN64
+    : WIN16_
+    | WIN32_
+    | WIN64_
     | VBA6
     | VBA7
     | MAC
@@ -148,7 +148,7 @@ ENDIF
     | '#ENDIF'
     ;
 
-EMPTY
+EMPTY_
     : 'EMPTY'
     ;
 
@@ -168,15 +168,15 @@ THEN
     : 'THEN'
     ;
 
-WIN16
+WIN16_
     : 'WIN16'
     ;
 
-WIN32
+WIN32_
     : 'WIN32'
     ;
 
-WIN64
+WIN64_
     : 'WIN64'
     ;
 


### PR DESCRIPTION
VBA includes a precompiler of sorts, with its own grammar. The existing vba6 grammar tries to shoehorn it in with the main language, but there are situations where a VBA file with CC statements is not valid VBA until after the precompiler is run.
For example:

```vba
#If WIN64 Then
Function Foo(bar, Optional baz = 1)
#Else
Function Foo(bar, Optional baz = 2)
#End If
End Function
```

This new grammar powers a precompiler which can turn this example into valid VBA given a set of environment variables. 