### PR TITLE
reordered EXIT rule before the NAME rule so that it matches correctly

### DIFF
--- a/fortran/fortran90/Fortran90Lexer.g4
+++ b/fortran/fortran90/Fortran90Lexer.g4
@@ -456,9 +456,9 @@ ICON: NUM+;
 
 TYPE: 'type' | 'TYPE' | 'Type';
 
-NAME: LETTER ( ALPHANUMERIC_CHARACTER)*;
-
 EXIT: 'EXIT' | 'exit';
+
+NAME: LETTER ( ALPHANUMERIC_CHARACTER)*;
 
 BLANK: 'BLANK' | 'blank';
 


### PR DESCRIPTION
When compiling this program section, the `exit` command in fortran did not produce the correct token 

```
    do
        print *, "Add:"
        read *, a
        if (a == 0) then
            exit
        else
            sum = sum + a
        end if
    end do
```

`[@63,392:395='exit',<NAME>,16:12]` was produced from the `-tokens` output
`[@63,392:395='exit',<EXIT>,16:12]` is the expected token

This was because the `NAME` lexer rule came before the `EXIT` rule, taking precedence. I reordered them in the lexer, which fixed the issue.