### PR TITLE
[ICalendar] add trailing CRLF to request-status property

### DIFF
--- a/icalendar/ICalendar.g4
+++ b/icalendar/ICalendar.g4
@@ -732,7 +732,7 @@ x_prop
 
 // 3.8.8.3 - Request Status
 rstatus
-    : k_request_status rstatparam* COL statcode SCOL text (SCOL text)?
+    : k_request_status rstatparam* COL statcode SCOL text (SCOL text)? CRLF
     ;
 
 rstatparam

--- a/icalendar/ICalendar.g4
+++ b/icalendar/ICalendar.g4
@@ -725,7 +725,7 @@ iana_prop
     : iana_token (SCOL icalparameter)* COL value CRLF
     ;
 
-// 3.8.8.2 - Non-Standard Propertie
+// 3.8.8.2 - Non-Standard Properties
 x_prop
     : x_name (SCOL icalparameter)* COL value CRLF
     ;


### PR DESCRIPTION
According to a [recently accepted errata](https://www.rfc-editor.org/errata/eid7945), the `REQUEST-STATUS` property should be parsed with a trailing CRLF, as all other properties already are.

This PR adds the CRLF and also fixes a small typo along the way.