### PR TITLE
Fix #4143 [javascript] Fixed the end detection of the placeholder in template literals.

### DIFF
--- a/javascript/javascript/Cpp/JavaScriptLexerBase.h
+++ b/javascript/javascript/Cpp/JavaScriptLexerBase.h
@@ -15,7 +15,9 @@ public:
 
     bool useStrictDefault = false;
     bool useStrictCurrent = false;
-    int _templateDepth = 0;
+
+    int currentDepth = 0;
+    std::stack<int> templateDepthStack;
 
     bool IsStartOfFile();
     bool getStrictDefault();
@@ -26,8 +28,8 @@ public:
     void ProcessOpenBrace();
     void ProcessCloseBrace();
     void ProcessStringLiteral();
-    void IncreaseTemplateDepth();
-    void DecreaseTemplateDepth();
+	void ProcessTemplateOpenBrace();
+	void ProcessTemplateCloseBrace();
     bool IsRegexPossible();
     virtual void reset() override;
 };

--- a/javascript/javascript/Java/JavaScriptLexerBase.java
+++ b/javascript/javascript/Java/JavaScriptLexerBase.java
@@ -27,15 +27,14 @@ public abstract class JavaScriptLexerBase extends Lexer
      */
     private boolean useStrictCurrent = false;
     /**
-     * Keeps track of the the current depth of nested template string backticks.
-     * E.g. after the X in:
-     *
-     * `${a ? `${X
-     *
-     * templateDepth will be 2. This variable is needed to determine if a `}` is a
-     * plain CloseBrace, or one that closes an expression inside a template string.
+     * Preserves depth due to braces including template literals.
      */
-    private int templateDepth = 0;
+	private int currentDepth = 0;
+
+    /**
+     * Preserves the starting depth of template literals to correctly handle braces inside template literals.
+     */
+	private Deque<Integer> templateDepthStack = new ArrayDeque<Integer>();
 
     public JavaScriptLexerBase(CharStream input) {
         super(input);
@@ -59,7 +58,7 @@ public abstract class JavaScriptLexerBase extends Lexer
     }
 
     public boolean IsInTemplateString() {
-        return this.templateDepth > 0;
+		return !templateDepthStack.isEmpty() && templateDepthStack.peek() == currentDepth;
     }
 
     /**
@@ -85,6 +84,7 @@ public abstract class JavaScriptLexerBase extends Lexer
 
     protected void ProcessOpenBrace()
     {
+		currentDepth++;
         useStrictCurrent = scopeStrictModes.size() > 0 && scopeStrictModes.peek() ? true : useStrictDefault;
         scopeStrictModes.push(useStrictCurrent);
     }
@@ -92,7 +92,18 @@ public abstract class JavaScriptLexerBase extends Lexer
     protected void ProcessCloseBrace()
     {
         useStrictCurrent = scopeStrictModes.size() > 0 ? scopeStrictModes.pop() : useStrictDefault;
+		currentDepth--;
     }
+
+	protected void ProcessTemplateOpenBrace() {
+		currentDepth++;
+		this.templateDepthStack.push(currentDepth);
+	}
+
+	protected void ProcessTemplateCloseBrace() {
+		this.templateDepthStack.pop();
+		currentDepth--;
+	}
 
     protected void ProcessStringLiteral()
     {
@@ -107,14 +118,6 @@ public abstract class JavaScriptLexerBase extends Lexer
                 scopeStrictModes.push(useStrictCurrent);
             }
         }
-    }
-
-    public void IncreaseTemplateDepth() {
-        this.templateDepth++;
-    }
-
-    public void DecreaseTemplateDepth() {
-        this.templateDepth--;
     }
 
     /**
@@ -155,7 +158,8 @@ public abstract class JavaScriptLexerBase extends Lexer
         this.lastToken = null;
         this.useStrictDefault = false;
         this.useStrictCurrent = false;
-        this.templateDepth = 0;
+	    this.currentDepth = 0;
+	    this.templateDepthStack = new Stack<Integer>();
         super.reset();
     }
 }

--- a/javascript/javascript/Java/JavaScriptLexerBase.java
+++ b/javascript/javascript/Java/JavaScriptLexerBase.java
@@ -159,7 +159,7 @@ public abstract class JavaScriptLexerBase extends Lexer
         this.useStrictDefault = false;
         this.useStrictCurrent = false;
 	    this.currentDepth = 0;
-	    this.templateDepthStack = new Stack<Integer>();
+	    this.templateDepthStack = new ArrayDeque<Integer>();
         super.reset();
     }
 }

--- a/javascript/javascript/JavaScript/JavaScriptLexerBase.js
+++ b/javascript/javascript/JavaScript/JavaScriptLexerBase.js
@@ -9,7 +9,8 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
         this.lastToken = null;
         this.useStrictDefault = false;
         this.useStrictCurrent = false;
-        this.templateDepth = 0;
+        this.currentDepth = 0;
+        this.templateDepthStack = new Array();
     }
 
     getStrictDefault() {
@@ -26,7 +27,7 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
     }
 
     IsInTemplateString() {
-        return this.templateDepth > 0;
+        return this.templateDepthStack.length > 0 && this.templateDepthStack[this.templateDepthStack.length - 1] === this.currentDepth;
     }
 
     getCurrentToken() {
@@ -43,6 +44,7 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
     }
 
     ProcessOpenBrace() {
+        this.currentDepth++;
         this.useStrictCurrent =
             this.scopeStrictModes.length > 0 && this.scopeStrictModes[this.scopeStrictModes.length - 1]
                 ? true
@@ -55,6 +57,7 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
             this.scopeStrictModes.length > 0
                 ? this.scopeStrictModes.pop()
                 : this.useStrictDefault;
+        this.currentDepth--;
     }
 
     ProcessStringLiteral() {
@@ -70,12 +73,14 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
         }
     }
 
-    IncreaseTemplateDepth() {
-        this.templateDepth++;
+    ProcessTemplateOpenBrace() {
+        this.currentDepth++;
+        this.templateDepthStack.push(this.currentDepth);
     }
 
-    DecreaseTemplateDepth() {
-        this.templateDepth--;
+    ProcessTemplateCloseBrace() {
+        this.templateDepthStack.pop();
+        this.currentDepth--;
     }
 
     IsRegexPossible() {
@@ -111,7 +116,8 @@ export default class JavaScriptLexerBase extends antlr4.Lexer {
         this.lastToken = null;
         this.useStrictDefault = false;
         this.useStrictCurrent = false;
-        this.templateDepth = 0;
+        this.currentDepth = 0;
+        this.templateDepthStack = new Array();
         super.reset();
     }
 }

--- a/javascript/javascript/JavaScriptLexer.g4
+++ b/javascript/javascript/JavaScriptLexer.g4
@@ -57,7 +57,8 @@ CloseBracket               : ']';
 OpenParen                  : '(';
 CloseParen                 : ')';
 OpenBrace                  : '{' {this.ProcessOpenBrace();};
-TemplateCloseBrace         :     {this.IsInTemplateString()}? '}' -> popMode;
+TemplateCloseBrace         :     {this.IsInTemplateString()}? '}' // Break lines here to ensure proper transformation by Go/transformGrammar.py
+                                                                  {this.ProcessTemplateCloseBrace();} -> popMode;
 CloseBrace                 : '}' {this.ProcessCloseBrace();};
 SemiColon                  : ';';
 Comma                      : ',';
@@ -206,7 +207,7 @@ StringLiteral:
     ('"' DoubleStringCharacter* '"' | '\'' SingleStringCharacter* '\'') {this.ProcessStringLiteral();}
 ;
 
-BackTick: '`' {this.IncreaseTemplateDepth();} -> pushMode(TEMPLATE);
+BackTick: '`' -> pushMode(TEMPLATE);
 
 WhiteSpaces: [\t\u000B\u000C\u0020\u00A0]+ -> channel(HIDDEN);
 
@@ -220,8 +221,8 @@ UnexpectedCharacter : .                     -> channel(ERROR);
 
 mode TEMPLATE;
 
-BackTickInside                : '`'  {this.DecreaseTemplateDepth();} -> type(BackTick), popMode;
-TemplateStringStartExpression : '${' -> pushMode(DEFAULT_MODE);
+BackTickInside                : '`' -> type(BackTick), popMode;
+TemplateStringStartExpression : '${' {this.ProcessTemplateOpenBrace();} -> pushMode(DEFAULT_MODE);
 TemplateStringAtom            : ~[`];
 
 // Fragment rules

--- a/javascript/javascript/examples/TemplateLiterals.js
+++ b/javascript/javascript/examples/TemplateLiterals.js
@@ -13,6 +13,7 @@ var card = { amount: 7, product: "Bar", unitprice: 42 }
 var message = `Hello ${customer.name},
 want to buy ${card.amount} ${card.product} for
 a total of ${card.amount * card.unitprice} bucks?`
+var nested = `Object in template literal ${JSON.stringify({ key: 'value' })}`
 
 //------------------------------------------------------------------------------
 // Custom Interpolation


### PR DESCRIPTION
This PR fixes #4143.

The parsing error in #4143 seems to be caused by the handling of curly braces inside template literals.
In the following example described in the issue, the error occurs because the `}` in `{ key: 'value' }` is misidentified as the end of the placeholder.

```javascript
var nested = `Object in template literal ${JSON.stringify({ key: 'value' })}`
```

This PR fixes the problem by managing the number of curly braces and correctly recognizing the end of the placeholder.