### PR TITLE
Fix case *_ error

### DIFF
--- a/python/python3_12/PythonParser.g4
+++ b/python/python3_12/PythonParser.g4
@@ -27,6 +27,11 @@ THE SOFTWARE.
   *
   */
 
+  /*
+   * Contributors :
+   * [Willie Shen](https://github.com/Willie169) : Fix that `case [a, *_] if a == 0:` throws error `rule soft_kw__not__wildcard failed predicate: {this.isnotEqualToCurrentTokenText("_")}?`
+  */
+
 parser grammar PythonParser; // Python 3.12.6  https://docs.python.org/3.12/reference/grammar.html#full-grammar-specification
 options {
     tokenVocab=PythonLexer;
@@ -427,8 +432,7 @@ maybe_star_pattern
     | pattern;
 
 star_pattern
-    : '*' pattern_capture_target
-    | '*' wildcard_pattern;
+    : '*' NAME;
 
 mapping_pattern
     : LBRACE RBRACE

--- a/python/python3_12/changes.md
+++ b/python/python3_12/changes.md
@@ -5,3 +5,8 @@ Type comments will now be tokenized as plain comment tokens.
 
 Line continuation for string literals (backslash followed by a newline) is no longer resolved.
 (backslash+newline is no longer removed from string literals)
+
+---
+Oct. 18, 2024
+---
+Fix that `case [a, *_] if a == 0:` throws error `rule soft_kw__not__wildcard failed predicate: {this.isnotEqualToCurrentTokenText("_")}?`

--- a/python/python3_12/tests/test_match_case.py
+++ b/python/python3_12/tests/test_match_case.py
@@ -1,0 +1,16 @@
+# COMMAND LINE:
+# grun Python file_input -tokens test_match_case.py
+#
+# EXPECTATIONS:
+#   - [@63,234:234='*',<'*'>,12:13]
+#   - [@64,235:235='_',<NAME>,12:14]
+#   - no error message
+
+a, *b = [1, 2, 3, 4]
+match b:
+    case [2]:
+        print("0")
+    case [f, *_] if f==2:
+        print("1")
+    case _:
+        print("2")


### PR DESCRIPTION
Fix that `case [a, *_] if a == 0:` throws error `rule soft_kw__not__wildcard failed predicate: {this.isnotEqualToCurrentTokenText("_")}?`