### PR TITLE
Improved ANTLR Grammar for R Code in JPlag

### DIFF
--- a/r/R.g4
+++ b/r/R.g4
@@ -79,9 +79,9 @@ expr
     | expr ('<-' | '<<-' | '=' | '->' | '->>' | ':=') expr
     | 'function' '(' formlist? ')' expr // define function
     | expr '(' sublist ')'              // call function
-    | '{' exprlist '}'                  // compound statement
+    | '{' NL* exprlist '}'                  // compound statement
     | 'if' '(' expr ')' expr
-    | 'if' '(' expr ')' expr 'else' expr
+    | 'if' '(' expr ')' expr NL* 'else' expr
     | 'for' '(' ID 'in' expr ')' expr
     | 'while' '(' expr ')' expr
     | 'repeat' expr
@@ -101,11 +101,16 @@ expr
     | 'NaN'
     | 'TRUE'
     | 'FALSE'
+    | NL expr
+    ;
+
+ifCont
+    : 'else' expr
+    |
     ;
 
 exprlist
     : expr ((';' | NL) expr?)*
-    |
     ;
 
 formlist

--- a/r/R.g4
+++ b/r/R.g4
@@ -104,11 +104,6 @@ expr
     | NL expr
     ;
 
-ifCont
-    : 'else' expr
-    |
-    ;
-
 exprlist
     : expr ((';' | NL) expr?)*
     ;

--- a/r/R.g4
+++ b/r/R.g4
@@ -79,7 +79,7 @@ expr
     | expr ('<-' | '<<-' | '=' | '->' | '->>' | ':=') expr
     | 'function' '(' formlist? ')' expr // define function
     | expr '(' sublist ')'              // call function
-    | '{' NL* exprlist '}'                  // compound statement
+    | '{' exprlist '}'                  // compound statement
     | 'if' '(' expr ')' expr
     | 'if' '(' expr ')' expr NL* 'else' expr
     | 'for' '(' ID 'in' expr ')' expr

--- a/r/examples/Complete.R
+++ b/r/examples/Complete.R
@@ -1,0 +1,39 @@
+# Taken from the JPlag repository (https://github.com/jplag/JPlag/blob/570efab64f89ad368bf262d1c1e57710557c0fed/languages/rlang/src/test/resources/de/jplag/rlang/Complete.R)
+
+# This R code sample is supposed to contain the corresponding AST structure for each type of RToken.
+# It is also working code.
+# Author: Robin Maisch
+
+main <- function() {
+	sixteen <- square(4);
+	squareOkay <- ifelse(sixteen==16, TRUE, FALSE);
+	cat("Should be 16: ", sixteen, squareOkay);
+	?cat;
+
+	if (squareOkay) {
+		perfectSquare <- square
+	} else {
+		perfectSquare <- function (x) x*x
+	}
+
+	for (i in 1:10) {
+		print(apply(arg=i, func=perfectSquare))
+	}
+
+	repeat {
+		if (FALSE) next
+		else break
+	}
+
+	idx <- 0
+	while (FALSE) {
+		idx <- idx + 1
+		print((0:40)[idx=])
+	}
+}
+oneMore <- function(var) base::'+'(var, 1)  		# weird way to access + operator
+square <- function(x) x+x   						# works for x=2, so that's not bad
+identity <- function(x) x
+apply <- function(arg=0, func=identity) func(arg)
+
+main()

--- a/r/examples/Game.R
+++ b/r/examples/Game.R
@@ -1,0 +1,94 @@
+# Taken from the JPlag repository (https://github.com/jplag/JPlag/blob/570efab64f89ad368bf262d1c1e57710557c0fed/languages/rlang/src/test/resources/de/jplag/rlang/Game.R)
+
+# Sample R program
+# Author: Robin Maisch
+
+readBool <- function()
+{ 
+  n <- readline(prompt="Yes or no? (y/n): ")
+  while (!grepl("[YyNn]",n))
+  {
+	 n <- readline()
+  }
+  return(ifelse(n=="y"||n=="Y", TRUE, FALSE))
+}
+
+
+getFilterBalance <- function(f, elements) {
+	return(abs(length(Filter(f, elements)) - length(elements)/2))
+}
+
+divisibleByFilter <- function(i) {
+	res <- c(function(x) x %% i == 0, paste("a multiple of", i), NA);
+	return(res)
+}
+
+greaterThanFilter <- function(i) {
+	res <- c(function(x) x > i, paste("greater than", i), NA);
+	return(res)
+}
+
+smallerThanFilter <- function(i) {
+	res <- c(function(x) x < i, paste("smaller than", i), NA);
+	return(res)
+}
+
+endsWithFilter <- function(i) {
+	res <- c(function(x) x %% 10 == i, paste("'s last digit a'", i), NA);
+	return(res)
+}
+
+# real program start here
+  
+main <- function() {
+	filters <- c(lapply(2:20, divisibleByFilter),
+				lapply(0:100, greaterThanFilter),
+				lapply(0:100, smallerThanFilter),
+				lapply(0:10, endsWithFilter))
+	filters <- aperm(simplify2array(filters, higher=FALSE), c(2,1))
+	activeFilters = list()
+
+	cat("Think of a number between 0 and 100.\n")
+	count <- 1
+	candidates <- c()
+	repeat {
+		cat("\n +++ Round",count,"+++\n\n")
+		candidates = 0:100
+		for (f in activeFilters) {
+			filterFunc = ifelse(f[[3]], function(x) f[[1]](x), function(x) !f[[1]](x))
+			candidates = Filter(filterFunc, candidates)
+		}
+		if (length(candidates) == 1) {
+			break
+		}
+
+		balance <- sapply(1:(length(filters)/3), function(i) {return(getFilterBalance(filters[i,][[1]], candidates))})
+		rank <- rank(balance, ties="first")
+		risk = max(20-2*count, 1)
+		lowerEnd = 1
+		topFiveIdx = order(rank)[lowerEnd:risk]
+		# print(filters[topFiveIdx[1:3],2])
+		winnerIdx = topFiveIdx[sample.int(risk-lowerEnd + 1,1)]
+		winnerFilter = filters[winnerIdx,]
+
+		cat("Is your number", winnerFilter[[2]], "?\n")
+		winnerFilter[[3]] <- readBool()
+
+		cat("Okay, now, let's see...\n")
+		activeFilters[[length(activeFilters)+1]] = winnerFilter
+		# cat("Now we have", length(activeFilters), "active filters.\n")
+
+		filters[- winnerIdx,] # remove element
+		count <- count + 1
+	}
+
+	cat("Your number must be", candidates[1], ", right???\n")
+	answer <- readBool()
+	if (answer) {
+		cat("Hahaha, I knew it. I'm a genius.\n")
+	} else {
+		cat("You must be joking!\n")
+	}
+
+}
+main()


### PR DESCRIPTION
The JPlag repository has two large examples of R code (can be found here: [JPlag R examples](https://github.com/jplag/JPlag/tree/main/languages/rlang/src/test/resources/de/jplag/rlang)). I encountered several issues with these two files that I tried to address.

The problems were:
- In exprlist ANTLR seemed to prefer the empty option always. I resolved this by removing the empty option and making exprlist optional within expr.
- The grammar didn't allow for line-breaks before expressions, so I added an option "NL expr" for expr.
- There were no linebreaks allowed between an if block and the else keyword

I should mention that I know neither ANTLR nor R well, so it would be nice if someone could look this over.