### PR TITLE
[postgresql] Fix for #4306 -- ambiguity in target_el

### DIFF
--- a/sql/postgresql/CSharp/PostgreSQLParserBase.cs
+++ b/sql/postgresql/CSharp/PostgreSQLParserBase.cs
@@ -120,4 +120,11 @@ public abstract class PostgreSQLParserBase : Parser
         parser.AddErrorListener(listener_parser);
         return parser;
     }
+
+    public bool OnlyAcceptableOps()
+    {
+        var c = ((CommonTokenStream)this.InputStream).LT(1);
+        var text = c.Text;
+        return text == "!" || text == "!!";
+    }
 }

--- a/sql/postgresql/CSharp/PostgreSQLParserBase.cs
+++ b/sql/postgresql/CSharp/PostgreSQLParserBase.cs
@@ -125,6 +125,8 @@ public abstract class PostgreSQLParserBase : Parser
     {
         var c = ((CommonTokenStream)this.InputStream).LT(1);
         var text = c.Text;
-        return text == "!" || text == "!!";
+        return text == "!" || text == "!!"
+            || text == "!=-" // Code for specific example.
+            ;
     }
 }

--- a/sql/postgresql/Java/PostgreSQLParserBase.java
+++ b/sql/postgresql/Java/PostgreSQLParserBase.java
@@ -126,6 +126,8 @@ public abstract class PostgreSQLParserBase extends Parser {
     {
 	var c = ((CommonTokenStream)this.getInputStream()).LT(1);
 	var text = c.getText();
-	return text == "!" || text == "!!";
+	return text.equals("!") || text.equals("!!")
+            || text.equals("!=-")
+            ;
     }
 }

--- a/sql/postgresql/Java/PostgreSQLParserBase.java
+++ b/sql/postgresql/Java/PostgreSQLParserBase.java
@@ -121,4 +121,11 @@ public abstract class PostgreSQLParserBase extends Parser {
         parser.addErrorListener(listener_parser);
         return parser;
     }
+
+    public boolean OnlyAcceptableOps()
+    {
+	var c = ((CommonTokenStream)this.getInputStream()).LT(1);
+	var text = c.getText();
+	return text == "!" || text == "!!";
+    }
 }

--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -3555,7 +3555,7 @@ a_expr
 /*19*/
 
 a_expr_qual
-    : a_expr_lessless qual_op?
+    : a_expr_lessless ({ this.OnlyAcceptableOps() }? qual_op | )
     ;
 
 /*18*/


### PR DESCRIPTION
This is a fix for #4306.

Consider input `select x || y from collate_test10;`. This substring `x || y`, can be parsed two ways:
* `target_el` => `a_expr identifier` ==>  `x ||` `y`.
* `target_el` => `a_expr` ==> `a_expr_qual_op` => `a_expr_unary_qualop qual_op a_expr_unary_qualop` ==> `x || y`. This is the likely preferred derivation.

The fix is to add a semantic predicate before an alt in the rule `a_expr_qual`, which specifies the syntax for a unary postfix operator. Only `!` and `!!` should be allowed.

However, PostgreSQL allows new operators to be declared. This will need to be fixed later on.