### PR TITLE
Fix the definition of interfaces for typescript

### DIFF
--- a/javascript/typescript/CSharp/TypeScriptParserBase.cs
+++ b/javascript/typescript/CSharp/TypeScriptParserBase.cs
@@ -53,10 +53,10 @@ public abstract class TypeScriptParserBase : Parser
         return !here(LineTerminator);
     }
 
-    protected bool notOpenBraceAndNotFunction()
+    protected bool notOpenBraceAndNotFunctionAndNotInterface()
     {
         int nextTokenType = _input.LT(1).Type;
-        return nextTokenType != OpenBrace && nextTokenType != Function_;
+        return nextTokenType != OpenBrace && nextTokenType != Function_ && nextTokenType != Interface;
     }
 
     protected bool closeBrace()

--- a/javascript/typescript/Cpp/TypeScriptParserBase.cpp
+++ b/javascript/typescript/Cpp/TypeScriptParserBase.cpp
@@ -31,11 +31,11 @@ bool TypeScriptParserBase::notLineTerminator()
     return !here(TypeScriptParser::LineTerminator);
 }
 
-bool TypeScriptParserBase::notOpenBraceAndNotFunction()
+bool TypeScriptParserBase::notOpenBraceAndNotFunctionAndNotInterface()
 {
     int nextTokenType = _input->LT(1)->getType();
-    return nextTokenType != TypeScriptParser::OpenBrace && nextTokenType != TypeScriptParser::Function_;
-
+    return nextTokenType != TypeScriptParser::OpenBrace && nextTokenType != TypeScriptParser::Function_
+            && nextTokenType != TypeScriptParser::Interface;
 }
 
 bool TypeScriptParserBase::closeBrace()

--- a/javascript/typescript/Cpp/TypeScriptParserBase.h
+++ b/javascript/typescript/Cpp/TypeScriptParserBase.h
@@ -10,7 +10,7 @@ public:
     bool n(std::string str);
     bool next(std::string str);
     bool notLineTerminator();
-    bool notOpenBraceAndNotFunction();
+    bool notOpenBraceAndNotFunctionAndNotInterface();
     bool closeBrace();
     bool here(int type);
     bool lineTerminatorAhead();

--- a/javascript/typescript/Java/TypeScriptParserBase.java
+++ b/javascript/typescript/Java/TypeScriptParserBase.java
@@ -42,9 +42,10 @@ public abstract class TypeScriptParserBase extends Parser
         return !here(TypeScriptParser.LineTerminator);
     }
 
-    protected boolean notOpenBraceAndNotFunction() {
+    protected boolean notOpenBraceAndNotFunctionAndNotInterface() {
         int nextTokenType = _input.LT(1).getType();
-        return nextTokenType != TypeScriptParser.OpenBrace && nextTokenType != TypeScriptParser.Function_;
+        return nextTokenType != TypeScriptParser.OpenBrace && nextTokenType != TypeScriptParser.Function_
+                && nextTokenType != TypeScriptParser.Interface;
     }
 
     protected boolean closeBrace() {

--- a/javascript/typescript/TypeScript/TypeScriptParserBase.ts
+++ b/javascript/typescript/TypeScript/TypeScriptParserBase.ts
@@ -43,9 +43,10 @@ export default abstract class TypeScriptParserBase extends Parser {
         return !this.here(TypeScriptParser.LineTerminator);
     }
 
-    protected notOpenBraceAndNotFunction():boolean {
+    protected notOpenBraceAndNotFunctionAndNotInterface():boolean {
         const nextTokenType:number = this._input.LT(1).type;
-        return nextTokenType != TypeScriptParser.OpenBrace && nextTokenType != TypeScriptParser.Function_;
+        return nextTokenType != TypeScriptParser.OpenBrace && nextTokenType != TypeScriptParser.Function_
+            && nextTokenType != TypeScriptParser.Interface;
     }
 
     protected closeBrace():boolean {

--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -345,14 +345,14 @@ sourceElement
 
 statement
     : block
-    | variableStatement    
+    | variableStatement
     | importStatement
     | exportStatement
     | emptyStatement_
     | abstractDeclaration //ADDED
     | classDeclaration
     | functionDeclaration
-    | expressionStatement    
+    | expressionStatement
     | interfaceDeclaration //ADDED
     | namespaceDeclaration //ADDED
     | ifStatement
@@ -476,7 +476,7 @@ emptyStatement_
     ;
 
 expressionStatement
-    : {this.notOpenBraceAndNotFunction()}? expressionSequence SemiColon?
+    : {this.notOpenBraceAndNotFunctionAndNotInterface()}? expressionSequence SemiColon?
     ;
 
 ifStatement
@@ -752,11 +752,11 @@ singleExpression
     | '-' singleExpression                                            # UnaryMinusExpression
     | '~' singleExpression                                            # BitNotExpression
     | '!' singleExpression                                            # NotExpression
-    | Await singleExpression                                          # AwaitExpression    
-    | <assoc = right> singleExpression '**' singleExpression          # PowerExpression    
+    | Await singleExpression                                          # AwaitExpression
+    | <assoc = right> singleExpression '**' singleExpression          # PowerExpression
     | singleExpression ('*' | '/' | '%') singleExpression             # MultiplicativeExpression
     | singleExpression ('+' | '-') singleExpression                   # AdditiveExpression
-    | singleExpression '??' singleExpression                          # CoalesceExpression    
+    | singleExpression '??' singleExpression                          # CoalesceExpression
     | singleExpression ('<<' | '>' '>' | '>' '>' '>') singleExpression # BitShiftExpression
     | singleExpression ('<' | '>' | '<=' | '>=') singleExpression     # RelationalExpression
     | singleExpression Instanceof singleExpression                    # InstanceofExpression
@@ -801,7 +801,7 @@ assignable
     ;
 
 anonymousFunction
-    : functionDeclaration 
+    : functionDeclaration
     | Async? Function_ '*'? '(' formalParameterList? ')' typeAnnotation? '{' functionBody '}'
     | arrowFunctionDeclaration
     ;
@@ -833,7 +833,7 @@ assignmentOperator
     | '^='
     | '|='
     | '**='
-    | '??='    
+    | '??='
     ;
 
 literal
@@ -964,7 +964,7 @@ keyword
     | Static
     | Yield
     | Async
-    | Await        
+    | Await
     | ReadOnly
     | From
     | As


### PR DESCRIPTION
The parser does not define an interface if it does not have the keyword "declare".

Code for example:

```typescript
export declare interface ITest1 {
    name: string;
}

declare interface ITest2 {
    name: string;
}

export interface ITest3 {
    name: string;
}

interface ITest4 {
    name: string;
}
```

<details> 
  <summary>Parser result now</summary>

```
sourceElements
  sourceElement
    export
    statement
      interfaceDeclaration
        declare
        interface
        identifier
          ITest1
        objectType
          {
          typeBody
            typeMemberList
              typeMember
                propertySignatur
                  propertyName
                    identifierName
                      identifier
                        name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
            ;
          }
  sourceElement
    statement
      interfaceDeclaration
        declare
        interface
        identifier
          ITest2
        objectType
          {
          typeBody
            typeMemberList
              typeMember
                propertySignatur
                  propertyName
                    identifierName
                      identifier
                        name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
            ;
          }
  sourceElement
    export
    statement
      expressionStatement
        expressionSequence
          singleExpression
            identifierName
              reservedWord
                keyword
                  interface
            singleExpression
              identifierName
                identifier
                  ITest3
  sourceElement
    statement
      block
        {
        statementList
          statement
            variableStatement
              variableDeclarationList
                variableDeclaration
                  identifierOrKeyWord
                    identifier
                      name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
              ;
        }
  sourceElement
    statement
      expressionStatement
        expressionSequence
          singleExpression
            identifierName
              reservedWord
                keyword
                  interface
            singleExpression
              identifierName
                identifier
                  ITest4
  sourceElement
    statement
      block
        {
        statementList
          statement
            variableStatement
              variableDeclarationList
                variableDeclaration
                  identifierOrKeyWord
                    identifier
                      name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
              ;
        }
```
</details>

Interfaces without "declare" are not recognized as "interfaceDeclaration", for the parser it is "expressionStatement" and "block".

<details> 
  <summary>Parser result with fix</summary>

```
sourceElements
  sourceElement
    export
    statement
      interfaceDeclaration
        declare
        interface
        identifier
          ITest1
        objectType
          {
          typeBody
            typeMemberList
              typeMember
                propertySignatur
                  propertyName
                    identifierName
                      identifier
                        name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
            ;
          }
  sourceElement
    statement
      interfaceDeclaration
        declare
        interface
        identifier
          ITest2
        objectType
          {
          typeBody
            typeMemberList
              typeMember
                propertySignatur
                  propertyName
                    identifierName
                      identifier
                        name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
            ;
          }
  sourceElement
    export
    statement
      interfaceDeclaration
        interface
        identifier
          ITest3
        objectType
          {
          typeBody
            typeMemberList
              typeMember
                propertySignatur
                  propertyName
                    identifierName
                      identifier
                        name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
            ;
          }
  sourceElement
    statement
      interfaceDeclaration
        interface
        identifier
          ITest4
        objectType
          {
          typeBody
            typeMemberList
              typeMember
                propertySignatur
                  propertyName
                    identifierName
                      identifier
                        name
                  typeAnnotation
                    :
                    type_
                      unionOrIntersectionOrPrimaryType
                        primaryType
                          predefinedType
                            string
            ;
          }


```
</details>