### PR TITLE
[build] Fix ClickHouse pom typo

### DIFF
--- a/sql/clickhouse/pom.xml
+++ b/sql/clickhouse/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>clickhouse</artifactId>
     <packaging>jar</packaging>
-    <name>Clickhouse grammar</name>
+    <name>ClickHouse grammar</name>
     <parent>
         <groupId>org.antlr.grammars</groupId>
         <artifactId>sqlparent</artifactId>
@@ -18,8 +18,8 @@
                 <configuration>
                     <sourceDirectory>${basedir}</sourceDirectory>
                     <includes>
-                        <include>ClickhouseLexer.g4</include>
-                        <include>ClickhouseParser.g4</include>
+                        <include>ClickHouseLexer.g4</include>
+                        <include>ClickHouseParser.g4</include>
                     </includes>
                     <visitor>true</visitor>
                     <listener>true</listener>
@@ -40,7 +40,7 @@
                     <verbose>true</verbose>
                     <showTree>true</showTree>
                     <entryPoint>queryStmt</entryPoint>
-                    <grammarName>clickhouse</grammarName>
+                    <grammarName>ClickHouse</grammarName>
                     <packageName></packageName>
                     <exampleFiles>examples</exampleFiles>
                 </configuration>


### PR DESCRIPTION
There's a build error, and it's easy to fix.

before:
![5C4DA950A021668DFCF2377934810BEC](https://github.com/user-attachments/assets/e3973dc6-3194-4719-a9b0-f897f36bc5b6)

after:
![QQ_1728973465996](https://github.com/user-attachments/assets/a8759aba-6653-4763-af82-cc42b94583c4)
