### PR TITLE
[bison] Fix for #4312 -- replace recursion with kleene *-operators, and add TypeScript and Antlr4ng ports

### DIFF
--- a/bison/Antlr4ng/BisonLexerBase.ts
+++ b/bison/Antlr4ng/BisonLexerBase.ts
@@ -1,0 +1,34 @@
+import { CommonToken, Lexer, CharStream, Token } from "antlr4ng";
+import { BisonLexer } from './BisonLexer.js';
+
+export default abstract class BisonLexerBase extends Lexer {
+    percent_percent_count: number;
+
+    constructor(input: CharStream) {
+        super(input);
+        this.percent_percent_count = 0;
+    }
+
+    reset() {
+        this.percent_percent_count = 0;
+        super.reset();
+    }
+
+    NextMode()
+    {
+	    ++this.percent_percent_count;
+	    if (this.percent_percent_count == 1)
+	    {
+		    return;
+	    } else if (this.percent_percent_count == 2)
+	    {
+		    this.pushMode(BisonLexer.EpilogueMode);
+		    return;
+	    } else
+	    {
+		    this.type = BisonLexer.PercentPercent;
+		    return;
+	    }
+    }
+}
+

--- a/bison/Antlr4ng/transformGrammar.py
+++ b/bison/Antlr4ng/transformGrammar.py
@@ -1,0 +1,31 @@
+"""The script transforms the grammar to fit for the c++ target """
+import sys
+import re
+import shutil
+from glob import glob
+from pathlib import Path
+
+def main():
+    """Executes the script."""
+    for file in glob("./*.g4"):
+        transform_grammar(file)
+
+def transform_grammar(file_path):
+    """Transforms the grammar to fit for the target"""
+    print("Altering " + file_path)
+    if not Path(file_path).is_file:
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+
+    shutil.move(file_path, file_path + ".bak")
+    with open(file_path + ".bak",'r', encoding="utf-8") as input_file:
+        with open(file_path, 'w', encoding="utf-8") as output_file:
+            for line in input_file:
+                line = re.sub(r"(\/\/ Insert here @header for C\+\+ lexer\.)",\
+                    '@header {import BisonLexerBase from "./BisonLexerBase.js"}', line)
+                output_file.write(line)
+
+    print("Writing ...")
+
+if __name__ == '__main__':
+    main()

--- a/bison/BisonLexer.g4
+++ b/bison/BisonLexer.g4
@@ -2,9 +2,10 @@
 // Copyright 2020-2022
 // MIT License
 
-// $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
-// $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
-// $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
+
+// $antlr-format alignColons trailing, alignLabels true, alignLexerCommands true, alignSemicolons ownLine, alignTrailers true
+// $antlr-format alignTrailingComments true, allowShortBlocksOnASingleLine true, allowShortRulesOnASingleLine true, columnLimit 150
+// $antlr-format maxEmptyLinesToKeep 1, minEmptyLines 0, reflowComments false, singleLineOverrulesHangingColon true, useTab false
 
 lexer grammar BisonLexer;
 
@@ -141,7 +142,7 @@ PercentPercent: '%%' { this.NextMode(); };
      option name, with a single string argument.  Otherwise, add exceptions
      to ../build-aux/cross-options.pl.  */
 
-NONASSOC: '%binary';
+PERCENT_BINARY: '%binary';
 
 CODE: '%code';
 

--- a/bison/BisonParser.g4
+++ b/bison/BisonParser.g4
@@ -21,8 +21,9 @@
 | Grammar.  |
 \==========*/
 
-// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
-// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+// $antlr-format alignColons hanging, alignSemicolons hanging, alignTrailingComments true, allowShortBlocksOnASingleLine true
+// $antlr-format allowShortRulesOnASingleLine false, columnLimit 150, maxEmptyLinesToKeep 1, minEmptyLines 1, reflowComments false, useTab false
 
 parser grammar BisonParser;
 
@@ -74,8 +75,7 @@ prologue_declaration
     ;
 
 params
-    : params actionBlock
-    | actionBlock
+    : actionBlock+
     ;
 
 /*----------------------.
@@ -118,6 +118,7 @@ precedence_declarator
     : PERCENT_LEFT
     | PERCENT_RIGHT
     | PERCENT_NONASSOC
+    | PERCENT_BINARY
     | PRECEDENCE
     ;
 
@@ -193,9 +194,7 @@ alias
 // FOO and 'foo' as two different symbols instead of aliasing them.
 
 token_decls_for_prec
-    : token_decl_for_prec+
-    | TAG token_decl_for_prec+
-    | token_decls_for_prec TAG token_decl_for_prec+
+    : (token_decl_for_prec+ | TAG token_decl_for_prec+) (TAG token_decl_for_prec+)*
     ;
 
 // One token declaration for precedence declaration.
@@ -212,9 +211,7 @@ token_decl_for_prec
 // A non empty list of typed symbols (for %type).
 
 symbol_decls
-    : symbol+
-    | TAG symbol+
-    | symbol_decls TAG symbol+
+    : (symbol+ | TAG symbol+) (TAG symbol+)*
     ;
 
 /*------------------------------------------.
@@ -222,8 +219,7 @@ symbol_decls
 `------------------------------------------*/
 
 bison_grammar
-    : rules_or_grammar_declaration
-    | bison_grammar rules_or_grammar_declaration
+    : rules_or_grammar_declaration+
     ;
 
 /* As a Bison extension, one can use the grammar declarations in the

--- a/bison/desc.xml
+++ b/bison/desc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>Cpp;CSharp;Dart;Go;Java;JavaScript;Python3</targets>
+   <targets>Antlr4ng;Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
 </desc>


### PR DESCRIPTION
The PR fixes #4312, where some rules were written with (left) recursion. While Antlr certainly can handle recursion, the main issue is performance. With recursion, I get stack overflows with the CSharp target in Release mode. I don't know why but Debug mode .NET builds are just fine.

The change refactors four rules with kleene `*`-operators. In addition, the TypeScript port, which did work, then stopped working, started to work again! I think this is due to numerous changes in the TypeScript runtime now in 4.13.2. With a TypeScript port, Antlr4ng wasn't far of a reach so I added that. The desc.xml is changed to reflect this.