### PR TITLE
[build] Fix for #4326 -- GitHub Action VMs running MacOS are unreliable.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Upgrade Pip.
       run: |
         python -m ensurepip --upgrade
-    - name: Test Pip.
+    - name: Test Pip
       run: |
         pip --version
     - name: Install Antlr tool
@@ -162,7 +162,13 @@ jobs:
             $Before = "${{ github.event.before }}"
             $After = "${{ github.event.after }}"
         }
-        _scripts/test.ps1 -target ${{ matrix.language }} -pc "$Before" -cc "$After"
+        if ("${{ matrix.os }}" -eq "ubuntu-latest") {
+            _scripts/test.ps1 -target ${{ matrix.language }} -pc "$Before" -cc "$After"
+        } elseif ("${{ matrix.os }}" -eq "windows-latest") {
+            _scripts/test.ps1 -target ${{ matrix.language }} -pc "$Before" -cc "$After"
+        } elseif ("${{ matrix.os }}" -eq "macos-latest") {
+            _scripts/test.ps1 -target ${{ matrix.language }} -pc "$Before" -cc "$After" -buildonly:true
+        }
 
   static-check:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
         } elseif ("${{ matrix.os }}" -eq "windows-latest") {
             _scripts/test.ps1 -target ${{ matrix.language }} -pc "$Before" -cc "$After"
         } elseif ("${{ matrix.os }}" -eq "macos-latest") {
-            _scripts/test.ps1 -target ${{ matrix.language }} -pc "$Before" -cc "$After" -buildonly:true
+            _scripts/test.ps1 -target ${{ matrix.language }} -pc "$Before" -cc "$After" -buildonly:1
         }
 
   static-check:

--- a/_scripts/test.ps1
+++ b/_scripts/test.ps1
@@ -1,7 +1,8 @@
 param (
     [string]$target='CSharp',
     [string]$pc,
-    [string]$cc
+    [string]$cc,
+    [bool]$buildonly=$false
 )
 
 function Get-GrammarSkip {
@@ -123,22 +124,23 @@ function Test-Grammar {
         }
 
         # test
-        $start2 = Get-Date
-        Write-Host "--- Testing files ---"
-$workingDirectory = Get-Location
-Write-Host "The pwd is  $workingDirectory"
-        ./test.ps1
-        $passed = $LASTEXITCODE -eq 0
-
-        if (! $passed) {
-            $success = $false
-            $failStage = [FailStage]::Test
-            Write-Host "Test completed, time: $((Get-Date) - $start2)" -ForegroundColor Yellow
-            Set-Location $cwd
-            return @{
-                Success     = $success
-                Stage       = $failStage
-                FailedCases = $failedList
+        if (! $buildonly) {
+            $start2 = Get-Date
+            Write-Host "--- Testing files ---"
+            $workingDirectory = Get-Location
+            Write-Host "The pwd is  $workingDirectory"
+            ./test.ps1
+            $passed = $LASTEXITCODE -eq 0
+            if (! $passed) {
+                $success = $false
+                $failStage = [FailStage]::Test
+                Write-Host "Test completed, time: $((Get-Date) - $start2)" -ForegroundColor Yellow
+                Set-Location $cwd
+                return @{
+                    Success     = $success
+                    Stage       = $failStage
+                    FailedCases = $failedList
+                }
             }
         }
     }

--- a/bnf/README.md
+++ b/bnf/README.md
@@ -16,3 +16,6 @@ https://dl.acm.org/doi/pdf/10.1145/366193.366201
 https://www.softwarepreservation.org/projects/ALGOL/paper/Backus-Syntax_and_Semantics_of_Proposed_IAL.pdf
 
 https://dl.acm.org/doi/pdf/10.1145/355588.365140
+
+### Issues
+* Grammar is ambiguous.


### PR DESCRIPTION
This PR fixes #4326.

With this change, the parse step is bypassed for MacOS. The bnf grammar was updated to test the PR.

Unfortunately, this won't fix the spurious hangs of the MacOS runners that we see. Google has a problem with the runner code and/or is using too few servers, or is using the slowest servers on the planet. However, bypassing the MacOS tester is a small price to pay to increase the chance for the tests to be completed in a reasonable amount of time. We need a compilation and link for C++ under the MacOS environment because it is the rate-limiting factor in the code we write for the C++ target.

Just yesterday, in antlr/antlr4, a PR was submitted in which 39 runners completed in a [minute or two](https://github.com/antlr/antlr4/actions/runs/11864106553/job/33066903765) on Windows and Ubuntu. However, the PR sat around for a MacOS test to complete in [1h 25m](https://github.com/antlr/antlr4/actions/runs/11864106553/job/33066900407), with the setup of PHP taking the majority of the time at 1h 23m!