### PR TITLE
[build] Fix for build regression -- #4243

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,73 +3,73 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trcaret"
       ]
     },
     "trcover": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trcover"
       ]
     },
     "trgen": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trgen"
       ]
     },
     "trglob": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trglob"
       ]
     },
     "triconv": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "triconv"
       ]
     },
     "trparse": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trparse"
       ]
     },
     "trquery": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trquery"
       ]
     },
     "trtext": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trtext"
       ]
     },
     "trwdog": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trwdog"
       ]
     },
     "trxgrep": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trxgrep"
       ]
     },
     "trxml": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trxml"
       ]
     },
     "trxml2": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trxml2"
       ]

--- a/.config/dotnet-tools.json.save
+++ b/.config/dotnet-tools.json.save
@@ -3,73 +3,73 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trcaret"
       ]
     },
     "trcover": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trcover"
       ]
     },
     "trgen": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trgen"
       ]
     },
     "trglob": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trglob"
       ]
     },
     "triconv": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "triconv"
       ]
     },
     "trparse": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trparse"
       ]
     },
     "trquery": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trquery"
       ]
     },
     "trtext": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trtext"
       ]
     },
     "trwdog": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trwdog"
       ]
     },
     "trxgrep": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trxgrep"
       ]
     },
     "trxml": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trxml"
       ]
     },
     "trxml2": {
-      "version": "0.23.3",
+      "version": "0.23.6",
       "commands": [
         "trxml2"
       ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,13 @@ jobs:
     - name: Test JavaScript
       run: |
         node --version
+    - name: ts-node typescript tsx
+      run: |
+        npm i -g ts-node typescript tsx
+        ts-node --version
+        tsc --version
+        npx -v
+        npx tsx -v
     - name: Update paths
       shell: pwsh
       run: |

--- a/_scripts/templates/Antlr4ng/st.Test.ts
+++ b/_scripts/templates/Antlr4ng/st.Test.ts
@@ -1,14 +1,21 @@
 // Generated from trgen <version>
 
 import { ATNSimulator } from 'antlr4ng';
+import { BaseErrorListener } from 'antlr4ng';
 import { CharStream } from 'antlr4ng';
 import { CommonTokenStream } from 'antlr4ng';
 import { ConsoleErrorListener } from 'antlr4ng';
-import { BaseErrorListener } from 'antlr4ng';
+import { ErrorNode } from 'antlr4ng';
 //import { InputStream } from 'antlr4ng';
+import { Parser } from 'antlr4ng';
+import { ParserRuleContext } from 'antlr4ng';
+import { ParseTree } from 'antlr4ng';
 import { Recognizer } from 'antlr4ng';
 import { RecognitionException } from 'antlr4ng';
+import { TerminalNode } from 'antlr4ng';
 import { Token } from 'antlr4ng';
+import { Trees } from 'antlr4ng';
+import { escapeWhitespace } from 'antlr4ng';
 import { readFileSync } from 'fs';
 import { writeFileSync } from 'fs';
 import { openSync } from 'fs';
@@ -16,6 +23,7 @@ import { readSync } from 'fs';
 import { writeSync } from 'fs';
 import { closeSync } from 'fs';
 import { readFile } from 'fs/promises'
+import { isToken } from 'antlr4ng';
 
 <tool_grammar_tuples: {x | import { <x.GrammarAutomName> \} from './<x.GrammarAutomName>.js';
 } >
@@ -219,6 +227,56 @@ function DoParse(str: CharStream, input_name: string, row_number: number) {
     if (tee) {
         closeSync(output);
     }
+}
+
+function toStringTree(tree: ParseTree, recog?: Parser | null): string {
+    var sb = new StringBuilder();
+	let ruleNames = recog.ruleNames;
+	toStringTree2(sb, tree, 0, ruleNames);
+	return sb.toString();
+}
+
+function toStringTree2(sb: StringBuilder, tree: ParseTree, indent: number, ruleNames: string[] | null): void {
+	let s = getNodeText(tree, ruleNames);
+	s = escapeWhitespace(s!, false);
+	const c = tree.getChildCount();
+	if (c === 0) {
+	    for (let i = 0; i \< indent; ++i) sb.Append(" ");
+		sb.Append(s); sb.AppendLine("");
+		return;
+	}
+    for (let i = 0; i \< indent; ++i) sb.Append(" ");
+	sb.Append(s); sb.AppendLine("");
+	for (let i = 0; i \< c; i++) {
+		toStringTree2(sb, tree.getChild(i)!, indent+1, ruleNames);
+	}
+}
+
+function getNodeText(t: ParseTree, ruleNames: string[] | null, recog?: Parser | null): string | undefined {
+	if (ruleNames !== null) {
+		if (t instanceof ParserRuleContext) {
+			const context = t.ruleContext;
+			const altNumber = context.getAltNumber();
+			// use const value of ATN.INVALID_ALT_NUMBER to avoid circular dependency
+			if (altNumber !== 0) {
+				return ruleNames[t.ruleIndex] + ":" + altNumber;
+			}
+
+			return ruleNames[t.ruleIndex];
+		} else if (t instanceof ErrorNode) {
+			return t.toString();
+		} else if (t instanceof TerminalNode) {
+			if (t.symbol !== null) {
+				return t.symbol.text;
+			}
+		}
+	}
+	const payload = t.getPayload();
+	if (isToken(payload)) {
+		return payload.text;
+	}
+
+	return String(t.getPayload());
 }
 
 

--- a/_scripts/templates/Antlr4ng/st.perf.sh
+++ b/_scripts/templates/Antlr4ng/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 # Individual parsing.

--- a/_scripts/templates/Antlr4ng/st.run.sh
+++ b/_scripts/templates/Antlr4ng/st.run.sh
@@ -1,19 +1,7 @@
 # Generated from trgen <version>
 set -e
-# set -x
+set -x
 
-# ts-node is a bash script, so duplicate that code and call node via trwdog.
-tsnode=`which ts-node`
+exec npx tsx Test.js "$@"
 
-basedir=$(dirname "$(echo "$tsnode" | sed -e 's,\\\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node" "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
-else 
-  exec node "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
-fi
 exit $?

--- a/_scripts/templates/Antlr4ng/st.test.ps1
+++ b/_scripts/templates/Antlr4ng/st.test.ps1
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- pwsh -command "ts-node Test.js -q -tee -tree $_" *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- pwsh -command "npx tsx Test.js -q -tee -tree $_" *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- pwsh -command "ts-node Test.js -q -x -tee -tree" *> parse.txt
+get-content "tests.txt" | dotnet trwdog -- pwsh -command "npx tsx Test.js -q -x -tee -tree" *> parse.txt
 $status=$LASTEXITCODE
 <endif>
 
@@ -66,8 +66,26 @@ if ( $size -eq 0 ) {
     exit 1
 }
 
+function func {
+    param (
+        [string]$p
+    )
+
+    # Find the index of the first asterisk (*)
+    $index = $p.IndexOf('*')
+
+    if ($index -eq -1) {
+        # No asterisk found, return the entire path
+        return $p
+    } else {
+        # Asterisk found, return the path up to but not including the asterisk
+        $path = $p.Substring(0, $index)
+        return $path
+    }
+}
+
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false
@@ -88,6 +106,7 @@ foreach ($item in Get-ChildItem . -Recurse) {
     $file = $item.fullname
     $ext = $item.Extension
     if ($ext -eq ".tree") {
+        [IO.File]::WriteAllText($file, $([IO.File]::ReadAllText($file) -replace "`r`n", "`n"))
         git diff --exit-code $file *>> $old/updated.txt
 	$st = $LASTEXITCODE
         if ($st -ne 0) {

--- a/_scripts/templates/Antlr4ng/st.test.sh
+++ b/_scripts/templates/Antlr4ng/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=1
-
 # glob patterns
 shopt -s globstar
 
@@ -13,17 +10,11 @@ IFS=$(echo -en "\n\b")
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
 files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -45,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- sh -c "ts-node Test.js -q -tee -tree $f" >> parse.txt 2>&1
-    else
-        trwdog sh -c "ts-node Test.js -q -tee -tree $f" >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- sh -c "npx tsx Test.js -q -tee -tree $f" >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -59,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- sh -c "ts-node Test.js -q -x -tee -tree" > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog sh -c "ts-node Test.js -q -x -tee -tree" > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- sh -c "npx tsx Test.js -q -x -tee -tree" > parse.txt 2>&1
 status="$?"
 <endif>
 
@@ -104,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/CSharp/MyParserInterpreter.cs
+++ b/_scripts/templates/CSharp/MyParserInterpreter.cs
@@ -1,0 +1,449 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Atn;
+using Antlr4.Runtime.Dfa;
+using Antlr4.Runtime.Misc;
+using Antlr4.Runtime.Sharpen;
+
+/// <summary>
+/// A parser simulator that mimics what ANTLR's generated
+/// parser code does.
+/// </summary>
+/// <remarks>
+/// A parser simulator that mimics what ANTLR's generated
+/// parser code does. A ParserATNSimulator is used to make
+/// predictions via adaptivePredict but this class moves a pointer through the
+/// ATN to simulate parsing. ParserATNSimulator just
+/// makes us efficient rather than having to backtrack, for example.
+/// This properly creates parse trees even for left recursive rules.
+/// We rely on the left recursive rule invocation and special predicate
+/// transitions to make left recursive rules work.
+/// See TestParserInterpreter for examples.
+/// </remarks>
+public class MyParserInterpreter : Parser
+{
+    private readonly string _grammarFileName;
+
+    private readonly ATN _atn;
+
+    private readonly DFA[] _decisionToDFA;
+
+    protected internal readonly BitSet pushRecursionContextStates;
+
+    private readonly string[] _ruleNames;
+
+    [NotNull]
+    private readonly IVocabulary vocabulary;
+
+    private Stack<Tuple<ParserRuleContext, int>> _parentContextStack = new Stack<Tuple<ParserRuleContext, int>>();
+
+    /** We need a map from (decision,inputIndex)->forced alt for computing ambiguous
+     *  parse trees. For now, we allow exactly one override.
+     */
+    protected int overrideDecision = -1;
+    protected int overrideDecisionInputIndex = -1;
+    protected int overrideDecisionAlt = -1;
+    protected bool overrideDecisionReached = false; // latch and only override once; error might trigger infinite loop
+
+    /** What is the current context when we override a decisions?  This tells
+     *  us what the root of the parse tree is when using override
+     *  for an ambiguity/lookahead check.
+     */
+    protected InterpreterRuleContext overrideDecisionRoot = null;
+    protected InterpreterRuleContext rootContext;
+
+    public MyParserInterpreter(IVocabulary vocabulary, IEnumerable<string> ruleNames, ATN atn, ITokenStream input)
+        : base(input)
+    {
+        this._atn = atn;
+        this._ruleNames = ruleNames.ToArray();
+        this.vocabulary = vocabulary;
+        // identify the ATN states where pushNewRecursionContext must be called
+        this.pushRecursionContextStates = new BitSet(atn.states.Count);
+        foreach (ATNState state in atn.states)
+        {
+            if (!(state is StarLoopEntryState))
+            {
+                continue;
+            }
+            if (((StarLoopEntryState)state).isPrecedenceDecision)
+            {
+                this.pushRecursionContextStates.Set(state.stateNumber);
+            }
+        }
+
+        //init decision DFA
+        int numberofDecisions = atn.NumberOfDecisions;
+        this._decisionToDFA = new DFA[numberofDecisions];
+        for (int i = 0; i < numberofDecisions; i++)
+        {
+            DecisionState decisionState = atn.GetDecisionState(i);
+            _decisionToDFA[i] = new DFA(decisionState, i);
+        }
+         // get atn simulator that knows how to do predictions
+        Interpreter = new ParserATNSimulator(this, atn, _decisionToDFA, null);
+    }
+
+    public override void Reset() {
+        base.Reset();
+        overrideDecisionReached = false;
+        overrideDecisionRoot = null;
+        overrideDecision = -1;
+        overrideDecisionInputIndex = -1;
+        overrideDecisionAlt = -1;
+        _parentContextStack = new Stack<Tuple<ParserRuleContext, int>>();
+        overrideDecisionRoot = null;
+        rootContext = null;
+    }
+
+    public override ATN Atn
+    {
+        get
+        {
+            return _atn;
+        }
+    }
+
+    public override IVocabulary Vocabulary
+    {
+        get
+        {
+            return vocabulary;
+        }
+    }
+
+    public override string[] RuleNames
+    {
+        get
+        {
+            return _ruleNames;
+        }
+    }
+
+    /// <summary>Begin parsing at startRuleIndex</summary>
+    public virtual ParserRuleContext Parse(int startRuleIndex)
+    {
+        RuleStartState startRuleStartState = _atn.ruleToStartState[startRuleIndex];
+        InterpreterRuleContext rootContext = new InterpreterRuleContext(null, ATNState.InvalidStateNumber, startRuleIndex);
+        if (startRuleStartState.isPrecedenceRule)
+        {
+            EnterRecursionRule(rootContext, startRuleStartState.stateNumber, startRuleIndex, 0);
+        }
+        else
+        {
+            EnterRule(rootContext, startRuleStartState.stateNumber, startRuleIndex);
+        }
+        while (true)
+        {
+            ATNState p = AtnState;
+            switch (p.StateType)
+            {
+                case StateType.RuleStop:
+                {
+                    // pop; return from rule
+                    if (RuleContext.IsEmpty)
+                    {
+                        if (startRuleStartState.isPrecedenceRule)
+                        {
+                            ParserRuleContext result = RuleContext;
+                            Tuple<ParserRuleContext, int> parentContext = _parentContextStack.Pop();
+                            UnrollRecursionContexts(parentContext.Item1);
+                            return result;
+                        }
+                        else
+                        {
+                            ExitRule();
+                            return rootContext;
+                        }
+                    }
+                    VisitRuleStopState(p);
+                    break;
+                }
+
+                default:
+                {
+                    try
+                    {
+                        VisitState(p);
+                    }
+                    catch (RecognitionException e)
+                    {
+                        State = _atn.ruleToStopState[p.ruleIndex].stateNumber;
+                        Context.exception = e;
+                        ErrorHandler.ReportError(this, e);
+                        ErrorHandler.Recover(this, e);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    public override void EnterRecursionRule(ParserRuleContext localctx, int state, int ruleIndex, int precedence)
+    {
+        _parentContextStack.Push(Tuple.Create(RuleContext, localctx.invokingState));
+        base.EnterRecursionRule(localctx, state, ruleIndex, precedence);
+    }
+
+    protected internal virtual ATNState AtnState
+    {
+        get
+        {
+            return _atn.states[State];
+        }
+    }
+
+    public override string GrammarFileName => throw new NotImplementedException();
+
+    protected internal virtual void VisitState(ATNState p)
+    {
+        int predictedAlt = 1;
+        if ( p is DecisionState ) {
+            predictedAlt = visitDecisionState((DecisionState) p);
+        }
+
+        Transition transition = p.Transition(predictedAlt - 1);
+        switch (transition.TransitionType)
+        {
+            case TransitionType.EPSILON:
+            {
+                if (pushRecursionContextStates.Get(p.stateNumber) && !(transition.target is LoopEndState))
+                {
+                    InterpreterRuleContext ctx = new InterpreterRuleContext(_parentContextStack.Peek().Item1, _parentContextStack.Peek().Item2, RuleContext.RuleIndex);
+                    PushNewRecursionContext(ctx, _atn.ruleToStartState[p.ruleIndex].stateNumber, RuleContext.RuleIndex);
+                }
+                break;
+            }
+
+            case TransitionType.ATOM:
+            {
+                Match(((AtomTransition)transition).token);
+                break;
+            }
+
+            case TransitionType.RANGE:
+            case TransitionType.SET:
+            case TransitionType.NOT_SET:
+            {
+                if (!transition.Matches(TokenStream.LA(1), TokenConstants.MinUserTokenType, 65535))
+                {
+                    ErrorHandler.RecoverInline(this);
+                }
+                MatchWildcard();
+                break;
+            }
+
+            case TransitionType.WILDCARD:
+            {
+                MatchWildcard();
+                break;
+            }
+
+            case TransitionType.RULE:
+            {
+                RuleStartState ruleStartState = (RuleStartState)transition.target;
+                int ruleIndex = ruleStartState.ruleIndex;
+                InterpreterRuleContext ctx_1 = new InterpreterRuleContext(RuleContext, p.stateNumber, ruleIndex);
+                if (ruleStartState.isPrecedenceRule)
+                {
+                    EnterRecursionRule(ctx_1, ruleStartState.stateNumber, ruleIndex, ((RuleTransition)transition).precedence);
+                }
+                else
+                {
+                    EnterRule(ctx_1, transition.target.stateNumber, ruleIndex);
+                }
+                break;
+            }
+
+            case TransitionType.PREDICATE:
+            {
+                PredicateTransition predicateTransition = (PredicateTransition)transition;
+                if (!Sempred(RuleContext, predicateTransition.ruleIndex, predicateTransition.predIndex))
+                {
+                    throw new FailedPredicateException(this);
+                }
+                break;
+            }
+
+            case TransitionType.ACTION:
+            {
+                ActionTransition actionTransition = (ActionTransition)transition;
+                Action(RuleContext, actionTransition.ruleIndex, actionTransition.actionIndex);
+                break;
+            }
+
+            case TransitionType.PRECEDENCE:
+            {
+                if (!Precpred(RuleContext, ((PrecedencePredicateTransition)transition).precedence))
+                {
+                    throw new FailedPredicateException(this, string.Format("precpred(Context, {0})", ((PrecedencePredicateTransition)transition).precedence));
+                }
+                break;
+            }
+
+            default:
+            {
+                throw new NotSupportedException("Unrecognized ATN transition type.");
+            }
+        }
+        State = transition.target.stateNumber;
+    }
+
+    /** Method visitDecisionState() is called when the interpreter reaches
+     *  a decision state (instance of DecisionState). It gives an opportunity
+     *  for subclasses to track interesting things.
+     */
+    protected int visitDecisionState(DecisionState p) {
+        int predictedAlt = 1;
+        if ( p.NumberOfTransitions > 1 ) {
+            ErrorHandler.Sync(this);
+            int decision = p.decision;
+            if ( decision == overrideDecision && InputStream.Index == overrideDecisionInputIndex &&
+                 !overrideDecisionReached )
+            {
+                predictedAlt = overrideDecisionAlt;
+                overrideDecisionReached = true;
+            }
+            else {
+                predictedAlt = Interpreter.AdaptivePredict((ITokenStream)InputStream, decision, Context);
+            }
+        }
+        return predictedAlt;
+    }
+
+    /** Provide simple "factory" for InterpreterRuleContext's.
+     *  @since 4.5.1
+     */
+    protected InterpreterRuleContext createInterpreterRuleContext(
+        ParserRuleContext parent,
+        int invokingStateNumber,
+        int ruleIndex)
+    {
+        return new InterpreterRuleContext(parent, invokingStateNumber, ruleIndex);
+    }
+
+    protected internal virtual void VisitRuleStopState(ATNState p)
+    {
+        RuleStartState ruleStartState = _atn.ruleToStartState[p.ruleIndex];
+        if (ruleStartState.isPrecedenceRule)
+        {
+            Tuple<ParserRuleContext, int> parentContext = _parentContextStack.Pop();
+            UnrollRecursionContexts(parentContext.Item1);
+            State = parentContext.Item2;
+        }
+        else
+        {
+            ExitRule();
+        }
+        RuleTransition ruleTransition = (RuleTransition)_atn.states[State].Transition(0);
+        State = ruleTransition.followState.stateNumber;
+    }
+
+
+    /** Override this parser interpreters normal decision-making process
+     *  at a particular decision and input token index. Instead of
+     *  allowing the adaptive prediction mechanism to choose the
+     *  first alternative within a block that leads to a successful parse,
+     *  force it to take the alternative, 1..n for n alternatives.
+     *
+     *  As an implementation limitation right now, you can only specify one
+     *  override. This is sufficient to allow construction of different
+     *  parse trees for ambiguous input. It means re-parsing the entire input
+     *  in general because you're never sure where an ambiguous sequence would
+     *  live in the various parse trees. For example, in one interpretation,
+     *  an ambiguous input sequence would be matched completely in expression
+     *  but in another it could match all the way back to the root.
+     *
+     *  s : e '!'? ;
+     *  e : ID
+     *    | ID '!'
+     *    ;
+     *
+     *  Here, x! can be matched as (s (e ID) !) or (s (e ID !)). In the first
+     *  case, the ambiguous sequence is fully contained only by the root.
+     *  In the second case, the ambiguous sequences fully contained within just
+     *  e, as in: (e ID !).
+     *
+     *  Rather than trying to optimize this and make
+     *  some intelligent decisions for optimization purposes, I settled on
+     *  just re-parsing the whole input and then using
+     *  {link Trees#getRootOfSubtreeEnclosingRegion} to find the minimal
+     *  subtree that contains the ambiguous sequence. I originally tried to
+     *  record the call stack at the point the parser detected and ambiguity but
+     *  left recursive rules create a parse tree stack that does not reflect
+     *  the actual call stack. That impedance mismatch was enough to make
+     *  it it challenging to restart the parser at a deeply nested rule
+     *  invocation.
+     *
+     *  Only parser interpreters can override decisions so as to avoid inserting
+     *  override checking code in the critical ALL(*) prediction execution path.
+     *
+     *  @since 4.5.1
+     */
+    public void AddDecisionOverride(int decision, int tokenIndex, int forcedAlt) {
+        overrideDecision = decision;
+        overrideDecisionInputIndex = tokenIndex;
+        overrideDecisionAlt = forcedAlt;
+    }
+
+    public InterpreterRuleContext GetOverrideDecisionRoot() {
+        return overrideDecisionRoot;
+    }
+
+    /** Rely on the error handler for this parser but, if no tokens are consumed
+     *  to recover, add an error node. Otherwise, nothing is seen in the parse
+     *  tree.
+     */
+    protected void Recover(RecognitionException e) {
+        int i = InputStream.Index;
+        ErrorHandler.Recover(this, e);
+        if ( InputStream.Index==i ) {
+            // no input consumed, better add an error node
+            if ( e is InputMismatchException ) {
+                InputMismatchException ime = (InputMismatchException)e;
+                IToken tok = e.OffendingToken;
+                int expectedTokenType = TokenConstants.InvalidType;
+                if ( !ime.GetExpectedTokens().IsNil ) {
+                    expectedTokenType = ime.GetExpectedTokens().MinElement; // get any element
+                }
+                IToken errToken = TokenFactory.Create(new Tuple<ITokenSource, ICharStream>(tok.TokenSource, tok.TokenSource.InputStream),
+                    expectedTokenType, tok.Text,
+                    TokenConstants.DefaultChannel,
+                    -1, -1, // invalid start/stop
+                    tok.Line, tok.Column);
+                Context.AddErrorNode(errToken);
+            }
+            else { // NoViableAlt
+                IToken tok = e.OffendingToken;
+                IToken errToken = TokenFactory.Create(new Tuple<ITokenSource, ICharStream>(tok.TokenSource, tok.TokenSource.InputStream),
+                    TokenConstants.InvalidType, tok.Text,
+                    TokenConstants.DefaultChannel,
+                    -1, -1, // invalid start/stop
+                    tok.Line, tok.Column);
+                Context.AddErrorNode(errToken);
+            }
+        }
+    }
+
+    protected IToken RecoverInline() {
+        return ErrorHandler.RecoverInline(this);
+    }
+
+    /** Return the root of the parse, which can be useful if the parser
+     *  bails out. You still can access the top node. Note that,
+     *  because of the way left recursive rules add children, it's possible
+     *  that the root will not have any children if the start rule immediately
+     *  called and left recursive rule that fails.
+     *
+     * @since 4.5.1
+     */
+    public InterpreterRuleContext GetRootContext() {
+        return rootContext;
+    }
+}

--- a/_scripts/templates/CSharp/st.ErrorListener.cs
+++ b/_scripts/templates/CSharp/st.ErrorListener.cs
@@ -47,6 +47,10 @@ public class MyDiagnosticErrorListener : DiagnosticErrorListener
     public override void ReportAmbiguity​(Parser recognizer, DFA dfa, int startIndex, int stopIndex,
         bool exact, BitSet ambigAlts, ATNConfigSet configs)
     {
+        string decisionDescription = GetDecisionDescription(recognizer, dfa);
+        string text = ((ITokenStream)recognizer.InputStream).GetText(Interval.Of(startIndex, stopIndex));
+        string msg = $"ReportAmbiguity​ d={decisionDescription}, input='{text}'";
+        System.Console.WriteLine(msg);
         NewMethod(recognizer, dfa, startIndex, stopIndex, configs);
     }
 
@@ -78,7 +82,7 @@ public class MyDiagnosticErrorListener : DiagnosticErrorListener
     {
         string decisionDescription = GetDecisionDescription(recognizer, dfa);
         string text = ((ITokenStream)recognizer.InputStream).GetText(Interval.Of(startIndex, stopIndex));
-        string msg = $"reportAttemptingFullContext d={decisionDescription}, input='{text}'";
+        string msg = $"ReportAttemptingFullContext d={decisionDescription}, input='{text}'";
         System.Console.WriteLine(msg);
         NewMethod(recognizer, dfa, startIndex, stopIndex, configs);
     }
@@ -88,7 +92,7 @@ public class MyDiagnosticErrorListener : DiagnosticErrorListener
     {
         string decisionDescription = GetDecisionDescription(recognizer, dfa);
         string text = ((ITokenStream)recognizer.InputStream).GetText(Interval.Of(startIndex, stopIndex));
-        string msg = $"reportContextSensitivity d={decisionDescription}, input='{text}'";
+        string msg = $"ReportContextSensitivity d={decisionDescription}, input='{text}'";
         System.Console.WriteLine(msg);
         NewMethod(recognizer, dfa, startIndex, stopIndex, configs);
     }

--- a/_scripts/templates/CSharp/st.MyParser.cs
+++ b/_scripts/templates/CSharp/st.MyParser.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using Antlr4.Runtime;
+using System.IO;
+using Antlr4.Runtime.Atn;
+using Antlr4.Runtime.Sharpen;
+using Antlr4.Runtime.Tree;
+
+public class MyParser : <parser_name> {
+    private readonly ITokenStream _tokens;
+    public MyParserInterpreter _ParserInterpreter;
+
+    public MyParser(ITokenStream input)
+        : base(input)
+    {
+        _tokens = input;
+        _ParserInterpreter = new MyParserInterpreter(
+            this.Vocabulary,
+            this.RuleNames,
+            this.Atn,
+            input);
+    }
+
+    public List\<ParserRuleContext> getAllPossibleParseTrees(
+        int decision,
+        BitSet alts,
+        int startIndex,
+        int stopIndex,
+        int startRuleIndex)
+    {
+        _ParserInterpreter.Interpreter.PredictionMode = PredictionMode.LL_EXACT_AMBIG_DETECTION;
+        var trees = new List\<ParserRuleContext>();
+        
+        if ( stopIndex>=(_tokens.Size - 1) ) { // if we are pointing at EOF token
+            // EOF is not in tree, so must be 1 less than last non-EOF token
+            stopIndex = _tokens.Size - 2;
+        }
+
+        // get ambig trees
+        int alt = alts.NextSetBit(0);
+        while ( alt >= 0 )
+        {
+            // re-parse entire input for all ambiguous alternatives
+            // (don't have to do first as it's been parsed, but do again for simplicity
+            //  using this temp parser.)
+            _ParserInterpreter.Reset();
+            _ParserInterpreter.AddDecisionOverride(decision, startIndex, alt);
+            ParserRuleContext t = _ParserInterpreter.Parse(startRuleIndex);
+            trees.Add(t);
+            alt = alts.NextSetBit(alt+1);
+        }
+        return trees;
+    }
+
+    public override void RemoveErrorListener(IAntlrErrorListener\<IToken> listener)
+    {
+        base.RemoveErrorListener(listener);
+        _ParserInterpreter.RemoveErrorListener(listener);
+    }
+
+    public override void RemoveErrorListeners()
+    {
+        base.RemoveErrorListeners();
+        _ParserInterpreter.RemoveErrorListeners();
+    }
+
+    public override void AddErrorListener(IAntlrErrorListener\<IToken> listener)
+    {
+        base.AddErrorListener(listener);
+        _ParserInterpreter.AddErrorListener(listener);
+    }
+}

--- a/_scripts/templates/CSharp/st.ProfilingCommonTokenStream.cs
+++ b/_scripts/templates/CSharp/st.ProfilingCommonTokenStream.cs
@@ -1,0 +1,83 @@
+// Generated from trgen <version>
+
+using Antlr4.Runtime;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+public class ProfilingCommonTokenStream : CommonTokenStream
+{
+    public Dictionary\<int, int> HitCount = new Dictionary\<int, int>();
+    public Dictionary\<int, Dictionary\<string,int>> CallStacks = new Dictionary\<int, Dictionary\<string, int>>();
+
+    public ProfilingCommonTokenStream(ITokenSource tokenSource)
+        : base(tokenSource)
+    {
+    }
+
+    public override IToken Get(int i)
+    {
+        IToken token = base.Get(i);
+        if (token == null)
+        {
+            return null;
+        }
+
+        return token;
+    }
+
+    public override int LA(int i)
+    {
+        var token = LT(i);
+        if (token == null)
+        {
+            return -1;
+        }
+
+        return token.Type;
+    }
+
+    public override IToken LT(int k)
+    {
+        IToken token = base.LT(k);
+        if (token == null)
+        {
+            return null;
+        }
+
+        HitCount.TryGetValue(token.TokenIndex, out int before);
+        var after = before + 1;
+        HitCount[token.TokenIndex] = after;
+
+        // Get call stack and note parser rule context.
+        System.Diagnostics.StackTrace t = new System.Diagnostics.StackTrace();
+        // Note all different types of call stack traces.
+        StringBuilder tb = new StringBuilder();
+        bool record = false;
+        bool breakon = false;
+        foreach (var frame in t.GetFrames().Reverse())
+        {
+            string method = frame.GetMethod().Name;
+            string line_number = frame.GetNativeOffset().ToString();
+            if (method == "Parse2") record = true;
+            if (method == "LT") breakon = true;
+            if (record)
+            {
+                tb.Append(method + ":" + line_number + ";");
+            }
+            if (breakon) break;
+        }
+        var call_stack = tb.ToString();
+        if (!CallStacks.ContainsKey(token.TokenIndex))
+        {
+            CallStacks[token.TokenIndex] = new Dictionary\<string, int>();
+        }
+
+        CallStacks[token.TokenIndex].TryGetValue(call_stack, out int b);
+        CallStacks[token.TokenIndex][call_stack] = 1 + b;
+        return token;
+    }
+}

--- a/_scripts/templates/CSharp/st.Test.cs
+++ b/_scripts/templates/CSharp/st.Test.cs
@@ -4,12 +4,10 @@ using Antlr4.Runtime;
 using Antlr4.Runtime.Atn;
 using Antlr4.Runtime.Tree;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Runtime.CompilerServices;
-using System.Collections.Generic;
-using System.Net.Sockets;
 <if(has_name_space)>namespace <name_space>
 {<endif>
 
@@ -17,22 +15,30 @@ public class Program
 {
     public static <parser_name> Parser { get; set; }
     public static ErrorListener\<IToken> ParserErrorListener { get; set; }
-    public static Lexer Lexer { get; set; }
+    public static <lexer_name> Lexer { get; set; }
     public static ErrorListener\<int> LexerErrorListener { get; set; }
     public static ITokenStream TokenStream { get; set; }
     public static ICharStream CharStream { get; set; }
     public static IParseTree Tree { get; set; }
+    public static List\<IParseTree> Trees { get; set; }
     public static string StartSymbol { get; set; } = "<start_symbol>";
     public static string Input { get; set; }
+    public static bool HeatMap { get; set; } = false;
     public static void SetupParse2(string input, bool quiet = false)
     {
         ICharStream str = new AntlrInputStream(input);
         CharStream = str;
         var lexer = new <lexer_name>(str);
         Lexer = lexer;
-        var tokens = new CommonTokenStream(lexer);
+        CommonTokenStream tokens = null;
+        if (HeatMap) {
+            tokens = new ProfilingCommonTokenStream(lexer);
+        }
+        else {
+            tokens = new CommonTokenStream(lexer);
+        }
         TokenStream = tokens;
-        var parser = new <parser_name>(tokens);
+        var parser = new MyParser(tokens);
         Parser = parser;
         var listener_lexer = new ErrorListener\<int>(false, false, System.Console.Error);
         var listener_parser = new ErrorListener\<IToken>(false, false, System.Console.Error);
@@ -53,6 +59,41 @@ public class Program
         return tree;
     }
 
+    public static List\<Tuple\<int, List\<IParseTree>>> Parse3()
+    {
+        Parser.Profile = true;
+        var tree = Parser.<start_symbol>();
+        var decisions = Parser.ParseInfo.getDecisionInfo().Where(d => d.ambiguities.Any()).ToList();
+        var result = new List\<Tuple\<int, List\<IParseTree>>>();
+        foreach (var decision in decisions)
+        {
+            var am = decision.ambiguities;
+            var trees = new List\<IParseTree>();
+            foreach (AmbiguityInfo ai in am)
+            {
+                var parser_decision = ai.decision;
+                var parser_alts = ai.ambigAlts;
+                var parser_startIndex = ai.startIndex;
+                var parser_stopIndex = ai.stopIndex;
+                var p = Parser.RuleNames.Select((value, index) => new { value, index })
+                        .Where(pair => (pair.value == "<start_symbol>"))
+                        .Select(pair => pair.index).First();
+                var parser_startRuleIndex = p;
+                var parser_trees = ((MyParser)Parser).getAllPossibleParseTrees(
+                    parser_decision,
+                    parser_alts,
+                    parser_startIndex,
+                    parser_stopIndex,
+                    parser_startRuleIndex);
+                trees.AddRange(parser_trees);
+            }
+            result.Add(new Tuple\<int, List\<IParseTree>>(decision.decision, trees));
+        }
+        Input = Lexer.InputStream.ToString();
+        TokenStream = Parser.TokenStream;
+        return result;
+    }
+
     public static bool AnyErrors()
     {
         return ParserErrorListener.had_error || LexerErrorListener.had_error;
@@ -64,7 +105,13 @@ public class Program
         CharStream = str;
         var lexer = new <lexer_name>(str);
         Lexer = lexer;
-        var tokens = new CommonTokenStream(lexer);
+        CommonTokenStream tokens = null;
+        if (show_hit) {
+            tokens = new ProfilingCommonTokenStream(lexer);
+        }
+        else {
+            tokens = new CommonTokenStream(lexer);
+        }
         TokenStream = tokens;
         var parser = new <parser_name>(tokens);
         Parser = parser;
@@ -82,11 +129,13 @@ public class Program
     }
 
     static bool tee = false;
+    static bool show_diagnostic = false;
+    static bool show_hit = false;
+    static bool show_ambig = false;
     static bool show_profile = false;
-    static bool show_tree = false;
     static bool show_tokens = false;
     static bool show_trace = false;
-    static bool show_diagnostic = false;
+    static bool show_tree = false;
     static bool old = false;
     static bool two_byte = false;
     static int exit_code = 0;
@@ -104,6 +153,10 @@ public class Program
             if (args[i] == "-d")
             {
                 show_diagnostic = true;
+            }
+            else if (args[i] == "-ambig")
+            {
+                show_ambig = true;
             }
             else if (args[i] == "-profile")
             {
@@ -245,8 +298,14 @@ public class Program
             System.Console.Error.WriteLine(new_s.ToString());
             lexer.Reset();
         }
-        var tokens = new CommonTokenStream(lexer);
-        var parser = new <parser_name>(tokens);
+        CommonTokenStream tokens = null;
+        if (show_hit) {
+            tokens = new ProfilingCommonTokenStream(lexer);
+        }
+        else {
+            tokens = new CommonTokenStream(lexer);
+        }
+        var parser = new MyParser(tokens);
         var output = tee ? new StreamWriter(input_name + ".errors") : System.Console.Error;
         var listener_lexer = new ErrorListener\<int>(quiet, tee, output);
         var listener_parser = new ErrorListener\<IToken>(quiet, tee, output);
@@ -258,7 +317,7 @@ public class Program
         {
             parser.AddErrorListener(new MyDiagnosticErrorListener());
         }
-        if (show_profile)
+        if (show_profile || show_ambig)
         {
             parser.Profile = true;
         }
@@ -285,8 +344,7 @@ public class Program
             if (tee)
             {
                 System.IO.File.WriteAllText(input_name + ".tree", tree.ToStringTree(parser));
-            } else
-            {
+            } else {
                 System.Console.Error.WriteLine(tree.ToStringTree(parser));
             }
         }
@@ -294,11 +352,123 @@ public class Program
         {
             System.Console.Error.WriteLine(String.Join(",\n\r", parser.ParseInfo.getDecisionInfo().Select(d => d.ToString())));
         }
+        if (show_ambig)
+        {
+            var decs = parser.ParseInfo.getDecisionInfo().Where(d =>
+                d.ambiguities.Any()).Select(d => d.ambiguities).ToList();
+            foreach (var decision in decs)
+            {
+                foreach (var ai in decision)
+                {
+                    var parser_decision = ai.decision;
+                    var parser_alts = ai.ambigAlts;
+                    var parser_startIndex = ai.startIndex;
+                    var parser_stopIndex = ai.stopIndex;
+                    var nfa_state = parser.Atn.states.Where(s =>
+                    {
+                        if (s is BasicBlockStartState s2) return s2.decision == parser_decision;
+                        else return false;
+                    }).ToList();
+                    var p = parser.RuleNames.Select((value, index) => new { value, index })
+                            .Where(pair => (pair.value == "<start_symbol>"))
+                            .Select(pair => pair.index).First();
+                    var parser_startRuleIndex = p;
+                    var parser_trees = parser.getAllPossibleParseTrees(
+                        parser_decision,
+                        parser_alts,
+                        parser_startIndex,
+                        parser_stopIndex,
+                        parser_startRuleIndex);
+                    foreach (var parser_tree in parser_trees)
+                    {
+                        System.Console.WriteLine(parser_tree.ToStringTree(parser));
+                        System.Console.WriteLine();
+                    }
+                }
+            }
+        }
         if (!quiet)
         {
             System.Console.Error.WriteLine(prefix + "CSharp " + row_number + " " + input_name + " " + result + " " + (after - before).TotalSeconds);
         }
         if (tee) output.Close();
+    }
+
+    public static string ToStringTree(ITree tree, Parser recog)
+    {
+        StringBuilder sb = new StringBuilder();
+        string[] ruleNames = recog != null ? recog.RuleNames : null;
+        IList\<string> ruleNamesList = ruleNames != null ? ruleNames.ToList() : null;
+        ToStringTree(sb, tree, 0, ruleNamesList);
+        return sb.ToString();
+    }
+
+    public static void ToStringTree(StringBuilder sb, ITree t, int indent, IList\<string> ruleNames)
+    {
+        string s = Antlr4.Runtime.Misc.Utils.EscapeWhitespace(GetNodeText(t, ruleNames), false);
+        if (t.ChildCount == 0)
+        {
+            for (int i = 0; i \< indent; ++i) sb.Append(" ");
+            sb.AppendLine(s);
+            return;
+        }
+        s = Antlr4.Runtime.Misc.Utils.EscapeWhitespace(GetNodeText(t, ruleNames), false);
+        for (int i = 0; i \< indent; ++i) sb.Append(' ');
+        sb.AppendLine(s);
+        for (int i = 0; i \< t.ChildCount; i++)
+        {
+            ToStringTree(sb, t.GetChild(i), indent+1, ruleNames);
+        }
+    }
+
+    public static string GetNodeText(ITree t, Parser recog)
+    {
+        string[] ruleNames = recog != null ? recog.RuleNames : null;
+        IList\<string> ruleNamesList = ruleNames != null ? ruleNames.ToList() : null;
+        return GetNodeText(t, ruleNamesList);
+    }
+
+    public static string GetNodeText(ITree t, IList\<string> ruleNames)
+    {
+        if (ruleNames != null)
+        {
+            if (t is RuleContext)
+            {
+                int ruleIndex = ((RuleContext)t).RuleIndex;
+                string ruleName = ruleNames[ruleIndex];
+                int altNumber = ((RuleContext)t).getAltNumber();
+                if ( altNumber!= Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
+                    return ruleName+":"+altNumber;
+                }
+                return ruleName;
+            }
+            else
+            {
+                if (t is IErrorNode)
+                {
+                    return t.ToString();
+                }
+                else
+                {
+                    if (t is ITerminalNode)
+                    {
+                        IToken symbol = ((ITerminalNode)t).Symbol;
+                        if (symbol != null)
+                        {
+                            string s = symbol.Text;
+                            return s;
+                        }
+                    }
+                }
+            }
+        }
+        // no recog for rule names
+        object payload = t.Payload;
+        if (payload is IToken)
+        {
+            return ((IToken)payload).Text;
+        }
+        return t.Payload.ToString();
     }
 }
 

--- a/_scripts/templates/CSharp/st.perf.sh
+++ b/_scripts/templates/CSharp/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 n=10
 

--- a/_scripts/templates/CSharp/st.test-cover.sh
+++ b/_scripts/templates/CSharp/st.test-cover.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
+    if [ -d "$f" ]; then continue; fi
     dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 <if(individual_parsing)>

--- a/_scripts/templates/CSharp/st.test.ps1
+++ b/_scripts/templates/CSharp/st.test.ps1
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false
@@ -88,6 +88,7 @@ foreach ($item in Get-ChildItem . -Recurse) {
     $file = $item.fullname
     $ext = $item.Extension
     if ($ext -eq ".tree") {
+        [IO.File]::WriteAllText($file, $([IO.File]::ReadAllText($file) -replace "`r`n", "`n"))
         git diff --exit-code $file *>> $old/updated.txt
 	$st = $LASTEXITCODE
         if ($st -ne 0) {

--- a/_scripts/templates/CSharp/st.test.sh
+++ b/_scripts/templates/CSharp/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
-    else
-        trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/Cpp/st.build.ps1
+++ b/_scripts/templates/Cpp/st.build.ps1
@@ -16,13 +16,22 @@ rmrf('build')
 New-Item -Path 'build' -ItemType Directory
 Set-Location 'build'
 
-$(& cmake .. <cmake_target> ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+<if(test.IsWindows)>
+$(& cmake .. -G "Visual Studio 17 2022" -A x64 ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+<else>$(& cmake .. ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+<endif>
 if($compile_exit_code -ne 0){
     Write-Host "Failed first cmake call $compile_exit_code."
     exit $compile_exit_code
 }
 
-$(& <if(os_win)>cmake --build . --config Release<else>make<endif> ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+<if(test.IsWindows)>
+$(& cmake --build . --config Release ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+<else>
+$make = which make
+$(& $make ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+<endif>
+
 if($compile_exit_code -ne 0){
     Write-Host "Failed second cmake call $compile_exit_code."
     exit $compile_exit_code

--- a/_scripts/templates/Cpp/st.build.sh
+++ b/_scripts/templates/Cpp/st.build.sh
@@ -4,6 +4,10 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 rm -rf build
 mkdir build
 cd build
-cmake .. <cmake_target>
-<if(os_win)>cmake --build . --config Release<else>make<endif>
+<if(test.IsWindows)>cmake .. -G "Visual Studio 17 2022" -A x64
+<else>cmake ..
+<endif>
+<if(test.IsWindows)>cmake --build . --config Release
+<else>make
+<endif>
 exit 0

--- a/_scripts/templates/Cpp/st.perf.sh
+++ b/_scripts/templates/Cpp/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 # Individual parsing.

--- a/_scripts/templates/Cpp/st.test.ps1
+++ b/_scripts/templates/Cpp/st.test.ps1
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false

--- a/_scripts/templates/Cpp/st.test.sh
+++ b/_scripts/templates/Cpp/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -tee -tree $f >> parse.txt
-    else
-        trwdog ./build/<if(os_win)>Release/<endif><exec_name> -q -tee -tree $f >> parse.txt
-    fi
+    dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -tee -tree $f >> parse.txt
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog ./build/<if(os_win)>Release/<endif><exec_name> -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -x -tee -tree > parse.txt 2>&1
 status="$?"
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/Dart/st.perf.sh
+++ b/_scripts/templates/Dart/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 # Individual parsing.

--- a/_scripts/templates/Dart/st.test.ps1
+++ b/_scripts/templates/Dart/st.test.ps1
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false

--- a/_scripts/templates/Dart/st.test.sh
+++ b/_scripts/templates/Dart/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- ./Test.exe -q -tee -tree $f >> parse.txt
-    else
-        trwdog ./Test.exe -q -tee -tree $f >> parse.txt
-    fi
+    dotnet trwdog -- ./Test.exe -q -tee -tree $f >> parse.txt
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- ./Test.exe -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog ./Test.exe -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- ./Test.exe -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/Go/st.perf.sh
+++ b/_scripts/templates/Go/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 n=10
 

--- a/_scripts/templates/Go/st.test.ps1
+++ b/_scripts/templates/Go/st.test.ps1
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false

--- a/_scripts/templates/Go/st.test.sh
+++ b/_scripts/templates/Go/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
-    else
-        trwdog ./<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog ./<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/Java/st.Test.java
+++ b/_scripts/templates/Java/st.Test.java
@@ -17,6 +17,8 @@ import java.io.OutputStreamWriter;
 import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.io.File;
+import org.antlr.v4.runtime.misc.*;
+import org.antlr.v4.runtime.tree.*;
 
 public class Test {
 
@@ -221,4 +223,64 @@ public class Test {
         }
         if (tee) output.close();
     }
+
+    public static String toStringTree(Tree tree, Parser recog) {
+	StringBuilder sb = new StringBuilder();
+	String[] ruleNames = recog != null ? recog.getRuleNames() : null;
+	List\<String> ruleNamesList = ruleNames != null ? List.of(ruleNames) : null;
+	toStringTree(sb, tree, 0, ruleNamesList);
+	return sb.toString();
+    }
+
+    public static void toStringTree(StringBuilder sb, Tree t, int indent, List\<String> ruleNames) {
+	String s = org.antlr.v4.runtime.misc.Utils.escapeWhitespace(getNodeText(t, ruleNames), false);
+	if (t.getChildCount() == 0) {
+	    for (int i = 0; i \< indent; ++i) sb.append(" ");
+	    sb.append(s).append(System.lineSeparator());
+	    return;
+	}
+	s = org.antlr.v4.runtime.misc.Utils.escapeWhitespace(getNodeText(t, ruleNames), false);
+	for (int i = 0; i \< indent; ++i) sb.append(' ');
+	sb.append(s).append(System.lineSeparator());
+	for (int i = 0; i \< t.getChildCount(); i++) {
+	    toStringTree(sb, t.getChild(i), indent + 1, ruleNames);
+	}
+    }
+
+    public static String getNodeText(Tree t, Parser recog) {
+	String[] ruleNames = recog != null ? recog.getRuleNames() : null;
+	List\<String> ruleNamesList = ruleNames != null ? java.util.Arrays.asList(ruleNames) : null;
+	return getNodeText(t, ruleNamesList);
+    }
+    
+    public static String getNodeText(Tree t, List\<String> ruleNames) {
+	if ( ruleNames!=null ) {
+	    if ( t instanceof RuleContext ) {
+		int ruleIndex = ((RuleContext)t).getRuleContext().getRuleIndex();
+		String ruleName = ruleNames.get(ruleIndex);
+		int altNumber = ((RuleContext) t).getAltNumber();
+		if ( altNumber!=ATN.INVALID_ALT_NUMBER ) {
+		    return ruleName+":"+altNumber;
+		}
+		return ruleName;
+	    }
+	    else if ( t instanceof ErrorNode) {
+		return t.toString();
+	    }
+	    else if ( t instanceof TerminalNode) {
+		Token symbol = ((TerminalNode)t).getSymbol();
+		if (symbol != null) {
+		    String s = symbol.getText();
+		    return s;
+		}
+	    }
+	}
+		// no recog for rule names
+	Object payload = t.getPayload();
+	if ( payload instanceof Token ) {
+	    return ((Token)payload).getText();
+	}
+	return t.getPayload().toString();
+    }
+
 }

--- a/_scripts/templates/Java/st.perf.sh
+++ b/_scripts/templates/Java/st.perf.sh
@@ -1,30 +1,17 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -32,6 +19,15 @@ do
 done
 
 n=10
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 version=`grep "version=" build.sh | awk -F= '{print $2}'`

--- a/_scripts/templates/Java/st.test.ps1
+++ b/_scripts/templates/Java/st.test.ps1
@@ -69,7 +69,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false
@@ -90,6 +90,7 @@ foreach ($item in Get-ChildItem . -Recurse) {
     $file = $item.fullname
     $ext = $item.Extension
     if ($ext -eq ".tree") {
+        [IO.File]::WriteAllText($file, $([IO.File]::ReadAllText($file) -replace "`r`n", "`n"))
         git diff --exit-code $file *>> $old/updated.txt
 	$st = $LASTEXITCODE
         if ($st -ne 0) {

--- a/_scripts/templates/Java/st.test.sh
+++ b/_scripts/templates/Java/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -53,12 +39,7 @@ CLASSPATH="$JAR<if(path_sep_semi)>\;<else>:<endif>."
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- java -classpath "$CLASSPATH" Test -q -tee -tree $f >> parse.txt 2>&1
-    else
-        trwdog java -classpath "$CLASSPATH" Test -q -tee -tree $f >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- java -classpath "$CLASSPATH" Test -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -67,12 +48,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- java -classpath "$CLASSPATH" Test -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog java -classpath "$CLASSPATH" Test -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- java -classpath "$CLASSPATH" Test -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 
@@ -112,7 +88,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/JavaScript/st.package.json
+++ b/_scripts/templates/JavaScript/st.package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "4.13.2",
+    "antlr4": "4.13.1",
     "fs-extra": "^11.1.0",
     "timer-node": "^5.0.6",
     "typescript-string-operations": "^1.4.1"

--- a/_scripts/templates/JavaScript/st.package.json
+++ b/_scripts/templates/JavaScript/st.package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "4.13.1",
+    "antlr4": "4.13.2",
     "fs-extra": "^11.1.0",
     "timer-node": "^5.0.6",
     "typescript-string-operations": "^1.4.1"

--- a/_scripts/templates/JavaScript/st.perf.sh
+++ b/_scripts/templates/JavaScript/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 # Individual parsing.

--- a/_scripts/templates/JavaScript/st.test.ps1
+++ b/_scripts/templates/JavaScript/st.test.ps1
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false

--- a/_scripts/templates/JavaScript/st.test.sh
+++ b/_scripts/templates/JavaScript/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- node Test.js -q -tee -tree $f >> parse.txt 2>&1
-    else
-        trwdog node Test.js -q -tee -tree $f >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- node Test.js -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- node Test.js -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog node Test.js -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- node Test.js -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/PHP/st.perf.sh
+++ b/_scripts/templates/PHP/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' -type f | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 # Individual parsing.

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false

--- a/_scripts/templates/PHP/st.test.sh
+++ b/_scripts/templates/PHP/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- php -d memory_limit=1G Test.php -q -tee -tree $f >> parse.txt 2>&1
-    else
-        trwdog php -d memory_limit=1G Test.php -q -tee -tree $f >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- php -d memory_limit=1G Test.php -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- php -d memory_limit=1G Test.php -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog php -d memory_limit=1G Test.php -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- php -d memory_limit=1G Test.php -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/Python3/st.perf.sh
+++ b/_scripts/templates/Python3/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 # Individual parsing.

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false

--- a/_scripts/templates/Python3/st.test.sh
+++ b/_scripts/templates/Python3/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- python3 Test.py -q -tee -tree $f >> parse.txt 2>&1
-    else
-        trwdog python3 Test.py -q -tee -tree $f >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- python3 Test.py -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- python3 Test.py -q -x -tee -tree > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog python3 Test.py -q -x -tee -tree > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- python3 Test.py -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/templates/TypeScript/package.json
+++ b/_scripts/templates/TypeScript/package.json
@@ -13,6 +13,7 @@
     "buffer": "^6.0.3",
     "fs-extra": "^11.1.1",
     "timer-node": "^5.0.6",
+    "typescript-collections": "^1.3.3",
     "typescript-string-operations": "^1.5.0"
   },
   "type": "module",

--- a/_scripts/templates/TypeScript/st.build.ps1
+++ b/_scripts/templates/TypeScript/st.build.ps1
@@ -16,7 +16,7 @@ if($compile_exit_code -ne 0){
 \}
 }>
 
-$(& npm install -g typescript@5.3.3 ts-node@10.9.2 ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+$(& npm install -g typescript ts-node ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
 if($compile_exit_code -ne 0){
     exit $compile_exit_code
 \}

--- a/_scripts/templates/TypeScript/st.build.sh
+++ b/_scripts/templates/TypeScript/st.build.sh
@@ -13,7 +13,7 @@ version=`grep antlr4 package.json | awk '{print $2}' | tr -d '"' | tr -d ',' | t
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileName>
 } >
 
-npm install -g typescript@5.3.3 ts-node@10.9.2
+npm install -g typescript ts-node
 npm install
 tsc -p tsconfig.json --pretty
 exit 0

--- a/_scripts/templates/TypeScript/st.perf.sh
+++ b/_scripts/templates/TypeScript/st.perf.sh
@@ -1,35 +1,31 @@
 # Generated from trgen <version>
 
-# People often specify a test file directory, but sometimes no
-# tests are provided. Git won't check in an empty directory.
-# Test if the test file directory does not exist, or it is just
-# an empty directory.
-if [ ! -d ../<example_files_unix> ]
-then
-    echo "No test cases provided."
-    exit 0
-elif [ ! "$(ls -A ../<example_files_unix>)" ]
-then
-    echo "No test cases provided."
-    exit 0
-fi
-
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`find ../<example_files_unix> -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
-    triconv -f utf-8 $f > /dev/null 2>&1
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
     fi
 done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
 
 # Parse all input files.
 # Individual parsing.

--- a/_scripts/templates/TypeScript/st.run.sh
+++ b/_scripts/templates/TypeScript/st.run.sh
@@ -1,19 +1,7 @@
 # Generated from trgen <version>
 set -e
-# set -x
+set -x
 
-# ts-node is a bash script, so duplicate that code and call node via trwdog.
-tsnode=`which ts-node`
+exec npx tsx Test.js "$@"
 
-basedir=$(dirname "$(echo "$tsnode" | sed -e 's,\\\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node" "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
-else 
-  exec node "$basedir/node_modules/ts-node/dist/bin.js" Test.js "$@"
-fi
 exit $?

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- pwsh -command "ts-node Test.js -q -tee -tree $_" *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- pwsh -command "npx tsx Test.js -q -tee -tree $_" *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- pwsh -command "ts-node Test.js -q -x -tee -tree" *> parse.txt
+get-content "tests.txt" | dotnet trwdog -- pwsh -command "npx tsx Test.js -q -x -tee -tree" *> parse.txt
 $status=$LASTEXITCODE
 <endif>
 
@@ -67,7 +67,7 @@ if ( $size -eq 0 ) {
 }
 
 $old = Get-Location
-Set-Location ..
+Set-Location "<if(os_win)>../<example_dir_win><else>../<example_dir_unix><endif>"
 
 # Check if any .errors/.tree files have changed. That's not good.
 git config --global pager.diff false

--- a/_scripts/templates/TypeScript/st.test.sh
+++ b/_scripts/templates/TypeScript/st.test.sh
@@ -1,8 +1,5 @@
 # Generated from trgen <version>
 
-# comment for local dotnet tools.
-global=""
-
 # glob patterns
 shopt -s globstar
 
@@ -12,23 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-if [ "$global" == "" ]
-then
-    files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-else
-    files2=`trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
-fi
-
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    if [ "$global" == "" ]
-    then
-        dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
-    else
-        triconv -f utf-8 $f > /dev/null 2>&1
-    fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -50,12 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    if [ "$global" == "" ]
-    then
-        dotnet trwdog -- sh -c "ts-node Test.js -q -tee -tree $f" >> parse.txt 2>&1
-    else
-        trwdog sh -c "ts-node Test.js -q -tee -tree $f" >> parse.txt 2>&1
-    fi
+    dotnet trwdog -- sh -c "npx tsx Test.js -q -tee -tree $f" >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -64,12 +45,7 @@ do
 done
 <else>
 # Group parsing.
-if [ "$global" == "" ]
-then
-    echo "${files[*]}" | dotnet trwdog -- sh -c "ts-node Test.js -q -x -tee -tree" > parse.txt 2>&1
-else
-    echo "${files[*]}" | trwdog sh -c "ts-node Test.js -q -x -tee -tree" > parse.txt 2>&1
-fi
+echo "${files[*]}" | dotnet trwdog -- sh -c "npx tsx Test.js -q -x -tee -tree" > parse.txt 2>&1
 status="$?"
 <endif>
 
@@ -109,7 +85,7 @@ then
     gen=`find ../<example_files_unix> -type f -name '*.errors' -o -name '*.tree'`
     if [ "$gen" != "" ]
     then
-        dos2unix $gen
+        dos2unix -f $gen
     fi
 fi
 

--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -153,7 +153,7 @@ OPTIONS
 
        -t
            Specifies the targets to test. Possible targets are
-           "CSharp", "Cpp", "Dart", "Go", "Java", "JavaScript", "PHP", "Python3".
+           "CSharp", "Cpp", "Dart", "Go", "Java", "JavaScript", "Python3".
            All targets are tested by default.
 
 EOF
@@ -268,7 +268,7 @@ fi
 
 if [ "$targets" == "" ]
 then
-    targets=( CSharp Cpp Dart Go Java JavaScript PHP Python3 TypeScript )
+    targets=( Antlr4ng CSharp Cpp Dart Go Java JavaScript Python3 TypeScript )
 fi
 
 echo grammars = ${grammars[@]}


### PR DESCRIPTION
This is a fix for #4243.

### What changed?

* Trash version 0.23.6 is now used.
* The Github workflow now installs ts-node, typescript, and tsx because these are used in testing Antlr4ng and TypeScript. This change also fixes problems with split grammars with base classes for TypeScript.
* Templates for testing have been updated to correct various problems.
    * Replacing `find` with `trglob`.
    * Replacing global dotnet tool calls with local.
    * Fixing calls to Antlr4ng and TypeScript programs using `npx tsx`.
    * For CSharp target, adding code for outputting ambiguous trees with `-ambig` option, and `trparse --ambig`.
 