### PR TITLE
[postgresql] Fix for #4291 -- non-idiomatic usage of "(foo | )" instead of "foo?"

### DIFF
--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -188,13 +188,13 @@ callstmt
     ;
 
 createrolestmt
-    : CREATE ROLE roleid opt_with optrolelist
+    : CREATE ROLE roleid with_? optrolelist
     ;
 
-opt_with
+with_
     : WITH
     //| WITH_LA
-    |
+    
     ;
 
 optrolelist
@@ -224,20 +224,20 @@ createoptroleelem
     ;
 
 createuserstmt
-    : CREATE USER roleid opt_with optrolelist
+    : CREATE USER roleid with_? optrolelist
     ;
 
 alterrolestmt
-    : ALTER (ROLE | USER) rolespec opt_with alteroptrolelist
+    : ALTER (ROLE | USER) rolespec with_? alteroptrolelist
     ;
 
-opt_in_database
+in_database_
     :
-    | IN_P DATABASE name
+     IN_P DATABASE name
     ;
 
 alterrolesetstmt
-    : ALTER (ROLE | USER) ALL? rolespec opt_in_database setresetclause
+    : ALTER (ROLE | USER) ALL? rolespec in_database_? setresetclause
     ;
 
 droprolestmt
@@ -245,7 +245,7 @@ droprolestmt
     ;
 
 creategroupstmt
-    : CREATE GROUP_P roleid opt_with optrolelist
+    : CREATE GROUP_P roleid with_? optrolelist
     ;
 
 altergroupstmt
@@ -258,12 +258,12 @@ add_drop
     ;
 
 createschemastmt
-    : CREATE SCHEMA (IF_P NOT EXISTS)? (optschemaname AUTHORIZATION rolespec | colid) optschemaeltlist
+    : CREATE SCHEMA (IF_P NOT EXISTS)? (optschemaname? AUTHORIZATION rolespec | colid) optschemaeltlist
     ;
 
 optschemaname
     : colid
-    |
+    
     ;
 
 optschemaeltlist
@@ -299,7 +299,7 @@ set_rest_more
     | TIME ZONE zone_value
     | CATALOG sconst
     | SCHEMA sconst
-    | NAMES opt_encoding
+    | NAMES encoding_?
     | ROLE nonreservedword_or_sconst
     | SESSION AUTHORIZATION nonreservedword_or_sconst
     | XML_P OPTION document_or_content
@@ -315,7 +315,7 @@ var_list
     ;
 
 var_value
-    : opt_boolean_or_string
+    : boolean_or_string_
     | numericonly
     ;
 
@@ -325,7 +325,7 @@ iso_level
     | SERIALIZABLE
     ;
 
-opt_boolean_or_string
+boolean_or_string_
     : TRUE_P
     | FALSE_P
     | ON
@@ -335,17 +335,17 @@ opt_boolean_or_string
 zone_value
     : sconst
     | identifier
-    | constinterval sconst opt_interval
+    | constinterval sconst interval_?
     | constinterval OPEN_PAREN iconst CLOSE_PAREN sconst
     | numericonly
     | DEFAULT
     | LOCAL
     ;
 
-opt_encoding
+encoding_
     : sconst
     | DEFAULT
-    |
+    
     ;
 
 nonreservedword_or_sconst
@@ -407,13 +407,13 @@ discardstmt
 
 altertablestmt
     : ALTER TABLE (IF_P EXISTS)? relation_expr (alter_table_cmds | partition_cmd)
-    | ALTER TABLE ALL IN_P TABLESPACE name (OWNED BY role_list)? SET TABLESPACE name opt_nowait
+    | ALTER TABLE ALL IN_P TABLESPACE name (OWNED BY role_list)? SET TABLESPACE name nowait_?
     | ALTER INDEX (IF_P EXISTS)? qualified_name (alter_table_cmds | index_partition_cmd)
-    | ALTER INDEX ALL IN_P TABLESPACE name (OWNED BY role_list)? SET TABLESPACE name opt_nowait
+    | ALTER INDEX ALL IN_P TABLESPACE name (OWNED BY role_list)? SET TABLESPACE name nowait_?
     | ALTER SEQUENCE (IF_P EXISTS)? qualified_name alter_table_cmds
     | ALTER VIEW (IF_P EXISTS)? qualified_name alter_table_cmds
     | ALTER MATERIALIZED VIEW (IF_P EXISTS)? qualified_name alter_table_cmds
-    | ALTER MATERIALIZED VIEW ALL IN_P TABLESPACE name (OWNED BY role_list)? SET TABLESPACE name opt_nowait
+    | ALTER MATERIALIZED VIEW ALL IN_P TABLESPACE name (OWNED BY role_list)? SET TABLESPACE name nowait_?
     | ALTER FOREIGN TABLE (IF_P EXISTS)? relation_expr alter_table_cmds
     ;
 
@@ -435,29 +435,29 @@ alter_table_cmd
     | ADD_P IF_P NOT EXISTS columnDef
     | ADD_P COLUMN columnDef
     | ADD_P COLUMN IF_P NOT EXISTS columnDef
-    | ALTER opt_column colid alter_column_default
-    | ALTER opt_column colid DROP NOT NULL_P
-    | ALTER opt_column colid SET NOT NULL_P
-    | ALTER opt_column colid DROP EXPRESSION
-    | ALTER opt_column colid DROP EXPRESSION IF_P EXISTS
-    | ALTER opt_column colid SET STATISTICS signediconst
-    | ALTER opt_column iconst SET STATISTICS signediconst
-    | ALTER opt_column colid SET reloptions
-    | ALTER opt_column colid RESET reloptions
-    | ALTER opt_column colid SET STORAGE colid
-    | ALTER opt_column colid ADD_P GENERATED generated_when AS IDENTITY_P optparenthesizedseqoptlist
-    | ALTER opt_column colid alter_identity_column_option_list
-    | ALTER opt_column colid DROP IDENTITY_P
-    | ALTER opt_column colid DROP IDENTITY_P IF_P EXISTS
-    | DROP opt_column IF_P EXISTS colid opt_drop_behavior
-    | DROP opt_column colid opt_drop_behavior
-    | ALTER opt_column colid opt_set_data TYPE_P typename opt_collate_clause alter_using
-    | ALTER opt_column colid alter_generic_options
+    | ALTER column_? colid alter_column_default
+    | ALTER column_? colid DROP NOT NULL_P
+    | ALTER column_? colid SET NOT NULL_P
+    | ALTER column_? colid DROP EXPRESSION
+    | ALTER column_? colid DROP EXPRESSION IF_P EXISTS
+    | ALTER column_? colid SET STATISTICS signediconst
+    | ALTER column_? iconst SET STATISTICS signediconst
+    | ALTER column_? colid SET reloptions
+    | ALTER column_? colid RESET reloptions
+    | ALTER column_? colid SET STORAGE colid
+    | ALTER column_? colid ADD_P GENERATED generated_when AS IDENTITY_P optparenthesizedseqoptlist?
+    | ALTER column_? colid alter_identity_column_option_list
+    | ALTER column_? colid DROP IDENTITY_P
+    | ALTER column_? colid DROP IDENTITY_P IF_P EXISTS
+    | DROP column_? IF_P EXISTS colid drop_behavior_?
+    | DROP column_? colid drop_behavior_?
+    | ALTER column_? colid set_data_? TYPE_P typename collate_clause_? alter_using?
+    | ALTER column_? colid alter_generic_options
     | ADD_P tableconstraint
     | ALTER CONSTRAINT name constraintattributespec
     | VALIDATE CONSTRAINT name
-    | DROP CONSTRAINT IF_P EXISTS name opt_drop_behavior
-    | DROP CONSTRAINT name opt_drop_behavior
+    | DROP CONSTRAINT IF_P EXISTS name drop_behavior_?
+    | DROP CONSTRAINT name drop_behavior_?
     | SET WITHOUT OIDS
     | CLUSTER ON name
     | SET WITHOUT CLUSTER
@@ -496,20 +496,20 @@ alter_column_default
     | DROP DEFAULT
     ;
 
-opt_drop_behavior
+drop_behavior_
     : CASCADE
     | RESTRICT
-    |
+    
     ;
 
-opt_collate_clause
+collate_clause_
     : COLLATE any_name
-    |
+    
     ;
 
 alter_using
     : USING a_expr
-    |
+    
     ;
 
 replica_identity
@@ -523,9 +523,9 @@ reloptions
     : OPEN_PAREN reloption_list CLOSE_PAREN
     ;
 
-opt_reloptions
+reloptions_
     : WITH reloptions
-    |
+    
     ;
 
 reloption_list
@@ -541,7 +541,7 @@ alter_identity_column_option_list
     ;
 
 alter_identity_column_option
-    : RESTART (opt_with numericonly)?
+    : RESTART (with_? numericonly)?
     | SET (seqoptelem | GENERATED generated_when)
     ;
 
@@ -569,9 +569,9 @@ alter_type_cmds
     ;
 
 alter_type_cmd
-    : ADD_P ATTRIBUTE tablefuncelement opt_drop_behavior
-    | DROP ATTRIBUTE (IF_P EXISTS)? colid opt_drop_behavior
-    | ALTER ATTRIBUTE colid opt_set_data TYPE_P typename opt_collate_clause opt_drop_behavior
+    : ADD_P ATTRIBUTE tablefuncelement drop_behavior_?
+    | DROP ATTRIBUTE (IF_P EXISTS)? colid drop_behavior_?
+    | ALTER ATTRIBUTE colid set_data_? TYPE_P typename collate_clause_? drop_behavior_?
     ;
 
 closeportalstmt
@@ -579,8 +579,8 @@ closeportalstmt
     ;
 
 copystmt
-    : COPY opt_binary qualified_name opt_column_list copy_from opt_program copy_file_name copy_delimiter opt_with copy_options where_clause
-    | COPY OPEN_PAREN preparablestmt CLOSE_PAREN TO opt_program copy_file_name opt_with copy_options
+    : COPY binary_? qualified_name column_list_? copy_from program_? copy_file_name copy_delimiter? with_? copy_options where_clause?
+    | COPY OPEN_PAREN preparablestmt CLOSE_PAREN TO program_? copy_file_name with_? copy_options
     ;
 
 copy_from
@@ -588,9 +588,9 @@ copy_from
     | TO
     ;
 
-opt_program
+program_
     : PROGRAM
-    |
+    
     ;
 
 copy_file_name
@@ -611,12 +611,12 @@ copy_opt_list
 copy_opt_item
     : BINARY
     | FREEZE
-    | DELIMITER opt_as sconst
-    | NULL_P opt_as sconst
+    | DELIMITER as_? sconst
+    | NULL_P as_? sconst
     | CSV
     | HEADER_P
-    | QUOTE opt_as sconst
-    | ESCAPE opt_as sconst
+    | QUOTE as_? sconst
+    | ESCAPE as_? sconst
     | FORCE QUOTE columnlist
     | FORCE QUOTE STAR
     | FORCE NOT NULL_P columnlist
@@ -624,19 +624,19 @@ copy_opt_item
     | ENCODING sconst
     ;
 
-opt_binary
+binary_
     : BINARY
-    |
+    
     ;
 
 copy_delimiter
-    : opt_using DELIMITERS sconst
-    |
+    : using_? DELIMITERS sconst
+    
     ;
 
-opt_using
+using_
     : USING
-    |
+    
     ;
 
 copy_generic_opt_list
@@ -644,15 +644,15 @@ copy_generic_opt_list
     ;
 
 copy_generic_opt_elem
-    : collabel copy_generic_opt_arg
+    : collabel copy_generic_opt_arg?
     ;
 
 copy_generic_opt_arg
-    : opt_boolean_or_string
+    : boolean_or_string_
     | numericonly
     | STAR
     | OPEN_PAREN copy_generic_opt_arg_list CLOSE_PAREN
-    |
+    
     ;
 
 copy_generic_opt_arg_list
@@ -660,15 +660,15 @@ copy_generic_opt_arg_list
     ;
 
 copy_generic_opt_arg_list_item
-    : opt_boolean_or_string
+    : boolean_or_string_
     ;
 
 createstmt
-    : CREATE opttemp TABLE (IF_P NOT EXISTS)? qualified_name (
-        OPEN_PAREN opttableelementlist CLOSE_PAREN optinherit optpartitionspec table_access_method_clause optwith oncommitoption opttablespace
-        | OF any_name opttypedtableelementlist optpartitionspec table_access_method_clause optwith oncommitoption opttablespace
-        | PARTITION OF qualified_name opttypedtableelementlist partitionboundspec optpartitionspec table_access_method_clause optwith oncommitoption
-            opttablespace
+    : CREATE opttemp? TABLE (IF_P NOT EXISTS)? qualified_name (
+        OPEN_PAREN opttableelementlist? CLOSE_PAREN optinherit? optpartitionspec? table_access_method_clause? optwith? oncommitoption? opttablespace?
+        | OF any_name opttypedtableelementlist? optpartitionspec? table_access_method_clause? optwith? oncommitoption? opttablespace?
+        | PARTITION OF qualified_name opttypedtableelementlist? partitionboundspec optpartitionspec? table_access_method_clause? optwith? oncommitoption?
+            opttablespace?
     )
     ;
 
@@ -678,17 +678,17 @@ opttemp
     | LOCAL (TEMPORARY | TEMP)
     | GLOBAL (TEMPORARY | TEMP)
     | UNLOGGED
-    |
+    
     ;
 
 opttableelementlist
     : tableelementlist
-    |
+    
     ;
 
 opttypedtableelementlist
     : OPEN_PAREN typedtableelementlist CLOSE_PAREN
-    |
+    
     ;
 
 tableelementlist
@@ -711,7 +711,7 @@ typedtableelement
     ;
 
 columnDef
-    : colid typename create_generic_options colquallist
+    : colid typename create_generic_options? colquallist
     ;
 
 columnOptions
@@ -732,15 +732,15 @@ colconstraint
 colconstraintelem
     : NOT NULL_P
     | NULL_P
-    | UNIQUE opt_definition optconstablespace
-    | PRIMARY KEY opt_definition optconstablespace
-    | CHECK OPEN_PAREN a_expr CLOSE_PAREN opt_no_inherit
+    | UNIQUE definition_? optconstablespace?
+    | PRIMARY KEY definition_? optconstablespace?
+    | CHECK OPEN_PAREN a_expr CLOSE_PAREN no_inherit_?
     | DEFAULT b_expr
     | GENERATED generated_when AS (
-        IDENTITY_P optparenthesizedseqoptlist
+        IDENTITY_P optparenthesizedseqoptlist?
         | OPEN_PAREN a_expr CLOSE_PAREN STORED
     )
-    | REFERENCES qualified_name opt_column_list key_match key_actions
+    | REFERENCES qualified_name column_list_? key_match? key_actions?
     ;
 
 generated_when
@@ -782,26 +782,26 @@ tableconstraint
 constraintelem
     : CHECK OPEN_PAREN a_expr CLOSE_PAREN constraintattributespec
     | UNIQUE (
-        OPEN_PAREN columnlist CLOSE_PAREN opt_c_include opt_definition optconstablespace constraintattributespec
+        OPEN_PAREN columnlist CLOSE_PAREN c_include_? definition_? optconstablespace? constraintattributespec
         | existingindex constraintattributespec
     )
     | PRIMARY KEY (
-        OPEN_PAREN columnlist CLOSE_PAREN opt_c_include opt_definition optconstablespace constraintattributespec
+        OPEN_PAREN columnlist CLOSE_PAREN c_include_? definition_? optconstablespace? constraintattributespec
         | existingindex constraintattributespec
     )
-    | EXCLUDE access_method_clause OPEN_PAREN exclusionconstraintlist CLOSE_PAREN opt_c_include opt_definition optconstablespace exclusionwhereclause
+    | EXCLUDE access_method_clause? OPEN_PAREN exclusionconstraintlist CLOSE_PAREN c_include_? definition_? optconstablespace? exclusionwhereclause?
         constraintattributespec
-    | FOREIGN KEY OPEN_PAREN columnlist CLOSE_PAREN REFERENCES qualified_name opt_column_list key_match key_actions constraintattributespec
+    | FOREIGN KEY OPEN_PAREN columnlist CLOSE_PAREN REFERENCES qualified_name column_list_? key_match? key_actions? constraintattributespec
     ;
 
-opt_no_inherit
+no_inherit_
     : NO INHERIT
-    |
+    
     ;
 
-opt_column_list
+column_list_
     : OPEN_PAREN columnlist CLOSE_PAREN
-    |
+    
     ;
 
 columnlist
@@ -812,14 +812,14 @@ columnElem
     : colid
     ;
 
-opt_c_include
+c_include_
     : INCLUDE OPEN_PAREN columnlist CLOSE_PAREN
-    |
+    
     ;
 
 key_match
     : MATCH (FULL | PARTIAL | SIMPLE)
-    |
+    
     ;
 
 exclusionconstraintlist
@@ -832,7 +832,7 @@ exclusionconstraintelem
 
 exclusionwhereclause
     : WHERE OPEN_PAREN a_expr CLOSE_PAREN
-    |
+    
     ;
 
 key_actions
@@ -840,7 +840,7 @@ key_actions
     | key_delete
     | key_update key_delete
     | key_delete key_update
-    |
+    
     ;
 
 key_update
@@ -860,12 +860,12 @@ key_action
 
 optinherit
     : INHERITS OPEN_PAREN qualified_name_list CLOSE_PAREN
-    |
+    
     ;
 
 optpartitionspec
     : partitionspec
-    |
+    
     ;
 
 partitionspec
@@ -877,35 +877,35 @@ part_params
     ;
 
 part_elem
-    : colid opt_collate opt_class
-    | func_expr_windowless opt_collate opt_class
-    | OPEN_PAREN a_expr CLOSE_PAREN opt_collate opt_class
+    : colid collate_? class_?
+    | func_expr_windowless collate_? class_?
+    | OPEN_PAREN a_expr CLOSE_PAREN collate_? class_?
     ;
 
 table_access_method_clause
     : USING name
-    |
+    
     ;
 
 optwith
     : WITH reloptions
     | WITHOUT OIDS
-    |
+    
     ;
 
 oncommitoption
     : ON COMMIT (DROP | DELETE_P ROWS | PRESERVE ROWS)
-    |
+    
     ;
 
 opttablespace
     : TABLESPACE name
-    |
+    
     ;
 
 optconstablespace
     : USING INDEX TABLESPACE name
-    |
+    
     ;
 
 existingindex
@@ -913,7 +913,7 @@ existingindex
     ;
 
 createstatsstmt
-    : CREATE STATISTICS (IF_P NOT EXISTS)? any_name opt_name_list ON expr_list FROM from_list
+    : CREATE STATISTICS (IF_P NOT EXISTS)? any_name name_list_? ON expr_list FROM from_list
     ;
 
 alterstatsstmt
@@ -921,37 +921,37 @@ alterstatsstmt
     ;
 
 createasstmt
-    : CREATE opttemp TABLE (IF_P NOT EXISTS)? create_as_target AS selectstmt opt_with_data
+    : CREATE opttemp? TABLE (IF_P NOT EXISTS)? create_as_target AS selectstmt with_data_?
     ;
 
 create_as_target
-    : qualified_name opt_column_list table_access_method_clause optwith oncommitoption opttablespace
+    : qualified_name column_list_? table_access_method_clause? optwith? oncommitoption? opttablespace?
     ;
 
-opt_with_data
+with_data_
     : WITH (DATA_P | NO DATA_P)
-    |
+    
     ;
 
 creatematviewstmt
-    : CREATE optnolog MATERIALIZED VIEW (IF_P NOT EXISTS)? create_mv_target AS selectstmt opt_with_data
+    : CREATE optnolog? MATERIALIZED VIEW (IF_P NOT EXISTS)? create_mv_target AS selectstmt with_data_?
     ;
 
 create_mv_target
-    : qualified_name opt_column_list table_access_method_clause opt_reloptions opttablespace
+    : qualified_name column_list_? table_access_method_clause? reloptions_? opttablespace?
     ;
 
 optnolog
     : UNLOGGED
-    |
+    
     ;
 
 refreshmatviewstmt
-    : REFRESH MATERIALIZED VIEW opt_concurrently qualified_name opt_with_data
+    : REFRESH MATERIALIZED VIEW concurrently_? qualified_name with_data_?
     ;
 
 createseqstmt
-    : CREATE opttemp SEQUENCE (IF_P NOT EXISTS)? qualified_name optseqoptlist
+    : CREATE opttemp? SEQUENCE (IF_P NOT EXISTS)? qualified_name optseqoptlist?
     ;
 
 alterseqstmt
@@ -960,12 +960,12 @@ alterseqstmt
 
 optseqoptlist
     : seqoptlist
-    |
+    
     ;
 
 optparenthesizedseqoptlist
     : OPEN_PAREN seqoptlist CLOSE_PAREN
-    |
+    
     ;
 
 seqoptlist
@@ -976,19 +976,19 @@ seqoptelem
     : AS simpletypename
     | CACHE numericonly
     | CYCLE
-    | INCREMENT opt_by numericonly
+    | INCREMENT by_? numericonly
     | MAXVALUE numericonly
     | MINVALUE numericonly
     | NO (MAXVALUE | MINVALUE | CYCLE)
     | OWNED BY any_name
     | SEQUENCE NAME_P any_name
-    | START opt_with numericonly
-    | RESTART opt_with numericonly?
+    | START with_? numericonly
+    | RESTART with_? numericonly?
     ;
 
-opt_by
+by_
     : BY
-    |
+    
     ;
 
 numericonly
@@ -1003,23 +1003,23 @@ numericonly_list
     ;
 
 createplangstmt
-    : CREATE opt_or_replace opt_trusted opt_procedural LANGUAGE name (
-        HANDLER handler_name opt_inline_handler opt_validator
+    : CREATE or_replace_? trusted_? procedural_? LANGUAGE name (
+        HANDLER handler_name inline_handler_? validator_?
     )?
     ;
 
-opt_trusted
+trusted_
     : TRUSTED
-    |
+    
     ;
 
 handler_name
     : name attrs?
     ;
 
-opt_inline_handler
+inline_handler_
     : INLINE_P handler_name
-    |
+    
     ;
 
 validator_clause
@@ -1027,23 +1027,23 @@ validator_clause
     | NO VALIDATOR
     ;
 
-opt_validator
+validator_
     : validator_clause
-    |
+    
     ;
 
-opt_procedural
+procedural_
     : PROCEDURAL
-    |
+    
     ;
 
 createtablespacestmt
-    : CREATE TABLESPACE name opttablespaceowner LOCATION sconst opt_reloptions
+    : CREATE TABLESPACE name opttablespaceowner? LOCATION sconst reloptions_?
     ;
 
 opttablespaceowner
     : OWNER rolespec
-    |
+    
     ;
 
 droptablespacestmt
@@ -1051,7 +1051,7 @@ droptablespacestmt
     ;
 
 createextensionstmt
-    : CREATE EXTENSION (IF_P NOT EXISTS)? name opt_with create_extension_opt_list
+    : CREATE EXTENSION (IF_P NOT EXISTS)? name with_? create_extension_opt_list
     ;
 
 create_extension_opt_list
@@ -1094,7 +1094,7 @@ alterextensioncontentsstmt
     ;
 
 createfdwstmt
-    : CREATE FOREIGN DATA_P WRAPPER name opt_fdw_options create_generic_options
+    : CREATE FOREIGN DATA_P WRAPPER name fdw_options_? create_generic_options?
     ;
 
 fdw_option
@@ -1108,19 +1108,19 @@ fdw_options
     : fdw_option+
     ;
 
-opt_fdw_options
+fdw_options_
     : fdw_options
-    |
+    
     ;
 
 alterfdwstmt
-    : ALTER FOREIGN DATA_P WRAPPER name opt_fdw_options alter_generic_options
+    : ALTER FOREIGN DATA_P WRAPPER name fdw_options_? alter_generic_options
     | ALTER FOREIGN DATA_P WRAPPER name fdw_options
     ;
 
 create_generic_options
     : OPTIONS OPEN_PAREN generic_option_list CLOSE_PAREN
-    |
+    
     ;
 
 generic_option_list
@@ -1155,22 +1155,22 @@ generic_option_arg
     ;
 
 createforeignserverstmt
-    : CREATE SERVER name opt_type opt_foreign_server_version FOREIGN DATA_P WRAPPER name create_generic_options
-    | CREATE SERVER IF_P NOT EXISTS name opt_type opt_foreign_server_version FOREIGN DATA_P WRAPPER name create_generic_options
+    : CREATE SERVER name type_? foreign_server_version_? FOREIGN DATA_P WRAPPER name create_generic_options?
+    | CREATE SERVER IF_P NOT EXISTS name type_? foreign_server_version_? FOREIGN DATA_P WRAPPER name create_generic_options?
     ;
 
-opt_type
+type_
     : TYPE_P sconst
-    |
+    
     ;
 
 foreign_server_version
     : VERSION_P (sconst | NULL_P)
     ;
 
-opt_foreign_server_version
+foreign_server_version_
     : foreign_server_version
-    |
+    
     ;
 
 alterforeignserverstmt
@@ -1178,15 +1178,15 @@ alterforeignserverstmt
     ;
 
 createforeigntablestmt
-    : CREATE FOREIGN TABLE qualified_name OPEN_PAREN opttableelementlist CLOSE_PAREN optinherit SERVER name create_generic_options
-    | CREATE FOREIGN TABLE IF_P NOT EXISTS qualified_name OPEN_PAREN opttableelementlist CLOSE_PAREN optinherit SERVER name create_generic_options
-    | CREATE FOREIGN TABLE qualified_name PARTITION OF qualified_name opttypedtableelementlist partitionboundspec SERVER name create_generic_options
-    | CREATE FOREIGN TABLE IF_P NOT EXISTS qualified_name PARTITION OF qualified_name opttypedtableelementlist partitionboundspec SERVER name
-        create_generic_options
+    : CREATE FOREIGN TABLE qualified_name OPEN_PAREN opttableelementlist? CLOSE_PAREN optinherit? SERVER name create_generic_options?
+    | CREATE FOREIGN TABLE IF_P NOT EXISTS qualified_name OPEN_PAREN opttableelementlist? CLOSE_PAREN optinherit? SERVER name create_generic_options?
+    | CREATE FOREIGN TABLE qualified_name PARTITION OF qualified_name opttypedtableelementlist? partitionboundspec SERVER name create_generic_options?
+    | CREATE FOREIGN TABLE IF_P NOT EXISTS qualified_name PARTITION OF qualified_name opttypedtableelementlist? partitionboundspec SERVER name
+        create_generic_options?
     ;
 
 importforeignschemastmt
-    : IMPORT_P FOREIGN SCHEMA name import_qualification FROM SERVER name INTO name create_generic_options
+    : IMPORT_P FOREIGN SCHEMA name import_qualification? FROM SERVER name INTO name create_generic_options?
     ;
 
 import_qualification_type
@@ -1196,12 +1196,12 @@ import_qualification_type
 
 import_qualification
     : import_qualification_type OPEN_PAREN relation_expr_list CLOSE_PAREN
-    |
+    
     ;
 
 createusermappingstmt
-    : CREATE USER MAPPING FOR auth_ident SERVER name create_generic_options
-    | CREATE USER MAPPING IF_P NOT EXISTS FOR auth_ident SERVER name create_generic_options
+    : CREATE USER MAPPING FOR auth_ident SERVER name create_generic_options?
+    | CREATE USER MAPPING IF_P NOT EXISTS FOR auth_ident SERVER name create_generic_options?
     ;
 
 auth_ident
@@ -1219,42 +1219,42 @@ alterusermappingstmt
     ;
 
 createpolicystmt
-    : CREATE POLICY name ON qualified_name rowsecuritydefaultpermissive rowsecuritydefaultforcmd rowsecuritydefaulttorole rowsecurityoptionalexpr
-        rowsecurityoptionalwithcheck
+    : CREATE POLICY name ON qualified_name rowsecuritydefaultpermissive? rowsecuritydefaultforcmd? rowsecuritydefaulttorole? rowsecurityoptionalexpr?
+        rowsecurityoptionalwithcheck?
     ;
 
 alterpolicystmt
-    : ALTER POLICY name ON qualified_name rowsecurityoptionaltorole rowsecurityoptionalexpr rowsecurityoptionalwithcheck
+    : ALTER POLICY name ON qualified_name rowsecurityoptionaltorole? rowsecurityoptionalexpr? rowsecurityoptionalwithcheck?
     ;
 
 rowsecurityoptionalexpr
     : USING OPEN_PAREN a_expr CLOSE_PAREN
-    |
+    
     ;
 
 rowsecurityoptionalwithcheck
     : WITH CHECK OPEN_PAREN a_expr CLOSE_PAREN
-    |
+    
     ;
 
 rowsecuritydefaulttorole
     : TO role_list
-    |
+    
     ;
 
 rowsecurityoptionaltorole
     : TO role_list
-    |
+    
     ;
 
 rowsecuritydefaultpermissive
     : AS identifier
-    |
+    
     ;
 
 rowsecuritydefaultforcmd
     : FOR row_security_cmd
-    |
+    
     ;
 
 row_security_cmd
@@ -1275,9 +1275,9 @@ am_type
     ;
 
 createtrigstmt
-    : CREATE TRIGGER name triggeractiontime triggerevents ON qualified_name triggerreferencing triggerforspec triggerwhen EXECUTE
+    : CREATE TRIGGER name triggeractiontime triggerevents ON qualified_name triggerreferencing? triggerforspec? triggerwhen? EXECUTE
         function_or_procedure func_name OPEN_PAREN triggerfuncargs CLOSE_PAREN
-    | CREATE CONSTRAINT TRIGGER name AFTER triggerevents ON qualified_name optconstrfromtable constraintattributespec FOR EACH ROW triggerwhen EXECUTE
+    | CREATE CONSTRAINT TRIGGER name AFTER triggerevents ON qualified_name optconstrfromtable? constraintattributespec FOR EACH ROW triggerwhen? EXECUTE
         function_or_procedure func_name OPEN_PAREN triggerfuncargs CLOSE_PAREN
     ;
 
@@ -1301,7 +1301,7 @@ triggeroneevent
 
 triggerreferencing
     : REFERENCING triggertransitions
-    |
+    
     ;
 
 triggertransitions
@@ -1309,7 +1309,7 @@ triggertransitions
     ;
 
 triggertransition
-    : transitionoldornew transitionrowortable opt_as transitionrelname
+    : transitionoldornew transitionrowortable as_? transitionrelname
     ;
 
 transitionoldornew
@@ -1327,13 +1327,13 @@ transitionrelname
     ;
 
 triggerforspec
-    : FOR triggerforopteach triggerfortype
-    |
+    : FOR triggerforopteach? triggerfortype
+    
     ;
 
 triggerforopteach
     : EACH
-    |
+    
     ;
 
 triggerfortype
@@ -1343,7 +1343,7 @@ triggerfortype
 
 triggerwhen
     : WHEN OPEN_PAREN a_expr CLOSE_PAREN
-    |
+    
     ;
 
 function_or_procedure
@@ -1364,7 +1364,7 @@ triggerfuncarg
 
 optconstrfromtable
     : FROM qualified_name
-    |
+    
     ;
 
 constraintattributespec
@@ -1413,13 +1413,13 @@ createassertionstmt
     ;
 
 definestmt
-    : CREATE opt_or_replace AGGREGATE func_name aggr_args definition
-    | CREATE opt_or_replace AGGREGATE func_name old_aggr_definition
+    : CREATE or_replace_? AGGREGATE func_name aggr_args definition
+    | CREATE or_replace_? AGGREGATE func_name old_aggr_definition
     | CREATE OPERATOR any_operator definition
     | CREATE TYPE_P any_name definition
     | CREATE TYPE_P any_name
-    | CREATE TYPE_P any_name AS OPEN_PAREN opttablefuncelementlist CLOSE_PAREN
-    | CREATE TYPE_P any_name AS ENUM_P OPEN_PAREN opt_enum_val_list CLOSE_PAREN
+    | CREATE TYPE_P any_name AS OPEN_PAREN opttablefuncelementlist? CLOSE_PAREN
+    | CREATE TYPE_P any_name AS ENUM_P OPEN_PAREN enum_val_list_? CLOSE_PAREN
     | CREATE TYPE_P any_name AS RANGE definition
     | CREATE TEXT_P SEARCH PARSER any_name definition
     | CREATE TEXT_P SEARCH DICTIONARY any_name definition
@@ -1464,9 +1464,9 @@ old_aggr_elem
     : identifier EQUAL def_arg
     ;
 
-opt_enum_val_list
+enum_val_list_
     : enum_val_list
-    |
+    
     ;
 
 enum_val_list
@@ -1474,19 +1474,19 @@ enum_val_list
     ;
 
 alterenumstmt
-    : ALTER TYPE_P any_name ADD_P VALUE_P opt_if_not_exists sconst
-    | ALTER TYPE_P any_name ADD_P VALUE_P opt_if_not_exists sconst BEFORE sconst
-    | ALTER TYPE_P any_name ADD_P VALUE_P opt_if_not_exists sconst AFTER sconst
+    : ALTER TYPE_P any_name ADD_P VALUE_P if_not_exists_? sconst
+    | ALTER TYPE_P any_name ADD_P VALUE_P if_not_exists_? sconst BEFORE sconst
+    | ALTER TYPE_P any_name ADD_P VALUE_P if_not_exists_? sconst AFTER sconst
     | ALTER TYPE_P any_name RENAME VALUE_P sconst TO sconst
     ;
 
-opt_if_not_exists
+if_not_exists_
     : IF_P NOT EXISTS
-    |
+    
     ;
 
 createopclassstmt
-    : CREATE OPERATOR CLASS any_name opt_default FOR TYPE_P typename USING name opt_opfamily AS opclass_item_list
+    : CREATE OPERATOR CLASS any_name default_? FOR TYPE_P typename USING name opfamily_? AS opclass_item_list
     ;
 
 opclass_item_list
@@ -1494,32 +1494,32 @@ opclass_item_list
     ;
 
 opclass_item
-    : OPERATOR iconst any_operator opclass_purpose opt_recheck
-    | OPERATOR iconst operator_with_argtypes opclass_purpose opt_recheck
+    : OPERATOR iconst any_operator opclass_purpose? recheck_?
+    | OPERATOR iconst operator_with_argtypes opclass_purpose? recheck_?
     | FUNCTION iconst function_with_argtypes
     | FUNCTION iconst OPEN_PAREN type_list CLOSE_PAREN function_with_argtypes
     | STORAGE typename
     ;
 
-opt_default
+default_
     : DEFAULT
-    |
+    
     ;
 
-opt_opfamily
+opfamily_
     : FAMILY any_name
-    |
+    
     ;
 
 opclass_purpose
     : FOR SEARCH
     | FOR ORDER BY any_name
-    |
+    
     ;
 
-opt_recheck
+recheck_
     : RECHECK
-    |
+    
     ;
 
 createopfamilystmt
@@ -1541,17 +1541,17 @@ opclass_drop
     ;
 
 dropopclassstmt
-    : DROP OPERATOR CLASS any_name USING name opt_drop_behavior
-    | DROP OPERATOR CLASS IF_P EXISTS any_name USING name opt_drop_behavior
+    : DROP OPERATOR CLASS any_name USING name drop_behavior_?
+    | DROP OPERATOR CLASS IF_P EXISTS any_name USING name drop_behavior_?
     ;
 
 dropopfamilystmt
-    : DROP OPERATOR FAMILY any_name USING name opt_drop_behavior
-    | DROP OPERATOR FAMILY IF_P EXISTS any_name USING name opt_drop_behavior
+    : DROP OPERATOR FAMILY any_name USING name drop_behavior_?
+    | DROP OPERATOR FAMILY IF_P EXISTS any_name USING name drop_behavior_?
     ;
 
 dropownedstmt
-    : DROP OWNED BY role_list opt_drop_behavior
+    : DROP OWNED BY role_list drop_behavior_?
     ;
 
 reassignownedstmt
@@ -1559,18 +1559,18 @@ reassignownedstmt
     ;
 
 dropstmt
-    : DROP object_type_any_name IF_P EXISTS any_name_list opt_drop_behavior
-    | DROP object_type_any_name any_name_list opt_drop_behavior
-    | DROP drop_type_name IF_P EXISTS name_list opt_drop_behavior
-    | DROP drop_type_name name_list opt_drop_behavior
-    | DROP object_type_name_on_any_name name ON any_name opt_drop_behavior
-    | DROP object_type_name_on_any_name IF_P EXISTS name ON any_name opt_drop_behavior
-    | DROP TYPE_P type_name_list opt_drop_behavior
-    | DROP TYPE_P IF_P EXISTS type_name_list opt_drop_behavior
-    | DROP DOMAIN_P type_name_list opt_drop_behavior
-    | DROP DOMAIN_P IF_P EXISTS type_name_list opt_drop_behavior
-    | DROP INDEX CONCURRENTLY any_name_list opt_drop_behavior
-    | DROP INDEX CONCURRENTLY IF_P EXISTS any_name_list opt_drop_behavior
+    : DROP object_type_any_name IF_P EXISTS any_name_list drop_behavior_?
+    | DROP object_type_any_name any_name_list drop_behavior_?
+    | DROP drop_type_name IF_P EXISTS name_list drop_behavior_?
+    | DROP drop_type_name name_list drop_behavior_?
+    | DROP object_type_name_on_any_name name ON any_name drop_behavior_?
+    | DROP object_type_name_on_any_name IF_P EXISTS name ON any_name drop_behavior_?
+    | DROP TYPE_P type_name_list drop_behavior_?
+    | DROP TYPE_P IF_P EXISTS type_name_list drop_behavior_?
+    | DROP DOMAIN_P type_name_list drop_behavior_?
+    | DROP DOMAIN_P IF_P EXISTS type_name_list drop_behavior_?
+    | DROP INDEX CONCURRENTLY any_name_list drop_behavior_?
+    | DROP INDEX CONCURRENTLY IF_P EXISTS any_name_list drop_behavior_?
     ;
 
 object_type_any_name
@@ -1602,7 +1602,7 @@ drop_type_name
     | EVENT TRIGGER
     | EXTENSION
     | FOREIGN DATA_P WRAPPER
-    | opt_procedural LANGUAGE
+    | procedural_? LANGUAGE
     | PUBLICATION
     | SCHEMA
     | SERVER
@@ -1631,13 +1631,13 @@ type_name_list
     ;
 
 truncatestmt
-    : TRUNCATE opt_table relation_expr_list opt_restart_seqs opt_drop_behavior
+    : TRUNCATE table_? relation_expr_list restart_seqs_? drop_behavior_?
     ;
 
-opt_restart_seqs
+restart_seqs_
     : CONTINUE_P IDENTITY_P
     | RESTART IDENTITY_P
-    |
+    
     ;
 
 commentstmt
@@ -1667,21 +1667,21 @@ comment_text
     ;
 
 seclabelstmt
-    : SECURITY LABEL opt_provider ON object_type_any_name any_name IS security_label
-    | SECURITY LABEL opt_provider ON COLUMN any_name IS security_label
-    | SECURITY LABEL opt_provider ON object_type_name name IS security_label
-    | SECURITY LABEL opt_provider ON TYPE_P typename IS security_label
-    | SECURITY LABEL opt_provider ON DOMAIN_P typename IS security_label
-    | SECURITY LABEL opt_provider ON AGGREGATE aggregate_with_argtypes IS security_label
-    | SECURITY LABEL opt_provider ON FUNCTION function_with_argtypes IS security_label
-    | SECURITY LABEL opt_provider ON LARGE_P OBJECT_P numericonly IS security_label
-    | SECURITY LABEL opt_provider ON PROCEDURE function_with_argtypes IS security_label
-    | SECURITY LABEL opt_provider ON ROUTINE function_with_argtypes IS security_label
+    : SECURITY LABEL provider_? ON object_type_any_name any_name IS security_label
+    | SECURITY LABEL provider_? ON COLUMN any_name IS security_label
+    | SECURITY LABEL provider_? ON object_type_name name IS security_label
+    | SECURITY LABEL provider_? ON TYPE_P typename IS security_label
+    | SECURITY LABEL provider_? ON DOMAIN_P typename IS security_label
+    | SECURITY LABEL provider_? ON AGGREGATE aggregate_with_argtypes IS security_label
+    | SECURITY LABEL provider_? ON FUNCTION function_with_argtypes IS security_label
+    | SECURITY LABEL provider_? ON LARGE_P OBJECT_P numericonly IS security_label
+    | SECURITY LABEL provider_? ON PROCEDURE function_with_argtypes IS security_label
+    | SECURITY LABEL provider_? ON ROUTINE function_with_argtypes IS security_label
     ;
 
-opt_provider
+provider_
     : FOR nonreservedword_or_sconst
-    |
+    
     ;
 
 security_label
@@ -1697,20 +1697,20 @@ fetchstmt
 fetch_args
     : cursor_name
     | from_in cursor_name
-    | NEXT opt_from_in cursor_name
-    | PRIOR opt_from_in cursor_name
-    | FIRST_P opt_from_in cursor_name
-    | LAST_P opt_from_in cursor_name
-    | ABSOLUTE_P signediconst opt_from_in cursor_name
-    | RELATIVE_P signediconst opt_from_in cursor_name
-    | signediconst opt_from_in cursor_name
-    | ALL opt_from_in cursor_name
-    | FORWARD opt_from_in cursor_name
-    | FORWARD signediconst opt_from_in cursor_name
-    | FORWARD ALL opt_from_in cursor_name
-    | BACKWARD opt_from_in cursor_name
-    | BACKWARD signediconst opt_from_in cursor_name
-    | BACKWARD ALL opt_from_in cursor_name
+    | NEXT from_in_? cursor_name
+    | PRIOR from_in_? cursor_name
+    | FIRST_P from_in_? cursor_name
+    | LAST_P from_in_? cursor_name
+    | ABSOLUTE_P signediconst from_in_? cursor_name
+    | RELATIVE_P signediconst from_in_? cursor_name
+    | signediconst from_in_? cursor_name
+    | ALL from_in_? cursor_name
+    | FORWARD from_in_? cursor_name
+    | FORWARD signediconst from_in_? cursor_name
+    | FORWARD ALL from_in_? cursor_name
+    | BACKWARD from_in_? cursor_name
+    | BACKWARD signediconst from_in_? cursor_name
+    | BACKWARD ALL from_in_? cursor_name
     ;
 
 from_in
@@ -1718,18 +1718,18 @@ from_in
     | IN_P
     ;
 
-opt_from_in
+from_in_
     : from_in
-    |
+    
     ;
 
 grantstmt
-    : GRANT privileges ON privilege_target TO grantee_list opt_grant_grant_option
+    : GRANT privileges ON privilege_target TO grantee_list grant_grant_option_?
     ;
 
 revokestmt
-    : REVOKE privileges ON privilege_target FROM grantee_list opt_drop_behavior
-    | REVOKE GRANT OPTION FOR privileges ON privilege_target FROM grantee_list opt_drop_behavior
+    : REVOKE privileges ON privilege_target FROM grantee_list drop_behavior_?
+    | REVOKE GRANT OPTION FOR privileges ON privilege_target FROM grantee_list drop_behavior_?
     ;
 
 privileges
@@ -1745,10 +1745,10 @@ privilege_list
     ;
 
 privilege
-    : SELECT opt_column_list
-    | REFERENCES opt_column_list
-    | CREATE opt_column_list
-    | colid opt_column_list
+    : SELECT column_list_?
+    | REFERENCES column_list_?
+    | CREATE column_list_?
+    | colid column_list_?
     ;
 
 privilege_target
@@ -1783,28 +1783,28 @@ grantee
     | GROUP_P rolespec
     ;
 
-opt_grant_grant_option
+grant_grant_option_
     : WITH GRANT OPTION
-    |
+    
     ;
 
 grantrolestmt
-    : GRANT privilege_list TO role_list opt_grant_admin_option opt_granted_by
+    : GRANT privilege_list TO role_list grant_admin_option_? granted_by_?
     ;
 
 revokerolestmt
-    : REVOKE privilege_list FROM role_list opt_granted_by opt_drop_behavior
-    | REVOKE ADMIN OPTION FOR privilege_list FROM role_list opt_granted_by opt_drop_behavior
+    : REVOKE privilege_list FROM role_list granted_by_? drop_behavior_?
+    | REVOKE ADMIN OPTION FOR privilege_list FROM role_list granted_by_? drop_behavior_?
     ;
 
-opt_grant_admin_option
+grant_admin_option_
     : WITH ADMIN OPTION
-    |
+    
     ;
 
-opt_granted_by
+granted_by_
     : GRANTED BY rolespec
-    |
+    
     ;
 
 alterdefaultprivilegesstmt
@@ -1822,9 +1822,9 @@ defacloption
     ;
 
 defaclaction
-    : GRANT privileges ON defacl_privilege_target TO grantee_list opt_grant_grant_option
-    | REVOKE privileges ON defacl_privilege_target FROM grantee_list opt_drop_behavior
-    | REVOKE GRANT OPTION FOR privileges ON defacl_privilege_target FROM grantee_list opt_drop_behavior
+    : GRANT privileges ON defacl_privilege_target TO grantee_list grant_grant_option_?
+    | REVOKE privileges ON defacl_privilege_target FROM grantee_list drop_behavior_?
+    | REVOKE GRANT OPTION FOR privileges ON defacl_privilege_target FROM grantee_list drop_behavior_?
     ;
 
 defacl_privilege_target
@@ -1839,30 +1839,30 @@ defacl_privilege_target
 //create index
 
 indexstmt
-    : CREATE opt_unique INDEX opt_concurrently opt_index_name ON relation_expr access_method_clause OPEN_PAREN index_params CLOSE_PAREN opt_include
-        opt_reloptions opttablespace where_clause
-    | CREATE opt_unique INDEX opt_concurrently IF_P NOT EXISTS name ON relation_expr access_method_clause OPEN_PAREN index_params CLOSE_PAREN
-        opt_include opt_reloptions opttablespace where_clause
+    : CREATE unique_? INDEX concurrently_? index_name_? ON relation_expr access_method_clause? OPEN_PAREN index_params CLOSE_PAREN include_?
+        reloptions_? opttablespace? where_clause?
+    | CREATE unique_? INDEX concurrently_? IF_P NOT EXISTS name ON relation_expr access_method_clause? OPEN_PAREN index_params CLOSE_PAREN
+        include_? reloptions_? opttablespace? where_clause?
     ;
 
-opt_unique
+unique_
     : UNIQUE
-    |
+    
     ;
 
-opt_concurrently
+concurrently_
     : CONCURRENTLY
-    |
+    
     ;
 
-opt_index_name
+index_name_
     : name
-    |
+    
     ;
 
 access_method_clause
     : USING name
-    |
+    
     ;
 
 index_params
@@ -1870,8 +1870,8 @@ index_params
     ;
 
 index_elem_options
-    : opt_collate opt_class opt_asc_desc opt_nulls_order
-    | opt_collate any_name reloptions opt_asc_desc opt_nulls_order
+    : collate_? class_? asc_desc_? nulls_order_?
+    | collate_? any_name reloptions asc_desc_? nulls_order_?
     ;
 
 index_elem
@@ -1880,48 +1880,48 @@ index_elem
     | OPEN_PAREN a_expr CLOSE_PAREN index_elem_options
     ;
 
-opt_include
+include_
     : INCLUDE OPEN_PAREN index_including_params CLOSE_PAREN
-    |
+    
     ;
 
 index_including_params
     : index_elem (COMMA index_elem)*
     ;
 
-opt_collate
+collate_
     : COLLATE any_name
-    |
+    
     ;
 
-opt_class
+class_
     : any_name
-    |
+    
     ;
 
-opt_asc_desc
+asc_desc_
     : ASC
     | DESC
-    |
+    
     ;
 
 //TOD NULLS_LA was used
 
-opt_nulls_order
+nulls_order_
     : NULLS_P FIRST_P
     | NULLS_P LAST_P
-    |
+    
     ;
 
 createfunctionstmt
-    : CREATE opt_or_replace (FUNCTION | PROCEDURE) func_name func_args_with_defaults (
+    : CREATE or_replace_? (FUNCTION | PROCEDURE) func_name func_args_with_defaults (
         RETURNS (func_return | TABLE OPEN_PAREN table_func_column_list CLOSE_PAREN)
     )? createfunc_opt_list
     ;
 
-opt_or_replace
+or_replace_
     : OR REPLACE
-    |
+    
     ;
 
 func_args
@@ -2061,9 +2061,9 @@ transform_type_list
     : FOR TYPE_P typename (COMMA FOR TYPE_P typename)*
     ;
 
-opt_definition
+definition_
     : WITH definition
-    |
+    
     ;
 
 table_func_column
@@ -2075,35 +2075,35 @@ table_func_column_list
     ;
 
 alterfunctionstmt
-    : ALTER (FUNCTION | PROCEDURE | ROUTINE) function_with_argtypes alterfunc_opt_list opt_restrict
+    : ALTER (FUNCTION | PROCEDURE | ROUTINE) function_with_argtypes alterfunc_opt_list restrict_?
     ;
 
 alterfunc_opt_list
     : common_func_opt_item+
     ;
 
-opt_restrict
+restrict_
     : RESTRICT
-    |
+    
     ;
 
 removefuncstmt
-    : DROP FUNCTION function_with_argtypes_list opt_drop_behavior
-    | DROP FUNCTION IF_P EXISTS function_with_argtypes_list opt_drop_behavior
-    | DROP PROCEDURE function_with_argtypes_list opt_drop_behavior
-    | DROP PROCEDURE IF_P EXISTS function_with_argtypes_list opt_drop_behavior
-    | DROP ROUTINE function_with_argtypes_list opt_drop_behavior
-    | DROP ROUTINE IF_P EXISTS function_with_argtypes_list opt_drop_behavior
+    : DROP FUNCTION function_with_argtypes_list drop_behavior_?
+    | DROP FUNCTION IF_P EXISTS function_with_argtypes_list drop_behavior_?
+    | DROP PROCEDURE function_with_argtypes_list drop_behavior_?
+    | DROP PROCEDURE IF_P EXISTS function_with_argtypes_list drop_behavior_?
+    | DROP ROUTINE function_with_argtypes_list drop_behavior_?
+    | DROP ROUTINE IF_P EXISTS function_with_argtypes_list drop_behavior_?
     ;
 
 removeaggrstmt
-    : DROP AGGREGATE aggregate_with_argtypes_list opt_drop_behavior
-    | DROP AGGREGATE IF_P EXISTS aggregate_with_argtypes_list opt_drop_behavior
+    : DROP AGGREGATE aggregate_with_argtypes_list drop_behavior_?
+    | DROP AGGREGATE IF_P EXISTS aggregate_with_argtypes_list drop_behavior_?
     ;
 
 removeoperstmt
-    : DROP OPERATOR operator_with_argtypes_list opt_drop_behavior
-    | DROP OPERATOR IF_P EXISTS operator_with_argtypes_list opt_drop_behavior
+    : DROP OPERATOR operator_with_argtypes_list drop_behavior_?
+    | DROP OPERATOR IF_P EXISTS operator_with_argtypes_list drop_behavior_?
     ;
 
 oper_argtypes
@@ -2139,28 +2139,28 @@ dostmt_opt_item
     ;
 
 createcaststmt
-    : CREATE CAST OPEN_PAREN typename AS typename CLOSE_PAREN WITH FUNCTION function_with_argtypes cast_context
-    | CREATE CAST OPEN_PAREN typename AS typename CLOSE_PAREN WITHOUT FUNCTION cast_context
-    | CREATE CAST OPEN_PAREN typename AS typename CLOSE_PAREN WITH INOUT cast_context
+    : CREATE CAST OPEN_PAREN typename AS typename CLOSE_PAREN WITH FUNCTION function_with_argtypes cast_context?
+    | CREATE CAST OPEN_PAREN typename AS typename CLOSE_PAREN WITHOUT FUNCTION cast_context?
+    | CREATE CAST OPEN_PAREN typename AS typename CLOSE_PAREN WITH INOUT cast_context?
     ;
 
 cast_context
     : AS IMPLICIT_P
     | AS ASSIGNMENT
-    |
+    
     ;
 
 dropcaststmt
-    : DROP CAST opt_if_exists OPEN_PAREN typename AS typename CLOSE_PAREN opt_drop_behavior
+    : DROP CAST if_exists_? OPEN_PAREN typename AS typename CLOSE_PAREN drop_behavior_?
     ;
 
-opt_if_exists
+if_exists_
     : IF_P EXISTS
-    |
+    
     ;
 
 createtransformstmt
-    : CREATE opt_or_replace TRANSFORM FOR typename LANGUAGE name OPEN_PAREN transform_element_list CLOSE_PAREN
+    : CREATE or_replace_? TRANSFORM FOR typename LANGUAGE name OPEN_PAREN transform_element_list CLOSE_PAREN
     ;
 
 transform_element_list
@@ -2171,14 +2171,14 @@ transform_element_list
     ;
 
 droptransformstmt
-    : DROP TRANSFORM opt_if_exists FOR typename LANGUAGE name opt_drop_behavior
+    : DROP TRANSFORM if_exists_? FOR typename LANGUAGE name drop_behavior_?
     ;
 
 reindexstmt
-    : REINDEX reindex_target_type opt_concurrently qualified_name
-    | REINDEX reindex_target_multitable opt_concurrently name
-    | REINDEX OPEN_PAREN reindex_option_list CLOSE_PAREN reindex_target_type opt_concurrently qualified_name
-    | REINDEX OPEN_PAREN reindex_option_list CLOSE_PAREN reindex_target_multitable opt_concurrently name
+    : REINDEX reindex_target_type concurrently_? qualified_name
+    | REINDEX reindex_target_multitable concurrently_? name
+    | REINDEX OPEN_PAREN reindex_option_list CLOSE_PAREN reindex_target_type concurrently_? qualified_name
+    | REINDEX OPEN_PAREN reindex_option_list CLOSE_PAREN reindex_target_multitable concurrently_? name
     ;
 
 reindex_target_type
@@ -2220,7 +2220,7 @@ renamestmt
     | ALTER FOREIGN DATA_P WRAPPER name RENAME TO name
     | ALTER FUNCTION function_with_argtypes RENAME TO name
     | ALTER GROUP_P roleid RENAME TO roleid
-    | ALTER opt_procedural LANGUAGE name RENAME TO name
+    | ALTER procedural_? LANGUAGE name RENAME TO name
     | ALTER OPERATOR CLASS any_name USING name RENAME TO name
     | ALTER OPERATOR FAMILY any_name USING name RENAME TO name
     | ALTER POLICY name ON qualified_name RENAME TO name
@@ -2243,16 +2243,16 @@ renamestmt
     | ALTER INDEX IF_P EXISTS qualified_name RENAME TO name
     | ALTER FOREIGN TABLE relation_expr RENAME TO name
     | ALTER FOREIGN TABLE IF_P EXISTS relation_expr RENAME TO name
-    | ALTER TABLE relation_expr RENAME opt_column name TO name
-    | ALTER TABLE IF_P EXISTS relation_expr RENAME opt_column name TO name
-    | ALTER VIEW qualified_name RENAME opt_column name TO name
-    | ALTER VIEW IF_P EXISTS qualified_name RENAME opt_column name TO name
-    | ALTER MATERIALIZED VIEW qualified_name RENAME opt_column name TO name
-    | ALTER MATERIALIZED VIEW IF_P EXISTS qualified_name RENAME opt_column name TO name
+    | ALTER TABLE relation_expr RENAME column_? name TO name
+    | ALTER TABLE IF_P EXISTS relation_expr RENAME column_? name TO name
+    | ALTER VIEW qualified_name RENAME column_? name TO name
+    | ALTER VIEW IF_P EXISTS qualified_name RENAME column_? name TO name
+    | ALTER MATERIALIZED VIEW qualified_name RENAME column_? name TO name
+    | ALTER MATERIALIZED VIEW IF_P EXISTS qualified_name RENAME column_? name TO name
     | ALTER TABLE relation_expr RENAME CONSTRAINT name TO name
     | ALTER TABLE IF_P EXISTS relation_expr RENAME CONSTRAINT name TO name
-    | ALTER FOREIGN TABLE relation_expr RENAME opt_column name TO name
-    | ALTER FOREIGN TABLE IF_P EXISTS relation_expr RENAME opt_column name TO name
+    | ALTER FOREIGN TABLE relation_expr RENAME column_? name TO name
+    | ALTER FOREIGN TABLE IF_P EXISTS relation_expr RENAME column_? name TO name
     | ALTER RULE name ON qualified_name RENAME TO name
     | ALTER TRIGGER name ON qualified_name RENAME TO name
     | ALTER EVENT TRIGGER name RENAME TO name
@@ -2265,31 +2265,31 @@ renamestmt
     | ALTER TEXT_P SEARCH TEMPLATE any_name RENAME TO name
     | ALTER TEXT_P SEARCH CONFIGURATION any_name RENAME TO name
     | ALTER TYPE_P any_name RENAME TO name
-    | ALTER TYPE_P any_name RENAME ATTRIBUTE name TO name opt_drop_behavior
+    | ALTER TYPE_P any_name RENAME ATTRIBUTE name TO name drop_behavior_?
     ;
 
-opt_column
+column_
     : COLUMN
-    |
+    
     ;
 
-opt_set_data
+set_data_
     : SET DATA_P
-    |
+    
     ;
 
 alterobjectdependsstmt
-    : ALTER FUNCTION function_with_argtypes opt_no DEPENDS ON EXTENSION name
-    | ALTER PROCEDURE function_with_argtypes opt_no DEPENDS ON EXTENSION name
-    | ALTER ROUTINE function_with_argtypes opt_no DEPENDS ON EXTENSION name
-    | ALTER TRIGGER name ON qualified_name opt_no DEPENDS ON EXTENSION name
-    | ALTER MATERIALIZED VIEW qualified_name opt_no DEPENDS ON EXTENSION name
-    | ALTER INDEX qualified_name opt_no DEPENDS ON EXTENSION name
+    : ALTER FUNCTION function_with_argtypes no_? DEPENDS ON EXTENSION name
+    | ALTER PROCEDURE function_with_argtypes no_? DEPENDS ON EXTENSION name
+    | ALTER ROUTINE function_with_argtypes no_? DEPENDS ON EXTENSION name
+    | ALTER TRIGGER name ON qualified_name no_? DEPENDS ON EXTENSION name
+    | ALTER MATERIALIZED VIEW qualified_name no_? DEPENDS ON EXTENSION name
+    | ALTER INDEX qualified_name no_? DEPENDS ON EXTENSION name
     ;
 
-opt_no
+no_
     : NO
-    |
+    
     ;
 
 alterobjectschemastmt
@@ -2354,7 +2354,7 @@ alterownerstmt
     | ALTER DATABASE name OWNER TO rolespec
     | ALTER DOMAIN_P any_name OWNER TO rolespec
     | ALTER FUNCTION function_with_argtypes OWNER TO rolespec
-    | ALTER opt_procedural LANGUAGE name OWNER TO rolespec
+    | ALTER procedural_? LANGUAGE name OWNER TO rolespec
     | ALTER LARGE_P OBJECT_P numericonly OWNER TO rolespec
     | ALTER OPERATOR operator_with_argtypes OWNER TO rolespec
     | ALTER OPERATOR CLASS any_name USING name OWNER TO rolespec
@@ -2375,12 +2375,12 @@ alterownerstmt
     ;
 
 createpublicationstmt
-    : CREATE PUBLICATION name opt_publication_for_tables opt_definition
+    : CREATE PUBLICATION name publication_for_tables_? definition_?
     ;
 
-opt_publication_for_tables
+publication_for_tables_
     : publication_for_tables
-    |
+    
     ;
 
 publication_for_tables
@@ -2396,7 +2396,7 @@ alterpublicationstmt
     ;
 
 createsubscriptionstmt
-    : CREATE SUBSCRIPTION name CONNECTION sconst PUBLICATION publication_name_list opt_definition
+    : CREATE SUBSCRIPTION name CONNECTION sconst PUBLICATION publication_name_list definition_?
     ;
 
 publication_name_list
@@ -2410,19 +2410,19 @@ publication_name_item
 altersubscriptionstmt
     : ALTER SUBSCRIPTION name SET definition
     | ALTER SUBSCRIPTION name CONNECTION sconst
-    | ALTER SUBSCRIPTION name REFRESH PUBLICATION opt_definition
-    | ALTER SUBSCRIPTION name SET PUBLICATION publication_name_list opt_definition
+    | ALTER SUBSCRIPTION name REFRESH PUBLICATION definition_?
+    | ALTER SUBSCRIPTION name SET PUBLICATION publication_name_list definition_?
     | ALTER SUBSCRIPTION name ENABLE_P
     | ALTER SUBSCRIPTION name DISABLE_P
     ;
 
 dropsubscriptionstmt
-    : DROP SUBSCRIPTION name opt_drop_behavior
-    | DROP SUBSCRIPTION IF_P EXISTS name opt_drop_behavior
+    : DROP SUBSCRIPTION name drop_behavior_?
+    | DROP SUBSCRIPTION IF_P EXISTS name drop_behavior_?
     ;
 
 rulestmt
-    : CREATE opt_or_replace RULE name AS ON event TO qualified_name where_clause DO opt_instead ruleactionlist
+    : CREATE or_replace_? RULE name AS ON event TO qualified_name where_clause? DO instead_? ruleactionlist
     ;
 
 ruleactionlist
@@ -2432,7 +2432,7 @@ ruleactionlist
     ;
 
 ruleactionmulti
-    : ruleactionstmtOrEmpty (SEMI ruleactionstmtOrEmpty)*
+    : ruleactionstmtOrEmpty? (SEMI ruleactionstmtOrEmpty?)*
     ;
 
 ruleactionstmt
@@ -2445,7 +2445,7 @@ ruleactionstmt
 
 ruleactionstmtOrEmpty
     : ruleactionstmt
-    |
+    
     ;
 
 event
@@ -2455,19 +2455,19 @@ event
     | INSERT
     ;
 
-opt_instead
+instead_
     : INSTEAD
     | ALSO
-    |
+    
     ;
 
 notifystmt
-    : NOTIFY colid notify_payload
+    : NOTIFY colid notify_payload?
     ;
 
 notify_payload
     : COMMA sconst
-    |
+    
     ;
 
 listenstmt
@@ -2480,26 +2480,26 @@ unlistenstmt
     ;
 
 transactionstmt
-    : ABORT_P opt_transaction opt_transaction_chain
-    | BEGIN_P opt_transaction transaction_mode_list_or_empty
-    | START TRANSACTION transaction_mode_list_or_empty
-    | COMMIT opt_transaction opt_transaction_chain
-    | END_P opt_transaction opt_transaction_chain
-    | ROLLBACK opt_transaction opt_transaction_chain
+    : ABORT_P transaction_? transaction_chain_?
+    | BEGIN_P transaction_? transaction_mode_list_or_empty?
+    | START TRANSACTION transaction_mode_list_or_empty?
+    | COMMIT transaction_? transaction_chain_?
+    | END_P transaction_? transaction_chain_?
+    | ROLLBACK transaction_? transaction_chain_?
     | SAVEPOINT colid
     | RELEASE SAVEPOINT colid
     | RELEASE colid
-    | ROLLBACK opt_transaction TO SAVEPOINT colid
-    | ROLLBACK opt_transaction TO colid
+    | ROLLBACK transaction_? TO SAVEPOINT colid
+    | ROLLBACK transaction_? TO colid
     | PREPARE TRANSACTION sconst
     | COMMIT PREPARED sconst
     | ROLLBACK PREPARED sconst
     ;
 
-opt_transaction
+transaction_
     : WORK
     | TRANSACTION
-    |
+    
     ;
 
 transaction_mode_item
@@ -2516,24 +2516,24 @@ transaction_mode_list
 
 transaction_mode_list_or_empty
     : transaction_mode_list
-    |
+    
     ;
 
-opt_transaction_chain
+transaction_chain_
     : AND NO? CHAIN
-    |
+    
     ;
 
 viewstmt
-    : CREATE (OR REPLACE)? opttemp (
-        VIEW qualified_name opt_column_list opt_reloptions
-        | RECURSIVE VIEW qualified_name OPEN_PAREN columnlist CLOSE_PAREN opt_reloptions
-    ) AS selectstmt opt_check_option
+    : CREATE (OR REPLACE)? opttemp? (
+        VIEW qualified_name column_list_? reloptions_?
+        | RECURSIVE VIEW qualified_name OPEN_PAREN columnlist CLOSE_PAREN reloptions_?
+    ) AS selectstmt check_option_?
     ;
 
-opt_check_option
+check_option_
     : WITH (CASCADED | LOCAL)? CHECK OPTION
-    |
+    
     ;
 
 loadstmt
@@ -2541,12 +2541,12 @@ loadstmt
     ;
 
 createdbstmt
-    : CREATE DATABASE name opt_with createdb_opt_list
+    : CREATE DATABASE name with_? createdb_opt_list?
     ;
 
 createdb_opt_list
     : createdb_opt_items
-    |
+    
     ;
 
 createdb_opt_items
@@ -2554,7 +2554,7 @@ createdb_opt_items
     ;
 
 createdb_opt_item
-    : createdb_opt_name opt_equal (signediconst | opt_boolean_or_string | DEFAULT)
+    : createdb_opt_name equal_? (signediconst | boolean_or_string_ | DEFAULT)
     ;
 
 createdb_opt_name
@@ -2567,13 +2567,13 @@ createdb_opt_name
     | TEMPLATE
     ;
 
-opt_equal
+equal_
     : EQUAL
-    |
+    
     ;
 
 alterdatabasestmt
-    : ALTER DATABASE name (WITH createdb_opt_list | createdb_opt_list | SET TABLESPACE name)
+    : ALTER DATABASE name (WITH createdb_opt_list? | createdb_opt_list? | SET TABLESPACE name)
     ;
 
 alterdatabasesetstmt
@@ -2581,7 +2581,7 @@ alterdatabasesetstmt
     ;
 
 dropdbstmt
-    : DROP DATABASE (IF_P EXISTS)? name (opt_with OPEN_PAREN drop_option_list CLOSE_PAREN)?
+    : DROP DATABASE (IF_P EXISTS)? name (with_? OPEN_PAREN drop_option_list CLOSE_PAREN)?
     ;
 
 drop_option_list
@@ -2601,7 +2601,7 @@ altersystemstmt
     ;
 
 createdomainstmt
-    : CREATE DOMAIN_P any_name opt_as typename colquallist
+    : CREATE DOMAIN_P any_name as_? typename colquallist
     ;
 
 alterdomainstmt
@@ -2610,14 +2610,14 @@ alterdomainstmt
         | DROP NOT NULL_P
         | SET NOT NULL_P
         | ADD_P tableconstraint
-        | DROP CONSTRAINT (IF_P EXISTS)? name opt_drop_behavior
+        | DROP CONSTRAINT (IF_P EXISTS)? name drop_behavior_?
         | VALIDATE CONSTRAINT name
     )
     ;
 
-opt_as
+as_
     : AS
-    |
+    
     ;
 
 altertsdictionarystmt
@@ -2641,28 +2641,28 @@ any_with
     ;
 
 createconversionstmt
-    : CREATE opt_default CONVERSION_P any_name FOR sconst TO sconst FROM any_name
+    : CREATE default_? CONVERSION_P any_name FOR sconst TO sconst FROM any_name
     ;
 
 clusterstmt
-    : CLUSTER opt_verbose qualified_name cluster_index_specification
-    | CLUSTER opt_verbose
-    | CLUSTER opt_verbose name ON qualified_name
+    : CLUSTER verbose_? qualified_name cluster_index_specification?
+    | CLUSTER verbose_?
+    | CLUSTER verbose_? name ON qualified_name
     ;
 
 cluster_index_specification
     : USING name
-    |
+    
     ;
 
 vacuumstmt
-    : VACUUM opt_full opt_freeze opt_verbose opt_analyze opt_vacuum_relation_list
-    | VACUUM OPEN_PAREN vac_analyze_option_list CLOSE_PAREN opt_vacuum_relation_list
+    : VACUUM full_? freeze_? verbose_? analyze_? vacuum_relation_list_?
+    | VACUUM OPEN_PAREN vac_analyze_option_list CLOSE_PAREN vacuum_relation_list_?
     ;
 
 analyzestmt
-    : analyze_keyword opt_verbose opt_vacuum_relation_list
-    | analyze_keyword OPEN_PAREN vac_analyze_option_list CLOSE_PAREN opt_vacuum_relation_list
+    : analyze_keyword verbose_? vacuum_relation_list_?
+    | analyze_keyword OPEN_PAREN vac_analyze_option_list CLOSE_PAREN vacuum_relation_list_?
     ;
 
 vac_analyze_option_list
@@ -2675,7 +2675,7 @@ analyze_keyword
     ;
 
 vac_analyze_option_elem
-    : vac_analyze_option_name vac_analyze_option_arg
+    : vac_analyze_option_name vac_analyze_option_arg?
     ;
 
 vac_analyze_option_name
@@ -2684,52 +2684,52 @@ vac_analyze_option_name
     ;
 
 vac_analyze_option_arg
-    : opt_boolean_or_string
+    : boolean_or_string_
     | numericonly
-    |
+    
     ;
 
-opt_analyze
+analyze_
     : analyze_keyword
-    |
+    
     ;
 
-opt_verbose
+verbose_
     : VERBOSE
-    |
+    
     ;
 
-opt_full
+full_
     : FULL
-    |
+    
     ;
 
-opt_freeze
+freeze_
     : FREEZE
-    |
+    
     ;
 
-opt_name_list
+name_list_
     : OPEN_PAREN name_list CLOSE_PAREN
-    |
+    
     ;
 
 vacuum_relation
-    : qualified_name opt_name_list
+    : qualified_name name_list_?
     ;
 
 vacuum_relation_list
     : vacuum_relation (COMMA vacuum_relation)*
     ;
 
-opt_vacuum_relation_list
+vacuum_relation_list_
     : vacuum_relation_list
-    |
+    
     ;
 
 explainstmt
     : EXPLAIN explainablestmt
-    | EXPLAIN analyze_keyword opt_verbose explainablestmt
+    | EXPLAIN analyze_keyword verbose_? explainablestmt
     | EXPLAIN VERBOSE explainablestmt
     | EXPLAIN OPEN_PAREN explain_option_list CLOSE_PAREN explainablestmt
     ;
@@ -2751,7 +2751,7 @@ explain_option_list
     ;
 
 explain_option_elem
-    : explain_option_name explain_option_arg
+    : explain_option_name explain_option_arg?
     ;
 
 explain_option_name
@@ -2760,18 +2760,18 @@ explain_option_name
     ;
 
 explain_option_arg
-    : opt_boolean_or_string
+    : boolean_or_string_
     | numericonly
-    |
+    
     ;
 
 preparestmt
-    : PREPARE name prep_type_clause AS preparablestmt
+    : PREPARE name prep_type_clause? AS preparablestmt
     ;
 
 prep_type_clause
     : OPEN_PAREN type_list CLOSE_PAREN
-    |
+    
     ;
 
 preparablestmt
@@ -2782,14 +2782,14 @@ preparablestmt
     ;
 
 executestmt
-    : EXECUTE name execute_param_clause
-    | CREATE opttemp TABLE create_as_target AS EXECUTE name execute_param_clause opt_with_data
-    | CREATE opttemp TABLE IF_P NOT EXISTS create_as_target AS EXECUTE name execute_param_clause opt_with_data
+    : EXECUTE name execute_param_clause?
+    | CREATE opttemp? TABLE create_as_target AS EXECUTE name execute_param_clause? with_data_?
+    | CREATE opttemp? TABLE IF_P NOT EXISTS create_as_target AS EXECUTE name execute_param_clause? with_data_?
     ;
 
 execute_param_clause
     : OPEN_PAREN expr_list CLOSE_PAREN
-    |
+    
     ;
 
 deallocatestmt
@@ -2800,7 +2800,7 @@ deallocatestmt
     ;
 
 insertstmt
-    : opt_with_clause INSERT INTO insert_target insert_rest opt_on_conflict returning_clause
+    : with_clause_? INSERT INTO insert_target insert_rest on_conflict_? returning_clause?
     ;
 
 insert_target
@@ -2827,20 +2827,20 @@ insert_column_item
     : colid opt_indirection
     ;
 
-opt_on_conflict
-    : ON CONFLICT opt_conf_expr DO (UPDATE SET set_clause_list where_clause | NOTHING)
-    |
+on_conflict_
+    : ON CONFLICT conf_expr_? DO (UPDATE SET set_clause_list where_clause? | NOTHING)
+    
     ;
 
-opt_conf_expr
-    : OPEN_PAREN index_params CLOSE_PAREN where_clause
+conf_expr_
+    : OPEN_PAREN index_params CLOSE_PAREN where_clause?
     | ON CONSTRAINT name
-    |
+    
     ;
 
 returning_clause
     : RETURNING target_list
-    |
+    
     ;
 
 // https://www.postgresql.org/docs/current/sql-merge.html
@@ -2864,21 +2864,21 @@ merge_delete_clause
     ;
 
 deletestmt
-    : opt_with_clause DELETE_P FROM relation_expr_opt_alias using_clause where_or_current_clause returning_clause
+    : with_clause_? DELETE_P FROM relation_expr_opt_alias using_clause? where_or_current_clause? returning_clause?
     ;
 
 using_clause
     : USING from_list
-    |
+    
     ;
 
 lockstmt
-    : LOCK_P opt_table relation_expr_list opt_lock opt_nowait
+    : LOCK_P table_? relation_expr_list lock_? nowait_?
     ;
 
-opt_lock
+lock_
     : IN_P lock_type MODE
-    |
+    
     ;
 
 lock_type
@@ -2888,19 +2888,19 @@ lock_type
     | EXCLUSIVE
     ;
 
-opt_nowait
+nowait_
     : NOWAIT
-    |
+    
     ;
 
-opt_nowait_or_skip
+nowait_or_skip_
     : NOWAIT
     | SKIP_P LOCKED
-    |
+    
     ;
 
 updatestmt
-    : opt_with_clause UPDATE relation_expr_opt_alias SET set_clause_list from_clause where_or_current_clause returning_clause
+    : with_clause_? UPDATE relation_expr_opt_alias SET set_clause_list from_clause? where_or_current_clause? returning_clause?
     ;
 
 set_clause_list
@@ -2921,7 +2921,7 @@ set_target_list
     ;
 
 declarecursorstmt
-    : DECLARE cursor_name cursor_options CURSOR opt_hold FOR selectstmt
+    : DECLARE cursor_name cursor_options CURSOR hold_? FOR selectstmt
     ;
 
 cursor_name
@@ -2932,9 +2932,9 @@ cursor_options
     : (NO SCROLL | SCROLL | BINARY | INSENSITIVE)*
     ;
 
-opt_hold
+hold_
     :
-    | WITH HOLD
+     WITH HOLD
     | WITHOUT HOLD
     ;
 
@@ -2958,28 +2958,28 @@ select_with_parens
     ;
 
 select_no_parens
-    : select_clause opt_sort_clause (
-        for_locking_clause opt_select_limit
-        | select_limit opt_for_locking_clause
+    : select_clause sort_clause_? (
+        for_locking_clause select_limit_?
+        | select_limit for_locking_clause_?
     )?
-    | with_clause select_clause opt_sort_clause (
-        for_locking_clause opt_select_limit
-        | select_limit opt_for_locking_clause
+    | with_clause select_clause sort_clause_? (
+        for_locking_clause select_limit_?
+        | select_limit for_locking_clause_?
     )?
     ;
 
 select_clause
-    : simple_select_intersect ((UNION | EXCEPT) all_or_distinct simple_select_intersect)*
+    : simple_select_intersect ((UNION | EXCEPT) all_or_distinct? simple_select_intersect)*
     ;
 
 simple_select_intersect
-    : simple_select_pramary (INTERSECT all_or_distinct simple_select_pramary)*
+    : simple_select_pramary (INTERSECT all_or_distinct? simple_select_pramary)*
     ;
 
 simple_select_pramary
     : (
-        SELECT (opt_all_clause into_clause opt_target_list | distinct_clause target_list) into_clause from_clause where_clause group_clause
-            having_clause window_clause
+        SELECT (all_clause_? into_clause? target_list_? | distinct_clause target_list) into_clause? from_clause? where_clause? group_clause?
+            having_clause? window_clause?
     )
     | values_clause
     | TABLE relation_expr
@@ -2995,60 +2995,60 @@ cte_list
     ;
 
 common_table_expr
-    : name opt_name_list AS opt_materialized OPEN_PAREN preparablestmt CLOSE_PAREN
+    : name name_list_? AS materialized_? OPEN_PAREN preparablestmt CLOSE_PAREN
     ;
 
-opt_materialized
+materialized_
     : MATERIALIZED
     | NOT MATERIALIZED
-    |
+    
     ;
 
-opt_with_clause
+with_clause_
     : with_clause
-    |
+    
     ;
 
 into_clause
-    : INTO (opt_strict opttempTableName | into_target)
-    |
+    : INTO (strict_? opttempTableName | into_target)
+    
     ;
 
-opt_strict
+strict_
     :
-    | STRICT_P
+     STRICT_P
     ;
 
 opttempTableName
-    : (LOCAL | GLOBAL)? (TEMPORARY | TEMP) opt_table qualified_name
-    | UNLOGGED opt_table qualified_name
+    : (LOCAL | GLOBAL)? (TEMPORARY | TEMP) table_? qualified_name
+    | UNLOGGED table_? qualified_name
     | TABLE qualified_name
     | qualified_name
     ;
 
-opt_table
+table_
     : TABLE
-    |
+    
     ;
 
 all_or_distinct
     : ALL
     | DISTINCT
-    |
+    
     ;
 
 distinct_clause
     : DISTINCT (ON OPEN_PAREN expr_list CLOSE_PAREN)?
     ;
 
-opt_all_clause
+all_clause_
     : ALL
-    |
+    
     ;
 
-opt_sort_clause
+sort_clause_
     : sort_clause
-    |
+    
     ;
 
 sort_clause
@@ -3060,7 +3060,7 @@ sortby_list
     ;
 
 sortby
-    : a_expr (USING qual_all_op | opt_asc_desc) opt_nulls_order
+    : a_expr (USING qual_all_op | asc_desc_?) nulls_order_?
     ;
 
 select_limit
@@ -3068,9 +3068,9 @@ select_limit
     | offset_clause limit_clause?
     ;
 
-opt_select_limit
+select_limit_
     : select_limit
-    |
+    
     ;
 
 limit_clause
@@ -3117,7 +3117,7 @@ first_or_next
 
 group_clause
     : GROUP_P BY group_by_list
-    |
+    
     ;
 
 group_by_list
@@ -3150,7 +3150,7 @@ grouping_sets_clause
 
 having_clause
     : HAVING a_expr
-    |
+    
     ;
 
 for_locking_clause
@@ -3158,9 +3158,9 @@ for_locking_clause
     | FOR READ ONLY
     ;
 
-opt_for_locking_clause
+for_locking_clause_
     : for_locking_clause
-    |
+    
     ;
 
 for_locking_items
@@ -3168,7 +3168,7 @@ for_locking_items
     ;
 
 for_locking_item
-    : for_locking_strength locked_rels_list opt_nowait_or_skip
+    : for_locking_strength locked_rels_list? nowait_or_skip_?
     ;
 
 for_locking_strength
@@ -3177,7 +3177,7 @@ for_locking_strength
 
 locked_rels_list
     : OF qualified_name_list
-    |
+    
     ;
 
 values_clause
@@ -3186,7 +3186,7 @@ values_clause
 
 from_clause
     : FROM from_list
-    |
+    
     ;
 
 from_list
@@ -3200,20 +3200,20 @@ non_ansi_join
 
 table_ref
     : (
-        relation_expr opt_alias_clause tablesample_clause?
-        | func_table func_alias_clause
-        | xmltable opt_alias_clause
-        | select_with_parens opt_alias_clause
+        relation_expr alias_clause_? tablesample_clause?
+        | func_table func_alias_clause?
+        | xmltable alias_clause_?
+        | select_with_parens alias_clause_?
         | LATERAL_P (
-            xmltable opt_alias_clause
-            | func_table func_alias_clause
-            | select_with_parens opt_alias_clause
+            xmltable alias_clause_?
+            | func_table func_alias_clause?
+            | select_with_parens alias_clause_?
         )
         | OPEN_PAREN table_ref (
             CROSS JOIN table_ref
             | NATURAL join_type? JOIN table_ref
             | join_type? JOIN table_ref join_qual
-        )? CLOSE_PAREN opt_alias_clause
+        )? CLOSE_PAREN alias_clause_?
     ) (
         CROSS JOIN table_ref
         | NATURAL join_type? JOIN table_ref
@@ -3225,9 +3225,9 @@ alias_clause
     : AS? colid (OPEN_PAREN name_list CLOSE_PAREN)?
     ;
 
-opt_alias_clause
+alias_clause_
     : table_alias_clause
-    |
+    
     ;
 
 table_alias_clause
@@ -3237,7 +3237,7 @@ table_alias_clause
 func_alias_clause
     : alias_clause
     | (AS colid? | colid) OPEN_PAREN tablefuncelementlist CLOSE_PAREN
-    |
+    
     ;
 
 join_type
@@ -3263,52 +3263,52 @@ relation_expr_opt_alias
     ;
 
 tablesample_clause
-    : TABLESAMPLE func_name OPEN_PAREN expr_list CLOSE_PAREN opt_repeatable_clause
+    : TABLESAMPLE func_name OPEN_PAREN expr_list CLOSE_PAREN repeatable_clause_?
     ;
 
-opt_repeatable_clause
+repeatable_clause_
     : REPEATABLE OPEN_PAREN a_expr CLOSE_PAREN
-    |
+    
     ;
 
 func_table
-    : func_expr_windowless opt_ordinality
-    | ROWS FROM OPEN_PAREN rowsfrom_list CLOSE_PAREN opt_ordinality
+    : func_expr_windowless ordinality_?
+    | ROWS FROM OPEN_PAREN rowsfrom_list CLOSE_PAREN ordinality_?
     ;
 
 rowsfrom_item
-    : func_expr_windowless opt_col_def_list
+    : func_expr_windowless col_def_list_?
     ;
 
 rowsfrom_list
     : rowsfrom_item (COMMA rowsfrom_item)*
     ;
 
-opt_col_def_list
+col_def_list_
     : AS OPEN_PAREN tablefuncelementlist CLOSE_PAREN
-    |
+    
     ;
 
 //TODO WITH_LA was used
 
-opt_ordinality
+ordinality_
     : WITH ORDINALITY
-    |
+    
     ;
 
 where_clause
     : WHERE a_expr
-    |
+    
     ;
 
 where_or_current_clause
     : WHERE (CURRENT_P OF cursor_name | a_expr)
-    |
+    
     ;
 
 opttablefuncelementlist
     : tablefuncelementlist
-    |
+    
     ;
 
 tablefuncelementlist
@@ -3316,7 +3316,7 @@ tablefuncelementlist
     ;
 
 tablefuncelement
-    : colid typename opt_collate_clause
+    : colid typename collate_clause_?
     ;
 
 xmltable
@@ -3369,7 +3369,7 @@ simpletypename
     | bit
     | character
     | constdatetime
-    | constinterval (opt_interval | OPEN_PAREN iconst CLOSE_PAREN)
+    | constinterval (interval_? | OPEN_PAREN iconst CLOSE_PAREN)
     ;
 
 consttypename
@@ -3380,12 +3380,12 @@ consttypename
     ;
 
 generictype
-    : (builtin_function_name | type_function_name | LEFT | RIGHT) attrs? opt_type_modifiers
+    : (builtin_function_name | type_function_name | LEFT | RIGHT) attrs? type_modifiers_?
     ;
 
-opt_type_modifiers
+type_modifiers_
     : OPEN_PAREN expr_list CLOSE_PAREN
-    |
+    
     ;
 
 numeric
@@ -3394,17 +3394,17 @@ numeric
     | SMALLINT
     | BIGINT
     | REAL
-    | FLOAT_P opt_float
+    | FLOAT_P float_?
     | DOUBLE_P PRECISION
-    | DECIMAL_P opt_type_modifiers
-    | DEC opt_type_modifiers
-    | NUMERIC opt_type_modifiers
+    | DECIMAL_P type_modifiers_?
+    | DEC type_modifiers_?
+    | NUMERIC type_modifiers_?
     | BOOLEAN_P
     ;
 
-opt_float
+float_
     : OPEN_PAREN iconst CLOSE_PAREN
-    |
+    
     ;
 
 //todo: merge alts
@@ -3420,11 +3420,11 @@ constbit
     ;
 
 bitwithlength
-    : BIT opt_varying OPEN_PAREN expr_list CLOSE_PAREN
+    : BIT varying_? OPEN_PAREN expr_list CLOSE_PAREN
     ;
 
 bitwithoutlength
-    : BIT opt_varying
+    : BIT varying_?
     ;
 
 character
@@ -3436,18 +3436,18 @@ constcharacter
     ;
 
 character_c
-    : (CHARACTER | CHAR_P | NCHAR) opt_varying
+    : (CHARACTER | CHAR_P | NCHAR) varying_?
     | VARCHAR
-    | NATIONAL (CHARACTER | CHAR_P) opt_varying
+    | NATIONAL (CHARACTER | CHAR_P) varying_?
     ;
 
-opt_varying
+varying_
     : VARYING
-    |
+    
     ;
 
 constdatetime
-    : (TIMESTAMP | TIME) (OPEN_PAREN iconst CLOSE_PAREN)? opt_timezone
+    : (TIMESTAMP | TIME) (OPEN_PAREN iconst CLOSE_PAREN)? timezone_?
     ;
 
 constinterval
@@ -3456,13 +3456,13 @@ constinterval
 
 //TODO with_la was used
 
-opt_timezone
+timezone_
     : WITH TIME ZONE
     | WITHOUT TIME ZONE
-    |
+    
     ;
 
-opt_interval
+interval_
     : YEAR_P
     | MONTH_P
     | DAY_P
@@ -3473,16 +3473,16 @@ opt_interval
     | DAY_P TO (HOUR_P | MINUTE_P | interval_second)
     | HOUR_P TO (MINUTE_P | interval_second)
     | MINUTE_P TO interval_second
-    |
+    
     ;
 
 interval_second
     : SECOND_P (OPEN_PAREN iconst CLOSE_PAREN)?
     ;
 
-opt_escape
+escape_
     : ESCAPE a_expr
-    |
+    
     ;
 
 //precendence accroding to Table 4.2. Operator Precedence (highest to lowest)
@@ -3633,7 +3633,7 @@ a_expr_compare
 /*10*/
 
 a_expr_like
-    : a_expr_qual_op (NOT? (LIKE | ILIKE | SIMILAR TO) a_expr_qual_op opt_escape)?
+    : a_expr_qual_op (NOT? (LIKE | ILIKE | SIMILAR TO) a_expr_qual_op escape_?)?
     ;
 
 /* 8*/
@@ -3735,16 +3735,16 @@ plsqlvariablename
 
 func_application
     : func_name OPEN_PAREN (
-        func_arg_list (COMMA VARIADIC func_arg_expr)? opt_sort_clause
-        | VARIADIC func_arg_expr opt_sort_clause
-        | (ALL | DISTINCT) func_arg_list opt_sort_clause
+        func_arg_list (COMMA VARIADIC func_arg_expr)? sort_clause_?
+        | VARIADIC func_arg_expr sort_clause_?
+        | (ALL | DISTINCT) func_arg_list sort_clause_?
         | STAR
         |
     ) CLOSE_PAREN
     ;
 
 func_expr
-    : func_application within_group_clause filter_clause over_clause
+    : func_application within_group_clause? filter_clause? over_clause?
     | func_expr_common_subexpr
     ;
 
@@ -3767,10 +3767,10 @@ func_expr_common_subexpr
     | CURRENT_CATALOG
     | CURRENT_SCHEMA
     | CAST OPEN_PAREN a_expr AS typename CLOSE_PAREN
-    | EXTRACT OPEN_PAREN extract_list CLOSE_PAREN
+    | EXTRACT OPEN_PAREN extract_list? CLOSE_PAREN
     | NORMALIZE OPEN_PAREN a_expr (COMMA unicode_normal_form)? CLOSE_PAREN
     | OVERLAY OPEN_PAREN overlay_list CLOSE_PAREN
-    | POSITION OPEN_PAREN position_list CLOSE_PAREN
+    | POSITION OPEN_PAREN position_list? CLOSE_PAREN
     | SUBSTRING OPEN_PAREN substr_list CLOSE_PAREN
     | TREAT OPEN_PAREN a_expr AS typename CLOSE_PAREN
     | TRIM OPEN_PAREN (BOTH | LEADING | TRAILING)? trim_list CLOSE_PAREN
@@ -3782,9 +3782,9 @@ func_expr_common_subexpr
     | XMLELEMENT OPEN_PAREN NAME_P collabel (COMMA (xml_attributes | expr_list))? CLOSE_PAREN
     | XMLEXISTS OPEN_PAREN c_expr xmlexists_argument CLOSE_PAREN
     | XMLFOREST OPEN_PAREN xml_attribute_list CLOSE_PAREN
-    | XMLPARSE OPEN_PAREN document_or_content a_expr xml_whitespace_option CLOSE_PAREN
+    | XMLPARSE OPEN_PAREN document_or_content a_expr xml_whitespace_option? CLOSE_PAREN
     | XMLPI OPEN_PAREN NAME_P collabel (COMMA a_expr)? CLOSE_PAREN
-    | XMLROOT OPEN_PAREN XML_P a_expr COMMA xml_root_version opt_xml_root_standalone CLOSE_PAREN
+    | XMLROOT OPEN_PAREN XML_P a_expr COMMA xml_root_version xml_root_standalone_? CLOSE_PAREN
     | XMLSERIALIZE OPEN_PAREN document_or_content a_expr AS simpletypename CLOSE_PAREN
     ;
 
@@ -3793,11 +3793,11 @@ xml_root_version
     | VERSION_P NO VALUE_P
     ;
 
-opt_xml_root_standalone
+xml_root_standalone_
     : COMMA STANDALONE_P YES_P
     | COMMA STANDALONE_P NO
     | COMMA STANDALONE_P NO VALUE_P
-    |
+    
     ;
 
 xml_attributes
@@ -3820,7 +3820,7 @@ document_or_content
 xml_whitespace_option
     : PRESERVE WHITESPACE_P
     | STRIP_P WHITESPACE_P
-    |
+    
     ;
 
 xmlexists_argument
@@ -3836,17 +3836,17 @@ xml_passing_mech
 
 within_group_clause
     : WITHIN GROUP_P OPEN_PAREN sort_clause CLOSE_PAREN
-    |
+    
     ;
 
 filter_clause
     : FILTER OPEN_PAREN WHERE a_expr CLOSE_PAREN
-    |
+    
     ;
 
 window_clause
     : WINDOW window_definition_list
-    |
+    
     ;
 
 window_definition_list
@@ -3859,28 +3859,28 @@ window_definition
 
 over_clause
     : OVER (window_specification | colid)
-    |
+    
     ;
 
 window_specification
-    : OPEN_PAREN opt_existing_window_name opt_partition_clause opt_sort_clause opt_frame_clause CLOSE_PAREN
+    : OPEN_PAREN existing_window_name_? partition_clause_? sort_clause_? frame_clause_? CLOSE_PAREN
     ;
 
-opt_existing_window_name
+existing_window_name_
     : colid
-    |
+    
     ;
 
-opt_partition_clause
+partition_clause_
     : PARTITION BY expr_list
-    |
+    
     ;
 
-opt_frame_clause
-    : RANGE frame_extent opt_window_exclusion_clause
-    | ROWS frame_extent opt_window_exclusion_clause
-    | GROUPS frame_extent opt_window_exclusion_clause
-    |
+frame_clause_
+    : RANGE frame_extent window_exclusion_clause_?
+    | ROWS frame_extent window_exclusion_clause_?
+    | GROUPS frame_extent window_exclusion_clause_?
+    
     ;
 
 frame_extent
@@ -3894,9 +3894,9 @@ frame_bound
     | a_expr (PRECEDING | FOLLOWING)
     ;
 
-opt_window_exclusion_clause
+window_exclusion_clause_
     : EXCLUDE (CURRENT_P ROW | GROUP_P | TIES | NO OTHERS)
-    |
+    
     ;
 
 row
@@ -3994,7 +3994,7 @@ array_expr_list
 
 extract_list
     : extract_arg FROM a_expr
-    |
+    
     ;
 
 extract_arg
@@ -4021,7 +4021,7 @@ overlay_list
 
 position_list
     : b_expr IN_P b_expr
-    |
+    
     ;
 
 substr_list
@@ -4045,7 +4045,7 @@ in_expr
     ;
 
 case_expr
-    : CASE case_arg when_clause_list case_default END_P
+    : CASE case_arg? when_clause_list case_default? END_P
     ;
 
 when_clause_list
@@ -4058,12 +4058,12 @@ when_clause
 
 case_default
     : ELSE a_expr
-    |
+    
     ;
 
 case_arg
     : a_expr
-    |
+    
     ;
 
 columnref
@@ -4072,12 +4072,12 @@ columnref
 
 indirection_el
     : DOT (attr_name | STAR)
-    | OPEN_BRACKET (a_expr | opt_slice_bound COLON opt_slice_bound) CLOSE_BRACKET
+    | OPEN_BRACKET (a_expr | slice_bound_? COLON slice_bound_?) CLOSE_BRACKET
     ;
 
-opt_slice_bound
+slice_bound_
     : a_expr
-    |
+    
     ;
 
 indirection
@@ -4088,9 +4088,9 @@ opt_indirection
     : indirection_el*
     ;
 
-opt_target_list
+target_list_
     : target_list
-    |
+    
     ;
 
 target_list
@@ -4140,9 +4140,9 @@ aexprconst
     | sconst
     | bconst
     | xconst
-    | func_name (sconst | OPEN_PAREN func_arg_list opt_sort_clause CLOSE_PAREN sconst)
+    | func_name (sconst | OPEN_PAREN func_arg_list sort_clause_? CLOSE_PAREN sconst)
     | consttypename sconst
-    | constinterval (sconst opt_interval | OPEN_PAREN iconst CLOSE_PAREN sconst)
+    | constinterval (sconst interval_? | OPEN_PAREN iconst CLOSE_PAREN sconst)
     | TRUE_P
     | FALSE_P
     | NULL_P
@@ -4165,7 +4165,7 @@ iconst
     ;
 
 sconst
-    : anysconst opt_uescape
+    : anysconst uescape_?
     ;
 
 anysconst
@@ -4175,9 +4175,9 @@ anysconst
     | EscapeStringConstant
     ;
 
-opt_uescape
+uescape_
     : UESCAPE anysconst
-    |
+    
     ;
 
 signediconst
@@ -4240,7 +4240,7 @@ collabel
     ;
 
 identifier
-    : Identifier opt_uescape
+    : Identifier uescape_?
     | QuotedIdentifier
     | UnicodeQuotedIdentifier
     | plsqlvariablename
@@ -4856,7 +4856,7 @@ builtin_function_name
 
 /************************************************************************************************************************************************************/
 pl_function
-    : comp_options pl_block opt_semi
+    : comp_options pl_block semi_?
     ;
 
 comp_options
@@ -4882,19 +4882,19 @@ option_value
     | unreserved_keyword
     ;
 
-opt_semi
+semi_
     :
-    | SEMI
+     SEMI
     ;
 
 // exception_sect means opt_exception_sect in original grammar, don't be confused!
 
 pl_block
-    : decl_sect BEGIN_P proc_sect exception_sect END_P opt_label
+    : decl_sect BEGIN_P proc_sect exception_sect? END_P label_?
     ;
 
 decl_sect
-    : opt_block_label (decl_start decl_stmts?)?
+    : block_label_? (decl_start decl_stmts?)?
     ;
 
 decl_start
@@ -4918,14 +4918,14 @@ decl_stmt
 decl_statement
     : decl_varname (
         ALIAS FOR decl_aliasitem
-        | decl_const decl_datatype decl_collate decl_notnull decl_defval
-        | opt_scrollable CURSOR decl_cursor_args decl_is_for decl_cursor_query
+        | decl_const? decl_datatype decl_collate? decl_notnull? decl_defval?
+        | scrollable_? CURSOR decl_cursor_args? decl_is_for decl_cursor_query
     ) SEMI
     ;
 
-opt_scrollable
+scrollable_
     :
-    | NO SCROLL
+     NO SCROLL
     | SCROLL
     ;
 
@@ -4935,7 +4935,7 @@ decl_cursor_query
 
 decl_cursor_args
     :
-    | OPEN_PAREN decl_cursor_arglist CLOSE_PAREN
+     OPEN_PAREN decl_cursor_arglist CLOSE_PAREN
     ;
 
 decl_cursor_arglist
@@ -4962,7 +4962,7 @@ decl_varname
 
 decl_const
     :
-    | CONSTANT
+     CONSTANT
     ;
 
 decl_datatype
@@ -4971,17 +4971,17 @@ decl_datatype
 
 decl_collate
     :
-    | COLLATE any_name
+     COLLATE any_name
     ;
 
 decl_notnull
     :
-    | NOT NULL_P
+     NOT NULL_P
     ;
 
 decl_defval
     :
-    | decl_defkey sql_expression
+     decl_defkey sql_expression
     ;
 
 decl_defkey
@@ -5031,13 +5031,13 @@ stmt_perform
     ;
 
 stmt_call
-    : CALL any_identifier OPEN_PAREN opt_expr_list CLOSE_PAREN SEMI
-    | DO any_identifier OPEN_PAREN opt_expr_list CLOSE_PAREN SEMI
+    : CALL any_identifier OPEN_PAREN expr_list_? CLOSE_PAREN SEMI
+    | DO any_identifier OPEN_PAREN expr_list_? CLOSE_PAREN SEMI
     ;
 
-opt_expr_list
+expr_list_
     :
-    | expr_list
+     expr_list
     ;
 
 stmt_assign
@@ -5045,12 +5045,12 @@ stmt_assign
     ;
 
 stmt_getdiag
-    : GET getdiag_area_opt DIAGNOSTICS getdiag_list SEMI
+    : GET getdiag_area_opt? DIAGNOSTICS getdiag_list SEMI
     ;
 
 getdiag_area_opt
     :
-    | CURRENT_P
+     CURRENT_P
     | STACKED
     ;
 
@@ -5075,7 +5075,7 @@ assign_var
     ;
 
 stmt_if
-    : IF_P expr_until_then THEN proc_sect stmt_elsifs stmt_else END_P IF_P SEMI
+    : IF_P expr_until_then THEN proc_sect stmt_elsifs stmt_else? END_P IF_P SEMI
     ;
 
 stmt_elsifs
@@ -5084,16 +5084,16 @@ stmt_elsifs
 
 stmt_else
     :
-    | ELSE proc_sect
+     ELSE proc_sect
     ;
 
 stmt_case
-    : CASE opt_expr_until_when case_when_list opt_case_else END_P CASE SEMI
+    : CASE opt_expr_until_when? case_when_list case_else_? END_P CASE SEMI
     ;
 
 opt_expr_until_when
     :
-    | sql_expression
+     sql_expression
     ;
 
 case_when_list
@@ -5104,53 +5104,53 @@ case_when
     : WHEN expr_list THEN proc_sect
     ;
 
-opt_case_else
+case_else_
     :
-    | ELSE proc_sect
+     ELSE proc_sect
     ;
 
 stmt_loop
-    : opt_loop_label loop_body
+    : loop_label_? loop_body
     ;
 
 stmt_while
-    : opt_loop_label WHILE expr_until_loop loop_body
+    : loop_label_? WHILE expr_until_loop loop_body
     ;
 
 stmt_for
-    : opt_loop_label FOR for_control loop_body
+    : loop_label_? FOR for_control loop_body
     ;
 
 //TODO: rewrite using read_sql_expression logic?
 
 for_control
     : for_variable IN_P (
-        cursor_name opt_cursor_parameters
+        cursor_name cursor_parameters_?
         | selectstmt
         | explainstmt
-        | EXECUTE a_expr opt_for_using_expression
-        | opt_reverse a_expr DOT_DOT a_expr opt_by_expression
+        | EXECUTE a_expr for_using_expression_?
+        | reverse_? a_expr DOT_DOT a_expr by_expression_?
     )
     ;
 
-opt_for_using_expression
+for_using_expression_
     :
-    | USING expr_list
+     USING expr_list
     ;
 
-opt_cursor_parameters
+cursor_parameters_
     :
-    | OPEN_PAREN a_expr (COMMA a_expr)* CLOSE_PAREN
+     OPEN_PAREN a_expr (COMMA a_expr)* CLOSE_PAREN
     ;
 
-opt_reverse
+reverse_
     :
-    | REVERSE
+     REVERSE
     ;
 
-opt_by_expression
+by_expression_
     :
-    | BY a_expr
+     BY a_expr
     ;
 
 for_variable
@@ -5158,16 +5158,16 @@ for_variable
     ;
 
 stmt_foreach_a
-    : opt_loop_label FOREACH for_variable foreach_slice IN_P ARRAY a_expr loop_body
+    : loop_label_? FOREACH for_variable foreach_slice? IN_P ARRAY a_expr loop_body
     ;
 
 foreach_slice
     :
-    | SLICE iconst
+     SLICE iconst
     ;
 
 stmt_exit
-    : exit_type opt_label opt_exitcond SEMI
+    : exit_type label_? exitcond_? SEMI
     ;
 
 exit_type
@@ -5180,14 +5180,14 @@ exit_type
 stmt_return
     : RETURN (
         NEXT sql_expression
-        | QUERY (EXECUTE a_expr opt_for_using_expression | selectstmt)
-        | opt_return_result
+        | QUERY (EXECUTE a_expr for_using_expression_? | selectstmt)
+        | opt_return_result?
     ) SEMI
     ;
 
 opt_return_result
     :
-    | sql_expression
+     sql_expression
     ;
 
 //https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html
@@ -5203,17 +5203,17 @@ opt_return_result
 //RAISE ;
 
 stmt_raise
-    : RAISE opt_stmt_raise_level sconst opt_raise_list opt_raise_using SEMI
-    | RAISE opt_stmt_raise_level identifier opt_raise_using SEMI
-    | RAISE opt_stmt_raise_level SQLSTATE sconst opt_raise_using SEMI
-    | RAISE opt_stmt_raise_level opt_raise_using SEMI
+    : RAISE stmt_raise_level_? sconst raise_list_? raise_using_? SEMI
+    | RAISE stmt_raise_level_? identifier raise_using_? SEMI
+    | RAISE stmt_raise_level_? SQLSTATE sconst raise_using_? SEMI
+    | RAISE stmt_raise_level_? raise_using_? SEMI
     | RAISE
     ;
 
-opt_stmt_raise_level
+stmt_raise_level_
     :
-    |
-    | DEBUG
+    
+     DEBUG
     | LOG
     | INFO
     | NOTICE
@@ -5221,37 +5221,37 @@ opt_stmt_raise_level
     | EXCEPTION
     ;
 
-opt_raise_list
+raise_list_
     :
-    | (COMMA a_expr)+
+     (COMMA a_expr)+
     ;
 
-opt_raise_using
+raise_using_
     :
-    | USING opt_raise_using_elem_list
+     USING raise_using_elem_list_
     ;
 
-opt_raise_using_elem
+raise_using_elem_
     : identifier EQUAL a_expr
     ;
 
-opt_raise_using_elem_list
-    : opt_raise_using_elem (COMMA opt_raise_using_elem)*
+raise_using_elem_list_
+    : raise_using_elem_ (COMMA raise_using_elem_)*
     ;
 
 //todo imnplement
 
 stmt_assert
-    : ASSERT sql_expression opt_stmt_assert_message SEMI
+    : ASSERT sql_expression stmt_assert_message_? SEMI
     ;
 
-opt_stmt_assert_message
+stmt_assert_message_
     :
-    | COMMA sql_expression
+     COMMA sql_expression
     ;
 
 loop_body
-    : LOOP proc_sect END_P LOOP opt_label SEMI
+    : LOOP proc_sect END_P LOOP label_? SEMI
     ;
 
 //TODO: looks like all other statements like INSERT/SELECT/UPDATE/DELETE are handled here;
@@ -5273,24 +5273,24 @@ stmt_execsql
 
 stmt_dynexecute
     : EXECUTE a_expr (
-        /*this is silly, but i have to time to find nice way to code */ opt_execute_into opt_execute_using
-        | opt_execute_using opt_execute_into
+        /*this is silly, but i have to time to find nice way to code */ execute_into_? execute_using_?
+        | execute_using_? execute_into_?
         |
     ) SEMI
     ;
 
-opt_execute_using
+execute_using_
     :
-    | USING opt_execute_using_list
+     USING execute_using_list_
     ;
 
-opt_execute_using_list
+execute_using_list_
     : a_expr (COMMA a_expr)*
     ;
 
-opt_execute_into
+execute_into_
     :
-    | INTO STRICT_P? into_target
+     INTO STRICT_P? into_target
     ;
 
 //https://www.postgresql.org/docs/current/plpgsql-cursors.html#PLPGSQL-CURSOR-OPENING
@@ -5305,33 +5305,33 @@ opt_execute_into
 
 stmt_open
     : OPEN (
-        cursor_variable opt_scroll_option FOR (selectstmt | EXECUTE sql_expression opt_open_using)
-        | colid (OPEN_PAREN opt_open_bound_list CLOSE_PAREN)?
+        cursor_variable scroll_option_? FOR (selectstmt | EXECUTE sql_expression open_using_?)
+        | colid (OPEN_PAREN open_bound_list_ CLOSE_PAREN)?
     ) SEMI
     ;
 
-opt_open_bound_list_item
+open_bound_list_item_
     : colid COLON_EQUALS a_expr
     | a_expr
     ;
 
-opt_open_bound_list
-    : opt_open_bound_list_item (COMMA opt_open_bound_list_item)*
+open_bound_list_
+    : open_bound_list_item_ (COMMA open_bound_list_item_)*
     ;
 
-opt_open_using
+open_using_
     :
-    | USING expr_list
+     USING expr_list
     ;
 
-opt_scroll_option
+scroll_option_
     :
-    | opt_scroll_option_no SCROLL
+     scroll_option_no_? SCROLL
     ;
 
-opt_scroll_option_no
+scroll_option_no_
     :
-    | NO
+     NO
     ;
 
 //https://www.postgresql.org/docs/current/plpgsql-cursors.html#PLPGSQL-CURSOR-OPENING
@@ -5339,23 +5339,23 @@ opt_scroll_option_no
 //FETCH [ direction { FROM | IN } ] cursor INTO target;
 
 stmt_fetch
-    : FETCH direction = opt_fetch_direction opt_cursor_from cursor_variable INTO into_target SEMI
+    : FETCH direction = fetch_direction_ cursor_from_? cursor_variable INTO into_target SEMI
     ;
 
 into_target
     : expr_list
     ;
 
-opt_cursor_from
+cursor_from_
     :
-    | FROM
+     FROM
     | IN_P
     ;
 
-opt_fetch_direction
+fetch_direction_
     :
-    |
-    | NEXT
+    
+     NEXT
     | PRIOR
     | FIRST_P
     | LAST_P
@@ -5371,7 +5371,7 @@ opt_fetch_direction
 //MOVE [ direction { FROM | IN } ] cursor;
 
 stmt_move
-    : MOVE opt_fetch_direction cursor_variable SEMI
+    : MOVE fetch_direction_? cursor_variable SEMI
     ;
 
 stmt_close
@@ -5383,16 +5383,16 @@ stmt_null
     ;
 
 stmt_commit
-    : COMMIT plsql_opt_transaction_chain SEMI
+    : COMMIT plsql_opt_transaction_chain? SEMI
     ;
 
 stmt_rollback
-    : ROLLBACK plsql_opt_transaction_chain SEMI
+    : ROLLBACK plsql_opt_transaction_chain? SEMI
     ;
 
 plsql_opt_transaction_chain
     : AND NO? CHAIN
-    |
+    
     ;
 
 stmt_set
@@ -5407,7 +5407,7 @@ cursor_variable
 
 exception_sect
     :
-    | EXCEPTION proc_exceptions
+     EXCEPTION proc_exceptions
     ;
 
 proc_exceptions
@@ -5439,24 +5439,24 @@ proc_condition
 
 //;
 
-opt_block_label
+block_label_
     :
-    | label_decl
+     label_decl
     ;
 
-opt_loop_label
+loop_label_
     :
-    | label_decl
+     label_decl
     ;
 
-opt_label
+label_
     :
-    | any_identifier
+     any_identifier
     ;
 
-opt_exitcond
+exitcond_
     : WHEN expr_until_semi
-    |
+    
     ;
 
 any_identifier
@@ -5555,7 +5555,7 @@ plsql_unreserved_keyword
     ;
 
 sql_expression
-    : opt_target_list into_clause from_clause where_clause group_clause having_clause window_clause
+    : target_list_? into_clause? from_clause? where_clause? group_clause? having_clause? window_clause?
     ;
 
 expr_until_then
@@ -5575,10 +5575,10 @@ expr_until_loop
     ;
 
 make_execsql_stmt
-    : stmt opt_returning_clause_into
+    : stmt returning_clause_into_?
     ;
 
-opt_returning_clause_into
-    : INTO opt_strict into_target
-    |
+returning_clause_into_
+    : INTO strict_? into_target
+    
     ;

--- a/sql/postgresql/README.md
+++ b/sql/postgresql/README.md
@@ -1,8 +1,19 @@
 # PostgreSQL grammar
 
-PostgreSQL sql/pgsql grammar based on sources from https://github.com/postgres/postgres/tree/master/src/
-Sample scripts taken from https://github.com/postgres/postgres/tree/master/src/test/regress/sql
-Lexer taken from https://github.com/tunnelvisionlabs/antlr4-grammar-postgresql/blob/master/src/com/tunnelvisionlabs/postgresql/PostgreSqlLexer.g4
+PostgreSQL sql/pgsql grammar based on the
+[Bison grammar at the Github mirror](https://github.com/postgres/postgres/blob/9be4e5d293b554d8a0800790c57fc707a3b5cf0f/src/backend/parser/gram.y).
 
-Not all rules are balanced, that's why the produced trees may be incorrect.
-However, the script still be parsed with no errors.
+Lexer was derived from https://github.com/tunnelvisionlabs/antlr4-grammar-postgresql/blob/master/src/com/tunnelvisionlabs/postgresql/PostgreSqlLexer.g4.
+
+Sample SQL tests are derived from the sources
+at https://github.com/postgres/postgres/tree/master/src/test/regress/sql.
+
+# Issues
+
+* There are two warnings from the Antlr Tool in the parser grammar
+(`rule stmt_case contains an optional block with at least one alternative that can match an empty string`
+and `rule stmt_return contains an optional block with at least one alternative that can match an empty string`).
+* There are two warnings from the Antlr Tool in the lexer grammar
+(`non-fragment lexer rule AfterEscapeStringConstantMode_NotContinued can match the empty string` and `non-fragment lexer rule AfterEscapeStringConstantWithNewlineMode_NotContinued can match the empty string`).
+* The grammar is ambiguous.
+

--- a/sql/postgresql/fixups/detect.sh
+++ b/sql/postgresql/fixups/detect.sh
@@ -1,0 +1,10 @@
+#
+# set -x
+set -e
+set -o pipefail
+for dir in `find . -name desc.xml | sed 's#/desc.xml##' | sort -u`
+do
+	# Find rules that contain top-level empty alts.
+	# Note, not complete because the alt may be not empty, but could derive empty.
+	dotnet trparse -l $dir/*.g4 2>/dev/null | dotnet trxgrep ' //parserRuleSpec[./ruleBlock/ruleAltList/labeledAlt/alternative[count(./*) = 0]]/RULE_REF' | dotnet trcaret
+done

--- a/sql/postgresql/fixups/fix.sh
+++ b/sql/postgresql/fixups/fix.sh
@@ -1,0 +1,22 @@
+#
+# set -x
+set -e
+set -o pipefail
+for dir in `find . -name desc.xml | sed 's#/desc.xml##' | sort -u`
+do
+	echo $dir
+	# Find rules that contain top-level empty alts.
+	# Note, not complete because the alt may be not empty, but could derive empty.
+	dotnet trparse -l $dir/*.g4 2>/dev/null > save.pt
+	cat save.pt | dotnet trxgrep ' //parserRuleSpec[./ruleBlock/ruleAltList/labeledAlt/alternative[count(./*) = 0]]/RULE_REF/text()' > rules.txt
+	# Find locations of use that an operator applied to it.
+	for r in `cat rules.txt`
+	do
+		rr=`echo $r | tr -d '\n' | tr -d '\r'`
+		echo Working on $rr
+		dotnet trparse $dir/*.g4 2>/dev/null | dotnet trquery replace ' //parserRuleSpec/ruleBlock//element[./atom and not(./ebnfSuffix)]/atom/ruleref/RULE_REF[./text() = "'$rr'"]' "'$rr?'" | dotnet trsponge -o $dir -c
+		# Remove empty alt in the rule.
+		dotnet trparse $dir/*.g4 2>/dev/null | dotnet trquery delete "  //parserRuleSpec[RULE_REF/text() = '$rr']/ruleBlock/ruleAltList/labeledAlt[alternative/count(./*) = 0 and ./preceding-sibling::*[last()]/self::OR]/(. | ./preceding-sibling::OR[last()])" | dotnet trsponge -o $dir -c
+		dotnet trparse $dir/*.g4 2>/dev/null | dotnet trquery delete "  //parserRuleSpec[RULE_REF/text() = '$rr']/ruleBlock/ruleAltList/labeledAlt[alternative/count(./*) = 0 and ./following-sibling::*[1]/self::OR]/(. | ./following-sibling::OR[1])" | dotnet trsponge -o $dir -c
+	done
+done

--- a/sql/postgresql/fixups/rename.sh
+++ b/sql/postgresql/fixups/rename.sh
@@ -1,0 +1,13 @@
+names=`dotnet trparse PostgreSQLParser.g4 | dotnet trnullable | \
+	grep ' False' | grep '^opt_' | awk '{print $1}'`
+for i in $names
+do
+#	echo got $i
+	old=$i
+	new=${old:4}_
+#	echo old $old new $new
+	rename="$old,$new${sep:=}$rename"
+	sep=";"
+done
+echo $rename
+dotnet trparse PostgreSQLParser.g4 | dotnet trrename "$rename" | dotnet trsponge -o . -c


### PR DESCRIPTION
This is a change to fix one of the types of problems with the [postgresql grammar](https://github.com/antlr/grammars-v4/tree/199a5121ece05d2f2e7eca330d0738220499e80c/sql/postgresql).

As noted in #4291, the grammar contains numerous non-idiomatic rule definitions. In particular, the grammar contains rules with empty alternatives, appearing to be derived from a grammar for another parser generator. Indeed, that conclusion is correct: this grammar is derived from the Bison grammar at https://github.com/postgres/postgres/blob/9be4e5d293b554d8a0800790c57fc707a3b5cf0f/src/backend/parser/gram.y/. Bison/yacc does not support an optional operator EBNF. But, Antlr does.

This change refactors empty production rules to non-empty rules and adds the `?`-operator to the applied occurrences of the parser symbol. The names of these parser rules are changed to not have the "opt_" prefix, as they don't derive empty (generally) anymore.

The scripts to make these changes have been added to the sub-directory `fixups/`. `detect.sh` finds all productions that have an empty top-level alt. `fix.sh` refactors these productions by removing the empty alt, and adding the `?`-operator to the applied occurrences. `rename.sh` renames rules that are not nullable.

These changes do not affect the performance.

There are two new warnings from the Antlr Tool (` rule stmt_case contains an optional block with
 at least one alternative that can match an empty string` and `rule stmt_return contains an optional block with at least one alternative that can match an empty string`). These do not affect the performance or correctness of the parser. These will be delt with in a later fix to correct other warnings (`non-fragment lexer rule AfterEscapeStringConstantMode_NotContinued can match the empty string` and `non-fragment lexer rule AfterEscapeStringConstantWithNewlineMode_NotContinued can match the empty string`). In addition, the ambiguity in the grammar results in terrible performance, which also needs to be corrected.

I've updated the readme.md to note the actual grammar source and issues.
