### PR TITLE
[postgresql] Fix for #4300 -- ambiguity in from_list

### DIFF
--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -3190,12 +3190,7 @@ from_clause
     ;
 
 from_list
-    : non_ansi_join
-    | table_ref (COMMA table_ref)*
-    ;
-
-non_ansi_join
-    : table_ref (COMMA table_ref)+
+    : table_ref (COMMA table_ref)*
     ;
 
 table_ref


### PR DESCRIPTION
This PR fixes a grammar ambiguity introduced with https://github.com/antlr/grammars-v4/pull/3008.

Consider input `select x from t c1, t c2;`. The substring `t c1, t c2` can be parsed two ways:
* `from_list` => `non_ansi_join` => `table_ref ...` ==> `t c1, t c2`
* `from_list` => `table_ref ...` ==> `t c1, t c2`

As I point out in the write-up for #4300, from_list is defined with two alts that overlap. The two alts did not fix anything. It simply added to the ambiguity of the grammar and made the parser perform worse.

I discovered this using [trparse --ambig](https://github.com/kaby76/Trash/tree/main/src/trparse).