### PR TITLE
[postgresql] Fixes for #4321, #4322

### DIFF
--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -3339,8 +3339,10 @@ xml_namespace_el
     ;
 
 typename
-    : SETOF? simpletypename (opt_array_bounds | ARRAY (OPEN_BRACKET iconst CLOSE_BRACKET)?)
-    | qualified_name PERCENT (ROWTYPE | TYPE_P)
+    : SETOF? simpletypename
+	( opt_array_bounds
+	| ARRAY (OPEN_BRACKET iconst CLOSE_BRACKET)?
+	)
     ;
 
 opt_array_bounds
@@ -3653,7 +3655,7 @@ a_expr_mul
 /* 5*/
 
 a_expr_caret
-    : a_expr_unary_sign (CARET a_expr)?
+    : a_expr_unary_sign (CARET a_expr_unary_sign)?
     ;
 
 /* 4*/
@@ -3709,7 +3711,6 @@ c_expr
     | /*22*/ UNIQUE select_with_parens                                 # c_expr_expr
     | columnref                                                        # c_expr_expr
     | aexprconst                                                       # c_expr_expr
-    | plsqlvariablename                                                # c_expr_expr
     | OPEN_PAREN a_expr_in_parens = a_expr CLOSE_PAREN opt_indirection # c_expr_expr
     | case_expr                                                        # c_expr_case
     | func_expr                                                        # c_expr_expr
@@ -4797,7 +4798,7 @@ unreserved_keyword
 col_name_keyword
     : BETWEEN
     | BIGINT
-    | bit
+    | BIT
     | BOOLEAN_P
     | CHAR_P
     | character
@@ -4831,7 +4832,7 @@ col_name_keyword
     | NONE
     | NORMALIZE
     | NULLIF
-    | numeric
+    | NUMERIC
     | OUT_P
     | OVERLAY
     | POSITION

--- a/sql/postgresql/README.md
+++ b/sql/postgresql/README.md
@@ -10,9 +10,6 @@ at https://github.com/postgres/postgres/tree/master/src/test/regress/sql.
 
 # Issues
 
-* There are two warnings from the Antlr Tool in the parser grammar
-(`rule stmt_case contains an optional block with at least one alternative that can match an empty string`
-and `rule stmt_return contains an optional block with at least one alternative that can match an empty string`).
 * There are two warnings from the Antlr Tool in the lexer grammar
 (`non-fragment lexer rule AfterEscapeStringConstantMode_NotContinued can match the empty string` and `non-fragment lexer rule AfterEscapeStringConstantWithNewlineMode_NotContinued can match the empty string`).
 * The grammar is ambiguous.


### PR DESCRIPTION
This PR fixes #4321 and #4322.

For #4321, the grammar rule `typename` was refactored from the gram.y. The second alt was removed because it added ambiguity.

For #4322, `a_expr_caret` was corrected to follow the usual Floyd operator precedence grammar pattern. The input `SELECT 1 * 2 ^ 3 + 4;` is no longer ambiguous.

Several other rules were corrected to remove some of the lingering pl/pgsql grammar rules, which caused ambiguity in `col_name_keyword` and `c_expr`.

As I progress in the clean up of this grammar, keep an eye on the list of rules with ambiguity. Before I started a couple of weeks ago, the list of ambiguous rules was this:
```
a_expr_add
a_expr_and
a_expr_compare
a_expr_qual_op
alter_table_cmd
c_expr
col_name_keyword
colid
collabel
createfunc_opt_list
frame_bound
from_list
func_type
group_by_item
into_clause
opt_analyze
opt_target_list
optschemaeltlist
reindexstmt
select_with_parens
selectstmt
stmt
table_ref
tableelement
type_function_name
zone_value
```

It is now this:
```
a_expr_and
a_expr_compare
c_expr
frame_bound
group_by_item
select_with_parens
selectstmt
table_ref
```

The readme was updated to reflect fixes to the grammar that removed Antlr Tool warnings.