### PR TITLE
Feature/r parser labels

### DIFF
--- a/r/R.g4
+++ b/r/R.g4
@@ -49,7 +49,7 @@ $ java TestR sample.R
 grammar R;
 
 prog
-    : (expr (SEMICOLON | NL)* )* EOF
+    : ((SEMICOLON | NL)+ | expr )* EOF
     ;
 
 /*

--- a/r/R.g4
+++ b/r/R.g4
@@ -49,7 +49,7 @@ $ java TestR sample.R
 grammar R;
 
 prog
-    : (expr (SEMICOLON | NL)* | NL)* EOF
+    : (expr (SEMICOLON | NL)* )* EOF
     ;
 
 /*
@@ -76,7 +76,7 @@ expr
     | expr OR expr #Or
     | '~' expr #ModelFormulaePrefix
     | expr '~' expr #ModelFormulaeInfix
-    | expr ASSIGN expr #Assignment
+    | expr (ASSIGN | EQUALS) expr #Assignment
     | FUNCTION PAREN_L formlist? PAREN_R expr #FunctionDefinition // define function
     | expr PAREN_L sublist PAREN_R #FunctionCall              // call function
     | CURLY_L exprlist CURLY_R #CompoundStatement                  // compound statement
@@ -101,7 +101,7 @@ expr
     | NAN #Nan
     | TRUE #True
     | FALSE #False
-    | NL expr #Newline
+    | NL+ expr #Newline
     ;
 
 exprlist
@@ -109,7 +109,7 @@ exprlist
     ;
 
 formlist
-    : form (SEMICOLON form)*
+    : form (',' form)*
     ;
 
 form

--- a/r/R.g4
+++ b/r/R.g4
@@ -49,7 +49,7 @@ $ java TestR sample.R
 grammar R;
 
 prog
-    : (expr (';' | NL)* | NL)* EOF
+    : (expr (SEMICOLON | NL)* | NL)* EOF
     ;
 
 /*
@@ -60,56 +60,56 @@ expr_or_assign
 */
 
 expr
-    : expr '[[' sublist ']' ']' // '[[' follows R's yacc grammar
-    | expr '[' sublist ']'
-    | expr ('::' | ':::') expr
-    | expr ('$' | '@') expr
+    : expr LIST_ACCESS_START sublist LIST_ACCESS_END // '[[' follows R's yacc grammar
+    | expr ARRAY_ACCESS_START sublist ARRAY_ACCESS_END
+    | expr NAMESPACE_ACCESS expr
+    | expr COMPONENT_ACCESS expr
     | <assoc = right> expr '^' expr
-    | ('-' | '+') expr
-    | expr ':' expr
+    | ADD_SUB expr
+    | expr RANGE_OPERATOR expr
     | expr USER_OP expr // anything wrappedin %: '%' .* '%'
-    | expr ('*' | '/') expr
-    | expr ('+' | '-') expr
-    | expr ('>' | '>=' | '<' | '<=' | '==' | '!=') expr
-    | '!' expr
-    | expr ('&' | '&&') expr
-    | expr ('|' | '||') expr
+    | expr MULT_DIV expr
+    | expr ADD_SUB expr
+    | expr COMPARATOR expr
+    | NOT expr
+    | expr AND expr
+    | expr OR expr
     | '~' expr
     | expr '~' expr
-    | expr ('<-' | '<<-' | '=' | '->' | '->>' | ':=') expr
-    | 'function' '(' formlist? ')' expr // define function
-    | expr '(' sublist ')'              // call function
-    | '{' exprlist '}'                  // compound statement
-    | 'if' '(' expr ')' expr
-    | 'if' '(' expr ')' expr NL* 'else' expr
-    | 'for' '(' ID 'in' expr ')' expr
-    | 'while' '(' expr ')' expr
-    | 'repeat' expr
-    | '?' expr // get help on expr, usually string or ID
-    | 'next'
-    | 'break'
-    | '(' expr ')'
+    | expr ASSIGN expr
+    | FUNCTION PAREN_L formlist? PAREN_R expr // define function
+    | expr PAREN_L sublist PAREN_R              // call function
+    | CURLY_L exprlist CURLY_R                  // compound statement
+    | IF PAREN_L expr PAREN_R expr
+    | IF PAREN_L expr PAREN_R expr NL* ELSE expr
+    | FOR PAREN_L ID IN expr PAREN_R expr
+    | WHILE PAREN_L expr PAREN_R expr
+    | REPEAT expr
+    | HELP expr // get help on expr, usually string or ID
+    | NEXT
+    | BREAK
+    | PAREN_L expr PAREN_R
     | ID
     | STRING
     | HEX
     | INT
     | FLOAT
     | COMPLEX
-    | 'NULL'
-    | 'NA'
-    | 'Inf'
-    | 'NaN'
-    | 'TRUE'
-    | 'FALSE'
+    | NULL
+    | NA
+    | INF
+    | NAN
+    | TRUE
+    | FALSE
     | NL expr
     ;
 
 exprlist
-    : expr ((';' | NL) expr?)*
+    : expr ((SEMICOLON | NL) expr?)*
     ;
 
 formlist
-    : form (',' form)*
+    : form (SEMICOLON form)*
     ;
 
 form
@@ -125,16 +125,58 @@ sublist
 
 sub
     : expr
-    | ID '='
-    | ID '=' expr
-    | STRING '='
-    | STRING '=' expr
-    | 'NULL' '='
-    | 'NULL' '=' expr
+    | ID EQUALS
+    | ID EQUALS expr
+    | STRING EQUALS
+    | STRING EQUALS expr
+    | NULL EQUALS
+    | NULL EQUALS expr
     | '...'
     | '.'
     |
     ;
+
+IF: 'if';
+FOR: 'for';
+WHILE: 'while';
+REPEAT: 'repeat';
+FUNCTION: 'function';
+ELSE: 'else';
+IN: 'in';
+
+LIST_ACCESS_START: '[[';
+LIST_ACCESS_END: ']]';
+ARRAY_ACCESS_START: '[';
+ARRAY_ACCESS_END: ']';
+NAMESPACE_ACCESS: ':::' | '::';
+COMPONENT_ACCESS: '$' | '@';
+
+HELP: '?';
+NEXT: 'next';
+BREAK: 'break';
+
+NULL: 'NULL';
+NA: 'NA';
+INF: 'inf';
+NAN: 'NaN';
+TRUE: 'TRUE';
+FALSE: 'FALSE';
+
+NOT: '!';
+RANGE_OPERATOR: ':';
+
+MULT_DIV: '*' | '/';
+ADD_SUB: '+' | '-';
+COMPARATOR: '>' | '>=' | '<' | '<=' | '==' | '!=';
+ASSIGN: '<-' | '<<-' | '->' | '->>' | ':=';
+EQUALS: '=';
+AND: '&&' | '&';
+OR: '||' | '|';
+
+PAREN_L: '(';
+PAREN_R: ')';
+CURLY_L: '{';
+CURLY_R: '}';
 
 HEX
     : '0' ('x' | 'X') HEXDIGIT+ [Ll]?
@@ -216,6 +258,8 @@ COMMENT
 NL
     : '\r'? '\n'
     ;
+
+SEMICOLON: ';';
 
 WS
     : [ \t\u000C]+ -> skip

--- a/r/R.g4
+++ b/r/R.g4
@@ -60,48 +60,48 @@ expr_or_assign
 */
 
 expr
-    : expr LIST_ACCESS_START sublist LIST_ACCESS_END // '[[' follows R's yacc grammar
-    | expr ARRAY_ACCESS_START sublist ARRAY_ACCESS_END
-    | expr NAMESPACE_ACCESS expr
-    | expr COMPONENT_ACCESS expr
-    | <assoc = right> expr '^' expr
-    | ADD_SUB expr
-    | expr RANGE_OPERATOR expr
-    | expr USER_OP expr // anything wrappedin %: '%' .* '%'
-    | expr MULT_DIV expr
-    | expr ADD_SUB expr
-    | expr COMPARATOR expr
-    | NOT expr
-    | expr AND expr
-    | expr OR expr
-    | '~' expr
-    | expr '~' expr
-    | expr ASSIGN expr
-    | FUNCTION PAREN_L formlist? PAREN_R expr // define function
-    | expr PAREN_L sublist PAREN_R              // call function
-    | CURLY_L exprlist CURLY_R                  // compound statement
-    | IF PAREN_L expr PAREN_R expr
-    | IF PAREN_L expr PAREN_R expr NL* ELSE expr
-    | FOR PAREN_L ID IN expr PAREN_R expr
-    | WHILE PAREN_L expr PAREN_R expr
-    | REPEAT expr
-    | HELP expr // get help on expr, usually string or ID
-    | NEXT
-    | BREAK
-    | PAREN_L expr PAREN_R
-    | ID
-    | STRING
-    | HEX
-    | INT
-    | FLOAT
-    | COMPLEX
-    | NULL
-    | NA
-    | INF
-    | NAN
-    | TRUE
-    | FALSE
-    | NL expr
+    : expr LIST_ACCESS_START sublist LIST_ACCESS_END #ListAccess // '[[' follows R's yacc grammar
+    | expr ARRAY_ACCESS_START sublist ARRAY_ACCESS_END #ArrayAccess
+    | expr NAMESPACE_ACCESS expr #NamespaceAccess
+    | expr COMPONENT_ACCESS expr #ComponentAccess
+    | <assoc = right> expr '^' expr #Exponent
+    | ADD_SUB expr #Sign
+    | expr RANGE_OPERATOR expr #Range
+    | expr USER_OP expr #UserDefinedOperation // anything wrappedin %: '%' .* '%'
+    | expr MULT_DIV expr #MultOrDiv
+    | expr ADD_SUB expr #AddOrSub
+    | expr COMPARATOR expr #Comparison
+    | NOT expr #Not
+    | expr AND expr #And
+    | expr OR expr #Or
+    | '~' expr #ModelFormulaePrefix
+    | expr '~' expr #ModelFormulaeInfix
+    | expr ASSIGN expr #Assignment
+    | FUNCTION PAREN_L formlist? PAREN_R expr #FunctionDefinition // define function
+    | expr PAREN_L sublist PAREN_R #FunctionCall              // call function
+    | CURLY_L exprlist CURLY_R #CompoundStatement                  // compound statement
+    | IF PAREN_L expr PAREN_R expr #If
+    | IF PAREN_L expr PAREN_R expr NL* ELSE expr #IfElse
+    | FOR PAREN_L ID IN expr PAREN_R expr #For
+    | WHILE PAREN_L expr PAREN_R expr #While
+    | REPEAT expr #Repeat
+    | HELP expr #Help // get help on expr, usually string or ID
+    | NEXT #Next
+    | BREAK #Break
+    | PAREN_L expr PAREN_R #BracketTerm
+    | ID #Id
+    | STRING #String
+    | HEX #Hex
+    | INT #Int
+    | FLOAT #Float
+    | COMPLEX #Complex
+    | NULL #Null
+    | NA #Na
+    | INF #Inf
+    | NAN #Nan
+    | TRUE #True
+    | FALSE #False
+    | NL expr #Newline
     ;
 
 exprlist
@@ -114,7 +114,7 @@ formlist
 
 form
     : ID
-    | ID '=' expr
+    | ID EQUALS expr
     | '...'
     | '.'
     ;

--- a/r/RFilter.g4
+++ b/r/RFilter.g4
@@ -45,7 +45,7 @@ protected int curlies = 0;
 
 // TODO: MAKE THIS GET ONE COMMAND ONLY
 stream
-    : (elem | NL | ';')* EOF
+    : (elem | NL | SEMICOLON)* EOF
     ;
 
 eat
@@ -55,15 +55,15 @@ eat
 elem
     : op eat?
     | atom
-    | '{' eat? {curlies++;} (elem | NL | ';')* {curlies--;} '}'
-    | '(' (elem | eat)* ')'
-    | '[' (elem | eat)* ']'
-    | '[[' (elem | eat)* ']' ']'
-    | 'function' eat? '(' (elem | eat)* ')' eat?
-    | 'for' eat? '(' (elem | eat)* ')' eat?
-    | 'while' eat? '(' (elem | eat)* ')' eat?
-    | 'if' eat? '(' (elem | eat)* ')' eat?
-    | 'else' {
+    | CURLY_L eat? {curlies++;} (elem | NL | SEMICOLON)* {curlies--;} CURLY_R
+    | PAREN_L (elem | eat)* PAREN_R
+    | ARRAY_ACCESS_START (elem | eat)* ARRAY_ACCESS_END
+    | LIST_ACCESS_START (elem | eat)* LIST_ACCESS_END
+    | FUNCTION eat? PAREN_L (elem | eat)* PAREN_R eat?
+    | FOR eat? PAREN_L (elem | eat)* PAREN_R eat?
+    | WHILE eat? PAREN_L (elem | eat)* PAREN_R eat?
+    | IF eat? PAREN_L (elem | eat)* PAREN_R eat?
+    | ELSE {
         // ``inside a compound expression, a newline before else is discarded,
         // whereas at the outermost level, the newline terminates the if
         // construction and a subsequent else causes a syntax error.''
@@ -89,53 +89,40 @@ elem
     ;
 
 atom
-    : 'next'
-    | 'break'
+    : NEXT
+    | BREAK
     | ID
     | STRING
     | HEX
     | INT
     | FLOAT
     | COMPLEX
-    | 'NULL'
-    | 'NA'
-    | 'Inf'
-    | 'NaN'
-    | 'TRUE'
-    | 'FALSE'
+    | NULL
+    | NA
+    | INF
+    | NAN
+    | TRUE
+    | FALSE
     ;
 
 op
-    : '+'
-    | '-'
-    | '*'
-    | '/'
+    : ADD_SUB
+    | MULT_DIV
     | '^'
-    | '<'
-    | '<='
-    | '>='
-    | '>'
-    | '=='
-    | '!='
-    | '&'
-    | '&&'
+    | COMPARATOR
+    | AND
     | USER_OP
-    | 'repeat'
-    | 'in'
-    | '?'
-    | '!'
-    | '='
-    | ':'
+    | REPEAT
+    | IN
+    | HELP
+    | NOT
+    | EQUALS
+    | RANGE_OPERATOR
     | '~'
-    | '$'
-    | '@'
-    | '<-'
-    | '->'
-    | '='
-    | '::'
-    | ':::'
+    | COMPONENT_ACCESS
+    | ASSIGN
+    | NAMESPACE_ACCESS
     | ','
     | '...'
-    | '||'
-    | '|'
+    | OR
     ;


### PR DESCRIPTION
In its current state the R grammar is hard to use, since there is one parser rule containing almost everything. Additionally, most tokens are defined implicitly. Therefore the AST elements that are generated can only be distinguished by comparing the strings in the tokens. That requires a lot of hard-coded string literals in the application code.

To make using the AST easier, this PR defines most tokens explicitly and adds labels to all cases of "expr".
With these changes the AST nodes can be distinguished by the generated *Context classes.
Terminal nodes can be identified through named constants.

As far as I can tell the functionality of the grammar has not changed. I would appreciate it if someone could confirm that.

For some reason I had to change the prog rule, since it clashed with the `NL+ expr` option in expr. As far as I can tell, this version works and does the same.

This PR is a follow up to https://github.com/antlr/grammars-v4/pull/4160.