### PR TITLE
[cpp] Fix for #4149 -- fix translation/refactoring of several rules from the ISO spec

### DIFF
--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -699,11 +699,14 @@ abstractDeclarator
     ;
 
 pointerAbstractDeclarator
-    : pointerOperator* ( noPointerAbstractDeclarator | pointerOperator )
+    : pointerOperator* (noPointerAbstractDeclarator | pointerOperator)
     ;
 
 noPointerAbstractDeclarator
-    : (parametersAndQualifiers | LeftParen pointerAbstractDeclarator RightParen) (parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )*
+    : (parametersAndQualifiers | LeftParen pointerAbstractDeclarator RightParen) (
+        parametersAndQualifiers
+        | LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
+    )*
     ;
 
 abstractPackDeclarator
@@ -711,7 +714,10 @@ abstractPackDeclarator
     ;
 
 noPointerAbstractPackDeclarator
-    : Ellipsis ( parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )*
+    : Ellipsis (
+        parametersAndQualifiers
+        | LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
+    )*
     ;
 
 parameterDeclarationClause

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -699,8 +699,7 @@ abstractDeclarator
     ;
 
 pointerAbstractDeclarator
-    : noPointerAbstractDeclarator
-    | pointerOperator pointerAbstractDeclarator?
+    : pointerOperator* ( noPointerAbstractDeclarator | pointerOperator )
     ;
 
 noPointerAbstractDeclarator

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -711,9 +711,7 @@ abstractPackDeclarator
     ;
 
 noPointerAbstractPackDeclarator
-    : noPointerAbstractPackDeclarator parametersAndQualifiers
-    | noPointerAbstractPackDeclarator LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
-    | Ellipsis
+    : Ellipsis ( parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )*
     ;
 
 parameterDeclarationClause

--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -700,17 +700,11 @@ abstractDeclarator
 
 pointerAbstractDeclarator
     : noPointerAbstractDeclarator
-    | pointerOperator+ noPointerAbstractDeclarator?
+    | pointerOperator pointerAbstractDeclarator?
     ;
 
 noPointerAbstractDeclarator
-    : noPointerAbstractDeclarator (
-        parametersAndQualifiers
-        | noPointerAbstractDeclarator LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
-    )
-    | parametersAndQualifiers
-    | LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
-    | LeftParen pointerAbstractDeclarator RightParen
+    : (parametersAndQualifiers | LeftParen pointerAbstractDeclarator RightParen) (parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )*
     ;
 
 abstractPackDeclarator
@@ -718,10 +712,8 @@ abstractPackDeclarator
     ;
 
 noPointerAbstractPackDeclarator
-    : noPointerAbstractPackDeclarator (
-        parametersAndQualifiers
-        | LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
-    )
+    : noPointerAbstractPackDeclarator parametersAndQualifiers
+    | noPointerAbstractPackDeclarator LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
     | Ellipsis
     ;
 

--- a/cpp/examples/g4-4149.cpp
+++ b/cpp/examples/g4-4149.cpp
@@ -1,0 +1,4 @@
+Test<char(*)[21]> type;
+Test<void(*)(void)> type;
+Test<char(&)[21]> type;
+Test<char(&&)[21]> type;


### PR DESCRIPTION
This PR corrects improper translation/refactoring of several rules from the ISO Spec. Below are the rules from the spec and the transformations used to obtain final form. The changes fix #4149.

* Rules re-scraped and transformed from Spec into correct syntax.
* Rules have been reformatted according to the Coding Standard for this repo using [antlr-format-cli](https://github.com/mike-lischke/antlr-format/blob/main/cli/ReadMe.md).
* New tests entered to test declarations in #4149.
* There is new work to be done. https://github.com/antlr/grammars-v4/issues/4151 https://github.com/antlr/grammars-v4/issues/4152

### ptr-abstract-declarator
Spec:
```
ptr-abstract-declarator:
    noptr-abstract-declarator
    ptr-operator ptr-abstract-declaratoropt
```
* Step 1: Convert to Antlr4 syntax.
```
pointerAbstractDeclarator
    : noPointerAbstractDeclarator
    | pointerOperator pointerAbstractDeclarator?
    ;
```
* Step 2: Remove `?`-operator (two sub-steps: `a x? => a(x| ) => a x | a`):
```
pointerAbstractDeclarator
    : noPointerAbstractDeclarator
    | pointerOperator pointerAbstractDeclarator
    | pointerOperator
    ;
```
* Step 3: Reorder alts.
```
pointerAbstractDeclarator
    : pointerOperator pointerAbstractDeclarator
    | noPointerAbstractDeclarator
    | pointerOperator
    ;
```
* Step 4: Group.
```
pointerAbstractDeclarator
    : pointerOperator pointerAbstractDeclarator
    | ( noPointerAbstractDeclarator | pointerOperator )
    ;
```
* Step 5: Convert to Kleene operator.
Note: [From Trash code](https://github.com/kaby76/Trash/blob/5a7f2a6cfce957babcc64fa7f04cf0a7fafc8cf6/src/LanguageServer/Transform.cs#L2407-L2409):
```
// Right recursion:
// Convert A -> b1 A | b2 A | ... | a1 | a2 | ... ;
// into A ->   (b1 | b2 | ...)* (a1 | a2 | ... )
```
```
pointerAbstractDeclarator
    : pointerOperator* ( noPointerAbstractDeclarator | pointerOperator )
    ;
```

### noptr-abstract-declarator
Spec:
```
noptr-abstract-declarator:
    noptr-abstract-declaratoropt parameters-and-qualifiers
    noptr-abstract-declaratoropt [ constant-expressionopt ] attribute-specifier-seqopt
    ( ptr-abstract-declarator )
```

* Step 1: Translated to Antlr4 syntax, which is mutually-left recursive.
```
noPointerAbstractDeclarator
    : noPointerAbstractDeclarator? parametersAndQualifiers
    | noPointerAbstractDeclarator? LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
    | LeftParen pointerAbstractDeclarator RightParen
    ;
```

* Step 2: Remove `?`-operator.
```
noPointerAbstractDeclarator
    : noPointerAbstractDeclarator parametersAndQualifiers
    | parametersAndQualifiers
    | noPointerAbstractDeclarator LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
    | LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
    | LeftParen pointerAbstractDeclarator RightParen
    ;
```

* Step 3: Reorder alts.
```
noPointerAbstractDeclarator
    : noPointerAbstractDeclarator parametersAndQualifiers
    | noPointerAbstractDeclarator LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
    | parametersAndQualifiers
    | LeftParen pointerAbstractDeclarator RightParen
    ;
```

* Step 4: Group alts.
```
noPointerAbstractDeclarator
    : noPointerAbstractDeclarator (parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )
    | (parametersAndQualifiers | LeftParen pointerAbstractDeclarator RightParen)
    ;
```

* Step 5: Transform to `*`-operator closure.
Note: [From Trash code](https://github.com/kaby76/Trash/blob/5a7f2a6cfce957babcc64fa7f04cf0a7fafc8cf6/src/LanguageServer/Transform.cs#L2396-L2398)
```
// Left recursion:
// A -> A b1 | A b2 | ... | a1 | a2 | ... ;
// => A ->  (a1 | a2 | ... ) (b1 | b2 | ...)*;
```

```
noPointerAbstractDeclarator
    : (parametersAndQualifiers | LeftParen pointerAbstractDeclarator RightParen) (parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )*
    ;
```

### abstract-pack-declarator (checking correctness)
Spec:
```
abstract-pack-declarator:
    noptr-abstract-pack-declarator
    ptr-operator abstract-pack-declarator
```

* Step 1: Convert to Antlr4 syntax.
```
abstractPackDeclarator
    : noPointerAbstractPackDeclarator
    | pointerOperator abstractPackDeclarator
    ;
```

* Step 2: Convert to kleene operator.
```
abstractPackDeclarator
    : pointerOperator* noPointerAbstractPackDeclarator
    ;
```
This rule is correct and does not need any changes.

### noptr-abstract-pack-declarator
Spec:
```
noptr-abstract-pack-declarator:
    noptr-abstract-pack-declarator parameters-and-qualifiers
    noptr-abstract-pack-declarator [ constant-expressionopt ] attribute-specifier-seqopt
    ...
```

* Step 1: Convert to Antlr4 syntax.
```
noPointerAbstractPackDeclarator
    : noPointerAbstractPackDeclarator parametersAndQualifiers
    | noPointerAbstractPackDeclarator LeftBracket constantExpression? RightBracket attributeSpecifierSeq?
    | Ellipsis
    ;
```

* Step 2: Group.
```
noPointerAbstractPackDeclarator
    : noPointerAbstractPackDeclarator ( parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )
    | Ellipsis
    ;
```

* Step 3: Kleene-ize rule.
```
noPointerAbstractPackDeclarator
    : Ellipsis ( parametersAndQualifiers | LeftBracket constantExpression? RightBracket attributeSpecifierSeq? )*
    ;
```