### PR TITLE
Fix for #4174 -- get "mvn clean test" working again.

### DIFF
--- a/acme/pom.xml
+++ b/acme/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>acme</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Acme grammar</name>
+	<name>Acme grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/action/pom.xml
+++ b/action/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>action</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Action! grammar</name>
+	<name>Action! grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/agc/pom.xml
+++ b/agc/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>agc</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com agc grammar</name>
+	<name>agc grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/alef/pom.xml
+++ b/alef/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>alef</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Alef grammar</name>
+	<name>Alef grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/algol60/pom.xml
+++ b/algol60/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>algol60</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com algol60 grammar</name>
+	<name>algol60 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/alloy/pom.xml
+++ b/alloy/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>alloy</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Alloy grammar</name>
+	<name>Alloy grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/alpaca/pom.xml
+++ b/alpaca/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>alpaca</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com alpaca grammar</name>
+	<name>alpaca grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/angelscript/pom.xml
+++ b/angelscript/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>angelscript</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Arithmetic grammar</name>
+	<name>Angelscript grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/argus/pom.xml
+++ b/argus/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>argus</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Argus grammar</name>
+	<name>Argus grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/arithmetic/pom.xml
+++ b/arithmetic/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>arithmetic</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Arithmetic grammar</name>
+	<name>Arithmetic grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/aterm/pom.xml
+++ b/aterm/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>aterm</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com ATerm grammar</name>
+	<name>ATerm grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/b/pom.xml
+++ b/b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>b</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com B grammar</name>
+	<name>B grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>basic</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BASIC grammar</name>
+	<name>BASIC grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/bcl/pom.xml
+++ b/bcl/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>bcl</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BCL grammar</name>
+	<name>BCL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/bcpl/pom.xml
+++ b/bcpl/pom.xml
@@ -3,14 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>bcpl</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BCPL grammar</name>
+	<name>BCPL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-      <sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/bdf/pom.xml
+++ b/bdf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>bdf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BDF grammar</name>
+	<name>BDF grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/bencoding/pom.xml
+++ b/bencoding/pom.xml
@@ -10,7 +10,6 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <build>
-        <sourceDirectory>Java</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.antlr</groupId>

--- a/bibcode/pom.xml
+++ b/bibcode/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>bibcode</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Bibcode grammar</name>
+	<name>Bibcode grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/bnf/README.md
+++ b/bnf/README.md
@@ -16,3 +16,17 @@ https://dl.acm.org/doi/pdf/10.1145/366193.366201
 https://www.softwarepreservation.org/projects/ALGOL/paper/Backus-Syntax_and_Semantics_of_Proposed_IAL.pdf
 
 https://dl.acm.org/doi/pdf/10.1145/355588.365140
+
+### Examples
+
+BNF for Scheme
+* Revised 5: https://people.csail.mit.edu/jaffer/r5rs_9.html
+* Revised 6: https://www.r6rs.org/ https://www.r6rs.org/final/html/r6rs/r6rs-Z-H-7.html#node_chap_4
+
+The Wikipedia description of BNF is given in wiki-bnf.bnf
+
+Examples from https://cs61.seas.harvard.edu/site/2020/BNFGrammars/
+on October 26, 2023
+
+Examples from https://isaaccomputerscience.org/concepts/dsa_toc_bnf?examBoard=all&stage=all
+on October 26, 2023

--- a/bnf/examples/harvard.edu/readme.md
+++ b/bnf/examples/harvard.edu/readme.md
@@ -1,2 +1,0 @@
-Examples from https://cs61.seas.harvard.edu/site/2020/BNFGrammars/
-on October 26, 2023

--- a/bnf/examples/ics/readme.md
+++ b/bnf/examples/ics/readme.md
@@ -1,2 +1,0 @@
-Examples from https://isaaccomputerscience.org/concepts/dsa_toc_bnf?examBoard=all&stage=all
-on October 26, 2023

--- a/bnf/examples/readme.md
+++ b/bnf/examples/readme.md
@@ -1,5 +1,0 @@
-BNF for Scheme
-* Revised 5: https://people.csail.mit.edu/jaffer/r5rs_9.html
-* Revised 6: https://www.r6rs.org/ https://www.r6rs.org/final/html/r6rs/r6rs-Z-H-7.html#node_chap_4
-
-The Wikipedia description of BNF is given in wiki-bnf.bnf

--- a/bnf/pom.xml
+++ b/bnf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>bnf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BNF grammar</name>
+	<name>BNF grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>
@@ -18,7 +18,8 @@
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
 					<includes>
-					   <include>bnf.g4</include>
+					   <include>bnfLexer.g4</include>
+					   <include>bnfParser.g4</include>
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
@@ -41,7 +42,7 @@
 					<entryPoint>start_</entryPoint>
 					<grammarName>bnf</grammarName>
 					<packageName></packageName>
-					<exampleFiles>examples/</exampleFiles>
+					<exampleFiles>examples</exampleFiles>
 				</configuration>
 				<executions>
 					<execution>

--- a/calculator/pom.xml
+++ b/calculator/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>calculator</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Calculator grammar</name>
+	<name>Calculator grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/callable/pom.xml
+++ b/callable/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>callable</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com callable grammar</name>
+	<name>callable grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/cayenne/pom.xml
+++ b/cayenne/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>cayenne</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Arithmetic grammar</name>
+	<name>Arithmetic grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/chip8/pom.xml
+++ b/chip8/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>chip8</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com chip8 grammar</name>
+	<name>chip8 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/clf/pom.xml
+++ b/clf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>clf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com CLF grammar</name>
+	<name>CLF grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/clu/pom.xml
+++ b/clu/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>clu</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com clu grammar</name>
+	<name>clu grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/cobol85/pom.xml
+++ b/cobol85/pom.xml
@@ -16,10 +16,8 @@
 				<artifactId>antlr4-maven-plugin</artifactId>
 				<version>${antlr.version}</version>
 				<configuration>
-					<sourceDirectory>${basedir}</sourceDirectory>
 					<includes>
 						<include>Cobol85.g4</include>
-						<include>Cobol85Preprocessor.g4</include>
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>
@@ -28,26 +26,6 @@
 					<execution>
 						<goals>
 							<goal>antlr4</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>com.khubla.antlr</groupId>
-				<artifactId>antlr4test-maven-plugin</artifactId>
-				<version>${antlr4test-maven-plugin.version}</version>
-				<configuration>
-					<verbose>false</verbose>
-					<showTree>false</showTree>
-					<entryPoint>startRule</entryPoint>
-					<grammarName>Cobol85</grammarName>
-					<packageName></packageName>
-					<exampleFiles>examples/</exampleFiles>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/cookie/pom.xml
+++ b/cookie/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>cookie</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com cookie grammar</name>
+	<name>cookie grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -9,7 +9,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/cql/pom.xml
+++ b/cql/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>cql</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Z39.5 CQL grammar</name>
+	<name>Z39.5 CQL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/creole/pom.xml
+++ b/creole/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>creole</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com creole grammar</name>
+	<name>creole grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/csharp/pom.xml
+++ b/csharp/pom.xml
@@ -3,14 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>csharp</artifactId>
 	<packaging>jar</packaging>
-	<name>C# grammar</name>
+	<name>csharp grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/ctl/pom.xml
+++ b/ctl/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>ctl</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com CTL grammar</name>
+	<name>CTL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/databank/pom.xml
+++ b/databank/pom.xml
@@ -3,14 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>databank</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com databank grammar</name>
+	<name>databank grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/datalog/pom.xml
+++ b/datalog/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>datalog</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Datalog grammar</name>
+	<name>Datalog grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/dif/pom.xml
+++ b/dif/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>dif</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com DIF grammar</name>
+	<name>DIF grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/doiurl/pom.xml
+++ b/doiurl/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>doiurl</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com DOI URLgrammar</name>
+	<name>DOI URLgrammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>grammarsv4</artifactId>

--- a/ebnf/pom.xml
+++ b/ebnf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>bnf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BNF grammar</name>
+	<name>EBNF grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/esolang/brainflak/pom.xml
+++ b/esolang/brainflak/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>brainflack</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Brainflak grammar</name>
+	<name>Brainflak grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/brainfuck/pom.xml
+++ b/esolang/brainfuck/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>brainfuck</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Brainfuck grammar</name>
+	<name>Brainfuck grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/dgol/pom.xml
+++ b/esolang/dgol/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>dgol</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com DGOL grammar</name>
+	<name>DGOL grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/lolcode/pom.xml
+++ b/esolang/lolcode/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>lolcode</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com lolcode grammar</name>
+	<name>lolcode grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/loop/pom.xml
+++ b/esolang/loop/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>loop</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com LOOP grammar</name>
+	<name>LOOP grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/nanofuck/pom.xml
+++ b/esolang/nanofuck/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>nanofuck</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Nanofuck grammar</name>
+	<name>Nanofuck grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/sickbay/pom.xml
+++ b/esolang/sickbay/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>sickbay</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com SICKBAY grammar</name>
+	<name>SICKBAY grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/snowball/pom.xml
+++ b/esolang/snowball/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>snowball</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com snowball grammar</name>
+	<name>snowball grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/esolang/wheel/pom.xml
+++ b/esolang/wheel/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>wheel</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Wheel grammar</name>
+	<name>Wheel grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>esolangparent</artifactId>

--- a/fasta/pom.xml
+++ b/fasta/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fasta</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com fasta grammar</name>
+	<name>fasta grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/fdo91/pom.xml
+++ b/fdo91/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fdo91</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com FDO91 grammar</name>
+	<name>FDO91 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/fen/pom.xml
+++ b/fen/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fen</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com fen grammar</name>
+	<name>fen grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/flowmatic/pom.xml
+++ b/flowmatic/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>flowmatic</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com FLOW-MATIC grammar</name>
+	<name>FLOW-MATIC grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/focal/pom.xml
+++ b/focal/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>focal</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com FOCAL grammar</name>
+	<name>FOCAL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/fortran/fortran77/desc.xml
+++ b/fortran/fortran77/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.13.0</antlr-version>
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3</targets>
 </desc>

--- a/fortran/fortran77/pom.xml
+++ b/fortran/fortran77/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/fortran/fortran90/pom.xml
+++ b/fortran/fortran90/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/gdscript/pom.xml
+++ b/gdscript/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gdscript</artifactId>
     <packaging>jar</packaging>
-    <name>Python3 grammar</name>
+    <name>gdscript grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>grammarsv4</artifactId>
@@ -14,7 +14,6 @@
         <src.dir>Java</src.dir>
     </properties>
     <build>
-        <sourceDirectory>${src.dir}</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.antlr</groupId>

--- a/gedcom/pom.xml
+++ b/gedcom/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>gedcom</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com GEDCOM grammar</name>
+	<name>GEDCOM grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/gff3/pom.xml
+++ b/gff3/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>gff3</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com gff3 grammar</name>
+	<name>gff3 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/gml/pom.xml
+++ b/gml/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>gml</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com GML grammar</name>
+	<name>GML grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/gtin/pom.xml
+++ b/gtin/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>gtin</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com GTIN grammar</name>
+	<name>GTIN grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/guido/pom.xml
+++ b/guido/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>guido</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com guido grammar</name>
+	<name>guido grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/guitartab/pom.xml
+++ b/guitartab/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>guitartab</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Guitar Tab grammar</name>
+	<name>Guitar Tab grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/haskell/pom.xml
+++ b/haskell/pom.xml
@@ -9,11 +9,7 @@
 		<artifactId>grammarsv4</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-	<properties>
-		<src.dir>Java</src.dir>
-	</properties>
 	<build>
-		<sourceDirectory>${src.dir}</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/html/pom.xml
+++ b/html/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>html</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com html grammar</name>
+	<name>html grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/icon/pom.xml
+++ b/icon/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>icon</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com icon grammar</name>
+	<name>icon grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>
@@ -38,7 +38,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>start</entryPoint>
+					<entryPoint>start_</entryPoint>
 					<grammarName>icon</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>

--- a/inf/pom.xml
+++ b/inf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>inf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com inf grammar</name>
+	<name>inf grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/infosapient/pom.xml
+++ b/infosapient/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>infosapient</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Infosapient grammar</name>
+	<name>Infosapient grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/istc/pom.xml
+++ b/istc/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>istc</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com ISTC grammar</name>
+	<name>ISTC grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/itn/pom.xml
+++ b/itn/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>itn</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com ITN grammar</name>
+	<name>ITN grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/jam/pom.xml
+++ b/jam/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jam</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com JAM grammar</name>
+	<name>JAM grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/janus/pom.xml
+++ b/janus/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>janus</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Janus grammar</name>
+	<name>Janus grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/javascript/javascript/pom.xml
+++ b/javascript/javascript/pom.xml
@@ -9,13 +9,8 @@
 		<artifactId>jsparent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-    <properties>
-        <!-- location of java sources -->
-        <src.dir>Java</src.dir>
-    </properties>
 	<build>
-        <sourceDirectory>${src.dir}</sourceDirectory>
-        <plugins>
+	     <plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>

--- a/javascript/jsx/pom.xml
+++ b/javascript/jsx/pom.xml
@@ -9,13 +9,8 @@
 		<artifactId>jsparent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-    <properties>
-        <!-- location of java sources -->
-        <src.dir>Java</src.dir>
-    </properties>
 	<build>
-        <sourceDirectory>${src.dir}</sourceDirectory>
-        <plugins>
+                <plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>

--- a/javascript/typescript/pom.xml
+++ b/javascript/typescript/pom.xml
@@ -14,7 +14,6 @@
         <src.dir>Java</src.dir>
     </properties>
 	<build>
-        <sourceDirectory>Java</sourceDirectory>
         <plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/joss/pom.xml
+++ b/joss/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>joss</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com JOSS grammar</name>
+	<name>JOSS grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/karel/pom.xml
+++ b/karel/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>karel</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com karel grammar</name>
+	<name>karel grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/kirikiri-tjs/pom.xml
+++ b/kirikiri-tjs/pom.xml
@@ -9,12 +9,7 @@
 		<artifactId>grammarsv4</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-	<properties>  
-		<!-- location of java sources -->      
-		<src.dir>Java</src.dir>
-	</properties>
 	<build>
-        <sourceDirectory>${src.dir}</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>lambda</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com lambda grammar</name>
+	<name>lambda grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/lark/pom.xml
+++ b/lark/pom.xml
@@ -39,7 +39,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>start</entryPoint>
+					<entryPoint>start_</entryPoint>
 					<grammarName>Lark</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>

--- a/lcc/pom.xml
+++ b/lcc/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>lcc</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com LCC (Library of Congress Classification) grammar</name>
+	<name>LCC (Library of Congress Classification) grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/limbo/pom.xml
+++ b/limbo/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>limbo</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com limbo grammar</name>
+	<name>limbo grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/lisa/pom.xml
+++ b/lisa/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>lisa</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com LISA grammar</name>
+	<name>LISA grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/lisp/pom.xml
+++ b/lisp/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>lisp</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com LISP grammar</name>
+	<name>LISP grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/logo/logo/pom.xml
+++ b/logo/logo/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>logo</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com logo grammar</name>
+	<name>logo grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>logoparent</artifactId>

--- a/lrc/pom.xml
+++ b/lrc/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>lrc</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com LRC grammar</name>
+	<name>LRC grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/ltl/pom.xml
+++ b/ltl/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>ltl</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com LTL grammar</name>
+	<name>LTL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/lua/desc.xml
+++ b/lua/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3</targets>
 </desc>

--- a/lua/pom.xml
+++ b/lua/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/matlab/pom.xml
+++ b/matlab/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>matlab</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com matlab grammar</name>
+	<name>matlab grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/metamath/pom.xml
+++ b/metamath/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>metamath</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Metamath grammar</name>
+	<name>Metamath grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/metric/pom.xml
+++ b/metric/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>metric</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com metric grammar</name>
+	<name>metric grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/microc/pom.xml
+++ b/microc/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>microc</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com MicroC grammar</name>
+	<name>MicroC grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/molecule/pom.xml
+++ b/molecule/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>molecule</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Molecule grammar</name>
+	<name>Molecule grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/moo/pom.xml
+++ b/moo/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>moo</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com moo grammar</name>
+	<name>moo grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/morsecode/pom.xml
+++ b/morsecode/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>morsecode</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Morse Code grammar</name>
+	<name>Morse Code grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/muddb/pom.xml
+++ b/muddb/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>muddb</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com muddb grammar</name>
+	<name>muddb grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/mumps/pom.xml
+++ b/mumps/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>mumps</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com MUMPS grammar</name>
+	<name>MUMPS grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/newick/pom.xml
+++ b/newick/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>newick</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Newick grammar</name>
+	<name>Newick grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/oberon/pom.xml
+++ b/oberon/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>oberon</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com oberon grammar</name>
+	<name>oberon grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>grammarsv4</artifactId>

--- a/orwell/pom.xml
+++ b/orwell/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>orwell</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com orwell grammar</name>
+	<name>orwell grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/out.txt
+++ b/out.txt
@@ -1,0 +1,6136 @@
+[INFO] Scanning for projects...
+[WARNING] The project org.antlr.grammars:grammarsv4:pom:1.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
+[INFO] ------------------------------------------------------------------------
+[INFO] Reactor Build Order:
+[INFO] 
+[INFO] ANTLR4 grammars                                                    [pom]
+[INFO] abb grammar                                                        [jar]
+[INFO] ABNF grammar                                                       [jar]
+[INFO] khubla.com Acme grammar                                            [jar]
+[INFO] khubla.com Action! grammar                                         [jar]
+[INFO] Ada Grammars                                                       [pom]
+[INFO] Ada 83 grammar                                                     [jar]
+[INFO] Ada 95 grammar                                                     [jar]
+[INFO] Ada 2005 grammar                                                   [jar]
+[INFO] Ada 2012 grammar                                                   [jar]
+[INFO] khubla.com Alef grammar                                            [jar]
+[INFO] khubla.com algol60 grammar                                         [jar]
+[INFO] khubla.com Alloy grammar                                           [jar]
+[INFO] khubla.com alpaca grammar                                          [jar]
+[INFO] localstack.cloud amazon-states-language                            [jar]
+[INFO] localstack.cloud amazon-states-language intrinsic-functions        [jar]
+[INFO] khubla.com Arithmetic grammar                                      [jar]
+[INFO] ANTLR Grammars                                                     [pom]
+[INFO] ANTLR2 grammar                                                     [jar]
+[INFO] ANTLR3 grammar                                                     [jar]
+[INFO] ANTLR4 grammar                                                     [jar]
+[INFO] Apex grammar                                                       [jar]
+[INFO] apt grammar                                                        [jar]
+[INFO] ArangoDb grammar                                                   [jar]
+[INFO] khubla.com Argus grammar                                           [jar]
+[INFO] khubla.com Arithmetic grammar                                      [jar]
+[INFO] ASL grammar                                                        [jar]
+[INFO] Assembler Grammars                                                 [pom]
+[INFO] ASM 6502 grammar                                                   [jar]
+[INFO] ASM 8080 grammar                                                   [jar]
+[INFO] ASM 8086 grammar                                                   [jar]
+[INFO] MASM grammar                                                       [jar]
+[INFO] ASM Z80 grammar                                                    [jar]
+[INFO] MASM grammar                                                       [jar]
+[INFO] NASM grammar                                                       [jar]
+[INFO] ASM pdp7 grammar                                                   [jar]
+[INFO] CUDA PTX ISA Grammars                                              [pom]
+[INFO] CUDA PTX ISA 1.0 grammar                                           [jar]
+[INFO] CUDA PTX ISA 2.1 grammar                                           [jar]
+[INFO] ASM RSICV grammar                                                  [jar]
+[INFO] ASN Grammars                                                       [pom]
+[INFO] ASN.1 grammar                                                      [jar]
+[INFO] ASN 3GPP grammar                                                   [jar]
+[INFO] khubla.com ATerm grammar                                           [jar]
+[INFO] ATL grammar                                                        [jar]
+[INFO] khubla.com B grammar                                               [jar]
+[INFO] khubla.com BASIC grammar                                           [jar]
+[INFO] khubla.com BCL grammar                                             [jar]
+[INFO] khubla.com BCPL grammar                                            [jar]
+[INFO] khubla.com BDF grammar                                             [jar]
+[INFO] Bencoding grammar                                                  [jar]
+[INFO] khubla.com Bibcode grammar                                         [jar]
+[INFO] Bicep grammar                                                      [jar]
+[INFO] khubla.com BNF grammar                                             [jar]
+[INFO] C grammar                                                          [jar]
+[INFO] khubla.com Calculator grammar                                      [jar]
+[INFO] khubla.com callable grammar                                        [jar]
+[INFO] Cap'n Proto schema language grammar                                [jar]
+[INFO] CaQL grammar                                                       [jar]
+[INFO] khubla.com Arithmetic grammar                                      [jar]
+[INFO] khubla.com CLF grammar                                             [jar]
+[INFO] Clojure grammar                                                    [jar]
+[INFO] khubla.com clu grammar                                             [jar]
+[INFO] CMake grammar                                                      [jar]
+[INFO] CodeQL grammar                                                     [jar]
+[INFO] khubla.com cookie grammar                                          [jar]
+[INFO] CPP14 grammar                                                      [jar]
+[INFO] khubla.com Z39.5 CQL grammar                                       [jar]
+[INFO] Apache Cassandra CQL 3 grammar                                     [jar]
+[INFO] khubla.com creole grammar                                          [jar]
+[INFO] csharp grammar                                                     [jar]
+[INFO] CSS3 grammar                                                       [jar]
+[INFO] ANTLR CSV grammar                                                  [jar]
+[INFO] khubla.com CTL grammar                                             [jar]
+[INFO] Hyperledger Composer Modeling Language grammar                     [jar]
+[INFO] Cypher grammar                                                     [jar]
+[INFO] Dart2 grammar                                                      [jar]
+[INFO] khubla.com databank grammar                                        [jar]
+[INFO] khubla.com Datalog grammar                                         [jar]
+[INFO] DCM grammar                                                        [jar]
+[INFO] Dice notation grammar                                              [jar]
+[INFO] khubla.com DIF grammar                                             [jar]
+[INFO] khubla.com DOI URLgrammar                                          [jar]
+[INFO] ANTLR dot grammar                                                  [jar]
+[INFO] EDIF 3 0 0 grammar                                                 [jar]
+[INFO] EDN grammar                                                        [jar]
+[INFO] Elixir grammar                                                     [jar]
+[INFO] Erlang grammar                                                     [jar]
+[INFO] Esoteric Language Grammars                                         [pom]
+[INFO] khubla.com Brainfuck grammar                                       [jar]
+[INFO] khubla.com Brainflak grammar                                       [jar]
+[INFO] COOL grammar                                                       [jar]
+[INFO] khubla.com DGOL grammar                                            [jar]
+[INFO] khubla.com lolcode grammar                                         [jar]
+[INFO] khubla.com LOOP grammar                                            [jar]
+[INFO] khubla.com Nanofuck grammar                                        [jar]
+[INFO] khubla.com SICKBAY grammar                                         [jar]
+[INFO] khubla.com snowball grammar                                        [jar]
+[INFO] khubla.com Wheel grammar                                           [jar]
+[INFO] EVM bytecode grammar                                               [jar]
+[INFO] khubla.com fasta grammar                                           [jar]
+[INFO] khubla.com FDO91 grammar                                           [jar]
+[INFO] khubla.com fen grammar                                             [jar]
+[INFO] FlatBuffers schema language grammar                                [jar]
+[INFO] khubla.com FLOW-MATIC grammar                                      [jar]
+[INFO] khubla.com FOCAL grammar                                           [jar]
+[INFO] First Order Logic grammar                                          [jar]
+[INFO] Fortran Grammars                                                   [pom]
+[INFO] fortran77 grammar                                                  [jar]
+[INFO] fortran90 grammar                                                  [jar]
+[INFO] fusion-tables grammar                                              [jar]
+[INFO] Python3 grammar                                                    [jar]
+[INFO] khubla.com GEDCOM grammar                                          [jar]
+[INFO] khubla.com gff3 grammar                                            [jar]
+[INFO] GLSL grammar                                                       [jar]
+[INFO] khubla.com GML grammar                                             [jar]
+[INFO] Go language grammar                                                [jar]
+[INFO] GraphQL grammar                                                    [jar]
+[INFO] ANTLR Graphstream DGS grammar                                      [jar]
+[INFO] khubla.com GTIN grammar                                            [jar]
+[INFO] khubla.com guido grammar                                           [jar]
+[INFO] khubla.com Guitar Tab grammar                                      [jar]
+[INFO] Haskell grammar                                                    [jar]
+[INFO] khubla.com html grammar                                            [jar]
+[INFO] HTTP grammar                                                       [jar]
+[INFO] HyperTalk grammar                                                  [jar]
+[INFO] ical grammar                                                       [jar]
+[INFO] khubla.com icon grammar                                            [jar]
+[INFO] IDL grammar                                                        [jar]
+[INFO] khubla.com inf grammar                                             [jar]
+[INFO] informix grammar                                                   [jar]
+[INFO] khubla.com Infosapient grammar                                     [jar]
+[INFO] IRI grammar                                                        [jar]
+[INFO] iso8601 grammar                                                    [jar]
+[INFO] khubla.com ISTC grammar                                            [jar]
+[INFO] khubla.com ITN grammar                                             [jar]
+[INFO] khubla.com JAM grammar                                             [jar]
+[INFO] khubla.com Janus grammar                                           [jar]
+[INFO] Java Grammars                                                      [pom]
+[INFO] Java                                                               [jar]
+[INFO] Java8 grammar                                                      [jar]
+[INFO] Java9 grammar                                                      [jar]
+[INFO] Java20                                                             [jar]
+[INFO] Javadoc grammar                                                    [jar]
+[INFO] Javascript Grammars                                                [pom]
+[INFO] ECMAScript grammar                                                 [jar]
+[INFO] JavaScript grammar                                                 [jar]
+[INFO] JSX grammar                                                        [jar]
+[INFO] TypeScript grammar                                                 [jar]
+[INFO] khubla.com JOSS grammar                                            [jar]
+[INFO] JPA grammar                                                        [jar]
+[INFO] ANTLR JSON grammar                                                 [jar]
+[INFO] ANTLR JSON5 grammar                                                [jar]
+[INFO] khubla.com karel grammar                                           [jar]
+[INFO] kirikiri-tjs grammar                                               [jar]
+[INFO] Kotlin Grammars                                                    [pom]
+[INFO] Kotlin grammar                                                     [jar]
+[INFO] Kotlin Formal grammar                                              [jar]
+[INFO] kuka grammar                                                       [jar]
+[INFO] KQuery grammar                                                     [jar]
+[INFO] khubla.com lambda grammar                                          [jar]
+[INFO] Lark grammar                                                       [jar]
+[INFO] khubla.com LCC (Library of Congress Classification) grammar        [jar]
+[INFO] less grammar                                                       [jar]
+[INFO] khubla.com limbo grammar                                           [jar]
+[INFO] khubla.com LISA grammar                                            [jar]
+[INFO] khubla.com LISP grammar                                            [jar]
+[INFO] Logo Grammars                                                      [pom]
+[INFO] khubla.com logo grammar                                            [jar]
+[INFO] UCB logo grammar                                                   [jar]
+[INFO] LPC grammar                                                        [jar]
+[INFO] khubla.com LRC grammar                                             [jar]
+[INFO] khubla.com LTL grammar                                             [jar]
+[INFO] Lua grammar                                                        [jar]
+[INFO] Lucene grammar                                                     [jar]
+[INFO] khubla.com matlab grammar                                          [jar]
+[INFO] McKeeman Form grammar                                              [jar]
+[INFO] mdx grammar                                                        [jar]
+[INFO] memcached grammar                                                  [jar]
+[INFO] khubla.com Metamath grammar                                        [jar]
+[INFO] khubla.com metric grammar                                          [jar]
+[INFO] khubla.com MicroC grammar                                          [jar]
+[INFO] Modelica grammar                                                   [jar]
+[INFO] Modula2 PIM4 grammar                                               [jar]
+[INFO] khubla.com Molecule grammar                                        [jar]
+[INFO] khubla.com moo grammar                                             [jar]
+[INFO] khubla.com Morse Code grammar                                      [jar]
+[INFO] PowerQuery grammar                                                 [jar]
+[INFO] MPS grammar                                                        [jar]
+[INFO] khubla.com muddb grammar                                           [jar]
+[INFO] muMath grammar                                                     [jar]
+[INFO] khubla.com MUMPS grammar                                           [jar]
+[INFO] ANTLR MuParser grammar                                             [jar]
+[INFO] khubla.com Newick grammar                                          [jar]
+[INFO] khubla.com oberon grammar                                          [jar]
+[INFO] ONCRPC and XDR grammars                                            [jar]
+[INFO] khubla.com orwell grammar                                          [jar]
+[INFO] khubla.com p grammar                                               [jar]
+[INFO] Parking Sign grammar                                               [jar]
+[INFO] khubla.com Pascal grammar                                          [jar]
+[INFO] khubla.com PBM grammar                                             [jar]
+[INFO] PCRE grammar                                                       [jar]
+[INFO] pddl logo grammar                                                  [jar]
+[INFO] khubla.com Portable Draughts Notation grammar                      [jar]
+[INFO] PeopleCode grammar                                                 [jar]
+[INFO] khubla.com pf grammar                                              [jar]
+[INFO] Pegen grammar (the CPython meta grammar)                           [jar]
+[INFO] Antlr pgn grammar                                                  [jar]
+[INFO] PHP grammar                                                        [jar]
+[INFO] khubla.com PII grammar                                             [jar]
+[INFO] khubla.com PL0 grammar                                             [jar]
+[INFO] khubla.com pLucid grammar                                          [jar]
+[INFO] khubla.com ply grammar                                             [jar]
+[INFO] khubla.com Portable Minsky Machine Notation grammar                [jar]
+[INFO] khubla.com postalcode grammar                                      [jar]
+[INFO] PowerBuilder grammar                                               [jar]
+[INFO] khubla.com prolog grammar                                          [jar]
+[INFO] PromQL grammar                                                     [jar]
+[INFO] khubla.com Propositional Calculus grammar                          [jar]
+[INFO] khubla.com Properties grammar                                      [jar]
+[INFO] Protobuf2 grammar                                                  [jar]
+[INFO] Protobuf3 grammar                                                  [jar]
+[INFO] W3C PROV-O Notation: PROV-N grammar                                [jar]
+[INFO] Python Grammars                                                    [pom]
+[INFO] Python grammar                                                     [jar]
+[INFO] Python2 Python Target grammar                                      [jar]
+[INFO] Python3 grammar                                                    [jar]
+[INFO] Python2 grammar                                                    [jar]
+[INFO] Python3 grammar                                                    [jar]
+[INFO] khubla.com QIF grammar                                             [jar]
+[INFO] khubla.com Quake map grammar                                       [jar]
+[INFO] R grammar                                                          [jar]
+[INFO] HTDP Racket grammar                                                [jar]
+[INFO] HTDP Racket grammar                                                [jar]
+[INFO] RCS                                                                [jar]
+[INFO] khubla.com RedCode grammar                                         [jar]
+[INFO] khubla.com Refal grammar                                           [jar]
+[INFO] Open Policy Agent's Rego grammar                                   [jar]
+[INFO] ReStructuredText grammar                                           [jar]
+[INFO] Rexx grammar                                                       [jar]
+[INFO] RFC822 Grammars                                                    [pom]
+[INFO] khubla.com DateTime grammar                                        [jar]
+[INFO] khubla.com RFC822 grammar                                          [jar]
+[INFO] khubla.com Domain grammar                                          [jar]
+[INFO] khubla.com RFC 1960 Filter grammar                                 [jar]
+[INFO] khubla.com BEEP grammar                                            [jar]
+[INFO] khubla.com RobotWar grammar                                        [jar]
+[INFO] khubla.com Roman Numerals grammar                                  [jar]
+[INFO] khubla.com RON grammar                                             [jar]
+[INFO] khubla.com RPN grammar                                             [jar]
+[INFO] Ruby-like language (Corundum) grammar                              [jar]
+[INFO] Rust grammar                                                       [jar]
+[INFO] Scala grammar                                                      [jar]
+[INFO] khubla.com Scotty grammar                                          [jar]
+[INFO] scss grammar                                                       [jar]
+[INFO] semantic version grammar                                           [jar]
+[INFO] sexpression grammar                                                [jar]
+[INFO] SGF-grammar                                                        [jar]
+[INFO] ADSP 2106x SHARC assembly language                                 [jar]
+[INFO] khubla.com SICI grammar                                            [jar]
+[INFO] khubla.com Sieve grammar                                           [jar]
+[INFO] Smalltalk grammar                                                  [jar]
+[INFO] khubla.com smiles grammar                                          [jar]
+[INFO] SMT-LIB Version 2 Grammar                                          [jar]
+[INFO] khubla.com SNOBOL grammar                                          [jar]
+[INFO] Solidity grammar                                                   [jar]
+[INFO] ANTLR4 Sparql grammar                                              [jar]
+[INFO] SPASS grammar                                                      [jar]
+[INFO] SQL Grammars                                                       [pom]
+[INFO] AWS Athena grammar                                                 [jar]
+[INFO] Apache Derby grammar                                               [jar]
+[INFO] Apache Drill grammar                                               [jar]
+[INFO] Apache Hive Grammars                                               [pom]
+[INFO] Apache Hive 2.3.8 grammar                                          [jar]
+[INFO] Apache Hive 3 grammar                                              [jar]
+[INFO] Apache Hive 4 grammar                                              [jar]
+[INFO] MariaDB grammar                                                    [jar]
+[INFO] MySQL grammar                                                      [jar]
+[INFO] Apache Phoenix grammar                                             [jar]
+[INFO] PL/SQL grammar                                                     [jar]
+[INFO] PostgreSQL grammar                                                 [jar]
+[INFO] Snowflake grammar                                                  [jar]
+[INFO] SQLite grammar                                                     [jar]
+[INFO] Trino grammar                                                      [jar]
+[INFO] T-SQL grammar                                                      [jar]
+[INFO] Informix SQL grammar                                               [jar]
+[INFO] stacktrace grammar                                                 [jar]
+[INFO] khubla.com star grammar                                            [jar]
+[INFO] stellaris grammar                                                  [jar]
+[INFO] stringtemplate grammar                                             [jar]
+[INFO] SUOKIF grammar                                                     [jar]
+[INFO] Swift Grammars                                                     [pom]
+[INFO] ANTLR Swift grammar                                                [jar]
+[INFO] ANTLR Swift grammar                                                [jar]
+[INFO] ANTLR Swift grammar                                                [jar]
+[INFO] Swift FIN grammar                                                  [jar]
+[INFO] khubla.com szf grammar                                             [jar]
+[INFO] khubla.com TCP grammar                                             [jar]
+[INFO] khubla.com Telephone grammar                                       [jar]
+[INFO] khubla.com Terraform grammar                                       [jar]
+[INFO] Apache Thrift IDL grammar                                          [jar]
+[INFO] khubla.com tiny grammar                                            [jar]
+[INFO] khubla.com tinybasic grammar                                       [jar]
+[INFO] khubla.com tinyc grammar                                           [jar]
+[INFO] khubla.com tinymud grammar                                         [jar]
+[INFO] khubla.com TL grammar                                              [jar]
+[INFO] tnsnames grammar                                                   [jar]
+[INFO] khubla.com TNT grammar                                             [jar]
+[INFO] ANTLR toml grammar                                                 [jar]
+[INFO] khubla.com TRAC grammar                                            [jar]
+[INFO] khubla.com TSV grammar                                             [jar]
+[INFO] khubla.com TTM grammar                                             [jar]
+[INFO] khubla.com Turing grammar                                          [jar]
+[INFO] ANTLR turtle grammar                                               [jar]
+[INFO] turtle doc grammar                                                 [jar]
+[INFO] ANTLR4 unicode grammars                                            [pom]
+[INFO] unicode16 grammar                                                  [jar]
+[INFO] Unicode TR29 Grapheme Cluster Boundary Parsing                     [jar]
+[INFO] Unreal Angelscript                                                 [jar]
+[INFO] UPNP search grammar                                                [jar]
+[INFO] khubla.com URL grammar                                             [jar]
+[INFO] khubla.com UserAgent grammar                                       [jar]
+[INFO] V grammar                                                          [jar]
+[INFO] VB6 grammar                                                        [jar]
+[INFO] VBA Grammars                                                       [pom]
+[INFO] VBA grammar                                                        [jar]
+[INFO] VBA 7.1 grammar                                                    [jar]
+[INFO] VBA 7.1 grammar                                                    [jar]
+[INFO] Velocity grammar                                                   [jar]
+[INFO] Verilog Grammars                                                   [pom]
+[INFO] Verilog grammar                                                    [jar]
+[INFO] SystemVerilog grammar                                              [jar]
+[INFO] ANTLR4 vhdl grammar                                                [jar]
+[INFO] khubla.com vmf grammar                                             [jar]
+[INFO] wat grammar                                                        [jar]
+[INFO] Wavefront grammar                                                  [jar]
+[INFO] webidl grammar                                                     [jar]
+[INFO] wkt grammar                                                        [jar]
+[INFO] wkt crs v1 grammar                                                 [jar]
+[INFO] khubla.com WLN grammar                                             [jar]
+[INFO] ANTLR WREN grammar                                                 [jar]
+[INFO] ANTLR XML grammar                                                  [jar]
+[INFO] XPath Grammars                                                     [pom]
+[INFO] XPath grammar                                                      [jar]
+[INFO] XPath20 grammar                                                    [jar]
+[INFO] XPath31 grammar                                                    [jar]
+[INFO] XML Schema Regular Expression grammar                              [jar]
+[INFO] khubla.com xyz grammar                                             [jar]
+[INFO] YARA grammar                                                       [jar]
+[INFO] Z grammar                                                          [jar]
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:grammarsv4 >--------------------
+[INFO] Building ANTLR4 grammars 1.0-SNAPSHOT                            [1/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ grammarsv4 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ grammarsv4 ---
+[INFO] Copying 77 resources
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ grammarsv4 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\target\generated-sources\copy\org\antlr\grammars\grammarsv4 added.
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:abb >-----------------------
+[INFO] Building abb grammar 1.0-SNAPSHOT                                [2/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ abb ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\abb\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ abb ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\abb\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ abb ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\abb\target\generated-sources\copy\org\antlr\grammars\abb added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ abb ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\abb
+[INFO] Processing grammar: abbLexer.g4
+[INFO] Processing grammar: abbParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ abb ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\abb\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ abb ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ abb ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\abb\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ abb ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ abb ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ abb ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\abb\examples\robdata.sys
+[INFO] Parse tree for 'robdata.sys' matches 'robdata.sys.tree'
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:abnf >-----------------------
+[INFO] Building ABNF grammar 1.0-SNAPSHOT                               [3/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ abnf ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\abnf\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ abnf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\abnf\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ abnf ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\abnf\target\generated-sources\copy\org\antlr\grammars\abnf added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ abnf ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\abnf
+[INFO] Processing grammar: Abnf.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ abnf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\abnf\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ abnf ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ abnf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\abnf\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ abnf ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ abnf ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ abnf ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\abnf\examples\iri.abnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\abnf\examples\postal.abnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\abnf\examples\rfc5322.abnf
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:acme >-----------------------
+[INFO] Building khubla.com Acme grammar 1.0-SNAPSHOT                    [4/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ acme ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\acme\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ acme ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\acme\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ acme ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\acme\target\generated-sources\copy\org\antlr\grammars\acme added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ acme ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\acme
+[INFO] Processing grammar: acme.g4
+[WARNING] warning(184): acme.g4:886:0: One of the token PATHSEPARATOR values unreachable. : is always overlapped by token COLON
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\acme.g4 [886:0]: One of the token PATHSEPARATOR values unreachable. : is always overlapped by token COLON
+[WARNING] warning(184): acme.g4:886:0: One of the token PATHSEPARATOR values unreachable. . is always overlapped by token DOT
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\acme.g4 [886:0]: One of the token PATHSEPARATOR values unreachable. . is always overlapped by token DOT
+[WARNING] warning(184): acme.g4:886:0: One of the token PATHSEPARATOR values unreachable. - is always overlapped by token MINUS
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\acme.g4 [886:0]: One of the token PATHSEPARATOR values unreachable. - is always overlapped by token MINUS
+[WARNING] warning(184): acme.g4:910:0: One of the token PLUS values unreachable. + is always overlapped by token PATHSEPARATOR
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\acme.g4 [910:0]: One of the token PLUS values unreachable. + is always overlapped by token PATHSEPARATOR
+[WARNING] warning(184): acme.g4:946:0: One of the token REM values unreachable. % is always overlapped by token PATHSEPARATOR
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\acme.g4 [946:0]: One of the token REM values unreachable. % is always overlapped by token PATHSEPARATOR
+[WARNING] warning(184): acme.g4:987:0: One of the token SLASH values unreachable. / is always overlapped by token PATHSEPARATOR
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\acme.g4 [987:0]: One of the token SLASH values unreachable. / is always overlapped by token PATHSEPARATOR
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ acme ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\acme\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ acme ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ acme ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\acme\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ acme ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ acme ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ acme ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\ClientAndServerFam.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\LayeredFam.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\MDSFam.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\MDSSystem.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\PipesAndFiltersFam.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\propertyUnification.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\PubSubFam.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\SabPerformanceFamily.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\SharedDataFam.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\test1.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\ThreeTieredFam.acmetest
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\acme\examples\cmu\TieredFam.acmetest
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:action >----------------------
+[INFO] Building khubla.com Action! grammar 1.0-SNAPSHOT                 [5/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ action ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\action\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ action ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\action\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ action ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\action\target\generated-sources\copy\org\antlr\grammars\action added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ action ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\action
+[INFO] Processing grammar: action.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ action ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\action\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ action ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ action ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\action\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ action ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ action ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ action ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\action\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\action\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\action\examples\primes.txt
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:adaparent >--------------------
+[INFO] Building Ada Grammars 1.0-SNAPSHOT                               [6/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ adaparent ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ adaparent ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ adaparent ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\ada\target\generated-sources\copy\org\antlr\grammars\adaparent added.
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:ada83 >----------------------
+[INFO] Building Ada 83 grammar 1.0-SNAPSHOT                             [7/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ada83 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\ada\ada83\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ada83 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada83\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ada83 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\ada\ada83\target\generated-sources\copy\org\antlr\grammars\ada83 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ada83 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\ada\ada83
+[INFO] Processing grammar: Ada83Lexer.g4
+[INFO] Processing grammar: Ada83Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ada83 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada83\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ada83 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ada83 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada83\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ada83 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ada83 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ada83 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada83\examples\pkg1.adb
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada83\examples\pkg1.ads
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:ada95 >----------------------
+[INFO] Building Ada 95 grammar 1.0-SNAPSHOT                             [8/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ada95 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\ada\ada95\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ada95 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada95\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ada95 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\ada\ada95\target\generated-sources\copy\org\antlr\grammars\ada95 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ada95 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\ada\ada95
+[INFO] Processing grammar: Ada95Lexer.g4
+[INFO] Processing grammar: Ada95Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ada95 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada95\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ada95 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ada95 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada95\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ada95 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ada95 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ada95 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada95\examples\pkg1.adb
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada95\examples\pkg1.ads
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:ada2005 >---------------------
+[INFO] Building Ada 2005 grammar 1.0-SNAPSHOT                           [9/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ada2005 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ada2005 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ada2005 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005\target\generated-sources\copy\org\antlr\grammars\ada2005 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ada2005 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005
+[INFO] Processing grammar: Ada2005Lexer.g4
+[INFO] Processing grammar: Ada2005Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ada2005 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ada2005 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ada2005 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ada2005 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ada2005 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ada2005 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005\examples\pkg1.adb
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada2005\examples\pkg1.ads
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:ada2012 >---------------------
+[INFO] Building Ada 2012 grammar 1.0-SNAPSHOT                          [10/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ada2012 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ada2012 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ada2012 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012\target\generated-sources\copy\org\antlr\grammars\ada2012 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ada2012 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012
+[INFO] Processing grammar: AdaLexer.g4
+[INFO] Processing grammar: AdaParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ada2012 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ada2012 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ada2012 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ada2012 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ada2012 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ada2012 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012\examples\pkg1.adb
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ada\ada2012\examples\pkg1.ads
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:alef >-----------------------
+[INFO] Building khubla.com Alef grammar 1.0-SNAPSHOT                   [11/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ alef ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\alef\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ alef ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alef\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ alef ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\alef\target\generated-sources\copy\org\antlr\grammars\alef added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ alef ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\alef
+[INFO] Processing grammar: alef.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ alef ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alef\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ alef ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ alef ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alef\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ alef ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ alef ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ alef ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\alef\examples\example1.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:algol60 >---------------------
+[INFO] Building khubla.com algol60 grammar 1.0-SNAPSHOT                [12/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ algol60 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\algol60\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ algol60 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\algol60\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ algol60 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\algol60\target\generated-sources\copy\org\antlr\grammars\algol60 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ algol60 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\algol60
+[INFO] Processing grammar: algol60.g4
+[WARNING] warning(131): algol60.g4:788:7: greedy block ()* contains wildcard; the non-greedy syntax ()*? may be preferred
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\algol60.g4 [788:7]: greedy block ()* contains wildcard; the non-greedy syntax ()*? may be preferred
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ algol60 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\algol60\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ algol60 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ algol60 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\algol60\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ algol60 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ algol60 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ algol60 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\algol60\examples\euler.a60
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\algol60\examples\jensen.a60
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\algol60\examples\nqueen.a60
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\algol60\examples\primes.a60
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:alloy >----------------------
+[INFO] Building khubla.com Alloy grammar 1.0-SNAPSHOT                  [13/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ alloy ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\alloy\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ alloy ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alloy\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ alloy ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\alloy\target\generated-sources\copy\org\antlr\grammars\alloy added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ alloy ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\alloy
+[INFO] Processing grammar: alloy.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ alloy ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alloy\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ alloy ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ alloy ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alloy\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ alloy ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ alloy ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ alloy ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\alloy\examples\fact.als
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\alloy\examples\fs.als
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\alloy\examples\sig.als
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:alpaca >----------------------
+[INFO] Building khubla.com alpaca grammar 1.0-SNAPSHOT                 [14/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ alpaca ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\alpaca\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ alpaca ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alpaca\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ alpaca ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\alpaca\target\generated-sources\copy\org\antlr\grammars\alpaca added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ alpaca ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\alpaca
+[INFO] Processing grammar: alpaca.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ alpaca ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alpaca\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ alpaca ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ alpaca ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\alpaca\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ alpaca ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ alpaca ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ alpaca ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\alpaca\examples\conway.alp
+[INFO] 
+[INFO] -------------< org.antlr.grammars:amazon-states-language >--------------
+[INFO] Building localstack.cloud amazon-states-language 1.0-SNAPSHOT   [15/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ amazon-states-language ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ amazon-states-language ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ amazon-states-language ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\target\generated-sources\copy\org\antlr\grammars\amazon-states-language added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ amazon-states-language ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language
+[INFO] Processing grammar: ASLLexer.g4
+[INFO] Processing grammar: ASLParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ amazon-states-language ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ amazon-states-language ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ amazon-states-language ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ amazon-states-language ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ amazon-states-language ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ amazon-states-language ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\choice_state.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\dynamodb_put_update_get_item.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\fail_state.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\lambda_catch.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\lambda_retry.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\map_state.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\map_state_legacy.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\parallel_state.json
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language\examples\pass_state.json
+[INFO] 
+[INFO] ---< org.antlr.grammars:amazon-states-language-intrinsic-functions >----
+[INFO] Building localstack.cloud amazon-states-language intrinsic-functions 1.0-SNAPSHOT [16/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ amazon-states-language-intrinsic-functions ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ amazon-states-language-intrinsic-functions ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ amazon-states-language-intrinsic-functions ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\target\generated-sources\copy\org\antlr\grammars\amazon-states-language-intrinsic-functions added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ amazon-states-language-intrinsic-functions ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions
+[INFO] Processing grammar: ASLIntrinsicLexer.g4
+[INFO] Processing grammar: ASLIntrinsicParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ amazon-states-language-intrinsic-functions ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ amazon-states-language-intrinsic-functions ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ amazon-states-language-intrinsic-functions ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ amazon-states-language-intrinsic-functions ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ amazon-states-language-intrinsic-functions ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ amazon-states-language-intrinsic-functions ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_array.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_array_contains.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_array_get_item.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_array_length.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_array_partition.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_array_range.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_array_unique.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_base_64_decode.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_base_64_encode.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_format.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_hash.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_json_merge.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_json_to_string.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_math_add.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_math_random.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_nested_calls.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_string_split.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_string_to_json.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\amazon-states-language-intrinsic-functions\examples\intrinsic_states_uuid.txt
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:angelscript >-------------------
+[INFO] Building khubla.com Arithmetic grammar 1.0-SNAPSHOT             [17/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ angelscript ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\angelscript\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ angelscript ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\angelscript\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ angelscript ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\angelscript\target\generated-sources\copy\org\antlr\grammars\angelscript added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ angelscript ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\angelscript
+[INFO] Processing grammar: angelscript.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ angelscript ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\angelscript\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ angelscript ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ angelscript ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\angelscript\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ angelscript ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ angelscript ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ angelscript ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\angelscript\examples\example1.txt
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:antlrparent >-------------------
+[INFO] Building ANTLR Grammars 1.0-SNAPSHOT                            [18/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ antlrparent ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ antlrparent ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\antlr\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ antlrparent ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\antlr\target\generated-sources\copy\org\antlr\grammars\antlrparent added.
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:antlr2 >----------------------
+[INFO] Building ANTLR2 grammar 1.0-SNAPSHOT                            [19/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ antlr2 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ antlr2 ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.4.0:add-source (add-source) @ antlr2 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\Java added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ antlr2 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2
+[INFO] Processing grammar: ANTLRv2Lexer.g4
+[INFO] Processing grammar: ANTLRv2Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ antlr2 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ antlr2 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ antlr2 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ antlr2 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ antlr2 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ antlr2 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\ada.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\ANTLRv2.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\asn1.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\cil.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\CSharpParser.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\DotLexer.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\DotParser.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\java.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\links.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\mumath.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\python.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\stdc.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\StdCParser.g2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\XQuery.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr2\examples\XQuery.g2
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:antlr3 >----------------------
+[INFO] Building ANTLR3 grammar 1.0-SNAPSHOT                            [20/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ antlr3 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ antlr3 ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.4.0:add-source (add-source) @ antlr3 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\Java added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ antlr3 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3
+[INFO] Processing grammar: ANTLRv3Lexer.g4
+[INFO] Processing grammar: ANTLRv3Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ antlr3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ antlr3 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ antlr3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ antlr3 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ antlr3 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ antlr3 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\Antlr3.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\ASN.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\C.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\css21.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\csv.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\DCM_2_0_grammar.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\FreeMPS.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\Java.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\Java6Lex.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\Java6Parse.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\JPA.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\krl.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\Lua.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\m2pim4_LL1.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\memcached_protocol.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\ObjectiveC2ansi.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\Sexpr.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\simplecalc.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\StackTraceText.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\Verilog3.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\WavefrontOBJ.g
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr3\examples\XPath2.g
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:antlr4 >----------------------
+[INFO] Building ANTLR4 grammar 1.0-SNAPSHOT                            [21/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ antlr4 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ antlr4 ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.4.0:add-source (add-source) @ antlr4 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\Java added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ antlr4 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4
+[INFO] Processing grammar: ANTLRv4Lexer.g4
+[INFO] Processing grammar: ANTLRv4Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ antlr4 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ antlr4 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ antlr4 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ antlr4 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ antlr4 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ antlr4 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\apt.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\CPP14.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\Hello.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\issue1165.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\issue1165_2.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\issue1165_3.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\issue1165_4.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\Issue1567.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\issue1956.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\LexerElementLabel.g4
+line 4:8 no viable alternative at input 'var'
+line 4:11 mismatched input '=' expecting {BEGIN_ARGUMENT, OPTIONS, 'returns', 'locals', 'throws', COLON, AT}
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\PhpLexer.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\PhpParser.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\three.g4
+line 4:0 mismatched input '<EOF>' expecting {'lexer', 'parser', 'grammar'}
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\TSqlLexer.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\TSqlParser.g4
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\antlr\antlr4\examples\twocomments.g4
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:apex >-----------------------
+[INFO] Building Apex grammar 1.0-SNAPSHOT                              [22/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ apex ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\apex\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ apex ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\apex\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ apex ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\apex\target\generated-sources\copy\org\antlr\grammars\apex added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ apex ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\apex
+[INFO] Processing grammar: apex.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ apex ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\apex\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ apex ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ apex ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\apex\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ apex ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ apex ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ apex ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\apex\examples\ExampleInvocableMethod.cls
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\apex\examples\ExampleRunAs.cls
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\apex\examples\ExampleSafeDereference.cls
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:apt >-----------------------
+[INFO] Building apt grammar 1.0-SNAPSHOT                               [23/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ apt ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\apt\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ apt ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\apt\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ apt ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\apt\target\generated-sources\copy\org\antlr\grammars\apt added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ apt ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\apt
+[INFO] Processing grammar: apt.g4
+[WARNING] warning(185): apt.g4:223:7: Range A..] probably contains not implied characters [\. Both bounds should be defined in lower or UPPER case
+[WARNING] C:\msys64\home\Kenne\issues\g4-4174\apt.g4 [223:7]: Range A..] probably contains not implied characters [\. Both bounds should be defined in lower or UPPER case
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ apt ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\apt\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ apt ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ apt ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\apt\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ apt ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ apt ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ apt ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:arangodb >---------------------
+[INFO] Building ArangoDb grammar 1.0-SNAPSHOT                          [24/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ arangodb ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\aql\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ arangodb ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\aql\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ arangodb ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\aql\target\generated-sources\copy\org\antlr\grammars\arangodb added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ arangodb ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\aql
+[INFO] Processing grammar: ArangoDbLexer.g4
+[INFO] Processing grammar: ArangoDbParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ arangodb ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\aql\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ arangodb ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 4 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ arangodb ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\aql\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ arangodb ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ arangodb ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ arangodb ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\access.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\access_arr.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\access_null.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\access_str.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\access_str2.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\collect_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\collect_2.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\collect_3.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\collect_4.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\for.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\insert_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\insert_2.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\let_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\let_2.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\remove_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\remove_2.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\replace_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\search_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\update_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\upsert_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\window_1.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\window_2.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\window_3.aql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aql\examples\window_4.aql
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:argus >----------------------
+[INFO] Building khubla.com Argus grammar 1.0-SNAPSHOT                  [25/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ argus ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\argus\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ argus ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\argus\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ argus ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\argus\target\generated-sources\copy\org\antlr\grammars\argus added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ argus ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\argus
+[INFO] Processing grammar: argus.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ argus ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\argus\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ argus ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ argus ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\argus\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ argus ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ argus ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ argus ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:arithmetic >--------------------
+[INFO] Building khubla.com Arithmetic grammar 1.0-SNAPSHOT             [26/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ arithmetic ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\arithmetic\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ arithmetic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\arithmetic\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ arithmetic ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\arithmetic\target\generated-sources\copy\org\antlr\grammars\arithmetic added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ arithmetic ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\arithmetic
+[INFO] Processing grammar: arithmetic.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ arithmetic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\arithmetic\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ arithmetic ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ arithmetic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\arithmetic\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ arithmetic ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ arithmetic ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ arithmetic ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\number1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\number2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\number3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\number4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\number5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\number6.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\paren1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\paren2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\pow1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\precedence1.txt
+[INFO] Parse tree for 'precedence1.txt' matches 'precedence1.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\precedence2.txt
+[INFO] Parse tree for 'precedence2.txt' matches 'precedence2.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\precedence3.txt
+[INFO] Parse tree for 'precedence3.txt' matches 'precedence3.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\pythagoras.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\pythagoras2.txt
+[INFO] Parse tree for 'pythagoras2.txt' matches 'pythagoras2.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\quadratic.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\simple.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\simple2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\arithmetic\examples\unary.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:ASL >-----------------------
+[INFO] Building ASL grammar 1.0-SNAPSHOT                               [27/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ASL ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asl\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ASL ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asl\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ASL ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asl\target\generated-sources\copy\org\antlr\grammars\ASL added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ASL ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asl
+[INFO] Processing grammar: ASL.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ASL ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asl\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ASL ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ASL ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asl\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ASL ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ASL ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ASL ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\assignments
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\comment
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\creates
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\events
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\finds
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\for
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\if
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\if_2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\inline
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\loop
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\loop_2
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\operations
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\relationships
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\set_operation
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\structures
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\switch
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asl\examples\timer
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:asmparent >--------------------
+[INFO] Building Assembler Grammars 1.0-SNAPSHOT                        [28/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asmparent ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asmparent ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asmparent ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\target\generated-sources\copy\org\antlr\grammars\asmparent added.
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:asm6502 >---------------------
+[INFO] Building ASM 6502 grammar 1.0-SNAPSHOT                          [29/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asm6502 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asm6502 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asm6502 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\target\generated-sources\copy\org\antlr\grammars\asm6502 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asm6502 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502
+[INFO] Processing grammar: asm6502.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asm6502 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asm6502 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asm6502 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asm6502 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asm6502 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asm6502 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\bubblesort.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\cascade.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\combsort.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\countdown.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\m.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\optsort.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\perm.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm6502\examples\sqrt.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:asm8080 >---------------------
+[INFO] Building ASM 8080 grammar 1.0-SNAPSHOT                          [30/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asm8080 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\asm8080\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asm8080 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8080\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asm8080 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\asm8080\target\generated-sources\copy\org\antlr\grammars\asm8080 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asm8080 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8080
+[INFO] Processing grammar: asm8080.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asm8080 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8080\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asm8080 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asm8080 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8080\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asm8080 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asm8080 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asm8080 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8080\examples\CPM22.ASM
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:asm8086 >---------------------
+[INFO] Building ASM 8086 grammar 1.0-SNAPSHOT                          [31/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asm8086 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asm8086 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asm8086 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\target\generated-sources\copy\org\antlr\grammars\asm8086 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asm8086 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086
+[INFO] Processing grammar: asm8086.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asm8086 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asm8086 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asm8086 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asm8086 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asm8086 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asm8086 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\BIOS.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\CBIOS.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\COPYDISK.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\LDBIOS.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\LDCOPY.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\LDCPM.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\ROM.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\TBIOS.A86
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asm8086\examples\TRACK.A86
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:asmMASM >---------------------
+[INFO] Building MASM grammar 1.0-SNAPSHOT                              [32/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asmMASM ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asmMASM ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asmMASM ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\target\generated-sources\copy\org\antlr\grammars\asmMASM added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asmMASM ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM
+[INFO] Processing grammar: asmMASM.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asmMASM ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asmMASM ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asmMASM ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asmMASM ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asmMASM ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asmMASM ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\examples\hello.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\examples\helloworld.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asmMASM\examples\powers.asm
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:asmZ80 >----------------------
+[INFO] Building ASM Z80 grammar 1.0-SNAPSHOT                           [33/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asmZ80 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\asmZ80\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asmZ80 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmZ80\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asmZ80 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\asmZ80\target\generated-sources\copy\org\antlr\grammars\asmZ80 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asmZ80 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\asmZ80
+[INFO] Processing grammar: asmZ80.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asmZ80 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmZ80\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asmZ80 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asmZ80 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmZ80\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asmZ80 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asmZ80 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asmZ80 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asmZ80\examples\CPM22.Z80
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:masm >-----------------------
+[INFO] Building MASM grammar 1.0-SNAPSHOT                              [34/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ masm ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\masm\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ masm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\masm\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ masm ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\masm\target\generated-sources\copy\org\antlr\grammars\masm added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ masm ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\masm
+[INFO] Processing grammar: MASM.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ masm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\masm\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ masm ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ masm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\masm\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ masm ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ masm ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ masm ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:nasm >-----------------------
+[INFO] Building NASM grammar 1.0-SNAPSHOT                              [35/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ nasm ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ nasm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ nasm ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\target\generated-sources\copy\org\antlr\grammars\nasm added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ nasm ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\nasm
+[INFO] Processing grammar: nasm_x86_64_Lexer.g4
+[INFO] Processing grammar: nasm_x86_64_Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ nasm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ nasm ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ nasm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ nasm ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ nasm ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ nasm ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\call1_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\fib_64l.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\fltarith_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\hello_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\horner_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\ifint_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\intarith_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\intlogic_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\loopint_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\printf1_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\printf2_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\shift_64.asm
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\nasm\examples\testreg_64.asm
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:pdp7 >-----------------------
+[INFO] Building ASM pdp7 grammar 1.0-SNAPSHOT                          [36/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ pdp7 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ pdp7 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ pdp7 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\target\generated-sources\copy\org\antlr\grammars\pdp7 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ pdp7 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7
+[INFO] Processing grammar: pdp7.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ pdp7 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ pdp7 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ pdp7 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ pdp7 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ pdp7 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ pdp7 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\adm.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\apr.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\as.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\bc.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\bi.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\bl.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\brt.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\cas.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\cat.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\check.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\chmod.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\chown.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\chrm.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\cp.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\db.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\dmabs.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\ds.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\dskio.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\dskres.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\dsksav.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\dsw.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\ed1.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\ed2.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\hello.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\init.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\maksys.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\ops.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\pbboot.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\pblsd.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\pbsh.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s1.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s2.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s3.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s4.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s5.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s6.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s7.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s8.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\s9.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\sop.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\sysmap
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\trysys.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktcat.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktcp.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktdate.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktln.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktls.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktmv.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktod.s
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\pdp7\examples\wktstat.s
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:ptx-parent >--------------------
+[INFO] Building CUDA PTX ISA Grammars 1.0-SNAPSHOT                     [37/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ptx-parent ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ptx-parent ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ptx-parent ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\target\generated-sources\copy\org\antlr\grammars\ptx-parent added.
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:ptx-1.0 >---------------------
+[INFO] Building CUDA PTX ISA 1.0 grammar 1.0-SNAPSHOT                  [38/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ptx-1.0 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-1.0\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ptx-1.0 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-1.0\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ptx-1.0 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-1.0\target\generated-sources\copy\org\antlr\grammars\ptx-1.0 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ptx-1.0 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-1.0
+[INFO] Processing grammar: PTXLexer.g4
+[INFO] Processing grammar: PTXParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ptx-1.0 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-1.0\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ptx-1.0 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ptx-1.0 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-1.0\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ptx-1.0 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ptx-1.0 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ptx-1.0 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-1.0\examples\basic.ptx
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:ptx-2.1 >---------------------
+[INFO] Building CUDA PTX ISA 2.1 grammar 1.0-SNAPSHOT                  [39/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ptx-2.1 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ptx-2.1 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ptx-2.1 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\target\generated-sources\copy\org\antlr\grammars\ptx-2.1 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ptx-2.1 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1
+[INFO] Processing grammar: Ptx.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ptx-2.1 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ptx-2.1 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ptx-2.1 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ptx-2.1 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ptx-2.1 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ptx-2.1 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\alignedTypes.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\alignedTypes.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\anot.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\anot2.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\anot3.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\anot4.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\anot5.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\asyncAPI.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\asyncAPI.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\b.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bandwidthTest.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bandwidthTest.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bicubicTexture.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bicubicTexture.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\binomialOptions_SM10.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\binomialOptions_SM10.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\binomialOptions_SM13.compute_13.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\binomialOptions_SM13.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bisect_large.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bisect_large.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bisect_small.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bisect_small.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bitonicSort.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bitonicSort.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\BlackScholes.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\BlackScholes.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bodysystemcuda.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bodysystemcuda.compute_13.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\bodysystemcuda.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\boxFilter_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\boxFilter_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\chw.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\chw.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\clock.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\clock.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\cmpmvs.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\concurrentKernels.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\concurrentKernels.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\convolutionFFT2D.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\convolutionFFT2D.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\convolutionSeparable.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\convolutionSeparable.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\convolutionTexture.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\convolutionTexture.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\cppIntegration.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\cppIntegration.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\dct8x8.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\dct8x8.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\dwtHaar1D.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\dwtHaar1D.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\dxtc.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\dxtc.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\f.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\f2.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fastWalshTransform.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fastWalshTransform.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\FDTD3dGPU.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\FDTD3dGPU.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fluidsD3D9_kernels.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fluidsD3D9_kernels.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fluidsGL.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fluidsGL.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fun.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\fun.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\FunctionPointers_kernels.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\histogram256.compute_11.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\histogram256.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\histogram64.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\histogram64.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\hw.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\hw.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\imageDenoising.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\imageDenoising.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\lineOfSight.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\lineOfSight.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\main.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\main.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\Mandelbrot_sm11.compute_11.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\Mandelbrot_sm11.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\Mandelbrot_sm13.compute_13.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\Mandelbrot_sm13.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\marchingCubes_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\marchingCubes_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\matrixMul.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\matrixMul.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\matrixMul_kernel.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MersenneTwister.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MersenneTwister.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM10.compute_10 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM10.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM10.compute_20 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM10.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM13.compute_13 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM13.compute_13.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM13.compute_20 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\MonteCarlo_SM13.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\mysort.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\NV12ToARGB_drvapi (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\NV12ToARGB_drvapi.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\NV12ToARGB_drvapi_32 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\NV12ToARGB_drvapi_32.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\o1.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\o2.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\oceanFFT_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\oceanFFT_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\oddEvenMergeSort.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\oddEvenMergeSort.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\ParticleSystem.compute_10 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\particleSystem.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\ParticleSystem.compute_20 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\particleSystem.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\postProcessGL.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\postProcessGL.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\quasirandomGenerator_SM10.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\quasirandomGenerator_SM10.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\quasirandomGenerator_SM13.compute_13.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\quasirandomGenerator_SM13.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\radixsort.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\radixsort.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\recursiveGaussian.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\recursiveGaussian.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\reduction_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\reduction_kernel.compute_13.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\reduction_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\scalarProd.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\scalarProd.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\scan.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\scan.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleAtomicIntrinsics.compute_11.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleAtomicIntrinsics.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleCUFFT.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleCUFFT.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleD3D10_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleD3D10_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleD3D9_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleD3D9_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleGL_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleGL_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleMultiCopy.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleMultiCopy.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleMultiGPU_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleMultiGPU_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simplePitchLinearTexture.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simplePitchLinearTexture.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleStreams.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleStreams.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleTemplates.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleTemplates.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleTexture.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleTexture.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleTexture3D_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleTexture3D_kernel.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleTexture_kernel.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleVoteIntrinsics.compute_12.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleVoteIntrinsics.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleZeroCopy.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\simpleZeroCopy.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\SobelFilter_kernels.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\SobelFilter_kernels.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\sobol_gpu.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\sobol_gpu.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\template.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\template.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\template.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_2d.compute_10 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_2d.compute_10 (3).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_2d.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_2d.compute_20 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_2d.compute_20 (3).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_2d.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_3d.compute_10 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_3d.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_3d.compute_20 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_3d.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_cube.compute_10 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_cube.compute_10 (3).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_cube.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_cube.compute_20 (2).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_cube.compute_20 (3).ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_cube.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_volume.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\texture_volume.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\threadFenceReduction.compute_11.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\threadFenceReduction.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\threadMigration.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\transpose.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\transpose.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\transposeNew.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\transposeNew.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\vectorAdd.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\vectorAdd.compute_20.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\vectorAdd.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\volumeRender_kernel.compute_10.ptx
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\ptx\ptx-isa-2.1\examples\volumeRender_kernel.compute_20.ptx
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:asmRSICV >---------------------
+[INFO] Building ASM RSICV grammar 1.0-SNAPSHOT                         [40/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asmRSICV ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asmRSICV ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asmRSICV ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV\target\generated-sources\copy\org\antlr\grammars\asmRSICV added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asmRSICV ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV
+[INFO] Processing grammar: Riscv64G.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asmRSICV ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asmRSICV ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asmRSICV ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asmRSICV ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asmRSICV ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asmRSICV ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV\examples\Hello.S
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asm\asmRISCV\examples\Test.S
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:asnparent >--------------------
+[INFO] Building ASN Grammars 1.0-SNAPSHOT                              [41/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asnparent ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asnparent ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asn\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asnparent ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asn\target\generated-sources\copy\org\antlr\grammars\asnparent added.
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:asn >-----------------------
+[INFO] Building ASN.1 grammar 1.0-SNAPSHOT                             [42/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asn ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asn\asn\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asn ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asn\asn\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asn ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asn\asn\target\generated-sources\copy\org\antlr\grammars\asn added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asn ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asn\asn
+[INFO] Processing grammar: ASN.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asn ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asn\asn\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asn ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asn ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asn\asn\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asn ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asn ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asn ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asn\asn\examples\example1.asn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asn\asn\examples\example2.asn
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:asn_3gpp >---------------------
+[INFO] Building ASN 3GPP grammar 1.0-SNAPSHOT                          [43/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ asn_3gpp ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\asn\asn_3gpp\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ asn_3gpp ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asn\asn_3gpp\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ asn_3gpp ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\asn\asn_3gpp\target\generated-sources\copy\org\antlr\grammars\asn_3gpp added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ asn_3gpp ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\asn\asn_3gpp
+[INFO] Processing grammar: ASN_3gpp.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ asn_3gpp ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asn\asn_3gpp\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ asn_3gpp ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ asn_3gpp ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\asn\asn_3gpp\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ asn_3gpp ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ asn_3gpp ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ asn_3gpp ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\asn\asn_3gpp\examples\example3-3gpp.asn
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:aterm >----------------------
+[INFO] Building khubla.com ATerm grammar 1.0-SNAPSHOT                  [44/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ aterm ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\aterm\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ aterm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\aterm\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ aterm ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\aterm\target\generated-sources\copy\org\antlr\grammars\aterm added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ aterm ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\aterm
+[INFO] Processing grammar: aterm.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ aterm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\aterm\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ aterm ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ aterm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\aterm\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ aterm ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ aterm ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ aterm ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example10.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example11.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example12.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example13.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example14.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example15.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example6.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example7.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example8.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\aterm\examples\example9.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:atl >-----------------------
+[INFO] Building ATL grammar 1.0-SNAPSHOT                               [45/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ atl ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\atl\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ atl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\atl\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ atl ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\atl\target\generated-sources\copy\org\antlr\grammars\atl added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ atl ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\atl
+[INFO] Processing grammar: ATL.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ atl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\atl\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ atl ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ atl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\atl\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ atl ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ atl ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ atl ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] ------------------------< org.antlr.grammars:b >------------------------
+[INFO] Building khubla.com B grammar 1.0-SNAPSHOT                      [46/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ b ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\b\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ b ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\b\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ b ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\b\target\generated-sources\copy\org\antlr\grammars\b added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ b ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\b
+[INFO] Processing grammar: b.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ b ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\b\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ b ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ b ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\b\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ b ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ b ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ b ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\b\examples\example1.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\b\examples\example2.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\b\examples\example3.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\b\examples\example4.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\b\examples\example5.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\b\examples\example6.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\b\examples\example7.b
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:basic >----------------------
+[INFO] Building khubla.com BASIC grammar 1.0-SNAPSHOT                  [47/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ basic ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\basic\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ basic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\basic\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ basic ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\basic\target\generated-sources\copy\org\antlr\grammars\basic added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ basic ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\basic
+[INFO] Processing grammar: jvmBasic.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ basic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\basic\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ basic ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ basic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\basic\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ basic ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ basic ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ basic ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\data.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\dim.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\e.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\for.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\gosub.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\goto.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\hello.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\if.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\include.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\input.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\math.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\simpleif.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\a\strings.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\lander.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\love.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\maintest.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\paint.bas
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\basic\examples\snoopy.bas
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:bcl >-----------------------
+[INFO] Building khubla.com BCL grammar 1.0-SNAPSHOT                    [48/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ bcl ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\bcl\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ bcl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bcl\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ bcl ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\bcl\target\generated-sources\copy\org\antlr\grammars\bcl added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ bcl ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\bcl
+[INFO] Processing grammar: bcl.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ bcl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bcl\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ bcl ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ bcl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bcl\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ bcl ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ bcl ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ bcl ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:bcpl >-----------------------
+[INFO] Building khubla.com BCPL grammar 1.0-SNAPSHOT                   [49/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ bcpl ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\bcpl\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ bcpl ---
+[INFO] Copying 2 resources
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ bcpl ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\bcpl\target\generated-sources\copy\org\antlr\grammars\bcpl added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ bcpl ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\bcpl
+[INFO] Processing grammar: bcplLexer.g4
+[INFO] Processing grammar: bcplParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ bcpl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bcpl\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ bcpl ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 8 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ bcpl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bcpl\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ bcpl ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ bcpl ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ bcpl ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bcpl\examples\cg8086.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bcpl\examples\fact.bcpl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bcpl\examples\fib.bcpl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bcpl\examples\hw.bcpl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bcpl\examples\interp.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bcpl\examples\unify.b
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:bdf >-----------------------
+[INFO] Building khubla.com BDF grammar 1.0-SNAPSHOT                    [50/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ bdf ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\bdf\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ bdf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bdf\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ bdf ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\bdf\target\generated-sources\copy\org\antlr\grammars\bdf added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ bdf ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\bdf
+[INFO] Processing grammar: bdf.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ bdf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bdf\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ bdf ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ bdf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bdf\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ bdf ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ bdf ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ bdf ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bdf\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bdf\examples\ib16x16u.bdf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bdf\examples\ie8x14u.bdf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bdf\examples\iv9x16u.bdf
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:bencoding >--------------------
+[INFO] Building Bencoding grammar 1.0-SNAPSHOT                         [51/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ bencoding ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\bencoding\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ bencoding ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ bencoding ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\bencoding\target\generated-sources\copy\org\antlr\grammars\bencoding added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ bencoding ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\bencoding
+[INFO] Processing grammar: BencodingLexer.g4
+[INFO] Processing grammar: BencodingParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ bencoding ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bencoding\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ bencoding ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ bencoding ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bencoding\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ bencoding ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ bencoding ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ bencoding ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\all-types.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\dictionary.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\empty-dictionary.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\empty-list.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\list.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\negative-integer.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\positive-integer.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bencoding\examples\string.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:bibcode >---------------------
+[INFO] Building khubla.com Bibcode grammar 1.0-SNAPSHOT                [52/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ bibcode ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\bibcode\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ bibcode ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bibcode\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ bibcode ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\bibcode\target\generated-sources\copy\org\antlr\grammars\bibcode added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ bibcode ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\bibcode
+[INFO] Processing grammar: bibcode.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ bibcode ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bibcode\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ bibcode ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ bibcode ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bibcode\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ bibcode ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ bibcode ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ bibcode ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bibcode\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bibcode\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bibcode\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bibcode\examples\example4.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:Bicep >----------------------
+[INFO] Building Bicep grammar 1.0-SNAPSHOT                             [53/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ Bicep ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\bicep\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ Bicep ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bicep\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ Bicep ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\bicep\target\generated-sources\copy\org\antlr\grammars\Bicep added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ Bicep ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\bicep
+[INFO] Processing grammar: Bicep.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ Bicep ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bicep\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ Bicep ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ Bicep ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bicep\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ Bicep ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ Bicep ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ Bicep ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\empty.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\importDecl.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\metadataDecl.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\moduleDecl.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\outputDecl.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\parameterDecl.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\program.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\resourceDecl.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\targetScope.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\typeDecl.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bicep\examples\variableDecl.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:bnf >-----------------------
+[INFO] Building khubla.com BNF grammar 1.0-SNAPSHOT                    [54/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ bnf ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\bnf\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ bnf ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ bnf ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\bnf\target\generated-sources\copy\org\antlr\grammars\bnf added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ bnf ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\bnf
+[INFO] Processing grammar: bnfLexer.g4
+[INFO] Processing grammar: bnfParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ bnf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bnf\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ bnf ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ bnf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\bnf\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ bnf ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ bnf ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ bnf ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\ebnf.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\empty.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\letter1.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\letter2.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\parens.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\pemdas.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\sh.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\shutup.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\harvard.edu\word.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\ics\digits.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\ics\exp.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\ics\name.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\postal.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\treutwein-algol60.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\unicode-ebnf.bnf
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\bnf\examples\wiki-bnf.bnf
+[INFO] 
+[INFO] ------------------------< org.antlr.grammars:C >------------------------
+[INFO] Building C grammar 1.0-SNAPSHOT                                 [55/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ C ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\c\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ C ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\c\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ C ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\c\target\generated-sources\copy\org\antlr\grammars\C added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ C ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\c
+[INFO] Processing grammar: C.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ C ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\c\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ C ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ C ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\c\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ C ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ C ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ C ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\add.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\BinaryDigit.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\bt.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\dialog.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\FuncCallAsFuncArgument.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\FuncCallwithVarArgs.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\FuncForwardDeclaration.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\FunctionCall.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\FunctionPointer.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\FunctionReturningPointer.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\helloworld.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\integrate.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\label_before_closing_curly_brace.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\ll.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\ParameterOfPointerType.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\pr403.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\TypeCast.c
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\c\examples\Wmisleading-indentation.pp.c
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:calculator >--------------------
+[INFO] Building khubla.com Calculator grammar 1.0-SNAPSHOT             [56/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ calculator ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\calculator\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ calculator ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\calculator\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ calculator ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\calculator\target\generated-sources\copy\org\antlr\grammars\calculator added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ calculator ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\calculator
+[INFO] Processing grammar: calculator.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ calculator ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\calculator\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ calculator ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ calculator ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\calculator\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ calculator ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ calculator ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ calculator ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\area.txt
+[INFO] Parse tree for 'area.txt' matches 'area.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\ees.txt
+[INFO] Parse tree for 'ees.txt' matches 'ees.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\euler.txt
+[INFO] Parse tree for 'euler.txt' matches 'euler.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\number1.txt
+[INFO] Parse tree for 'number1.txt' matches 'number1.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\number2.txt
+[INFO] Parse tree for 'number2.txt' matches 'number2.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\number3.txt
+[INFO] Parse tree for 'number3.txt' matches 'number3.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\number4.txt
+[INFO] Parse tree for 'number4.txt' matches 'number4.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\number5.txt
+[INFO] Parse tree for 'number5.txt' matches 'number5.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\number6.txt
+[INFO] Parse tree for 'number6.txt' matches 'number6.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\pow.txt
+[INFO] Parse tree for 'pow.txt' matches 'pow.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\pow2.txt
+[INFO] Parse tree for 'pow2.txt' matches 'pow2.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\powpow.txt
+[INFO] Parse tree for 'powpow.txt' matches 'powpow.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\pr501_1.txt
+[INFO] Parse tree for 'pr501_1.txt' matches 'pr501_1.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\pr501_2.txt
+[INFO] Parse tree for 'pr501_2.txt' matches 'pr501_2.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\pyth.txt
+[INFO] Parse tree for 'pyth.txt' matches 'pyth.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\quadratic.txt
+[INFO] Parse tree for 'quadratic.txt' matches 'quadratic.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\snell.txt
+[INFO] Parse tree for 'snell.txt' matches 'snell.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\sqrt.txt
+[INFO] Parse tree for 'sqrt.txt' matches 'sqrt.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\tan.txt
+[INFO] Parse tree for 'tan.txt' matches 'tan.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\unary.txt
+[INFO] Parse tree for 'unary.txt' matches 'unary.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\calculator\examples\weird.txt
+[INFO] Parse tree for 'weird.txt' matches 'weird.txt.tree'
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:callable >---------------------
+[INFO] Building khubla.com callable grammar 1.0-SNAPSHOT               [57/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ callable ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\callable\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ callable ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\callable\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ callable ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\callable\target\generated-sources\copy\org\antlr\grammars\callable added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ callable ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\callable
+[INFO] Processing grammar: callable_.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ callable ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\callable\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ callable ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ callable ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\callable\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ callable ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ callable ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ callable ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\callable\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\callable\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\callable\examples\example3.txt
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:capnproto >--------------------
+[INFO] Building Cap'n Proto schema language grammar 1.0-SNAPSHOT       [58/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ capnproto ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\capnproto\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ capnproto ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\capnproto\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ capnproto ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\capnproto\target\generated-sources\copy\org\antlr\grammars\capnproto added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ capnproto ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\capnproto
+[INFO] Processing grammar: CapnProto.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ capnproto ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\capnproto\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ capnproto ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ capnproto ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\capnproto\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ capnproto ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ capnproto ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ capnproto ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\addressbook.capnp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\calculator.capnp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\capnp-rust\test.capnp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\lua-capnproto\enums.capnp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\lua-capnproto\example.capnp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\lua-capnproto\lua.capnp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\lua-capnproto\struct.capnp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\capnproto\examples\node-capnp\test.capnp
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:caql >-----------------------
+[INFO] Building CaQL grammar 1.0-SNAPSHOT                              [59/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ caql ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\caql\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ caql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\caql\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ caql ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\caql\target\generated-sources\copy\org\antlr\grammars\caql added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ caql ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\caql
+[INFO] Processing grammar: CaQL.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ caql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\caql\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ caql ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ caql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\caql\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ caql ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ caql ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ caql ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\s1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\s2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\s3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\s4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\s5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\s6.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\s7.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\caql\examples\SampleData.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:cayenne >---------------------
+[INFO] Building khubla.com Arithmetic grammar 1.0-SNAPSHOT             [60/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cayenne ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cayenne\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cayenne ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cayenne\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cayenne ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cayenne\target\generated-sources\copy\org\antlr\grammars\cayenne added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cayenne ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cayenne
+[INFO] Processing grammar: cayenne.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cayenne ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cayenne\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cayenne ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cayenne ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cayenne\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cayenne ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cayenne ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cayenne ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:clf >-----------------------
+[INFO] Building khubla.com CLF grammar 1.0-SNAPSHOT                    [61/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ clf ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\clf\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ clf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clf\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ clf ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\clf\target\generated-sources\copy\org\antlr\grammars\clf added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ clf ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\clf
+[INFO] Processing grammar: clf.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ clf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clf\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ clf ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ clf ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clf\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ clf ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ clf ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ clf ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\clf\examples\access_log
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\clf\examples\combined1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\clf\examples\common1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\clf\examples\problem1.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:clojure >---------------------
+[INFO] Building Clojure grammar 1.0-SNAPSHOT                           [62/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ clojure ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\clojure\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ clojure ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clojure\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ clojure ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\clojure\target\generated-sources\copy\org\antlr\grammars\clojure added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ clojure ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\clojure
+[INFO] Processing grammar: Clojure.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ clojure ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clojure\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ clojure ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ clojure ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clojure\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ clojure ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ clojure ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ clojure ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\clojure\examples\example1.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:clu >-----------------------
+[INFO] Building khubla.com clu grammar 1.0-SNAPSHOT                    [63/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ clu ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\clu\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ clu ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clu\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ clu ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\clu\target\generated-sources\copy\org\antlr\grammars\clu added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ clu ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\clu
+[INFO] Processing grammar: clu.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ clu ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clu\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ clu ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ clu ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\clu\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ clu ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ clu ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ clu ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\clu\examples\bottles-133.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\clu\examples\hello.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:cmake >----------------------
+[INFO] Building CMake grammar 1.0-SNAPSHOT                             [64/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cmake ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cmake\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cmake ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cmake\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cmake ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cmake\target\generated-sources\copy\org\antlr\grammars\cmake added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cmake ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cmake
+[INFO] Processing grammar: CMake.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cmake ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cmake\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cmake ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cmake ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cmake\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cmake ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cmake ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cmake ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cmake\examples\CMakeLists.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:codeql >----------------------
+[INFO] Building CodeQL grammar 1.0-SNAPSHOT                            [65/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ codeql ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\codeql\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ codeql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\codeql\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ codeql ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\codeql\target\generated-sources\copy\org\antlr\grammars\codeql added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ codeql ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\codeql
+[INFO] Processing grammar: CodeQLLexer.g4
+[INFO] Processing grammar: CodeQLParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ codeql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\codeql\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ codeql ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ codeql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\codeql\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ codeql ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ codeql ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ codeql ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\alias.qll
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\annotation.ql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\expression.ql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\fomula.ql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\module.qll
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\predicates.ql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\signature.qll
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\types.ql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\codeql\examples\variable.ql
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:cookie >----------------------
+[INFO] Building khubla.com cookie grammar 1.0-SNAPSHOT                 [66/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cookie ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cookie\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cookie ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cookie\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cookie ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cookie\target\generated-sources\copy\org\antlr\grammars\cookie added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cookie ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cookie
+[INFO] Processing grammar: cookie.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cookie ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cookie\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cookie ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cookie ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cookie\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cookie ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cookie ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cookie ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cookie\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cookie\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cookie\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cookie\examples\example4.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:CPP14 >----------------------
+[INFO] Building CPP14 grammar 1.0-SNAPSHOT                             [67/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ CPP14 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cpp\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ CPP14 ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ CPP14 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cpp\target\generated-sources\copy\org\antlr\grammars\CPP14 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ CPP14 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cpp
+[INFO] Processing grammar: CPP14Lexer.g4
+[INFO] Processing grammar: CPP14Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ CPP14 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cpp\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ CPP14 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ CPP14 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cpp\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ CPP14 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ CPP14 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ CPP14 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\and_keyword.cpp
+[INFO] Parse tree for 'and_keyword.cpp' matches 'and_keyword.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\attribute.cpp
+[INFO] Parse tree for 'attribute.cpp' matches 'attribute.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\avrc_api.cc
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\function_definitions_and_integers.cpp
+[INFO] Parse tree for 'function_definitions_and_integers.cpp' matches 'function_definitions_and_integers.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\g4-4149.cpp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\helloworld.cpp
+[INFO] Parse tree for 'helloworld.cpp' matches 'helloworld.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\macro.cpp
+[INFO] Parse tree for 'macro.cpp' matches 'macro.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\not_keyword.cpp
+[INFO] Parse tree for 'not_keyword.cpp' matches 'not_keyword.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\no_return.cpp
+[INFO] Parse tree for 'no_return.cpp' matches 'no_return.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\or_keyword.cpp
+[INFO] Parse tree for 'or_keyword.cpp' matches 'or_keyword.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\pointer_declaration_example.cpp
+[INFO] Parse tree for 'pointer_declaration_example.cpp' matches 'pointer_declaration_example.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\pure-specifier.cpp
+[INFO] Parse tree for 'pure-specifier.cpp' matches 'pure-specifier.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\raw_string.cpp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\template_args_test.cpp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\test.cpp
+[INFO] Parse tree for 'test.cpp' matches 'test.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\test1.cpp
+[INFO] Parse tree for 'test1.cpp' matches 'test1.cpp.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\test2.cpp
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cpp\examples\union_non_inheritance.cpp
+line 4:8 no viable alternative at input 'unionB:'
+line 6:1 missing '{' at ';'
+line 6:2 missing '}' at '<EOF>'
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:cql >-----------------------
+[INFO] Building khubla.com Z39.5 CQL grammar 1.0-SNAPSHOT              [68/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cql ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cql\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cql\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cql ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cql\target\generated-sources\copy\org\antlr\grammars\cql added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cql ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cql
+[INFO] Processing grammar: cql.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cql\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cql ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cql ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cql\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cql ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cql ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cql ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql\examples\example4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql\examples\example5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql\examples\example6.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:cql3 >-----------------------
+[INFO] Building Apache Cassandra CQL 3 grammar 1.0-SNAPSHOT            [69/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cql3 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cql3\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cql3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cql3\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cql3 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cql3\target\generated-sources\copy\org\antlr\grammars\cql3 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cql3 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cql3
+[INFO] Processing grammar: CqlLexer.g4
+[INFO] Processing grammar: CqlParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cql3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cql3\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cql3 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cql3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cql3\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cql3 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cql3 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cql3 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\alterKeyspace.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\alterMaterializedView.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\alterRole.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\alterTable.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\alterType.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\alterUser.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\applyBatch.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createAggregate.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createFunction.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createIndex.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createKeyspace.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createMaterializedView.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createRole.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createTable.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createTrigger.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createType.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\createUser.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\delete.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropAggregate.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropFunction.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropIndex.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropKeyspace.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropMaterializedView.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropRole.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropTable.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropTrigger.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropType.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\dropUser.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\grant.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\insert.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\listPermissions.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\listRoles.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\revoke.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\select.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\truncate.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\update.cql
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cql3\examples\use.cql
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:creole >----------------------
+[INFO] Building khubla.com creole grammar 1.0-SNAPSHOT                 [70/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ creole ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\creole\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ creole ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\creole\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ creole ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\creole\target\generated-sources\copy\org\antlr\grammars\creole added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ creole ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\creole
+[INFO] Processing grammar: creole.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ creole ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\creole\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ creole ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ creole ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\creole\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ creole ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ creole ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ creole ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\creole\examples\bold.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\creole\examples\complete.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\creole\examples\italics.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\creole\examples\linebreaks.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\creole\examples\links.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\creole\examples\recursive.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\creole\examples\titles.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:csharp >----------------------
+[INFO] Building csharp grammar 1.0-SNAPSHOT                            [71/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ csharp ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\csharp\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ csharp ---
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ csharp ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\csharp\target\generated-sources\copy\org\antlr\grammars\csharp added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ csharp ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\csharp
+[INFO] Processing grammar: CSharpLexer.g4
+[INFO] Processing grammar: CSharpPreprocessorParser.g4
+[INFO] Processing grammar: CSharpParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ csharp ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\csharp\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ csharp ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 14 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ csharp ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\csharp\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ csharp ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ csharp ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ csharp ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\csharp\examples\AllInOneNoPreprocessor.cs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\csharp\examples\C2430-ok.cs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\csharp\examples\C2430.cs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\csharp\examples\issue-2612.txt
+line 4:17 mismatched input ':' expecting {'add', 'alias', '__arglist', 'ascending', 'async', 'await', 'by', 'descending', 'dynamic', 'equals', 'from', 'get', 'group', 'into', 'join', 'let', 'nameof', 'on', 'orderby', 'partial', 'remove', 'select', 'set', 'unmanaged', 'var', 'when', 'where', 'yield', IDENTIFIER, '[', '*', '?'}
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\csharp\examples\Multiple.cs
+line 5:18 rule local_variable_declaration failed predicate: { this.IsLocalVariableDeclaration() }?
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\csharp\examples\MultiplicativeExprsInArgList.cs
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:CSS3 >-----------------------
+[INFO] Building CSS3 grammar 1.0-SNAPSHOT                              [72/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ CSS3 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\css3\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ CSS3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\css3\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ CSS3 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\css3\target\generated-sources\copy\org\antlr\grammars\CSS3 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ CSS3 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\css3
+[INFO] Processing grammar: css3Lexer.g4
+[INFO] Processing grammar: css3Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ CSS3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\css3\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ CSS3 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ CSS3 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\css3\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ CSS3 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ CSS3 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ CSS3 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\at-rule.css
+[INFO] Parse tree for 'at-rule.css' matches 'at-rule.css.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\bootstrap-theme.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\bootstrap-theme.min.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\bootstrap.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\bootstrap.min.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\example1.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\example2.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\jquery-ui.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\jquery-ui.min.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-charset.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-counter-style.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-font-face.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-font-feature-values.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-import.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-keyframes.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-media.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-namespace.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-page.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-supports.css
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\css3\examples\mdn-at-viewport.css
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:csv >-----------------------
+[INFO] Building ANTLR CSV grammar 1.0-SNAPSHOT                         [73/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ csv ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\csv\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ csv ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\csv\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ csv ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\csv\target\generated-sources\copy\org\antlr\grammars\csv added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ csv ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\csv
+[INFO] Processing grammar: CSV.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ csv ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\csv\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ csv ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ csv ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\csv\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ csv ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ csv ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ csv ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\csv\examples\example1.csv
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:ctl >-----------------------
+[INFO] Building khubla.com CTL grammar 1.0-SNAPSHOT                    [74/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ctl ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\ctl\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ ctl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ctl\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ ctl ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\ctl\target\generated-sources\copy\org\antlr\grammars\ctl added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ ctl ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\ctl
+[INFO] Processing grammar: ctl.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ ctl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ctl\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ ctl ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ ctl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\ctl\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ ctl ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ ctl ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ ctl ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\ctl\examples\example1.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:cto >-----------------------
+[INFO] Building Hyperledger Composer Modeling Language grammar 1.0-SNAPSHOT [75/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cto ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cto\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cto ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cto\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cto ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cto\target\generated-sources\copy\org\antlr\grammars\cto added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cto ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cto
+[INFO] Processing grammar: CtoLexer.g4
+[INFO] Processing grammar: CtoParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cto ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cto\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cto ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 4 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cto ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cto\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cto ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cto ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cto ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cto\examples\invalid\datetime.cto
+line 5:28 mismatched input '"2000-01-31T23:59:59.001+05:41"' expecting DATE_TIME_LITERAL
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cto\examples\invalid\namespace.cto
+line 3:0 mismatched input 'enum' expecting 'namespace'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cto\examples\invalid\reference.cto
+line 5:23 extraneous input 'default' expecting {'}', ';', '--> ', 'o '}
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cto\examples\valid\car.cto
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cto\examples\valid\owner.cto
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cto\examples\valid\transaction.cto
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:cypher >----------------------
+[INFO] Building Cypher grammar 1.0-SNAPSHOT                            [76/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cypher ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\cypher\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cypher ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cypher\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cypher ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\cypher\target\generated-sources\copy\org\antlr\grammars\cypher added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cypher ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\cypher
+[INFO] Processing grammar: CypherLexer.g4
+[INFO] Processing grammar: CypherParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cypher ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cypher\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cypher ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cypher ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\cypher\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cypher ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cypher ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cypher ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\call1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\call2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\call3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\call4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\call5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\call6.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\call7.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\create1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\create2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\create3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match10.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match11.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match12.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match13.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match14.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match15.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match16.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match17.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match18.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match19.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match20.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match21.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match22.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match23.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match24.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match25.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match26.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match27.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match28.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match29.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match30.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match31.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match32.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match33.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match34.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match35.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match36.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match37.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match38.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match6.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match7.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match8.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\match9.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\remove1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\remove2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\set1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\with1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\cypher\examples\with2.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:Dart2 >----------------------
+[INFO] Building Dart2 grammar 1.0-SNAPSHOT                             [77/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ Dart2 ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\dart2\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ Dart2 ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.4.0:add-source (add-source) @ Dart2 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\dart2\Java added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ Dart2 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\dart2
+[INFO] Processing grammar: Dart2Lexer.g4
+[INFO] Processing grammar: Dart2Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ Dart2 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dart2\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ Dart2 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ Dart2 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dart2\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ Dart2 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ Dart2 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ Dart2 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\collections.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\escaped_backslash.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\escaped_string.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\escape_sequences.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\operator.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\regex.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\regex2.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\regex3.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\async.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\async_error.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\broadcast_stream_controller.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\deferred_load.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\future.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\future_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\schedule_microtask.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\stream.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\stream_controller.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\stream_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\stream_pipe.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\stream_transformers.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\timer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\async\zone.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\cli\cli.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\cli\wait_for.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\collection.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\collections.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\hash_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\hash_set.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\iterable.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\iterator.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\linked_hash_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\linked_hash_set.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\linked_list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\maps.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\queue.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\set.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\collection\splay_tree.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\ascii.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\base64.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\byte_conversion.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\chunked_conversion.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\codec.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\convert.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\converter.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\encoding.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\html_escape.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\json.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\latin1.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\line_splitter.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\string_conversion.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\convert\utf.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\annotations.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\bigint.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\bool.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\comparable.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\core.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\date_time.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\double.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\duration.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\enum.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\errors.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\exceptions.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\function.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\identical.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\int.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\invocation.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\iterable.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\iterator.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\null.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\num.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\object.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\pattern.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\print.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\regexp.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\set.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\sink.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\stacktrace.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\stopwatch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\string.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\string_buffer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\string_sink.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\symbol.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\type.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\uri.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\core\weak.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\developer\developer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\developer\extension.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\developer\profiler.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\developer\service.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\developer\timeline.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\abi.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\abi_specific.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\allocation.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\annotations.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\c_type.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\dynamic_library.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\ffi.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\native_finalizer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\native_type.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\struct.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\ffi\union.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\dart2js\html_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\dartium\nativewrappers.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\conversions.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\conversions_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\css_class_set.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\device.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\filtered_element_list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\html_common.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\html_common_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\lists.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\html\html_common\metadata.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\indexed_db\dart2js\indexed_db_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\async_cast.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\bytes_builder.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\cast.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\errors.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\internal.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\iterable.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\linked_list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\lowering.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\print.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\sort.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\internal\symbol.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\common.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\data_transformer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\directory.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\directory_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\embedder_config.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\eventhandler.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\file.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\file_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\file_system_entity.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\io.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\io_resource_info.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\io_service.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\io_sink.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\link.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\namespace_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\network_policy.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\network_profiling.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\overrides.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\platform.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\platform_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\process.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\secure_server_socket.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\secure_socket.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\security_context.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\service_object.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\socket.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\stdio.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\string_transformer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\io\sync_socket.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\isolate\capability.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\isolate\isolate.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js\js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js\js_wasm.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js\_js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js\_js_annotations.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js\_js_client.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js\_js_server.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js_util\js_util.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\js_util\js_util_wasm.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\math\math.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\math\point.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\math\random.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\math\rectangle.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\mirrors\mirrors.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\svg\dart2js\svg_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\typed_data\typed_data.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\typed_data\unmodifiable_typed_data.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\asset.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\client.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\constants.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\devfs.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\message.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\message_router.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\named_lookup.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\running_isolate.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\running_isolates.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\vmservice\vmservice.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\wasm\wasm_types.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\web_audio\dart2js\web_audio_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\web_gl\dart2js\web_gl_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\web_sql\dart2js\web_sql_dart2js.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\crypto.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\embedder_config.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\http.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\http_date.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\http_headers.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\http_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\http_parser.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\http_session.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\overrides.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\websocket.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_http\websocket_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\async_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\collection_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\convert_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\core_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\developer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\internal_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\io_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\isolate_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\js_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\math_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\patch\typed_data_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\annotations.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\custom_hash_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\ddc_runtime\classes.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\ddc_runtime\errors.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\ddc_runtime\operations.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\ddc_runtime\rtti.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\ddc_runtime\runtime.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\ddc_runtime\types.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\ddc_runtime\utils.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\debugger.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\foreign_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\identity_hash_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\interceptors.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\isolate_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\js_array.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\js_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\js_names.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\js_number.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\js_primitives.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\js_rti.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\js_string.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\linked_hash_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\mirror_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\native_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\native_typed_data.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\profile.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\regexp_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\runtime_metrics.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_dev_runtime\private\string_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\annotations.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\async_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\collection_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\constant_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\convert_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\core_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\dart2js_runtime_metrics.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\developer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\foreign_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\instantiation.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\interceptors.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\internal_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\io_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\isolate_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\js_array.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\js_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\js_names.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\js_number.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\js_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\js_primitives.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\js_string.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\late_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\linked_hash_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\math_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\native_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\native_typed_data.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\regexp_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\string_helper.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\synced\async_await_error_codes.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\synced\embedded_names.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_runtime\lib\typed_data_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_shared\lib\js_util_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_shared\lib\rti.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_shared\lib\synced\embedded_names.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\js_shared\lib\synced\recipe_syntax.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\sdk_library_metadata\lib\libraries.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\array.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\array_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\async_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\bigint_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\bool_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\class_id_fasta.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\collection_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\compact_hash.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\convert_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\core_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\date_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\deferred_load_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\developer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\double.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\double_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\empty_source.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\errors_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\expando_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\ffi_allocation_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\ffi_dynamic_library_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\ffi_native_finalizer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\ffi_native_type_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\ffi_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\ffi_struct_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\finalizer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\function.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\function_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\growable_array.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\hash_factories.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\identical_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\immutable_map.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\integers.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\integers_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\internal_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\invocation_mirror_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\isolate_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\lib_prefix.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\map_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\math_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\mirrors_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\mirrors_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\mirror_reference.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\null_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\object_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\print_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\profiler.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\regexp_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\schedule_microtask_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\stacktrace.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\stopwatch_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\string_buffer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\string_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\symbol_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\timeline.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\timer_impl.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\timer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\typed_data_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\type_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\uri_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\vm\lib\weak_property.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\bool.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\class_id.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\core_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\date_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\developer.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\double.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\errors_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\expando_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\function.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\growable_list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\hash_factories.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\identical_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\int.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\internal_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\js_util_wasm_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\list.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\math_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\object_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\print_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\stack_trace_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\string_buffer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\string_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\timer_patch.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\sdk\sdk\lib\_internal\wasm\lib\type.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\string_with_backslashes.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\try-dart\Classes.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\try-dart\CollectionsLiterals.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\try-dart\ComputePi.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\try-dart\ControlFlow.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\try-dart\Functions.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\try-dart\hw.dart
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dart2\examples\try-dart\Strings.dart
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:databank >---------------------
+[INFO] Building khubla.com databank grammar 1.0-SNAPSHOT               [78/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ databank ---
+[INFO] Deleting C:\msys64\home\Kenne\issues\g4-4174\databank\target
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ databank ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ databank ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\databank\target\generated-sources\copy\org\antlr\grammars\databank added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ databank ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\databank
+[INFO] Processing grammar: databank.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ databank ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\databank\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ databank ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ databank ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\databank\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ databank ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ databank ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ databank ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\databank\examples\example1.db
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\databank\examples\example2.db
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\databank\examples\example3.db
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\databank\examples\example4.db
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\databank\examples\example5.db
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:datalog >---------------------
+[INFO] Building khubla.com Datalog grammar 1.0-SNAPSHOT                [79/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ datalog ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ datalog ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\datalog\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ datalog ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\datalog\target\generated-sources\copy\org\antlr\grammars\datalog added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ datalog ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\datalog
+[INFO] Processing grammar: datalog.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ datalog ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\datalog\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ datalog ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ datalog ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\datalog\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ datalog ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ datalog ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ datalog ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\datalog\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\datalog\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\datalog\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\datalog\examples\example4.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:dcm >-----------------------
+[INFO] Building DCM grammar 1.0-SNAPSHOT                               [80/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ dcm ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ dcm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dcm\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ dcm ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\dcm\target\generated-sources\copy\org\antlr\grammars\dcm added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ dcm ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\dcm
+[INFO] Processing grammar: DCM_2_0_grammar.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ dcm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dcm\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ dcm ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ dcm ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dcm\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ dcm ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ dcm ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ dcm ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:dice >-----------------------
+[INFO] Building Dice notation grammar 1.0-SNAPSHOT                     [81/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ dice ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ dice ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dice\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ dice ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\dice\target\generated-sources\copy\org\antlr\grammars\dice added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ dice ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\dice
+[INFO] Processing grammar: DiceNotationLexer.g4
+[INFO] Processing grammar: DiceNotationParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ dice ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dice\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ dice ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ dice ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dice\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ dice ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ dice ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ dice ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\arithmetic_dice.txt
+[INFO] Parse tree for 'arithmetic_dice.txt' matches 'arithmetic_dice.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\arithmetic_mixed.txt
+[INFO] Parse tree for 'arithmetic_mixed.txt' matches 'arithmetic_mixed.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\arithmetic_mixed_div.txt
+[INFO] Parse tree for 'arithmetic_mixed_div.txt' matches 'arithmetic_mixed_div.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\arithmetic_mixed_mult.txt
+[INFO] Parse tree for 'arithmetic_mixed_mult.txt' matches 'arithmetic_mixed_mult.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\arithmetic_num.txt
+[INFO] Parse tree for 'arithmetic_num.txt' matches 'arithmetic_num.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\big_d.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\big_dice.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\dice.txt
+[INFO] Parse tree for 'dice.txt' matches 'dice.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\invalid_dice_format.txt
+line 1:2 token recognition error at: 'z'
+line 1:3 no viable alternative at input '5d'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\invalid_dice_missing_dice.txt
+[INFO] Parse tree for 'invalid_dice_missing_dice.txt' matches 'invalid_dice_missing_dice.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\invalid_dice_missing_side.txt
+line 1:2 no viable alternative at input '1d'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\invalid_dice_suffix.txt
+line 1:3 token recognition error at: 'y'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\invalid_dice_whitespace_end.txt
+line 1:2 token recognition error at: ' '
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\invalid_dice_whitespace_start.txt
+line 1:1 token recognition error at: ' '
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\negative_dice.txt
+[INFO] Parse tree for 'negative_dice.txt' matches 'negative_dice.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\negative_number.txt
+[INFO] Parse tree for 'negative_number.txt' matches 'negative_number.txt.tree'
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\no_dice.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dice\examples\number.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:dif >-----------------------
+[INFO] Building khubla.com DIF grammar 1.0-SNAPSHOT                    [82/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ dif ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ dif ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dif\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ dif ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\dif\target\generated-sources\copy\org\antlr\grammars\dif added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ dif ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\dif
+[INFO] Processing grammar: dif.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ dif ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dif\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ dif ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ dif ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dif\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ dif ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ dif ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ dif ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dif\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dif\examples\example2.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:doiurl >----------------------
+[INFO] Building khubla.com DOI URLgrammar 1.0-SNAPSHOT                 [83/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ doiurl ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ doiurl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\doiurl\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ doiurl ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\doiurl\target\generated-sources\copy\org\antlr\grammars\doiurl added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ doiurl ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\doiurl
+[INFO] Processing grammar: doiurl.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ doiurl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\doiurl\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ doiurl ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ doiurl ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\doiurl\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ doiurl ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ doiurl ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ doiurl ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example10.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example11.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example12.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example13.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example14.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example6.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example7.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example8.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\doiurl\examples\example9.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:dot >-----------------------
+[INFO] Building ANTLR dot grammar 1.0-SNAPSHOT                         [84/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ dot ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ dot ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dot\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ dot ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\dot\target\generated-sources\copy\org\antlr\grammars\dot added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ dot ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\dot
+[INFO] Processing grammar: DOT.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ dot ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dot\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ dot ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ dot ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\dot\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ dot ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ dot ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ dot ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dot\examples\cluster.dot
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dot\examples\crazy.dot
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\dot\examples\dg.dot
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:edif300 >---------------------
+[INFO] Building EDIF 3 0 0 grammar 1.0-SNAPSHOT                        [85/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ edif300 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ edif300 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\edif300\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ edif300 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\edif300\target\generated-sources\copy\org\antlr\grammars\edif300 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ edif300 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\edif300
+[INFO] Processing grammar: EDIF300.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ edif300 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\edif300\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ edif300 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 4 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ edif300 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\edif300\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ edif300 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ edif300 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ edif300 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edif300\examples\empty.edf
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:edn >-----------------------
+[INFO] Building EDN grammar 1.0-SNAPSHOT                               [86/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ edn ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ edn ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\edn\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ edn ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\edn\target\generated-sources\copy\org\antlr\grammars\edn added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ edn ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\edn
+[INFO] Processing grammar: edn.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ edn ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\edn\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ edn ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ edn ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\edn\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ edn ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ edn ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ edn ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\depds.edn
+line 159:7 extraneous input '.1' expecting {'nil', BooleanLiteral, StringLiteral, IntegerLiteral, FloatingPointLiteral, CharacterLiteral, '(', '[', '{', '#{', '#', ':', Symbol}
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\deps.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\large-keyword-map.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\large-symbol-map.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\list-of-nil.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\map-of-maps.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\map-tree.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\mixed-vector.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\serializability.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\set-of-keywords.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\set-of-longs.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\set-of-symbols.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vecor-of-maps.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-bigdecs.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-bigints.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-booleans.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-chars.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-doubles.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-instants.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-ints.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-keywords.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-longs.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-nil.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-strings.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-symbols.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-uuid.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-of-vectors.edn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\edn\examples\vector-tree.edn
+[INFO] 
+[INFO] ------------------< org.antlr.grammars:elixir-parser >------------------
+[INFO] Building Elixir grammar 1.0-SNAPSHOT                            [87/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ elixir-parser ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ elixir-parser ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\elixir\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ elixir-parser ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\elixir\target\generated-sources\copy\org\antlr\grammars\elixir-parser added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ elixir-parser ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\elixir
+[INFO] Processing grammar: ElixirLexer.g4
+[INFO] Processing grammar: ElixirParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ elixir-parser ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\elixir\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ elixir-parser ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ elixir-parser ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\elixir\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ elixir-parser ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ elixir-parser ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ elixir-parser ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\block.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_addExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_aliasExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_ampExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_andExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_anonymousFunctionExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_atExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_atomExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_binaryExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_bitExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_bitstringExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_boolExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_caseExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_codepointExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_condExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_defaultValueExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_doBlockExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_dotExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_eqExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_floatExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_forExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_functionCallExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_functionDefExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_hexadecimalExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_ifExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_inExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_integerExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_larrowExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_listExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_macroDefExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_mapExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_moduleDefExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_mulExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_multiLineCharlistExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_multiLineStringExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_nestedExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_nilExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_octalExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_operatorExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_orExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_otherExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_patternExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_pipeExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_prependExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_rarrowExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_relExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_sigilExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_singleLineCharlistExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_singleLineStringExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_tryExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_tupleExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_typeExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_unaryExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_unlessExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_variablesExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_whenExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\expression_withExpr.ex
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\elixir\examples\list.ex
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:erlang >----------------------
+[INFO] Building Erlang grammar 1.0-SNAPSHOT                            [88/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ erlang ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ erlang ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\erlang\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ erlang ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\erlang\target\generated-sources\copy\org\antlr\grammars\erlang added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ erlang ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\erlang
+[INFO] Processing grammar: Erlang.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ erlang ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\erlang\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ erlang ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ erlang ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\erlang\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ erlang ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ erlang ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ erlang ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\erlang\examples\fac.P
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\erlang\examples\getty.P
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\erlang\examples\helloword.P
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\erlang\examples\map.P
+[INFO] 
+[INFO] ------------------< org.antlr.grammars:esolangparent >------------------
+[INFO] Building Esoteric Language Grammars 1.0-SNAPSHOT                [89/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ esolangparent ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ esolangparent ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ esolangparent ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\target\generated-sources\copy\org\antlr\grammars\esolangparent added.
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:brainfuck >--------------------
+[INFO] Building khubla.com Brainfuck grammar 1.0-SNAPSHOT              [90/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ brainfuck ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ brainfuck ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ brainfuck ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\target\generated-sources\copy\org\antlr\grammars\brainfuck added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ brainfuck ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck
+[INFO] Processing grammar: brainfuck.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ brainfuck ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ brainfuck ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ brainfuck ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ brainfuck ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ brainfuck ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ brainfuck ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\examples\collatz.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\examples\comments.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\examples\empty.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\examples\fib.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\examples\helloworld.b
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainfuck\examples\matched.b
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:brainflack >--------------------
+[INFO] Building khubla.com Brainflak grammar 1.0-SNAPSHOT              [91/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ brainflack ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ brainflack ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ brainflack ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak\target\generated-sources\copy\org\antlr\grammars\brainflack added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ brainflack ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak
+[INFO] Processing grammar: brainflak.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ brainflack ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ brainflack ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ brainflack ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ brainflack ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ brainflack ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ brainflack ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\brainflak\examples\example3.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:cool >-----------------------
+[INFO] Building COOL grammar 1.0-SNAPSHOT                              [92/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ cool ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ cool ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ cool ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\target\generated-sources\copy\org\antlr\grammars\cool added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ cool ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\cool
+[INFO] Processing grammar: COOL.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ cool ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ cool ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ cool ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ cool ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cool ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ cool ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\arith.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\atoi.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\atoi_test.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\book_list.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\cells.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\complex.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\cool.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\graph.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\hairyscary.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\hello_world.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\io.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\lam.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\life.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\list.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\new_complex.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\palindrome.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\pr1154.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\pr1154_2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\primes.cl
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\cool\examples\sort_list.cl
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:dgol >-----------------------
+[INFO] Building khubla.com DGOL grammar 1.0-SNAPSHOT                   [93/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ dgol ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ dgol ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\dgol\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ dgol ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\dgol\target\generated-sources\copy\org\antlr\grammars\dgol added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ dgol ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\dgol
+[INFO] Processing grammar: dgol.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ dgol ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\dgol\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ dgol ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ dgol ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\dgol\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ dgol ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ dgol ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ dgol ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:lolcode >---------------------
+[INFO] Building khubla.com lolcode grammar 1.0-SNAPSHOT                [94/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ lolcode ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ lolcode ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\lolcode\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ lolcode ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\lolcode\target\generated-sources\copy\org\antlr\grammars\lolcode added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ lolcode ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\lolcode
+[INFO] Processing grammar: lolcode.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ lolcode ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\lolcode\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ lolcode ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ lolcode ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\lolcode\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ lolcode ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ lolcode ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ lolcode ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\lolcode\examples\hai.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:loop >-----------------------
+[INFO] Building khubla.com LOOP grammar 1.0-SNAPSHOT                   [95/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ loop ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ loop ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\loop\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ loop ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\loop\target\generated-sources\copy\org\antlr\grammars\loop added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ loop ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\loop
+[INFO] Processing grammar: loop.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ loop ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\loop\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ loop ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ loop ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\loop\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ loop ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ loop ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ loop ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\loop\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\loop\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\loop\examples\example5.txt
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:nanofuck >---------------------
+[INFO] Building khubla.com Nanofuck grammar 1.0-SNAPSHOT               [96/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ nanofuck ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ nanofuck ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\nanofuck\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ nanofuck ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\nanofuck\target\generated-sources\copy\org\antlr\grammars\nanofuck added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ nanofuck ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\nanofuck
+[INFO] Processing grammar: nanofuck.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ nanofuck ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\nanofuck\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ nanofuck ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ nanofuck ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\nanofuck\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ nanofuck ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ nanofuck ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ nanofuck ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\nanofuck\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\nanofuck\examples\example2.txt
+[INFO] 
+[INFO] ---------------------< org.antlr.grammars:sickbay >---------------------
+[INFO] Building khubla.com SICKBAY grammar 1.0-SNAPSHOT                [97/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ sickbay ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ sickbay ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\sickbay\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ sickbay ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\sickbay\target\generated-sources\copy\org\antlr\grammars\sickbay added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ sickbay ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\sickbay
+[INFO] Processing grammar: sickbay.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ sickbay ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\sickbay\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ sickbay ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ sickbay ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\sickbay\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ sickbay ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ sickbay ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ sickbay ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\sickbay\examples\hello.txt
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:snowball >---------------------
+[INFO] Building khubla.com snowball grammar 1.0-SNAPSHOT               [98/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ snowball ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ snowball ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\snowball\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ snowball ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\snowball\target\generated-sources\copy\org\antlr\grammars\snowball added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ snowball ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\snowball
+[INFO] Processing grammar: snowball.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ snowball ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\snowball\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ snowball ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ snowball ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\snowball\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ snowball ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ snowball ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ snowball ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\snowball\examples\example1.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:wheel >----------------------
+[INFO] Building khubla.com Wheel grammar 1.0-SNAPSHOT                  [99/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ wheel ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ wheel ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ wheel ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel\target\generated-sources\copy\org\antlr\grammars\wheel added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ wheel ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel
+[INFO] Processing grammar: wheel.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ wheel ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ wheel ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ wheel ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ wheel ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ wheel ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ wheel ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\esolang\wheel\examples\example3.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:EVMB >-----------------------
+[INFO] Building EVM bytecode grammar 1.0-SNAPSHOT                     [100/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ EVMB ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ EVMB ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\evm-bytecode\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ EVMB ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\evm-bytecode\target\generated-sources\copy\org\antlr\grammars\EVMB added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ EVMB ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\evm-bytecode
+[INFO] Processing grammar: EVMBLexer.g4
+[INFO] Processing grammar: EVMBParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ EVMB ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\evm-bytecode\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ EVMB ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ EVMB ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\evm-bytecode\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ EVMB ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ EVMB ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ EVMB ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\evm-bytecode\examples\0xcDA72070E455bb31C7690a170224Ce43623d0B6f
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:fasta >----------------------
+[INFO] Building khubla.com fasta grammar 1.0-SNAPSHOT                 [101/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fasta ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fasta ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fasta\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fasta ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fasta\target\generated-sources\copy\org\antlr\grammars\fasta added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ fasta ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\fasta
+[INFO] Processing grammar: fasta.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ fasta ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fasta\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ fasta ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ fasta ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fasta\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ fasta ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ fasta ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ fasta ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fasta\examples\NC_009925.faa
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fasta\examples\NC_009925.ffn
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fasta\examples\NC_009925.fna
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:fdo91 >----------------------
+[INFO] Building khubla.com FDO91 grammar 1.0-SNAPSHOT                 [102/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fdo91 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fdo91 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fdo91\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fdo91 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fdo91\target\generated-sources\copy\org\antlr\grammars\fdo91 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ fdo91 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\fdo91
+[INFO] Processing grammar: fdo91.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ fdo91 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fdo91\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ fdo91 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ fdo91 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fdo91\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ fdo91 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ fdo91 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ fdo91 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example10.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example11.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example12.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example13.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example4.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example5.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example6.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example7.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example8.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fdo91\examples\example9.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:fen >-----------------------
+[INFO] Building khubla.com fen grammar 1.0-SNAPSHOT                   [103/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fen ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fen ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fen\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fen ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fen\target\generated-sources\copy\org\antlr\grammars\fen added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ fen ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\fen
+[INFO] Processing grammar: fen.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ fen ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fen\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ fen ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ fen ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fen\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ fen ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ fen ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ fen ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fen\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fen\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fen\examples\example3.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fen\examples\example4.txt
+[INFO] 
+[INFO] -------------------< org.antlr.grammars:flatbuffers >-------------------
+[INFO] Building FlatBuffers schema language grammar 1.0-SNAPSHOT      [104/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ flatbuffers ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ flatbuffers ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ flatbuffers ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\target\generated-sources\copy\org\antlr\grammars\flatbuffers added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ flatbuffers ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\flatbuffers
+[INFO] Processing grammar: FlatBuffers.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ flatbuffers ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ flatbuffers ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ flatbuffers ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ flatbuffers ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ flatbuffers ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ flatbuffers ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\flatbench.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\greeter.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\monster.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\monster2.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\namespace_test1.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\namespace_test2.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\resultinfo.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\saveschema.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\assets.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\attributes.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\components.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\config.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\gpg.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\graph.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\input_config.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\rail_def.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\save_data.fbs
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flatbuffers\examples\zooshi\unlockables.fbs
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:flowmatic >--------------------
+[INFO] Building khubla.com FLOW-MATIC grammar 1.0-SNAPSHOT            [105/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ flowmatic ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ flowmatic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\flowmatic\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ flowmatic ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\flowmatic\target\generated-sources\copy\org\antlr\grammars\flowmatic added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ flowmatic ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\flowmatic
+[INFO] Processing grammar: flowmatic.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ flowmatic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\flowmatic\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ flowmatic ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ flowmatic ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\flowmatic\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ flowmatic ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ flowmatic ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ flowmatic ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\flowmatic\examples\example1.txt
+[INFO] 
+[INFO] ----------------------< org.antlr.grammars:focal >----------------------
+[INFO] Building khubla.com FOCAL grammar 1.0-SNAPSHOT                 [106/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ focal ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ focal ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\focal\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ focal ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\focal\target\generated-sources\copy\org\antlr\grammars\focal added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ focal ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\focal
+[INFO] Processing grammar: focal.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ focal ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\focal\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ focal ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ focal ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\focal\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ focal ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ focal ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ focal ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\focal\examples\example1.txt
+[INFO] 
+[INFO] -----------------------< org.antlr.grammars:fol >-----------------------
+[INFO] Building First Order Logic grammar 1.0-SNAPSHOT                [107/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fol ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fol ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fol\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fol ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fol\target\generated-sources\copy\org\antlr\grammars\fol added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ fol ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\fol
+[INFO] Processing grammar: fol.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ fol ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fol\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ fol ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ fol ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fol\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ fol ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ fol ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ fol ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fol\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fol\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fol\examples\example3.txt
+[INFO] 
+[INFO] ------------------< org.antlr.grammars:fortranparent >------------------
+[INFO] Building Fortran Grammars 1.0-SNAPSHOT                         [108/350]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fortranparent ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fortranparent ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fortran\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fortranparent ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fortran\target\generated-sources\copy\org\antlr\grammars\fortranparent added.
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:fortran77 >--------------------
+[INFO] Building fortran77 grammar 1.0-SNAPSHOT                        [109/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fortran77 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fortran77 ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fortran77 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\target\generated-sources\copy\org\antlr\grammars\fortran77 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ fortran77 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77
+[INFO] Processing grammar: Fortran77Lexer.g4
+[INFO] Processing grammar: Fortran77Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ fortran77 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ fortran77 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ fortran77 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ fortran77 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ fortran77 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ fortran77 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\examples\continue-example.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\examples\elseIfExample.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\examples\example1.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\examples\example2.txt
+[INFO] Parsing :C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran77\examples\goto-example.txt
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:fortran90 >--------------------
+[INFO] Building fortran90 grammar 1.0-SNAPSHOT                        [110/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fortran90 ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fortran90 ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fortran90 ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran90\target\generated-sources\copy\org\antlr\grammars\fortran90 added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ fortran90 ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran90
+[INFO] Processing grammar: Fortran90Lexer.g4
+[INFO] Processing grammar: Fortran90Parser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ fortran90 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran90\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ fortran90 ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 7 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ fortran90 ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fortran\fortran90\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ fortran90 ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ fortran90 ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ fortran90 ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] ------------------< org.antlr.grammars:fusiontables >-------------------
+[INFO] Building fusion-tables grammar 1.0-SNAPSHOT                    [111/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ fusiontables ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ fusiontables ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fusion-tables\Java
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ fusiontables ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\fusion-tables\target\generated-sources\copy\org\antlr\grammars\fusiontables added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ fusiontables ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\fusion-tables
+[INFO] Processing grammar: FusionTablesSql.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ fusiontables ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fusion-tables\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ fusiontables ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 6 source files with javac [debug target 11] to target\classes
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ fusiontables ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\fusion-tables\src\test\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:testCompile (default-testCompile) @ fusiontables ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ fusiontables ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- antlr4test-maven-plugin:1.22:test (default) @ fusiontables ---
+[INFO] Evaluating Scenario: Default Scenario
+[INFO] 
+[INFO] --------------------< org.antlr.grammars:gdscript >---------------------
+[INFO] Building Python3 grammar 1.0-SNAPSHOT                          [112/350]
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ gdscript ---
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:copy-resources (copy-resources) @ gdscript ---
+[INFO] Copying 1 resource
+[INFO] 
+[INFO] --- build-helper-maven-plugin:3.2.0:add-source (add-source) @ gdscript ---
+[INFO] Source directory: C:\msys64\home\Kenne\issues\g4-4174\gdscript\target\generated-sources\copy\org\antlr\grammars\gdscript added.
+[INFO] 
+[INFO] --- antlr4-maven-plugin:4.11.1:antlr4 (default) @ gdscript ---
+[INFO] ANTLR 4: Processing source directory C:\msys64\home\Kenne\issues\g4-4174\gdscript
+[INFO] Processing grammar: GDScriptLexer.g4
+[INFO] Processing grammar: GDScriptParser.g4
+[INFO] 
+[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ gdscript ---
+[INFO] skip non existing resourceDirectory C:\msys64\home\Kenne\issues\g4-4174\gdscript\src\main\resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.11.0:compile (default-compile) @ gdscript ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 8 source files with javac [debug target 11] to target\classes
+[INFO] -------------------------------------------------------------
+[WARNING] COMPILATION WARNING : 
+[INFO] -------------------------------------------------------------
+[WARNING] system modules path not set in conjunction with -source 11
+[INFO] 1 warning
+[INFO] -------------------------------------------------------------
+[INFO] -------------------------------------------------------------
+[ERROR] COMPILATION ERROR : 
+[INFO] -------------------------------------------------------------
+[ERROR] /C:/msys64/home/Kenne/issues/g4-4174/gdscript/Java/GDScriptLexerBase.java:[8,10] duplicate class: GDScriptLexerBase
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[INFO] ------------------------------------------------------------------------
+[INFO] Reactor Summary for ANTLR4 grammars 1.0-SNAPSHOT:
+[INFO] 
+[INFO] ANTLR4 grammars .................................... SUCCESS [  1.005 s]
+[INFO] abb grammar ........................................ SUCCESS [  2.768 s]
+[INFO] ABNF grammar ....................................... SUCCESS [  0.838 s]
+[INFO] khubla.com Acme grammar ............................ SUCCESS [  3.619 s]
+[INFO] khubla.com Action! grammar ......................... SUCCESS [  1.866 s]
+[INFO] Ada Grammars ....................................... SUCCESS [  0.005 s]
+[INFO] Ada 83 grammar ..................................... SUCCESS [  3.148 s]
+[INFO] Ada 95 grammar ..................................... SUCCESS [  4.305 s]
+[INFO] Ada 2005 grammar ................................... SUCCESS [  3.832 s]
+[INFO] Ada 2012 grammar ................................... SUCCESS [  3.888 s]
+[INFO] khubla.com Alef grammar ............................ SUCCESS [  0.996 s]
+[INFO] khubla.com algol60 grammar ......................... SUCCESS [  1.802 s]
+[INFO] khubla.com Alloy grammar ........................... SUCCESS [  0.692 s]
+[INFO] khubla.com alpaca grammar .......................... SUCCESS [  0.487 s]
+[INFO] localstack.cloud amazon-states-language ............ SUCCESS [  1.861 s]
+[INFO] localstack.cloud amazon-states-language intrinsic-functions SUCCESS [  1.219 s]
+[INFO] khubla.com Arithmetic grammar ...................... SUCCESS [  0.795 s]
+[INFO] ANTLR Grammars ..................................... SUCCESS [  0.003 s]
+[INFO] ANTLR2 grammar ..................................... SUCCESS [  1.701 s]
+[INFO] ANTLR3 grammar ..................................... SUCCESS [  1.921 s]
+[INFO] ANTLR4 grammar ..................................... SUCCESS [  1.873 s]
+[INFO] Apex grammar ....................................... SUCCESS [  1.719 s]
+[INFO] apt grammar ........................................ SUCCESS [  0.284 s]
+[INFO] ArangoDb grammar ................................... SUCCESS [  1.759 s]
+[INFO] khubla.com Argus grammar ........................... SUCCESS [  0.591 s]
+[INFO] khubla.com Arithmetic grammar ...................... SUCCESS [  1.328 s]
+[INFO] ASL grammar ........................................ SUCCESS [  2.217 s]
+[INFO] Assembler Grammars ................................. SUCCESS [  0.003 s]
+[INFO] ASM 6502 grammar ................................... SUCCESS [  0.749 s]
+[INFO] ASM 8080 grammar ................................... SUCCESS [  0.474 s]
+[INFO] ASM 8086 grammar ................................... SUCCESS [  1.093 s]
+[INFO] MASM grammar ....................................... SUCCESS [  0.818 s]
+[INFO] ASM Z80 grammar .................................... SUCCESS [  0.447 s]
+[INFO] MASM grammar ....................................... SUCCESS [  0.408 s]
+[INFO] NASM grammar ....................................... SUCCESS [  3.403 s]
+[INFO] ASM pdp7 grammar ................................... SUCCESS [  3.811 s]
+[INFO] CUDA PTX ISA Grammars .............................. SUCCESS [  0.005 s]
+[INFO] CUDA PTX ISA 1.0 grammar ........................... SUCCESS [  1.065 s]
+[INFO] CUDA PTX ISA 2.1 grammar ........................... SUCCESS [ 24.196 s]
+[INFO] ASM RSICV grammar .................................. SUCCESS [  0.782 s]
+[INFO] ASN Grammars ....................................... SUCCESS [  0.003 s]
+[INFO] ASN.1 grammar ...................................... SUCCESS [  1.983 s]
+[INFO] ASN 3GPP grammar ................................... SUCCESS [  2.028 s]
+[INFO] khubla.com ATerm grammar ........................... SUCCESS [  1.126 s]
+[INFO] ATL grammar ........................................ SUCCESS [  0.546 s]
+[INFO] khubla.com B grammar ............................... SUCCESS [  0.934 s]
+[INFO] khubla.com BASIC grammar ........................... SUCCESS [  2.547 s]
+[INFO] khubla.com BCL grammar ............................. SUCCESS [  0.189 s]
+[INFO] khubla.com BCPL grammar ............................ SUCCESS [ 14.148 s]
+[INFO] khubla.com BDF grammar ............................. SUCCESS [  0.960 s]
+[INFO] Bencoding grammar .................................. SUCCESS [  0.740 s]
+[INFO] khubla.com Bibcode grammar ......................... SUCCESS [  0.535 s]
+[INFO] Bicep grammar ...................................... SUCCESS [  1.408 s]
+[INFO] khubla.com BNF grammar ............................. SUCCESS [  2.126 s]
+[INFO] C grammar .......................................... SUCCESS [  2.413 s]
+[INFO] khubla.com Calculator grammar ...................... SUCCESS [  2.609 s]
+[INFO] khubla.com callable grammar ........................ SUCCESS [  0.414 s]
+[INFO] Cap'n Proto schema language grammar ................ SUCCESS [  0.966 s]
+[INFO] CaQL grammar ....................................... SUCCESS [  0.917 s]
+[INFO] khubla.com Arithmetic grammar ...................... SUCCESS [  0.214 s]
+[INFO] khubla.com CLF grammar ............................. SUCCESS [  0.517 s]
+[INFO] Clojure grammar .................................... SUCCESS [  0.700 s]
+[INFO] khubla.com clu grammar ............................. SUCCESS [  0.984 s]
+[INFO] CMake grammar ...................................... SUCCESS [  0.310 s]
+[INFO] CodeQL grammar ..................................... SUCCESS [  2.376 s]
+[INFO] khubla.com cookie grammar .......................... SUCCESS [  0.541 s]
+[INFO] CPP14 grammar ...................................... SUCCESS [  5.850 s]
+[INFO] khubla.com Z39.5 CQL grammar ....................... SUCCESS [  0.954 s]
+[INFO] Apache Cassandra CQL 3 grammar ..................... SUCCESS [  6.354 s]
+[INFO] khubla.com creole grammar .......................... SUCCESS [  0.870 s]
+[INFO] csharp grammar ..................................... SUCCESS [  5.195 s]
+[INFO] CSS3 grammar ....................................... SUCCESS [  4.474 s]
+[INFO] ANTLR CSV grammar .................................. SUCCESS [  0.311 s]
+[INFO] khubla.com CTL grammar ............................. SUCCESS [  0.295 s]
+[INFO] Hyperledger Composer Modeling Language grammar ..... SUCCESS [  1.126 s]
+[INFO] Cypher grammar ..................................... SUCCESS [  4.342 s]
+[INFO] Dart2 grammar ...................................... SUCCESS [01:03 min]
+[INFO] khubla.com databank grammar ........................ SUCCESS [  1.104 s]
+[INFO] khubla.com Datalog grammar ......................... SUCCESS [  0.666 s]
+[INFO] DCM grammar ........................................ SUCCESS [  0.379 s]
+[INFO] Dice notation grammar .............................. SUCCESS [  2.270 s]
+[INFO] khubla.com DIF grammar ............................. SUCCESS [  0.485 s]
+[INFO] khubla.com DOI URLgrammar .......................... SUCCESS [  1.283 s]
+[INFO] ANTLR dot grammar .................................. SUCCESS [  0.607 s]
+[INFO] EDIF 3 0 0 grammar ................................. SUCCESS [ 10.466 s]
+[INFO] EDN grammar ........................................ SUCCESS [  2.960 s]
+[INFO] Elixir grammar ..................................... SUCCESS [ 25.086 s]
+[INFO] Erlang grammar ..................................... SUCCESS [  3.176 s]
+[INFO] Esoteric Language Grammars ......................... SUCCESS [  0.003 s]
+[INFO] khubla.com Brainfuck grammar ....................... SUCCESS [  0.902 s]
+[INFO] khubla.com Brainflak grammar ....................... SUCCESS [  0.752 s]
+[INFO] COOL grammar ....................................... SUCCESS [  2.708 s]
+[INFO] khubla.com DGOL grammar ............................ SUCCESS [  0.450 s]
+[INFO] khubla.com lolcode grammar ......................... SUCCESS [  0.925 s]
+[INFO] khubla.com LOOP grammar ............................ SUCCESS [  0.789 s]
+[INFO] khubla.com Nanofuck grammar ........................ SUCCESS [  0.708 s]
+[INFO] khubla.com SICKBAY grammar ......................... SUCCESS [  0.509 s]
+[INFO] khubla.com snowball grammar ........................ SUCCESS [  0.825 s]
+[INFO] khubla.com Wheel grammar ........................... SUCCESS [  0.699 s]
+[INFO] EVM bytecode grammar ............................... SUCCESS [  0.595 s]
+[INFO] khubla.com fasta grammar ........................... SUCCESS [  3.111 s]
+[INFO] khubla.com FDO91 grammar ........................... SUCCESS [  1.668 s]
+[INFO] khubla.com fen grammar ............................. SUCCESS [  0.893 s]
+[INFO] FlatBuffers schema language grammar ................ SUCCESS [  2.779 s]
+[INFO] khubla.com FLOW-MATIC grammar ...................... SUCCESS [  0.899 s]
+[INFO] khubla.com FOCAL grammar ........................... SUCCESS [  1.022 s]
+[INFO] First Order Logic grammar .......................... SUCCESS [  0.857 s]
+[INFO] Fortran Grammars ................................... SUCCESS [  0.006 s]
+[INFO] fortran77 grammar .................................. SUCCESS [  5.221 s]
+[INFO] fortran90 grammar .................................. SUCCESS [  2.029 s]
+[INFO] fusion-tables grammar .............................. SUCCESS [  0.426 s]
+[INFO] Python3 grammar .................................... FAILURE [  0.569 s]
+[INFO] khubla.com GEDCOM grammar .......................... SKIPPED
+[INFO] khubla.com gff3 grammar ............................ SKIPPED
+[INFO] GLSL grammar ....................................... SKIPPED
+[INFO] khubla.com GML grammar ............................. SKIPPED
+[INFO] Go language grammar ................................ SKIPPED
+[INFO] GraphQL grammar .................................... SKIPPED
+[INFO] ANTLR Graphstream DGS grammar ...................... SKIPPED
+[INFO] khubla.com GTIN grammar ............................ SKIPPED
+[INFO] khubla.com guido grammar ........................... SKIPPED
+[INFO] khubla.com Guitar Tab grammar ...................... SKIPPED
+[INFO] Haskell grammar .................................... SKIPPED
+[INFO] khubla.com html grammar ............................ SKIPPED
+[INFO] HTTP grammar ....................................... SKIPPED
+[INFO] HyperTalk grammar .................................. SKIPPED
+[INFO] ical grammar ....................................... SKIPPED
+[INFO] khubla.com icon grammar ............................ SKIPPED
+[INFO] IDL grammar ........................................ SKIPPED
+[INFO] khubla.com inf grammar ............................. SKIPPED
+[INFO] informix grammar ................................... SKIPPED
+[INFO] khubla.com Infosapient grammar ..................... SKIPPED
+[INFO] IRI grammar ........................................ SKIPPED
+[INFO] iso8601 grammar .................................... SKIPPED
+[INFO] khubla.com ISTC grammar ............................ SKIPPED
+[INFO] khubla.com ITN grammar ............................. SKIPPED
+[INFO] khubla.com JAM grammar ............................. SKIPPED
+[INFO] khubla.com Janus grammar ........................... SKIPPED
+[INFO] Java Grammars ...................................... SKIPPED
+[INFO] Java ............................................... SKIPPED
+[INFO] Java8 grammar ...................................... SKIPPED
+[INFO] Java9 grammar ...................................... SKIPPED
+[INFO] Java20 ............................................. SKIPPED
+[INFO] Javadoc grammar .................................... SKIPPED
+[INFO] Javascript Grammars ................................ SKIPPED
+[INFO] ECMAScript grammar ................................. SKIPPED
+[INFO] JavaScript grammar ................................. SKIPPED
+[INFO] JSX grammar ........................................ SKIPPED
+[INFO] TypeScript grammar ................................. SKIPPED
+[INFO] khubla.com JOSS grammar ............................ SKIPPED
+[INFO] JPA grammar ........................................ SKIPPED
+[INFO] ANTLR JSON grammar ................................. SKIPPED
+[INFO] ANTLR JSON5 grammar ................................ SKIPPED
+[INFO] khubla.com karel grammar ........................... SKIPPED
+[INFO] kirikiri-tjs grammar ............................... SKIPPED
+[INFO] Kotlin Grammars .................................... SKIPPED
+[INFO] Kotlin grammar ..................................... SKIPPED
+[INFO] Kotlin Formal grammar .............................. SKIPPED
+[INFO] kuka grammar ....................................... SKIPPED
+[INFO] KQuery grammar ..................................... SKIPPED
+[INFO] khubla.com lambda grammar .......................... SKIPPED
+[INFO] Lark grammar ....................................... SKIPPED
+[INFO] khubla.com LCC (Library of Congress Classification) grammar SKIPPED
+[INFO] less grammar ....................................... SKIPPED
+[INFO] khubla.com limbo grammar ........................... SKIPPED
+[INFO] khubla.com LISA grammar ............................ SKIPPED
+[INFO] khubla.com LISP grammar ............................ SKIPPED
+[INFO] Logo Grammars ...................................... SKIPPED
+[INFO] khubla.com logo grammar ............................ SKIPPED
+[INFO] UCB logo grammar ................................... SKIPPED
+[INFO] LPC grammar ........................................ SKIPPED
+[INFO] khubla.com LRC grammar ............................. SKIPPED
+[INFO] khubla.com LTL grammar ............................. SKIPPED
+[INFO] Lua grammar ........................................ SKIPPED
+[INFO] Lucene grammar ..................................... SKIPPED
+[INFO] khubla.com matlab grammar .......................... SKIPPED
+[INFO] McKeeman Form grammar .............................. SKIPPED
+[INFO] mdx grammar ........................................ SKIPPED
+[INFO] memcached grammar .................................. SKIPPED
+[INFO] khubla.com Metamath grammar ........................ SKIPPED
+[INFO] khubla.com metric grammar .......................... SKIPPED
+[INFO] khubla.com MicroC grammar .......................... SKIPPED
+[INFO] Modelica grammar ................................... SKIPPED
+[INFO] Modula2 PIM4 grammar ............................... SKIPPED
+[INFO] khubla.com Molecule grammar ........................ SKIPPED
+[INFO] khubla.com moo grammar ............................. SKIPPED
+[INFO] khubla.com Morse Code grammar ...................... SKIPPED
+[INFO] PowerQuery grammar ................................. SKIPPED
+[INFO] MPS grammar ........................................ SKIPPED
+[INFO] khubla.com muddb grammar ........................... SKIPPED
+[INFO] muMath grammar ..................................... SKIPPED
+[INFO] khubla.com MUMPS grammar ........................... SKIPPED
+[INFO] ANTLR MuParser grammar ............................. SKIPPED
+[INFO] khubla.com Newick grammar .......................... SKIPPED
+[INFO] khubla.com oberon grammar .......................... SKIPPED
+[INFO] ONCRPC and XDR grammars ............................ SKIPPED
+[INFO] khubla.com orwell grammar .......................... SKIPPED
+[INFO] khubla.com p grammar ............................... SKIPPED
+[INFO] Parking Sign grammar ............................... SKIPPED
+[INFO] khubla.com Pascal grammar .......................... SKIPPED
+[INFO] khubla.com PBM grammar ............................. SKIPPED
+[INFO] PCRE grammar ....................................... SKIPPED
+[INFO] pddl logo grammar .................................. SKIPPED
+[INFO] khubla.com Portable Draughts Notation grammar ...... SKIPPED
+[INFO] PeopleCode grammar ................................. SKIPPED
+[INFO] khubla.com pf grammar .............................. SKIPPED
+[INFO] Pegen grammar (the CPython meta grammar) ........... SKIPPED
+[INFO] Antlr pgn grammar .................................. SKIPPED
+[INFO] PHP grammar ........................................ SKIPPED
+[INFO] khubla.com PII grammar ............................. SKIPPED
+[INFO] khubla.com PL0 grammar ............................. SKIPPED
+[INFO] khubla.com pLucid grammar .......................... SKIPPED
+[INFO] khubla.com ply grammar ............................. SKIPPED
+[INFO] khubla.com Portable Minsky Machine Notation grammar  SKIPPED
+[INFO] khubla.com postalcode grammar ...................... SKIPPED
+[INFO] PowerBuilder grammar ............................... SKIPPED
+[INFO] khubla.com prolog grammar .......................... SKIPPED
+[INFO] PromQL grammar ..................................... SKIPPED
+[INFO] khubla.com Propositional Calculus grammar .......... SKIPPED
+[INFO] khubla.com Properties grammar ...................... SKIPPED
+[INFO] Protobuf2 grammar .................................. SKIPPED
+[INFO] Protobuf3 grammar .................................. SKIPPED
+[INFO] W3C PROV-O Notation: PROV-N grammar ................ SKIPPED
+[INFO] Python Grammars .................................... SKIPPED
+[INFO] Python grammar ..................................... SKIPPED
+[INFO] Python2 Python Target grammar ...................... SKIPPED
+[INFO] Python3 grammar .................................... SKIPPED
+[INFO] Python2 grammar .................................... SKIPPED
+[INFO] Python3 grammar .................................... SKIPPED
+[INFO] khubla.com QIF grammar ............................. SKIPPED
+[INFO] khubla.com Quake map grammar ....................... SKIPPED
+[INFO] R grammar .......................................... SKIPPED
+[INFO] HTDP Racket grammar ................................ SKIPPED
+[INFO] HTDP Racket grammar ................................ SKIPPED
+[INFO] RCS ................................................ SKIPPED
+[INFO] khubla.com RedCode grammar ......................... SKIPPED
+[INFO] khubla.com Refal grammar ........................... SKIPPED
+[INFO] Open Policy Agent's Rego grammar ................... SKIPPED
+[INFO] ReStructuredText grammar ........................... SKIPPED
+[INFO] Rexx grammar ....................................... SKIPPED
+[INFO] RFC822 Grammars .................................... SKIPPED
+[INFO] khubla.com DateTime grammar ........................ SKIPPED
+[INFO] khubla.com RFC822 grammar .......................... SKIPPED
+[INFO] khubla.com Domain grammar .......................... SKIPPED
+[INFO] khubla.com RFC 1960 Filter grammar ................. SKIPPED
+[INFO] khubla.com BEEP grammar ............................ SKIPPED
+[INFO] khubla.com RobotWar grammar ........................ SKIPPED
+[INFO] khubla.com Roman Numerals grammar .................. SKIPPED
+[INFO] khubla.com RON grammar ............................. SKIPPED
+[INFO] khubla.com RPN grammar ............................. SKIPPED
+[INFO] Ruby-like language (Corundum) grammar .............. SKIPPED
+[INFO] Rust grammar ....................................... SKIPPED
+[INFO] Scala grammar ...................................... SKIPPED
+[INFO] khubla.com Scotty grammar .......................... SKIPPED
+[INFO] scss grammar ....................................... SKIPPED
+[INFO] semantic version grammar ........................... SKIPPED
+[INFO] sexpression grammar ................................ SKIPPED
+[INFO] SGF-grammar ........................................ SKIPPED
+[INFO] ADSP 2106x SHARC assembly language ................. SKIPPED
+[INFO] khubla.com SICI grammar ............................ SKIPPED
+[INFO] khubla.com Sieve grammar ........................... SKIPPED
+[INFO] Smalltalk grammar .................................. SKIPPED
+[INFO] khubla.com smiles grammar .......................... SKIPPED
+[INFO] SMT-LIB Version 2 Grammar .......................... SKIPPED
+[INFO] khubla.com SNOBOL grammar .......................... SKIPPED
+[INFO] Solidity grammar ................................... SKIPPED
+[INFO] ANTLR4 Sparql grammar .............................. SKIPPED
+[INFO] SPASS grammar ...................................... SKIPPED
+[INFO] SQL Grammars ....................................... SKIPPED
+[INFO] AWS Athena grammar ................................. SKIPPED
+[INFO] Apache Derby grammar ............................... SKIPPED
+[INFO] Apache Drill grammar ............................... SKIPPED
+[INFO] Apache Hive Grammars ............................... SKIPPED
+[INFO] Apache Hive 2.3.8 grammar .......................... SKIPPED
+[INFO] Apache Hive 3 grammar .............................. SKIPPED
+[INFO] Apache Hive 4 grammar .............................. SKIPPED
+[INFO] MariaDB grammar .................................... SKIPPED
+[INFO] MySQL grammar ...................................... SKIPPED
+[INFO] Apache Phoenix grammar ............................. SKIPPED
+[INFO] PL/SQL grammar ..................................... SKIPPED
+[INFO] PostgreSQL grammar ................................. SKIPPED
+[INFO] Snowflake grammar .................................. SKIPPED
+[INFO] SQLite grammar ..................................... SKIPPED
+[INFO] Trino grammar ...................................... SKIPPED
+[INFO] T-SQL grammar ...................................... SKIPPED
+[INFO] Informix SQL grammar ............................... SKIPPED
+[INFO] stacktrace grammar ................................. SKIPPED
+[INFO] khubla.com star grammar ............................ SKIPPED
+[INFO] stellaris grammar .................................. SKIPPED
+[INFO] stringtemplate grammar ............................. SKIPPED
+[INFO] SUOKIF grammar ..................................... SKIPPED
+[INFO] Swift Grammars ..................................... SKIPPED
+[INFO] ANTLR Swift grammar ................................ SKIPPED
+[INFO] ANTLR Swift grammar ................................ SKIPPED
+[INFO] ANTLR Swift grammar ................................ SKIPPED
+[INFO] Swift FIN grammar .................................. SKIPPED
+[INFO] khubla.com szf grammar ............................. SKIPPED
+[INFO] khubla.com TCP grammar ............................. SKIPPED
+[INFO] khubla.com Telephone grammar ....................... SKIPPED
+[INFO] khubla.com Terraform grammar ....................... SKIPPED
+[INFO] Apache Thrift IDL grammar .......................... SKIPPED
+[INFO] khubla.com tiny grammar ............................ SKIPPED
+[INFO] khubla.com tinybasic grammar ....................... SKIPPED
+[INFO] khubla.com tinyc grammar ........................... SKIPPED
+[INFO] khubla.com tinymud grammar ......................... SKIPPED
+[INFO] khubla.com TL grammar .............................. SKIPPED
+[INFO] tnsnames grammar ................................... SKIPPED
+[INFO] khubla.com TNT grammar ............................. SKIPPED
+[INFO] ANTLR toml grammar ................................. SKIPPED
+[INFO] khubla.com TRAC grammar ............................ SKIPPED
+[INFO] khubla.com TSV grammar ............................. SKIPPED
+[INFO] khubla.com TTM grammar ............................. SKIPPED
+[INFO] khubla.com Turing grammar .......................... SKIPPED
+[INFO] ANTLR turtle grammar ............................... SKIPPED
+[INFO] turtle doc grammar ................................. SKIPPED
+[INFO] ANTLR4 unicode grammars ............................ SKIPPED
+[INFO] unicode16 grammar .................................. SKIPPED
+[INFO] Unicode TR29 Grapheme Cluster Boundary Parsing ..... SKIPPED
+[INFO] Unreal Angelscript ................................. SKIPPED
+[INFO] UPNP search grammar ................................ SKIPPED
+[INFO] khubla.com URL grammar ............................. SKIPPED
+[INFO] khubla.com UserAgent grammar ....................... SKIPPED
+[INFO] V grammar .......................................... SKIPPED
+[INFO] VB6 grammar ........................................ SKIPPED
+[INFO] VBA Grammars ....................................... SKIPPED
+[INFO] VBA grammar ........................................ SKIPPED
+[INFO] VBA 7.1 grammar .................................... SKIPPED
+[INFO] VBA 7.1 grammar .................................... SKIPPED
+[INFO] Velocity grammar ................................... SKIPPED
+[INFO] Verilog Grammars ................................... SKIPPED
+[INFO] Verilog grammar .................................... SKIPPED
+[INFO] SystemVerilog grammar .............................. SKIPPED
+[INFO] ANTLR4 vhdl grammar ................................ SKIPPED
+[INFO] khubla.com vmf grammar ............................. SKIPPED
+[INFO] wat grammar ........................................ SKIPPED
+[INFO] Wavefront grammar .................................. SKIPPED
+[INFO] webidl grammar ..................................... SKIPPED
+[INFO] wkt grammar ........................................ SKIPPED
+[INFO] wkt crs v1 grammar ................................. SKIPPED
+[INFO] khubla.com WLN grammar ............................. SKIPPED
+[INFO] ANTLR WREN grammar ................................. SKIPPED
+[INFO] ANTLR XML grammar .................................. SKIPPED
+[INFO] XPath Grammars ..................................... SKIPPED
+[INFO] XPath grammar ...................................... SKIPPED
+[INFO] XPath20 grammar .................................... SKIPPED
+[INFO] XPath31 grammar .................................... SKIPPED
+[INFO] XML Schema Regular Expression grammar .............. SKIPPED
+[INFO] khubla.com xyz grammar ............................. SKIPPED
+[INFO] YARA grammar ....................................... SKIPPED
+[INFO] Z grammar .......................................... SKIPPED
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  04:57 min
+[INFO] Finished at: 2024-07-26T15:20:05-04:00
+[INFO] ------------------------------------------------------------------------
+[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project gdscript: Compilation failure
+[ERROR] /C:/msys64/home/Kenne/issues/g4-4174/gdscript/Java/GDScriptLexerBase.java:[8,10] duplicate class: GDScriptLexerBase
+[ERROR] 
+[ERROR] -> [Help 1]
+[ERROR] 
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR] 
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
+[ERROR] 
+[ERROR] After correcting the problems, you can resume the build with the command
+[ERROR]   mvn <args> -rf :gdscript

--- a/p/pom.xml
+++ b/p/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>p</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com p grammar</name>
+	<name>p grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pascal/pom.xml
+++ b/pascal/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pascal</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Pascal grammar</name>
+	<name>Pascal grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pbm/pom.xml
+++ b/pbm/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pbm</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com PBM grammar</name>
+	<name>PBM grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pdn/pom.xml
+++ b/pdn/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pdn</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Portable Draughts Notation grammar</name>
+	<name>Portable Draughts Notation grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pegen/pom.xml
+++ b/pegen/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/pf/pom.xml
+++ b/pf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com pf grammar</name>
+	<name>pf grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/php/pom.xml
+++ b/php/pom.xml
@@ -9,12 +9,7 @@
 		<artifactId>grammarsv4</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-	<properties>
-		<!-- location of java sources -->
-		<src.dir>Java</src.dir>
-	</properties>
 	<build>
-		<sourceDirectory>${src.dir}</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/pii/pom.xml
+++ b/pii/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pii</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com PII grammar</name>
+	<name>PII grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pike/pom.xml
+++ b/pike/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pike</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com pike grammar</name>
+	<name>pike grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pl0/pom.xml
+++ b/pl0/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pl0</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com PL0 grammar</name>
+	<name>PL0 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/plucid/pom.xml
+++ b/plucid/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>plucid</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com pLucid grammar</name>
+	<name>pLucid grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/ply/pom.xml
+++ b/ply/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>ply</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com ply grammar</name>
+	<name>ply grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pmmn/pom.xml
+++ b/pmmn/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>PMMN</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Portable Minsky Machine Notation grammar</name>
+	<name>Portable Minsky Machine Notation grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,6 @@
 				<module>clojure</module>
 				<module>clu</module>
 				<module>cmake</module>
-				<module>cobol85</module>
 				<module>codeql</module>
 				<module>cookie</module>
 				<module>cpp</module>

--- a/postalcode/pom.xml
+++ b/postalcode/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>postalcode</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com postalcode grammar</name>
+	<name>postalcode grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/prolog/pom.xml
+++ b/prolog/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>prolog</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com prolog grammar</name>
+	<name>prolog grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/propcalc/pom.xml
+++ b/propcalc/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>propcalc</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Propositional Calculus grammar</name>
+	<name>Propositional Calculus grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/properties/pom.xml
+++ b/properties/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>properties</artifactId>
     <packaging>jar</packaging>
-    <name>khubla.com Properties grammar</name>
+    <name>Properties grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>grammarsv4</artifactId>

--- a/python/python/pom.xml
+++ b/python/python/pom.xml
@@ -9,12 +9,7 @@
 		<artifactId>pythonparent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-	<properties>
-		<!-- location of java sources -->
-		<src.dir>Java</src.dir>
-	</properties>
 	<build>
-		<sourceDirectory>${src.dir}</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/python/python2_7_18/pom.xml
+++ b/python/python2_7_18/pom.xml
@@ -9,7 +9,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/python/python3/pom.xml
+++ b/python/python3/pom.xml
@@ -9,12 +9,7 @@
 		<artifactId>pythonparent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-	<properties>
-		<!-- location of java sources -->
-		<src.dir>Java</src.dir>
-	</properties>
 	<build>
-		<sourceDirectory>${src.dir}</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/python/python3_12_1/pom.xml
+++ b/python/python3_12_1/pom.xml
@@ -9,7 +9,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/qif/pom.xml
+++ b/qif/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>qif</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com QIF grammar</name>
+	<name>QIF grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/quakemap/pom.xml
+++ b/quakemap/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>quakemap</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Quake map grammar</name>
+	<name>Quake map grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/recfile/pom.xml
+++ b/recfile/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>recfile</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com recfile grammar</name>
+	<name>recfile grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/redcode/pom.xml
+++ b/redcode/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>redcode</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com RedCode grammar</name>
+	<name>RedCode grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/refal/pom.xml
+++ b/refal/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>refal</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Refal grammar</name>
+	<name>Refal grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/rexx/pom.xml
+++ b/rexx/pom.xml
@@ -9,12 +9,7 @@
 		<artifactId>grammarsv4</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
-	<properties>
-		<!-- location of java sources -->
-		<src.dir>Java</src.dir>
-	</properties>
 	<build>
-		<sourceDirectory>${src.dir}</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/rfc1035/pom.xml
+++ b/rfc1035/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>domain</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Domain grammar</name>
+	<name>Domain grammar</name>
 	 <parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/rfc1960/pom.xml
+++ b/rfc1960/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>filter</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com RFC 1960 Filter grammar</name>
+	<name>RFC 1960 Filter grammar</name>
 	 <parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/rfc3080/pom.xml
+++ b/rfc3080/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>beep</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BEEP grammar</name>
+	<name>BEEP grammar</name>
 	 <parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/rfc822/rfc822-datetime/pom.xml
+++ b/rfc822/rfc822-datetime/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>datetime</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com DateTime grammar</name>
+	<name>DateTime grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>rfc822parent</artifactId>

--- a/rfc822/rfc822-emailaddress/pom.xml
+++ b/rfc822/rfc822-emailaddress/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rfc822</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com RFC822 grammar</name>
+	<name>RFC822 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>rfc822parent</artifactId>

--- a/robotwars/pom.xml
+++ b/robotwars/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>robotwar</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com RobotWar grammar</name>
+	<name>RobotWar grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/romannumerals/pom.xml
+++ b/romannumerals/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>romannumerals</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Roman Numerals grammar</name>
+	<name>Roman Numerals grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/ron/pom.xml
+++ b/ron/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>ron</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com RON grammar</name>
+	<name>RON grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/rpn/pom.xml
+++ b/rpn/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rpn</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com RPN grammar</name>
+	<name>RPN grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/rust/pom.xml
+++ b/rust/pom.xml
@@ -10,27 +10,7 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.4.0</version>
-				<executions>
-					<execution>
-						<id>add-source</id>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>.</source>
-							</sources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>

--- a/scotty/pom.xml
+++ b/scotty/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>scotty</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Scotty grammar</name>
+	<name>Scotty grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/sici/pom.xml
+++ b/sici/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>sici</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com SICI grammar</name>
+	<name>SICI grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/sieve/pom.xml
+++ b/sieve/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>sieve</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Sieve grammar</name>
+	<name>Sieve grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>
@@ -38,7 +38,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>start</entryPoint>
+					<entryPoint>start_</entryPoint>
 					<grammarName>sieve</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>

--- a/smiles/pom.xml
+++ b/smiles/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>smiles</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com smiles grammar</name>
+	<name>smiles grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/smtlibv2/pom.xml
+++ b/smtlibv2/pom.xml
@@ -38,7 +38,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>start</entryPoint>
+					<entryPoint>start_</entryPoint>
 					<grammarName>SMTLIBv2</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>

--- a/snobol/pom.xml
+++ b/snobol/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>snobol</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com SNOBOL grammar</name>
+	<name>SNOBOL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/sql/postgresql/pom.xml
+++ b/sql/postgresql/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-		<sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/star/pom.xml
+++ b/star/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>star</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com star grammar</name>
+	<name>star grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/szf/pom.xml
+++ b/szf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>szf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com szf grammar</name>
+	<name>szf grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tcpheader/pom.xml
+++ b/tcpheader/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tcp</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com TCP grammar</name>
+	<name>TCP grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/telephone/pom.xml
+++ b/telephone/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>telephone</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Telephone grammar</name>
+	<name>Telephone grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/terraform/pom.xml
+++ b/terraform/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>terraform</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Terraform grammar</name>
+	<name>Terraform grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tiny/pom.xml
+++ b/tiny/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tiny</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com tiny grammar</name>
+	<name>tiny grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tinybasic/pom.xml
+++ b/tinybasic/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tinybasic</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com tinybasic grammar</name>
+	<name>tinybasic grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tinyc/pom.xml
+++ b/tinyc/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tinyc</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com tinyc grammar</name>
+	<name>tinyc grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tinymud/pom.xml
+++ b/tinymud/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tinymud</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com tinymud grammar</name>
+	<name>tinymud grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tl/pom.xml
+++ b/tl/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tl</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com TL grammar</name>
+	<name>TL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tnt/pom.xml
+++ b/tnt/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tnt</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com TNT grammar</name>
+	<name>TNT grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/trac/pom.xml
+++ b/trac/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>trac</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com TRAC grammar</name>
+	<name>TRAC grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/tsv/pom.xml
+++ b/tsv/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>tsv</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com TSV grammar</name>
+	<name>TSV grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/ttm/pom.xml
+++ b/ttm/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>ttm</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com TTM grammar</name>
+	<name>TTM grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/turing/pom.xml
+++ b/turing/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>turing</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com Turing grammar</name>
+	<name>Turing grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/url/pom.xml
+++ b/url/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>url</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com URL grammar</name>
+	<name>URL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/useragent/pom.xml
+++ b/useragent/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>useragent</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com UserAgent grammar</name>
+	<name>UserAgent grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/vba/pom.xml
+++ b/vba/pom.xml
@@ -5,7 +5,7 @@
     <packaging>pom</packaging>
     <name>VBA Grammars</name>
 
-     <parent>
+    <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>grammarsv4</artifactId>
         <version>1.0-SNAPSHOT</version>

--- a/vba/vba6/pom.xml
+++ b/vba/vba6/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>vba</artifactId>
+	<artifactId>vba6</artifactId>
 	<packaging>jar</packaging>
 	<name>VBA grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
-		<artifactId>grammarsv4</artifactId>
+		<artifactId>vbaparent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>

--- a/vba/vba_cc/pom.xml
+++ b/vba/vba_cc/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>vba7_1</artifactId>
+	<artifactId>vba_cc</artifactId>
 	<packaging>jar</packaging>
 	<name>VBA 7.1 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
-		<artifactId>grammarsv4</artifactId>
+		<artifactId>vbaparent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
@@ -18,8 +18,7 @@
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
 					<includes>
-					   <include>vbaLexer.g4</include>
-					   <include>vbaParser.g4</include>
+					   <include>vba_cc.g4</include>
 					</includes>
 					<visitor>true</visitor>
 					<listener>true</listener>

--- a/vba/vba_like/pom.xml
+++ b/vba/vba_like/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>vba7_1</artifactId>
+	<artifactId>vba_like</artifactId>
 	<packaging>jar</packaging>
 	<name>VBA 7.1 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
-		<artifactId>grammarsv4</artifactId>
+		<artifactId>vbaparent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>

--- a/vmf/pom.xml
+++ b/vmf/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>vmf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com vmf grammar</name>
+	<name>vmf grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/wavefront/pom.xml
+++ b/wavefront/pom.xml
@@ -38,7 +38,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>start</entryPoint>
+					<entryPoint>start_</entryPoint>
 					<grammarName>WavefrontOBJ</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>

--- a/wln/pom.xml
+++ b/wln/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>wln</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com WLN grammar</name>
+	<name>WLN grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/xpath/xpath20/pom.xml
+++ b/xpath/xpath20/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-        <sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/xpath/xpath31/pom.xml
+++ b/xpath/xpath31/pom.xml
@@ -10,7 +10,6 @@
 		<version>1.0-SNAPSHOT</version>
 	</parent>
 	<build>
-        <sourceDirectory>Java</sourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/xyz/pom.xml
+++ b/xyz/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>xyz</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com xyz grammar</name>
+	<name>xyz grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>


### PR DESCRIPTION
This PR fixes #4174, getting the old Maven tester working again. I'm not sure how long it's been broken, but it's best to have this fixed for people to have another option for testing, albeit one that tests incompletely..

In the pom.xml, the `<name>` elements were changed on quite a few grammars to remove the extraneous `khubla.com` copyright name. Khubla is already in the .g4's and likely in the readme.md.

Apparently, `<sourceDirectory>` does not work anymore, as those grammars that did have it would get "duplicate foobarParserBase" compilation errors (and fail the test). Maybe this indicates that the Maven tester now copies and includes all directories by default? It likely has to do with https://github.com/diffplug/spotless/issues/1214.

Some of the `<entrypoint>` elements used the wrong name (e.g., `start` instead of `start_`). I'm pretty sure I made those grammar changes without updating the pom.xml, so I'm guilty.

Anyways, the tester now works again. Remember, it's not used in the build testing, but only provided as a convenience.

Note, because this PR touches a ton of grammars, some of the grammars I found don't work anymore for TypeScript. I'm removing the TypeScript target and recommending that people use Antlr4ng. It's works, and is faster.