### PR TITLE
Fix for #4177 -- kotlin/kotlin/pom.xml and grammars.json

### DIFF
--- a/grammars.json
+++ b/grammars.json
@@ -2067,7 +2067,7 @@
  {
   "name": "Kotlin",
   "lexer": "https://raw.githubusercontent.com/antlr/grammars-v4/master/kotlin/kotlin/KotlinLexer.g4",
-  "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/kotlin/kotlin/KotlinLexer.g4",
+  "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/kotlin/kotlin/KotlinParser.g4",
   "start": "kotlinFile",
   "example": [
    "/bad_property.kt",
@@ -5484,6 +5484,29 @@
   ]
  },
  {
+  "name": "SPL",
+  "lexer": "https://raw.githubusercontent.com/antlr/grammars-v4/master/spl/SPLLexer.g4",
+  "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/spl/SPLParser.g4",
+  "start": "expression",
+  "example": [
+   "by.txt",
+   "complex_query_1.txt",
+   "complex_query_2.txt",
+   "in.txt",
+   "join.txt",
+   "like_1.txt",
+   "like_2.txt",
+   "not.txt",
+   "or.txt",
+   "outputnew.txt",
+   "regex.txt",
+   "simple_query.txt",
+   "time.txt",
+   "wildcard_1.txt",
+   "wildcard_2.txt"
+  ]
+ },
+ {
   "name": "Athena",
   "lexer": "https://raw.githubusercontent.com/antlr/grammars-v4/master/sql/athena/AthenaLexer.g4",
   "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/sql/athena/AthenaParser.g4",
@@ -5728,7 +5751,9 @@
    "iff.sql",
    "materialized_views.sql",
    "other.sql",
+   "password_policy.sql",
    "select.sql",
+   "session_policy.sql",
    "show.sql",
    "tables.sql",
    "tags.sql",
@@ -6449,7 +6474,7 @@
  {
   "name": "vba",
   "lexer": "",
-  "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/vba/vba.g4",
+  "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/vba/vba6/vba.g4",
   "start": "startRule",
   "example": [
    "example09_typeHints.bas",
@@ -6462,6 +6487,26 @@
    "example6dateliteral.bas",
    "example7linecontinuation.bas",
    "example8_lineNumbers.bas"
+  ]
+ },
+ {
+  "name": "vba_cc",
+  "lexer": "https://raw.githubusercontent.com/antlr/grammars-v4/master/vba/vba_cc/vbaLexer.g4",
+  "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/vba/vba_cc/vbaParser.g4",
+  "start": "startRule",
+  "example": [
+   "cc.bas"
+  ]
+ },
+ {
+  "name": "vba_like",
+  "lexer": "",
+  "parser": "https://raw.githubusercontent.com/antlr/grammars-v4/master/vba/vba_like/vba_like.g4",
+  "start": "program",
+  "example": [
+   "pattern01",
+   "pattern02",
+   "pattern03"
   ]
  },
  {

--- a/kotlin/kotlin/pom.xml
+++ b/kotlin/kotlin/pom.xml
@@ -18,7 +18,6 @@
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
 					<includes>
-						<include>UnicodeClasses.g4</include>
 						<include>KotlinLexer.g4</include>
 						<include>KotlinParser.g4</include>
 					</includes>


### PR DESCRIPTION
This PR fixes the top-level lexer grammar for kotlin/kotlin as listed in the pom.xml. The `<include>` element should only be for top-level grammars, not imported. UnicodeClasses.g4 is an imported grammar, but [it is listed in the pom.xml to be processed by the tool](https://github.com/antlr/grammars-v4/blame/883606611dd4407d686e920531962ee42c96553f/kotlin/kotlin/pom.xml#L21).

The grammars.json file is a list of all grammars in this repo for testing in lab.antlr.org. It contains an error for the kotlin grammar because of the pom error. The file has been regenerated to fix https://github.com/antlr/antlr4-lab/issues/92; the grammars.json file is computed by [mkindex.py](https://github.com/antlr/grammars-v4/blob/883606611dd4407d686e920531962ee42c96553f/_scripts/mkindex.py).