### PR TITLE
[build] Dotnet use of '--' changed

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,189 +3,189 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trcaret"
       ],
       "rollForward": false
     },
     "trcover": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trcover"
       ],
       "rollForward": false
     },
     "trgen": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trgen"
       ],
       "rollForward": false
     },
     "trglob": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trglob"
       ],
       "rollForward": false
     },
     "triconv": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "triconv"
       ],
       "rollForward": false
     },
     "trparse": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trparse"
       ],
       "rollForward": false
     },
     "trquery": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trquery"
       ],
       "rollForward": false
     },
     "trtext": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trtext"
       ],
       "rollForward": false
     },
     "trwdog": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trwdog"
       ],
       "rollForward": false
     },
     "trxgrep": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trxgrep"
       ],
       "rollForward": false
     },
     "trxml": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trxml"
       ],
       "rollForward": false
     },
     "trxml2": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trxml2"
       ],
       "rollForward": false
     },
     "trclonereplace": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trclonereplace"
       ],
       "rollForward": false
     },
     "trcombine": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trcombine"
       ],
       "rollForward": false
     },
     "trconvert": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trconvert"
       ],
       "rollForward": false
     },
     "trfoldlit": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trfoldlit"
       ],
       "rollForward": false
     },
     "trgenvsc": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trgenvsc"
       ],
       "rollForward": false
     },
     "tritext": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "tritext"
       ],
       "rollForward": false
     },
     "trjson": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trjson"
       ],
       "rollForward": false
     },
     "trperf": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trperf"
       ],
       "rollForward": false
     },
     "trrename": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trrename"
       ],
       "rollForward": false
     },
     "trsort": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trsort"
       ],
       "rollForward": false
     },
     "trsplit": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trsplit"
       ],
       "rollForward": false
     },
     "trsponge": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trsponge"
       ],
       "rollForward": false
     },
     "trtokens": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trtokens"
       ],
       "rollForward": false
     },
     "trtree": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trtree"
       ],
       "rollForward": false
     },
     "trunfold": {
-      "version": "0.23.6",
+      "version": "0.23.7",
       "commands": [
         "trunfold"
       ],

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,7 @@ jobs:
     - name: Test Trash install
       shell: bash
       run: |
-        dotnet trgen -- --help
+        dotnet trgen --help
     - name: Test
       shell: pwsh
       run: |
@@ -225,7 +225,7 @@ jobs:
     - name: Test Trash install
       shell: bash
       run: |
-        dotnet trgen -- --help
+        dotnet trgen --help
     - name: Test
       shell: bash
       run: |

--- a/_scripts/gen-desc.sh
+++ b/_scripts/gen-desc.sh
@@ -51,7 +51,7 @@ add() {
 
 setupdeps()
 {
-    dotnet trgen -- --version
+    dotnet trgen --version
     if [ $? != "0" ]
     then
         echo "Need to set up Trash."
@@ -139,7 +139,7 @@ do
         cd $root/$g
         rm -rf Generated-*
         echo "$g,$t:"
-        dotnet trgen -- -t "$t" --template-sources-directory "$full_path_templates"
+        dotnet trgen -t "$t" --template-sources-directory "$full_path_templates"
         if [ "$?" -ne 0 ]
         then
             failed=`add "$failed" "$g/$t"`

--- a/_scripts/perf-changed.sh
+++ b/_scripts/perf-changed.sh
@@ -13,7 +13,7 @@ if ! command -v trxml2 &> /dev/null
 then
     local=1
 fi
-if ! command -v dotnet trxml2 -- --version &> /dev/null
+if ! command -v dotnet trxml2 --version &> /dev/null
 then
     echo "'dotnet' could not be found. Install Microsoft NET."
     exit 1
@@ -96,7 +96,7 @@ do
         then
             gtargets=`trxml2 desc.xml | fgrep -e '/desc/targets' | awk -F '=' '{print $2}' | tr ';' '\n' | fgrep -e 'Java' | fgrep -v 'JavaScript'`
         else
-            gtargets=`dotnet trxml2 -- desc.xml | fgrep -e '/desc/targets' | awk -F '=' '{print $2}' | tr ';' '\n' | fgrep -e 'Java' | fgrep -v 'JavaScript'`
+            gtargets=`dotnet trxml2 desc.xml | fgrep -e '/desc/targets' | awk -F '=' '{print $2}' | tr ';' '\n' | fgrep -e 'Java' | fgrep -v 'JavaScript'`
         fi
         if [ "$gtargets" == "" ]; then continue; fi
     fi
@@ -146,7 +146,7 @@ do
                 exit 0
             fi
         else
-            dotnet trgen -- -t CSharp
+            dotnet trgen -t CSharp
             if [ "$?" != "0" ]
             then
                 echo "Build failed. Stopping test."
@@ -187,7 +187,7 @@ do
             then
                 what=`trxml2 desc.xml | grep inputs | head -1 | sed 's%^[^=]*=%%'`
             else
-                what=`dotnet trxml2 -- desc.xml | grep inputs | head -1 | sed 's%^[^=]*=%%'`
+                what=`dotnet trxml2 desc.xml | grep inputs | head -1 | sed 's%^[^=]*=%%'`
             fi
             if [ "$what" == "" ]
             then
@@ -197,7 +197,7 @@ do
                 then
                     what=( `trglob $p | grep -v '.errors$' | grep -v '.tree$'` )
                 else
-                    what=( `dotnet trglob -- $p | grep -v '.errors$' | grep -v '.tree$'` )
+                    what=( `dotnet trglob $p | grep -v '.errors$' | grep -v '.tree$'` )
                 fi
             else
                 dir=`pwd`
@@ -206,7 +206,7 @@ do
                 then
                     what=( `trglob $p | grep -v '.errors$' | grep -v '.tree$'` )
                 else
-                    what=( `dotnet trglob -- $p | grep -v '.errors$' | grep -v '.tree$'` )
+                    what=( `dotnet trglob $p | grep -v '.errors$' | grep -v '.tree$'` )
                 fi
             fi
             echo what = $what

--- a/_scripts/remaster.sh
+++ b/_scripts/remaster.sh
@@ -1,7 +1,7 @@
 #
 
 list=`find examples -name '*.tree'`
-dotnet trgen -- -t Java
+dotnet trgen -t Java
 cd Generated; make
 
 for i in $list

--- a/_scripts/templates/Antlr4ng/st.perf.sh
+++ b/_scripts/templates/Antlr4ng/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/Antlr4ng/st.test.ps1
+++ b/_scripts/templates/Antlr4ng/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- pwsh -command "npx tsx Test.js -q -tee -tree $_" *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog pwsh -command "npx tsx Test.js -q -tee -tree $_" *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- pwsh -command "npx tsx Test.js -q -x -tee -tree" *> parse.txt
+get-content "tests.txt" | dotnet trwdog pwsh -command "npx tsx Test.js -q -x -tee -tree" *> parse.txt
 $status=$LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/Antlr4ng/st.test.sh
+++ b/_scripts/templates/Antlr4ng/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- sh -c "npx tsx Test.js -q -tee -tree $f" >> parse.txt 2>&1
+    dotnet trwdog sh -c "npx tsx Test.js -q -tee -tree $f" >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- sh -c "npx tsx Test.js -q -x -tee -tree" > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog sh -c "npx tsx Test.js -q -x -tee -tree" > parse.txt 2>&1
 status="$?"
 <endif>
 

--- a/_scripts/templates/CSharp/st.perf.sh
+++ b/_scripts/templates/CSharp/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/CSharp/st.test-ambiguity.sh
+++ b/_scripts/templates/CSharp/st.test-ambiguity.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -32,7 +32,7 @@ fi
 # Individual parsing: NOT SUPPORTED!
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- dotnet trperf -- -x -c ar | grep -v '^0' | awk '{print $2}' | sort -u
+echo "${files[*]}" | dotnet trwdog dotnet trperf -x -c ar | grep -v '^0' | awk '{print $2}' | sort -u
 status=$?
 <endif>
 

--- a/_scripts/templates/CSharp/st.test-cover.sh
+++ b/_scripts/templates/CSharp/st.test-cover.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -32,7 +32,7 @@ fi
 # Individual parsing: NOT SUPPORTED!
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- dotnet trcover -- -x
+echo "${files[*]}" | dotnet trwdog dotnet trcover -x
 status=$?
 <endif>
 

--- a/_scripts/templates/CSharp/st.test.ps1
+++ b/_scripts/templates/CSharp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/CSharp/st.test.sh
+++ b/_scripts/templates/CSharp/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
+    dotnet trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog ./bin/Debug/net8.0/<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 

--- a/_scripts/templates/Cpp/st.perf.sh
+++ b/_scripts/templates/Cpp/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/Cpp/st.test.ps1
+++ b/_scripts/templates/Cpp/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog ./build/<if(os_win)>Release/<endif><exec_name> -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog ./build/<if(os_win)>Release/<endif><exec_name> -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/Cpp/st.test.sh
+++ b/_scripts/templates/Cpp/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -tee -tree $f >> parse.txt
+    dotnet trwdog ./build/<if(os_win)>Release/<endif><exec_name> -q -tee -tree $f >> parse.txt
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- ./build/<if(os_win)>Release/<endif><exec_name> -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog ./build/<if(os_win)>Release/<endif><exec_name> -q -x -tee -tree > parse.txt 2>&1
 status="$?"
 <endif>
 

--- a/_scripts/templates/Dart/st.perf.sh
+++ b/_scripts/templates/Dart/st.perf.sh
@@ -6,7 +6,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/Dart/st.test.ps1
+++ b/_scripts/templates/Dart/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- ./Test.exe -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog ./Test.exe -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- ./Test.exe -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog ./Test.exe -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/Dart/st.test.sh
+++ b/_scripts/templates/Dart/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- ./Test.exe -q -tee -tree $f >> parse.txt
+    dotnet trwdog ./Test.exe -q -tee -tree $f >> parse.txt
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- ./Test.exe -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog ./Test.exe -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 

--- a/_scripts/templates/Go/st.perf.sh
+++ b/_scripts/templates/Go/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/Go/st.test.ps1
+++ b/_scripts/templates/Go/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog ./<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog ./<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/Go/st.test.sh
+++ b/_scripts/templates/Go/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
+    dotnet trwdog ./<if(os_win)>Test.exe<else>Test<endif> -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- ./<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog ./<if(os_win)>Test.exe<else>Test<endif> -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 

--- a/_scripts/templates/Java/st.perf.sh
+++ b/_scripts/templates/Java/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/Java/st.test.ps1
+++ b/_scripts/templates/Java/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -42,10 +42,10 @@ $version = Select-String -Path "build.sh" -Pattern "version=" | ForEach-Object {
 $JAR = python -c "import os; from pathlib import Path; print(os.path.join(Path.home(), '.m2', 'repository', 'org', 'antlr', 'antlr4', '$version', ('antlr4-' + '$version' + '-complete.jar')))"
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- java -cp "$JAR<if(path_sep_semi)>;<else>:<endif>." Test -q -tee -tree *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog java -cp "$JAR<if(path_sep_semi)>;<else>:<endif>." Test -q -tee -tree *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- java -cp "${JAR}<if(path_sep_semi)>;<else>:<endif>." Test -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog java -cp "${JAR}<if(path_sep_semi)>;<else>:<endif>." Test -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/Java/st.test.sh
+++ b/_scripts/templates/Java/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -39,7 +39,7 @@ CLASSPATH="$JAR<if(path_sep_semi)>\;<else>:<endif>."
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- java -classpath "$CLASSPATH" Test -q -tee -tree $f >> parse.txt 2>&1
+    dotnet trwdog java -classpath "$CLASSPATH" Test -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -48,7 +48,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- java -classpath "$CLASSPATH" Test -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog java -classpath "$CLASSPATH" Test -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 

--- a/_scripts/templates/JavaScript/st.perf.sh
+++ b/_scripts/templates/JavaScript/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/JavaScript/st.test.ps1
+++ b/_scripts/templates/JavaScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- node Test.js -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog node Test.js -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- node Test.js -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog node Test.js -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/JavaScript/st.test.sh
+++ b/_scripts/templates/JavaScript/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- node Test.js -q -tee -tree $f >> parse.txt 2>&1
+    dotnet trwdog node Test.js -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- node Test.js -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog node Test.js -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 

--- a/_scripts/templates/PHP/st.perf.sh
+++ b/_scripts/templates/PHP/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' -type f | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- php -d memory_limit=1G Test.php -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog php -d memory_limit=1G Test.php -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- php -d memory_limit=1G Test.php -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog php -d memory_limit=1G Test.php -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/PHP/st.test.sh
+++ b/_scripts/templates/PHP/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- php -d memory_limit=1G Test.php -q -tee -tree $f >> parse.txt 2>&1
+    dotnet trwdog php -d memory_limit=1G Test.php -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- php -d memory_limit=1G Test.php -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog php -d memory_limit=1G Test.php -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 

--- a/_scripts/templates/Python3/st.perf.sh
+++ b/_scripts/templates/Python3/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- python3 Test.py -q -tee -tree $_ *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog python3 Test.py -q -tee -tree $_ *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- python3 Test.py -q -x -tee -tree *> parse.txt
+get-content "tests.txt" | dotnet trwdog python3 Test.py -q -x -tee -tree *> parse.txt
 $status = $LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/Python3/st.test.sh
+++ b/_scripts/templates/Python3/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- python3 Test.py -q -tee -tree $f >> parse.txt 2>&1
+    dotnet trwdog python3 Test.py -q -tee -tree $f >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- python3 Test.py -q -x -tee -tree > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog python3 Test.py -q -x -tee -tree > parse.txt 2>&1
 status=$?
 <endif>
 

--- a/_scripts/templates/TypeScript/st.perf.sh
+++ b/_scripts/templates/TypeScript/st.perf.sh
@@ -6,12 +6,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -20,7 +20,7 @@ foreach ($file in $allFiles) {
     } elseif ($ext -eq ".tree") {
         continue
     } else {
-        $(& dotnet triconv -- -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
+        $(& dotnet triconv -f utf-8 $file ; $last = $LASTEXITCODE ) | Out-Null
         if ($last -ne 0)
         {
             continue
@@ -40,10 +40,10 @@ if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
 # Parse all input files.
 <if(individual_parsing)>
 # Individual parsing.
-Get-Content "tests.txt" | ForEach-Object { dotnet trwdog -- pwsh -command "npx tsx Test.js -q -tee -tree $_" *>> parse.txt }
+Get-Content "tests.txt" | ForEach-Object { dotnet trwdog pwsh -command "npx tsx Test.js -q -tee -tree $_" *>> parse.txt }
 <else>
 # Group parsing.
-get-content "tests.txt" | dotnet trwdog -- pwsh -command "npx tsx Test.js -q -x -tee -tree" *> parse.txt
+get-content "tests.txt" | dotnet trwdog pwsh -command "npx tsx Test.js -q -x -tee -tree" *> parse.txt
 $status=$LASTEXITCODE
 <endif>
 

--- a/_scripts/templates/TypeScript/st.test.sh
+++ b/_scripts/templates/TypeScript/st.test.sh
@@ -9,12 +9,12 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do
     if [ -d "$f" ]; then continue; fi
-    dotnet triconv -- -f utf-8 $f > /dev/null 2>&1
+    dotnet triconv -f utf-8 $f > /dev/null 2>&1
     if [ "$?" = "0" ]
     then
         files+=( $f )
@@ -36,7 +36,7 @@ fi
 rm -f parse.txt
 for f in ${files[*]}
 do
-    dotnet trwdog -- sh -c "npx tsx Test.js -q -tee -tree $f" >> parse.txt 2>&1
+    dotnet trwdog sh -c "npx tsx Test.js -q -tee -tree $f" >> parse.txt 2>&1
     xxx="$?"
     if [ "$xxx" -ne 0 ]
     then
@@ -45,7 +45,7 @@ do
 done
 <else>
 # Group parsing.
-echo "${files[*]}" | dotnet trwdog -- sh -c "npx tsx Test.js -q -x -tee -tree" > parse.txt 2>&1
+echo "${files[*]}" | dotnet trwdog sh -c "npx tsx Test.js -q -x -tee -tree" > parse.txt 2>&1
 status="$?"
 <endif>
 

--- a/_scripts/test-cover.sh
+++ b/_scripts/test-cover.sh
@@ -308,7 +308,7 @@ do
         popd > /dev/null
         continue
     fi
-    desc_targets=`dotnet trxml2 -- desc.xml | grep '/desc/targets'`
+    desc_targets=`dotnet trxml2 desc.xml | grep '/desc/targets'`
     if [ "${PIPESTATUS[0]}" -ne 0 ]
     then
         echo "The desc.xml for $testname is malformed. Skipping."
@@ -336,7 +336,7 @@ do
     if [ "$filter" == "agnostic" ]
     then
         # Test whether the grammars have actions.
-        count=`dotnet trparse -- -t antlr4 *.g4 2> /dev/null | dotnet trxgrep -- ' //(actionBlock | argActionBlock)' | dotnet trtext -- -c`
+        count=`dotnet trparse -t ANTLRv4 *.g4 2> /dev/null | dotnet trxgrep -- ' //(actionBlock | argActionBlock)' | dotnet trtext -- -c`
         if [ "$count" == "0" ]
         then
             echo "no actions => skipping $testname."
@@ -348,7 +348,7 @@ do
     # Generate driver source code.
 
     if [ $quiet != "true" ]; then echo "Generating driver for $testname."; fi
-    bad=`dotnet trgen -- -t "$target" --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar 2> /dev/null`
+    bad=`dotnet trgen -t "$target" --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar 2> /dev/null`
     for i in $bad; do failed+=( "$testname/$target" ); done
 
     for d in `echo Generated-$target-* Generated-$target`

--- a/_scripts/test-static-checks.sh
+++ b/_scripts/test-static-checks.sh
@@ -345,7 +345,7 @@ do
     if [ "$filter" == "agnostic" ]
     then
         # Test whether the grammars have actions.
-        count=`dotnet trparse -- -t antlr4 *.g4 2> /dev/null | dotnet trxgrep ' //(actionBlock | argActionBlock)' | dotnet trtext -c`
+        count=`dotnet trparse -t ANTLRv4 *.g4 2> /dev/null | dotnet trxgrep ' //(actionBlock | argActionBlock)' | dotnet trtext -c`
         if [ "$count" == "0" ]
         then
             echo "no actions => skipping $testname."
@@ -378,7 +378,7 @@ do
 
     if [ "$target" == "ambiguity" ]
     then
-        dotnet trgen -- -t CSharp --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar
+        dotnet trgen -t CSharp --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar
 	if [ $? -ne 0 ]
 	then
             echo "::warning file=$testname,line=0,col=0,endColumn=0::Cannot test ambiguity, non-zero return from trgen."

--- a/_scripts/test.ps1
+++ b/_scripts/test.ps1
@@ -20,7 +20,7 @@ function Get-GrammarSkip {
         Write-Host "Intentionally skipping grammar $Grammar target $Target."
         return $True
     }
-    $desc_targets = dotnet trxml2 -- "$Grammar/desc.xml" | Select-String '/desc/targets'
+    $desc_targets = dotnet trxml2 "$Grammar/desc.xml" | Select-String '/desc/targets'
     if ($LASTEXITCODE -ne 0) {
         Write-Host "The desc.xml for $testname is malformed. Skipping."
         return $True
@@ -68,8 +68,8 @@ function Test-Grammar {
     $start = Get-Date
     Write-Host "Building"
     # codegen
-    Write-Host "dotnet trgen -- -t $Target --template-sources-directory $templates"
-    dotnet trgen -- -t $Target --template-sources-directory $templates | Write-Host
+    Write-Host "dotnet trgen -t $Target --template-sources-directory $templates"
+    dotnet trgen -t $Target --template-sources-directory $templates | Write-Host
     if ($LASTEXITCODE -ne 0) {
         $failStage = [FailStage]::CodeGeneration
         Write-Host "trgen failed" -ForegroundColor Red
@@ -252,7 +252,7 @@ function Get-ChangedGrammars {
             Set-Location "$old"
             continue
         }
-        $desc_targets = dotnet trxml2 -- desc.xml | Select-String '/desc/targets'
+        $desc_targets = dotnet trxml2 desc.xml | Select-String '/desc/targets'
         if ($LASTEXITCODE -ne 0) {
             Write-Host "The desc.xml for $testname is malformed. Skipping."
             Set-Location "$old"

--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -308,7 +308,7 @@ do
         popd > /dev/null
         continue
     fi
-    desc_targets=`dotnet trxml2 -- desc.xml | grep '/desc/targets'`
+    desc_targets=`dotnet trxml2 desc.xml | grep '/desc/targets'`
     if [ "${PIPESTATUS[0]}" -ne 0 ]
     then
         echo "The desc.xml for $testname is malformed. Skipping."
@@ -336,7 +336,7 @@ do
     if [ "$filter" == "agnostic" ]
     then
         # Test whether the grammars have actions.
-        count=`dotnet trparse -- -t antlr4 *.g4 2> /dev/null | dotnet trxgrep ' //(actionBlock | argActionBlock)' | dotnet trtext -c`
+        count=`dotnet trparse -t ANTLRv4 *.g4 2> /dev/null | dotnet trxgrep ' //(actionBlock | argActionBlock)' | dotnet trtext -c`
         if [ "$count" == "0" ]
         then
             echo "no actions => skipping $testname."
@@ -348,7 +348,7 @@ do
     # Generate driver source code.
 
     if [ $quiet != "true" ]; then echo "Generating driver for $testname."; fi
-    bad=`dotnet trgen -- -t "$target" --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar 2> /dev/null`
+    bad=`dotnet trgen -t "$target" --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar 2> /dev/null`
     for i in $bad; do failed+=( "$testname/$target" ); done
 
     for d in `echo Generated-$target-* Generated-$target`

--- a/_scripts/what-to-test.sh
+++ b/_scripts/what-to-test.sh
@@ -34,7 +34,7 @@ do
     fi
     if [ -f desc.xml ]
     then
-        gtargets=`dotnet trxml2 -- desc.xml | fgrep -e '/desc/targets' | awk -F = '{print $2}' | sed 's/;/ /g'`
+        gtargets=`dotnet trxml2 desc.xml | fgrep -e '/desc/targets' | awk -F = '{print $2}' | sed 's/;/ /g'`
         for t in $gtargets
         do
             targets[$t]=`expr ${targets[$t]} + 1`


### PR DESCRIPTION
Dotnet 8 functionality changed sometime over the last year with one of the "minor" revisions. Or CommandLineParser changed.   But the cause was irrelevant. `dotnet trgen -- --version` was printing an error not the version of the tool.

Also, `trparse` doesn't support `-t antlr4` anymore ([not since four months ago](https://github.com/kaby76/Trash/blame/main/src/trparse/Grun.cs#L239)), so [test-cover.sh](https://github.com/antlr/grammars-v4/blob/c82c128d980f4ce46fb3536f87b06b45b9619922/_scripts/test-cover.sh#L339) wasn't working perfectly in detecting grammars with actions--and then removing them from consideration. That was changed to `-t ANTLRv4`.

I'm also updating the Trash Toolkit to the latest as it takes care of this with its built-in templates, and fixes the analysis of the .g4s for a grammar.