### PR TITLE
[postgresql] Fix for #4311 -- remove Antlr "locals", stop calling sub-parser.

### DIFF
--- a/sql/postgresql/CSharp/PostgreSQLParserBase.cs
+++ b/sql/postgresql/CSharp/PostgreSQLParserBase.cs
@@ -56,14 +56,21 @@ public abstract class PostgreSQLParserBase : Parser
         if (func_as != null)
         {
             var txt = GetRoutineBodyString(func_as.func_as().sconst(0));
-            var ph = getPostgreSQLParser(txt);
             switch (lang)
             {
                 case "plpgsql":
-                    func_as.func_as().Definition = ph.plsqlroot();
+                    // Mutate tree.
+                    // NB: cannot use locals this way because
+                    // it does not work with ToStringTree().
+                    // var ph = getPostgreSQLParser(txt);
+                    // func_as.func_as().Definition = ph.plsqlroot();
                     break;
                 case "sql":
-                    func_as.func_as().Definition = ph.root();
+                    // Mutate tree.
+                    // NB: cannot use locals this way because
+                    // it does not work with ToStringTree().
+                    // func_as.func_as().Definition = ph.root();
+                    // ph.root();
                     break;
             }
         }

--- a/sql/postgresql/Java/PostgreSQLParserBase.java
+++ b/sql/postgresql/Java/PostgreSQLParserBase.java
@@ -63,13 +63,14 @@ public abstract class PostgreSQLParserBase extends Parser {
         }
         if (func_as != null) {
             String txt = GetRoutineBodyString(func_as.func_as().sconst(0));
-            PostgreSQLParser ph = getPostgreSQLParser(txt);
             switch (lang) {
                 case "plpgsql":
-                    func_as.func_as().Definition = ph.plsqlroot();
+                    //NB: Cannot be done this way.
+                    //PostgreSQLParser ph = getPostgreSQLParser(txt);
+                    //func_as.func_as().Definition = ph.plsqlroot();
                     break;
                 case "sql":
-                    func_as.func_as().Definition = ph.root();
+                    //func_as.func_as().Definition = ph.root();
                     break;
             }
         }
@@ -124,9 +125,9 @@ public abstract class PostgreSQLParserBase extends Parser {
 
     public boolean OnlyAcceptableOps()
     {
-	var c = ((CommonTokenStream)this.getInputStream()).LT(1);
-	var text = c.getText();
-	return text.equals("!") || text.equals("!!")
+        var c = ((CommonTokenStream)this.getInputStream()).LT(1);
+        var text = c.getText();
+        return text.equals("!") || text.equals("!!")
             || text.equals("!=-")
             ;
     }

--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -2045,7 +2045,6 @@ createfunc_opt_item
 //    | AS 'obj_file', 'link_symbol'
 
 func_as
-    locals[ParserRuleContext Definition]
     :
     /* |AS 'definition'*/ def = sconst
     /*| AS 'obj_file', 'link_symbol'*/


### PR DESCRIPTION
This PR fixes #4311. The problem is that the .g4 grammar file used `locals [ ... ]`. This cannot work for a multi-targeted grammar. In addition, the grammar tried to parse function bodies as always Pl/SQL. It ignores the fact that it could be something else.

* The `locals [ ... ]` declaration has been removed.
* The sub-parse of the function bodies was removed. I added `//NB` comments to re-implement the sub-parse in the correct way later.

The grammar is now twice as fast to parse the test suite in examples/, likely because it is not parsing pl/pgsql. To consider: is it better to create the parser once and use Reset() instead of creating a parser for each pl/pgsql input?
