### PR TITLE
[build] Add testing for grammar ambiguity.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest]
-        test: [ useless-parens, format ]
+        test: [ useless-parens, format, ambiguity ]
     steps:
     - name: Info
       shell: bash

--- a/_scripts/templates/CSharp/st.test-ambiguity.sh
+++ b/_scripts/templates/CSharp/st.test-ambiguity.sh
@@ -1,0 +1,49 @@
+# Generated from trgen <version>
+
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+
+# Get a list of test files from the test directory. Do not include any
+# .errors or .tree files. Pay close attention to remove only file names
+# that end with the suffix .errors or .tree.
+files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files=()
+for f in $files2
+do
+    if [ -d "$f" ]; then continue; fi
+    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    if [ "$?" = "0" ]
+    then
+        files+=( $f )
+    fi
+done
+
+# People often specify a test file directory, but sometimes no
+# tests are provided. Git won't check in an empty directory.
+# Test if there are no test files.
+if [ ${#files[@]} -eq 0 ]
+then
+    echo "No test cases provided."
+    exit 0
+fi
+
+# Parse all input files.
+<if(individual_parsing)>
+# Individual parsing: NOT SUPPORTED!
+<else>
+# Group parsing.
+echo "${files[*]}" | dotnet trwdog -- dotnet trperf -- -x -c ar | grep -v '^0' | awk '{print $2}' | sort -u
+status=$?
+<endif>
+
+# trwdog returns 255 if it cannot spawn the process. This could happen
+# if the environment for running the program does not exist, or the
+# program did not build.
+if [ "$status" = "255" ]
+then
+    echo "Test failed."
+    exit 1
+fi
+
+rm -f $old/updated.txt $old/new_errors2.txt $old/new_errors.txt
+exit 0

--- a/_scripts/test-static-checks.sh
+++ b/_scripts/test-static-checks.sh
@@ -296,7 +296,7 @@ fi
 
 if [ ${#targets[@]} -eq 0 ]
 then
-    targets=( useless-parens format )
+    targets=( useless-parens format ambiguity )
 fi
 
 echo grammars = ${grammars[@]}
@@ -374,6 +374,22 @@ do
         then
             echo "::warning file=$testname,line=0,col=0,endColumn=0::one or more grammars do not conform to the Antlr grammar coding standard format for this repo. Reformat using antlr-format."
         fi
+    fi
+
+    if [ "$target" == "ambiguity" ]
+    then
+        dotnet trgen -- -t CSharp --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar
+	if [ $? -ne 0 ]
+	then
+            echo "::warning file=$testname,line=0,col=0,endColumn=0::Cannot test ambiguity, non-zero return from trgen."
+	elif [ ! -d Generated-CSharp ]
+	then
+            echo "::warning file=$testname,line=0,col=0,endColumn=0::Cannot test ambiguity, no Generated-CSharp directory."
+	else
+	    cd Generated-CSharp
+	    bash build.sh
+	    bash test-ambiguity.sh
+	fi
     fi
 
     popd > /dev/null


### PR DESCRIPTION
I'm really excited about this one!!

This change adds testing for grammar ambiguity using trperf. The tool essentially runs the parser with the [ProfilingATNSimulator](https://github.com/antlr/antlr4/blob/2a7904a595479954ccfb1c78124fc3d7f5bebcb1/runtime/CSharp/src/Atn/ProfilingATNSimulator.cs). (It does not test the grammar using Z3/SMT. I am still working on that.)
* A CSharp parser is first generated for the grammar.
* The CSharp parser is built.
* The parser is run via trperf on all input files. trperf collects data on the ambiguity and rule name. This output is filtered using `grep` for non-zero ambiguity, then the list of rule names sorted and made unique. It's all done via the command line, using simple Bash piping.

The output is a little hard to read, but you can see the list of symbols that are ambiguous after all parses.
* abb: dataList
* aql: collect, expr, filter, for_in, let_list, limit, sort
* arden: exprBefore, exprFunction, exprSort
* asl: compound_logical_condition, event_generation, if_statement, logical_condition, operation_invocation, simple_logical_condition, struct_value
* ...
* bcpl: e0, e2, e3, e4, e5, e6, e7, e8, ...
* bnf: xalt, xelem, xlhs, xrhs
* c: blockItem, castExpression, ......
* ...

The entire list of grammars and ambiguity at this point are here: 
[ambig.txt](https://github.com/user-attachments/files/17265993/ambig.txt)


Note, the actual ambiguous parse trees can be obtained using `trparse --ambig`, but that can take a lot of time, so it is not done.
