### PR TITLE
[dot] Fix semicolon as attribute list separator

### DIFF
--- a/dot/DOT.g4
+++ b/dot/DOT.g4
@@ -59,7 +59,7 @@ attr_list
     ;
 
 a_list
-    : (id_ ( '=' id_)? ','?)+
+    : (id_ ( '=' id_)? (';' | ',')?)+
     ;
 
 edge_stmt


### PR DESCRIPTION
Attributes in Graphviz can be separated not only by comma, but also a semicolon. 

Example of a dot file that currently fails to parse, but works with graphviz `dot -Tsvg g.dot > g.svg`:
```dot
graph {
  A [color=blue; shape=hexagon]
}
```

Matching rule in [DOT language grammar](https://graphviz.org/doc/info/lang.html): 

![grammar.png](https://github.com/user-attachments/assets/0601cb60-f8d6-4108-b737-5e677b6c35c8)
