### PR TITLE
Changes withElement definition to be closer to CQL3 specification

### DIFF
--- a/cql3/CqlParser.g4
+++ b/cql3/CqlParser.g4
@@ -391,15 +391,16 @@ createTable
     ;
 
 withElement
-    : kwWith tableOptions? clusteringOrder?
-    ;
-
-clusteringOrder
-    : kwClustering kwOrder kwBy syntaxBracketLr column orderDirection? syntaxBracketRr
+    : kwWith tableOptions?
     ;
 
 tableOptions
-    : tableOptionItem (kwAnd tableOptionItem)*
+    : clusteringOrder (kwAnd tableOptionItem)*
+    | tableOptionItem (kwAnd tableOptionItem)*
+    ;
+
+clusteringOrder
+    : kwClustering kwOrder kwBy syntaxBracketLr (column orderDirection?) (syntaxComma column orderDirection?)* syntaxBracketRr
     ;
 
 tableOptionItem

--- a/cql3/CqlParser.g4
+++ b/cql3/CqlParser.g4
@@ -391,11 +391,12 @@ createTable
     ;
 
 withElement
-    : kwWith tableOptions?
+    : kwWith tableOptions
     ;
 
 tableOptions
-    : clusteringOrder (kwAnd tableOptionItem)*
+    : kwCompact kwStorage (kwAnd tableOptions)?
+    | clusteringOrder (kwAnd tableOptions)?
     | tableOptionItem (kwAnd tableOptionItem)*
     ;
 

--- a/cql3/examples/clusteringOrder.cql
+++ b/cql3/examples/clusteringOrder.cql
@@ -1,0 +1,8 @@
+CREATE TABLE cycling.race_winners (
+   a int,
+   b int,
+   c int,
+   PRIMARY KEY ((a), b, c)
+)
+WITH CLUSTERING ORDER BY (b ASC, c DESC)
+AND default_time_to_live = 300;

--- a/cql3/examples/tableOptions.cql
+++ b/cql3/examples/tableOptions.cql
@@ -4,5 +4,6 @@ CREATE TABLE cycling.race_winners (
    c int,
    PRIMARY KEY ((a), b, c)
 )
-WITH CLUSTERING ORDER BY (b ASC, c DESC)
+WITH COMPACT STORAGE
+AND CLUSTERING ORDER BY (b ASC, c DESC)
 AND default_time_to_live = 300;

--- a/cql3/examples/tableOptions.cql
+++ b/cql3/examples/tableOptions.cql
@@ -1,4 +1,4 @@
-CREATE TABLE cycling.race_winners (
+CREATE TABLE alphabet (
    a int,
    b int,
    c int,


### PR DESCRIPTION
This PR adds support the following:

1. Specifying `COMPACT STORAGE`.
2. Specifying the order of more than one clustering key.
3. Allowing for additional table options after `WITH CLUSTERING ORDER`.

All the above are allowed in CQL3. See the relevant section of the spec: https://cassandra.apache.org/doc/stable/cassandra/cql/ddl.html#create-table-statement

I believe the following changes are mostly backwards-compatible, with the exception of `clusteringOrder` moving from `withElement` to `tableOptions`.