### PR TITLE
[objc] Significantly improve Objc Lexer and Parser + Tests

### DIFF
--- a/objc/ObjectiveCLexer.g4
+++ b/objc/ObjectiveCLexer.g4
@@ -154,9 +154,19 @@ NULL_RESETTABLE  : 'null_resettable';
 
 // NS prefix
 
-NS_INLINE  : 'NS_INLINE';
-NS_ENUM    : 'NS_ENUM';
-NS_OPTIONS : 'NS_OPTIONS';
+NS_INLINE           : 'NS_INLINE';
+NS_ENUM             : 'NS_ENUM';
+NS_CLOSED_ENUM      : 'NS_CLOSED_ENUM';
+NS_ERROR_ENUM       : 'NS_ERROR_ENUM';
+NS_OPTIONS          : 'NS_OPTIONS';
+NS_SWIFT_NAME       : 'NS_SWIFT_NAME';
+NS_NOESCAPE         : 'NS_NOESCAPE';
+NS_UNAVAILABLE      : 'NS_UNAVAILABLE';
+NS_SWIFT_UNAVAILABLE: 'NS_SWIFT_UNAVAILABLE';
+
+// API availablility macros
+API_AVAILABLE: 'API_AVAILABLE';
+API_UNAVAILABLE: 'API_UNAVAILABLE';
 
 // Property attributes
 
@@ -203,6 +213,7 @@ COMMA        : ',';
 DOT          : '.';
 STRUCTACCESS : '->';
 AT           : '@';
+UNDERSCORE   : '_';
 
 // Operators
 

--- a/objc/ObjectiveCParser.g4
+++ b/objc/ObjectiveCParser.g4
@@ -237,10 +237,6 @@ blockType
     : NS_NOESCAPE? nullabilitySpecifier? typeSpecifier nullabilitySpecifier? LP NS_NOESCAPE? '^'
         nullabilitySpecifier? RP blockParameters?
     ;
-
-genericsSpecifierList
-    : LT (genericsSpecifier (',' genericsSpecifier)*)? GT
-    ;
     
 genericsSpecifier
     : genericsType = typeSpecifier (':' genericsConformanceType = typeSpecifier)?
@@ -422,9 +418,7 @@ declarationSpecifiers
         | NS_NOESCAPE
         | typePrefix
         | typeQualifier
-    )* typeSpecifier (
-        attributeSpecifier
-    )*
+    )* typeSpecifier attributeSpecifier*
     ;
 
 attributeSpecifier
@@ -508,12 +502,7 @@ typeSpecifierModifier
 
 typeSpecifier
     : 'void' typeQualifier*
-    | typeSpecifierModifier* 'char' typeQualifier*
-    | typeSpecifierModifier* 'short' typeQualifier*
-    | typeSpecifierModifier* 'int' typeQualifier*
-    | typeSpecifierModifier* 'long' typeQualifier*
-    | typeSpecifierModifier* 'float' typeQualifier*
-    | typeSpecifierModifier* 'double' typeQualifier*
+    | typeSpecifierModifier* ('char' | 'short' | 'int' | 'long' | 'float' | 'double') typeQualifier*
     | typeofExpression
     | structOrUnionSpecifier
     | enumSpecifier

--- a/objc/ObjectiveCParser.g4
+++ b/objc/ObjectiveCParser.g4
@@ -51,6 +51,7 @@ topLevelDeclaration
     | protocolDeclarationList
     | classDeclarationList
     | functionDefinition
+    | ';'
     ;
 
 importDeclaration
@@ -60,7 +61,7 @@ importDeclaration
 classInterface
     : IB_DESIGNABLE? '@interface' className = genericTypeSpecifier (
         ':' superclassName = identifier
-    )? (LT protocolList GT)? instanceVariables? interfaceDeclarationList? '@end'
+    )? (LT (protocolList | genericConformanceList) GT)* instanceVariables? interfaceDeclarationList? '@end'
     ;
 
 categoryInterface
@@ -78,11 +79,19 @@ categoryImplementation
     ;
 
 genericTypeSpecifier
-    : identifier ((LT protocolList GT) | genericsSpecifier)?
+    : identifier (LT (protocolList | genericConformanceList) GT)?
+    ;
+
+genericConformanceList
+    : genericConformance (',' genericConformance)*
+    ;
+
+genericConformance
+    : genericsType = declarationSpecifiers (':' genericsParentType = declarationSpecifiers)?
     ;
 
 protocolDeclaration
-    : '@protocol' protocolName (LT protocolList GT)? protocolDeclarationSection* '@end'
+    : macro? '@protocol' protocolName (LT protocolList GT)? protocolDeclarationSection* '@end'
     ;
 
 protocolDeclarationSection
@@ -95,7 +104,7 @@ protocolDeclarationList
     ;
 
 classDeclarationList
-    : '@class' identifier (',' identifier)* ';'
+    : '@class' genericTypeSpecifier (',' genericTypeSpecifier)* ';'
     ;
 
 protocolList
@@ -155,6 +164,7 @@ interfaceDeclarationList
         | instanceMethodDeclaration
         | propertyDeclaration
         | functionDeclaration
+        | ';'
     )+
     ;
 
@@ -167,7 +177,7 @@ instanceMethodDeclaration
     ;
 
 methodDeclaration
-    : methodType? methodSelector macro? ';'
+    : methodType? methodSelector macro* ';'
     ;
 
 implementationDefinitionList
@@ -224,19 +234,16 @@ propertySynthesizeItem
     ;
 
 blockType
-    : nullabilitySpecifier? typeSpecifier nullabilitySpecifier? LP '^' (
-        nullabilitySpecifier
-        | typeSpecifier
-    )? RP blockParameters?
+    : NS_NOESCAPE? nullabilitySpecifier? typeSpecifier nullabilitySpecifier? LP NS_NOESCAPE? '^'
+        nullabilitySpecifier? RP blockParameters?
     ;
 
+genericsSpecifierList
+    : LT (genericsSpecifier (',' genericsSpecifier)*)? GT
+    ;
+    
 genericsSpecifier
-    : LT (typeSpecifierWithPrefixes (',' typeSpecifierWithPrefixes)*)? GT
-    ;
-
-typeSpecifierWithPrefixes
-    : typePrefix* typeSpecifier
-    | typeName
+    : genericsType = typeSpecifier (':' genericsConformanceType = typeSpecifier)?
     ;
 
 dictionaryExpression
@@ -297,6 +304,7 @@ selectorExpression
 
 selectorName
     : selector
+    | UNDERSCORE
     | (selector? ':')+
     ;
 
@@ -376,37 +384,32 @@ attributeParameterAssignment
     ;
 
 declaration
-    : functionCallExpression
-    | enumDeclaration
-    | varDeclaration
-    | typedefDeclaration
+    : (
+        functionCallExpression
+        | enumDeclaration
+        | varDeclaration
+        | typedefDeclaration
+    ) macro? ';'
     ;
 
 functionCallExpression
-    : attributeSpecifier? identifier attributeSpecifier? LP directDeclarator RP ';'
+    : attributeSpecifier? identifier attributeSpecifier? LP declarator RP
     ;
 
 enumDeclaration
-    : attributeSpecifier? TYPEDEF? enumSpecifier identifier? ';'
+    : attributeSpecifier? TYPEDEF? (enumSpecifier identifier | nsEnumOrOptionSpecifier)
     ;
 
 varDeclaration
-    : (declarationSpecifiers initDeclaratorList | declarationSpecifiers) ';'
+    : declarationSpecifiers initDeclaratorList?
     ;
 
 typedefDeclaration
-    : attributeSpecifier? TYPEDEF (
-        declarationSpecifiers typeDeclaratorList
-        | declarationSpecifiers
-    ) ';'
+    : attributeSpecifier? TYPEDEF declarationSpecifiers typeDeclaratorList?
     ;
 
 typeDeclaratorList
-    : typeDeclarator (',' typeDeclarator)*
-    ;
-
-typeDeclarator
-    : pointer? directDeclarator
+    : declarator (',' declarator)*
     ;
 
 declarationSpecifiers
@@ -416,10 +419,12 @@ declarationSpecifiers
         | arcBehaviourSpecifier
         | nullabilitySpecifier
         | ibOutletQualifier
+        | NS_NOESCAPE
         | typePrefix
         | typeQualifier
-        | typeSpecifier
-    )+
+    )* typeSpecifier (
+        attributeSpecifier
+    )*
     ;
 
 attributeSpecifier
@@ -439,18 +444,7 @@ structOrUnionSpecifier
     ;
 
 fieldDeclaration
-    : specifierQualifierList fieldDeclaratorList macro? ';'
-    ;
-
-specifierQualifierList
-    : (
-        arcBehaviourSpecifier
-        | nullabilitySpecifier
-        | ibOutletQualifier
-        | typePrefix
-        | typeQualifier
-        | typeSpecifier
-    )+
+    : declarationSpecifiers fieldDeclaratorList macro? ';'
     ;
 
 ibOutletQualifier
@@ -504,22 +498,30 @@ protocolQualifier
     | 'byref'
     | 'oneway'
     ;
-
-typeSpecifier
-    : 'void'
-    | 'char'
-    | 'short'
-    | 'int'
+    
+typeSpecifierModifier
+    : 'short'
     | 'long'
-    | 'float'
-    | 'double'
     | 'signed'
     | 'unsigned'
+    ;
+
+typeSpecifier
+    : 'void' typeQualifier*
+    | typeSpecifierModifier* 'char' typeQualifier*
+    | typeSpecifierModifier* 'short' typeQualifier*
+    | typeSpecifierModifier* 'int' typeQualifier*
+    | typeSpecifierModifier* 'long' typeQualifier*
+    | typeSpecifierModifier* 'float' typeQualifier*
+    | typeSpecifierModifier* 'double' typeQualifier*
     | typeofExpression
-    | genericTypeSpecifier
     | structOrUnionSpecifier
     | enumSpecifier
-    | identifier pointer?
+    | nsEnumOrOptionSpecifier
+    | 'id' (LT protocolList GT)? (arcBehaviourSpecifier | nullabilitySpecifier | typeQualifier)*
+    | genericTypeSpecifier (arcBehaviourSpecifier | nullabilitySpecifier | typeQualifier)*
+    | identifier (arcBehaviourSpecifier | nullabilitySpecifier | typeQualifier)*
+    | typeSpecifier '*' (arcBehaviourSpecifier | nullabilitySpecifier | typeQualifier)*
     ;
 
 typeofExpression
@@ -540,7 +542,10 @@ enumSpecifier
         identifier ('{' enumeratorList '}')?
         | '{' enumeratorList '}'
     )
-    | ('NS_OPTIONS' | 'NS_ENUM') LP typeName ',' identifier RP '{' enumeratorList '}'
+    ;
+    
+nsEnumOrOptionSpecifier
+    : ('NS_OPTIONS' | 'NS_ENUM' | 'NS_CLOSED_ENUM' | 'NS_ERROR_ENUM') LP typeName ',' identifier RP ('{' enumeratorList '}')?
     ;
 
 enumeratorList
@@ -556,7 +561,7 @@ enumeratorIdentifier
     | 'default'
     ;
 
-directDeclarator
+declarator
     : (identifier | LP declarator RP) declaratorSuffix*
     | LP '^' nullabilitySpecifier? identifier? RP blockParameters
     ;
@@ -569,12 +574,52 @@ parameterList
     : parameterDeclarationList (',' '...')?
     ;
 
-pointer
-    : '*' declarationSpecifiers? pointer?
-    ;
-
 macro
     : identifier (LP primaryExpression (',' primaryExpression)* RP)?
+    | NS_UNAVAILABLE
+    | NS_SWIFT_NAME LP (swiftAliasExpression | swiftSelectorExpression) RP
+    | API_AVAILABLE LP apiAvailableOsVersion (',' apiAvailableOsVersion)* RP
+    | API_UNAVAILABLE LP identifier (',' identifier)* RP
+    | NS_SWIFT_UNAVAILABLE LP stringLiteral RP
+    | ATTRIBUTE LP LP clangAttribute (',' clangAttribute)* RP RP
+    ;
+
+// A list of __attribute__ are elaborated https://nshipster.com/__attribute__/
+clangAttribute
+    : identifier
+    | identifier LP clangAttributeArgument (',' clangAttributeArgument)* RP
+    ;
+    
+clangAttributeArgument
+    : identifier
+    | DECIMAL_LITERAL
+    | stringLiteral
+    | identifier '=' version
+    | identifier '=' stringLiteral
+    ;
+    
+swiftAliasExpression
+    : identifier ('.' identifier)*
+    ;
+
+swiftSelectorExpression
+    : identifier LP (swiftSelector ':')* RP
+    ;
+    
+// Swift selector may use reserved words
+swiftSelector
+    : identifier
+    | UNDERSCORE
+    | 'for'
+    ;
+
+apiAvailableOsVersion
+    : identifier LP version RP
+    ;
+    
+version
+    : FLOATING_POINT_LITERAL
+    | DECIMAL_LITERAL ('.' DECIMAL_LITERAL)*
     ;
 
 arrayInitializer
@@ -590,13 +635,12 @@ initializerList
     ;
 
 typeName
-    : specifierQualifierList abstractDeclarator?
+    : declarationSpecifiers abstractDeclarator?
     | blockType
     ;
 
 abstractDeclarator
-    : pointer abstractDeclarator?
-    | LP abstractDeclarator? RP abstractDeclaratorSuffix+
+    : LP abstractDeclarator? RP abstractDeclaratorSuffix+
     | ('[' constantExpression? ']')+
     ;
 
@@ -612,10 +656,6 @@ parameterDeclarationList
 parameterDeclaration
     : declarationSpecifiers declarator
     | 'void'
-    ;
-
-declarator
-    : pointer? directDeclarator
     ;
 
 statement
@@ -842,6 +882,7 @@ identifier
     | ATOMIC
     | NONATOMIC
     | RETAIN
+    | REGISTER
     | AUTORELEASING_QUALIFIER
     | BLOCK
     | BRIDGE_RETAINED
@@ -854,6 +895,7 @@ identifier
     | NS_INLINE
     | NS_ENUM
     | NS_OPTIONS
+    | NS_SWIFT_NAME
     | NULL_UNSPECIFIED
     | NULLABLE
     | NONNULL

--- a/objc/README.md
+++ b/objc/README.md
@@ -30,6 +30,13 @@ during parsing of the ordinary Objective-C code.
 
 # Testing
 
+You should use Maven to test Objective-C grammar.
+
+1. Clone grammars-v4. `git clone https://github.com/antlr/grammars-v4.git`
+2. Make sure you have Maven installed. [See the documentation](https://maven.apache.org/).
+3. `cd grammars-v4/objc`.
+4. Execute `mvn clean test`.
+
 ## One-step processing
 
 Successful parsing and conversion of complete projects,

--- a/objc/examples/ClassInterfaceTest.h
+++ b/objc/examples/ClassInterfaceTest.h
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Test lightweight generics.
+@interface GenericTabBarItemContainerDataSource<State, VC : UIViewController *> : GenericDeckContainerDataSource <State, VC>
+
+- (instancetype)initWithBuilder:(VC (^)(State))builder
+    preserveStateBlock:(nullable State (^)(VC))preserveStateBlock
+    purgeBehavior:(GenericDeckContainerDataSourcePurgeBehavior)purgeBehavior
+    purgeDelay:(NSInteger)purgeDelay
+    tabBarItemContainer:(id<TabBarItemContainer>)tabBarItemContainer;
+
+@end
+
+// Test covariant
+@interface AccessOrderedDictionary<__covariant KeyType, __covariant ObjectType> : OrderedDictionary <NSCoding>
+
+- (instancetype)initWithMaxSize:(NSInteger)maxSize;
+
+- (ObjectType)objectForKey:(KeyType)key updateOrder:(BOOL)updateOrder;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/objc/examples/Enums.h
+++ b/objc/examples/Enums.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+typedef enum : NSUInteger {
+    PINSpeedRecorderConnectionStatusNotReachable,
+    PINSpeedRecorderConnectionStatusWWAN,
+    PINSpeedRecorderConnectionStatusWiFi
+} PINSpeedRecorderConnectionStatus;
+
+typedef NS_ENUM(NSInteger, XYAttachmentType) {
+    XYAttachmentTypeOne = 0,
+    XYAttachmentTypeTwo = 1, 
+};

--- a/objc/examples/MASAttribute.h
+++ b/objc/examples/MASAttribute.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_OPTIONS(NSInteger, MASAttribute) {
+    MASAttributeLeft = 1 << NSLayoutAttributeLeft,
+    MASAttributeRight = 1 << NSLayoutAttributeRight,
+    MASAttributeTop = 1 << NSLayoutAttributeTop,
+    MASAttributeBottom = 1 << NSLayoutAttributeBottom,
+    MASAttributeLeading = 1 << NSLayoutAttributeLeading,
+    MASAttributeTrailing = 1 << NSLayoutAttributeTrailing,
+    MASAttributeWidth = 1 << NSLayoutAttributeWidth,
+    MASAttributeHeight = 1 << NSLayoutAttributeHeight,
+    MASAttributeCenterX = 1 << NSLayoutAttributeCenterX,
+    MASAttributeCenterY = 1 << NSLayoutAttributeCenterY,
+    MASAttributeBaseline = 1 << NSLayoutAttributeBaseline,
+};

--- a/objc/examples/ProtocolTest.h
+++ b/objc/examples/ProtocolTest.h
@@ -1,0 +1,57 @@
+#import <Foundation/Foundation.h>
+
+// Test typedef block
+typedef void (^ABCharactorCompletionBlock)(NSMutableDictionary *characterData, NSString *versionedId);
+typedef unsigned char HelloWorld;
+// Test nullability specifier in typedef
+typedef void (^CompletionBlock)(NSString *_Nonnull param);
+
+// Test consts
+static CGSize const kButtonSize = {50, 50};
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Test protocol alias in Swift
+NS_SWIFT_NAME(FooMeow)
+@protocol ABFoo <NSObject, ABAnotherProtocol>
+
+// Test inline declaration of block
+@property (nonatomic, copy, nullable) void (^handler_resultsForQuery)
+    (Query *, void (^)(ABResult<QueryResultModel *> *));
+        
+@property (nonatomic, assign, nonnull) BOOL (^enumerateProviders)(id<ABProviderProtocol> provider, BOOL *stop);
+
+@property (nonatomic, copy, nullable, readonly) NSString *string;
+
+@property (nonatomic, copy, nonnull) id<ABProviderProtocol> provider;
+        
+// Test blocks
+- (void)performBlock:(CompletionBlock)block;
+
+// Test NS_NOESCAPE
+- (void)noEscapeBlock:(NS_NOESCAPE CompletionBlock)block;
+
+- (void)dispatchWithBlock:(dispatch_block_t)block;
+
+// Test api availability and swift alias attributes
+- (void)startFoo:(AdFoo *)foo
+        completionHandler:(nullable void (^)(NSError *_Nullable error))completion
+    NS_SWIFT_NAME(startFooMeow(_:completionHandler:))API_AVAILABLE(ios(14.5))
+        API_UNAVAILABLE(macos, watchos)__TVOS_PROHIBITED;
+
+-(instancetype)init __attribute__((unavailable("init is not available.")));
++(instancetype) new __attribute__((unavailable("new is not available")));
+-(void)f __attribute__((availability(macosx,introduced=10.4,deprecated=10.6,message="hello world")));
+
+
+@optional
+
+// Test compound id types
+- (void)compoundType:(id<Foo, Bar> _Nonnull)fooBar;
+
+// Nullability specifiers
+- (nullable NSNumber *)someTypeWithOptionalStr:(nullable NSString *)optionalStr optionalStr2:(NSString *_Nullable)str2;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/objc/one-step-processing/ObjectiveCLexer.g4
+++ b/objc/one-step-processing/ObjectiveCLexer.g4
@@ -154,9 +154,19 @@ NULL_RESETTABLE  : 'null_resettable';
 
 // NS prefix
 
-NS_INLINE  : 'NS_INLINE';
-NS_ENUM    : 'NS_ENUM';
-NS_OPTIONS : 'NS_OPTIONS';
+NS_INLINE           : 'NS_INLINE';
+NS_ENUM             : 'NS_ENUM';
+NS_CLOSED_ENUM      : 'NS_CLOSED_ENUM';
+NS_ERROR_ENUM       : 'NS_ERROR_ENUM';
+NS_OPTIONS          : 'NS_OPTIONS';
+NS_SWIFT_NAME       : 'NS_SWIFT_NAME';
+NS_NOESCAPE         : 'NS_NOESCAPE';
+NS_UNAVAILABLE      : 'NS_UNAVAILABLE';
+NS_SWIFT_UNAVAILABLE: 'NS_SWIFT_UNAVAILABLE';
+
+// API availablility macros
+API_AVAILABLE: 'API_AVAILABLE';
+API_UNAVAILABLE: 'API_UNAVAILABLE';
 
 // Property attributes
 
@@ -203,6 +213,7 @@ COMMA        : ',';
 DOT          : '.';
 STRUCTACCESS : '->';
 AT           : '@';
+UNDERSCORE   : '_';
 
 // Operators
 

--- a/objc/pom.xml
+++ b/objc/pom.xml
@@ -42,7 +42,7 @@
 					<entryPoint>translationUnit</entryPoint>
 					<grammarName>ObjectiveC</grammarName>
 					<packageName></packageName>
-					<exampleFiles>examples_todo/</exampleFiles>
+					<exampleFiles>examples/</exampleFiles>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
## Changes
### Background
As an engineer of Snapchat, I build internal tools that parses existing objective-C api module files and translate them to Swift at scale. We found that the current syntax fails some cases and thus I fixed them, ran back tests and verified that current grammar can correctly parse 99.8% of our 7k+ .h files. The failed ones are due to Objective-C++ presence that is not considered to cover in this scope.

### Objc grammar
- Fixed issue of nested types with pointers and nullability specifiers may not get parsed correctly
  - Restructed syntax, so that pointer `*` is now a part of `typeSpecifier`.
- Add full support to parse API availability, Swift alias macros
- Fixed issue that [lightweight generics](https://medium.com/ios-os-x-development/generics-in-objective-c-8f54c9cfbce7) conformances in class interface cannot be parsed.
- Added 4 new test cases to cover the above mentioned cases.

### Others
- Corrected test path `examples` so that `maven clean test` can correctly find all the test files.
- Add testing section to objc's `README`

## Test & verify
`mvn clean test` in `objc/` dir.