### PR TITLE
Allow "yes" keyword to be used as an identifier

### DIFF
--- a/sql/mariadb/MariaDBParser.g4
+++ b/sql/mariadb/MariaDBParser.g4
@@ -3199,6 +3199,7 @@ keywordsCanBeId
     | XA
     | XA_RECOVER_ADMIN
     | XML
+    | YES
     // MariaDB-specific only
     | BINLOG_MONITOR
     | BINLOG_REPLAY

--- a/sql/mariadb/examples/fast/ddl_alter.sql
+++ b/sql/mariadb/examples/fast/ddl_alter.sql
@@ -25,6 +25,7 @@ alter table table1 add primary key (id);
 alter table table1 add primary key table_pk (id);
 alter table table1 add primary key `table_pk` (id);
 alter table table1 add primary key `table_pk` (`id`);
+alter table table1 add column yes varchar(255)  default '' null;
 alter table add_test add column if not exists col1 varchar(255);
 alter table add_test add column if not exists col4 varchar(255);
 alter table add_test add index if not exists ix_add_test_col1 using btree (col1) comment 'test index';

--- a/sql/mysql/Positive-Technologies/MySqlParser.g4
+++ b/sql/mysql/Positive-Technologies/MySqlParser.g4
@@ -3122,6 +3122,7 @@ keywordsCanBeId
     | XA
     | XA_RECOVER_ADMIN
     | XML
+    | YES
     ;
 
 functionNameBase

--- a/sql/mysql/Positive-Technologies/examples/ddl_alter.sql
+++ b/sql/mysql/Positive-Technologies/examples/ddl_alter.sql
@@ -39,6 +39,7 @@ alter table table1 add primary key `table_pk` (id);
 alter table table1 add primary key `table_pk` (`id`);
 alter table table1 drop foreign key fk_name;
 alter table table1 drop constraint cons;
+alter table table1 add column yes varchar(255)  default '' null;
 alter table add_test add column col1 int not null;
 alter table `some_table` add (primary key `id` (`id`),`k_id` int unsigned not null,`another_field` smallint not null,index `k_id` (`k_id`));
 alter table `some_table` add column (unique key `another_field` (`another_field`));


### PR DESCRIPTION
MySQL permits `yes` keyword to be used as an identifier.