### PR TITLE
Improve objc grammar: better expr syntax; fix some issues

### DIFF
--- a/objc/ObjectiveCLexer.g4
+++ b/objc/ObjectiveCLexer.g4
@@ -101,12 +101,12 @@ SELF            : 'self';
 SUPER           : 'super';
 YES             : 'YES';
 AUTORELEASEPOOL : '@autoreleasepool';
-CATCH           : '@catch';
+CATCH           : 'catch';
 CLASS           : '@class';
 DYNAMIC         : '@dynamic';
 ENCODE          : '@encode';
 END             : '@end';
-FINALLY         : '@finally';
+FINALLY         : 'finally';
 IMPLEMENTATION  : '@implementation';
 INTERFACE       : '@interface';
 IMPORT          : '@import';
@@ -122,14 +122,19 @@ SELECTOR        : '@selector';
 SYNCHRONIZED    : '@synchronized';
 SYNTHESIZE      : '@synthesize';
 THROW           : '@throw';
-TRY             : '@try';
+TRY             : 'try';
 ATOMIC          : 'atomic';
 NONATOMIC       : 'nonatomic';
 RETAIN          : 'retain';
+DIRECT          : 'direct';
 
 // Attributes with `__` prefix
 
+INLINE_ATTR                 : '__inline__';
 ATTRIBUTE                   : '__attribute__';
+EXTENSION                   : '__extension__';
+STATIC_ASSERT               : '_Static_assert';
+ALIGN_OF                    : '_Alignof';
 AUTORELEASING_QUALIFIER     : '__autoreleasing';
 BLOCK                       : '__block';
 BRIDGE                      : '__bridge';

--- a/objc/examples/BoxPhoto.m
+++ b/objc/examples/BoxPhoto.m
@@ -29,6 +29,13 @@ static NSSet *s_allowedExtensions;
     }
 }
 
+- (void)quirkyExpressions
+{
+    @    try { // The space after @ is intentional
+       typeof(self) __weak weakSelf = self;
+    } @catch (...) {} // Ellipsis is intentional
+}
+
 -(NSString*)stringValue:(NSDictionary*)photo name:(NSString*)name
 {
     id rawValue = photo[name];

--- a/objc/one-step-processing/ObjectiveCLexer.g4
+++ b/objc/one-step-processing/ObjectiveCLexer.g4
@@ -101,12 +101,12 @@ SELF            : 'self';
 SUPER           : 'super';
 YES             : 'YES';
 AUTORELEASEPOOL : '@autoreleasepool';
-CATCH           : '@catch';
+CATCH           : 'catch';
 CLASS           : '@class';
 DYNAMIC         : '@dynamic';
 ENCODE          : '@encode';
 END             : '@end';
-FINALLY         : '@finally';
+FINALLY         : 'finally';
 IMPLEMENTATION  : '@implementation';
 INTERFACE       : '@interface';
 IMPORT          : '@import';
@@ -122,14 +122,19 @@ SELECTOR        : '@selector';
 SYNCHRONIZED    : '@synchronized';
 SYNTHESIZE      : '@synthesize';
 THROW           : '@throw';
-TRY             : '@try';
+TRY             : 'try';
 ATOMIC          : 'atomic';
 NONATOMIC       : 'nonatomic';
 RETAIN          : 'retain';
+DIRECT          : 'direct';
 
 // Attributes with `__` prefix
 
+INLINE_ATTR                 : '__inline__';
 ATTRIBUTE                   : '__attribute__';
+EXTENSION                   : '__extension__';
+STATIC_ASSERT               : '_Static_assert';
+ALIGN_OF                    : '_Alignof';
 AUTORELEASING_QUALIFIER     : '__autoreleasing';
 BLOCK                       : '__block';
 BRIDGE                      : '__bridge';

--- a/objc/two-step-processing/ObjectiveCLexer.g4
+++ b/objc/two-step-processing/ObjectiveCLexer.g4
@@ -99,12 +99,12 @@ SELF            : 'self';
 SUPER           : 'super';
 YES             : 'YES';
 AUTORELEASEPOOL : '@autoreleasepool';
-CATCH           : '@catch';
+CATCH           : 'catch';
 CLASS           : '@class';
 DYNAMIC         : '@dynamic';
 ENCODE          : '@encode';
 END             : '@end';
-FINALLY         : '@finally';
+FINALLY         : 'finally';
 IMPLEMENTATION  : '@implementation';
 INTERFACE       : '@interface';
 IMPORT          : '@import';
@@ -120,14 +120,19 @@ SELECTOR        : '@selector';
 SYNCHRONIZED    : '@synchronized';
 SYNTHESIZE      : '@synthesize';
 THROW           : '@throw';
-TRY             : '@try';
+TRY             : 'try';
 ATOMIC          : 'atomic';
 NONATOMIC       : 'nonatomic';
 RETAIN          : 'retain';
+DIRECT          : 'direct';
 
 // Attributes with `__` prefix
 
+INLINE_ATTR                 : '__inline__';
 ATTRIBUTE                   : '__attribute__';
+EXTENSION                   : '__extension__';
+STATIC_ASSERT               : '_Static_assert';
+ALIGN_OF                    : '_Alignof';
 AUTORELEASING_QUALIFIER     : '__autoreleasing';
 BLOCK                       : '__block';
 BRIDGE                      : '__bridge';
@@ -152,9 +157,19 @@ NULL_RESETTABLE  : 'null_resettable';
 
 // NS prefix
 
-NS_INLINE  : 'NS_INLINE';
-NS_ENUM    : 'NS_ENUM';
-NS_OPTIONS : 'NS_OPTIONS';
+NS_INLINE           : 'NS_INLINE';
+NS_ENUM             : 'NS_ENUM';
+NS_CLOSED_ENUM      : 'NS_CLOSED_ENUM';
+NS_ERROR_ENUM       : 'NS_ERROR_ENUM';
+NS_OPTIONS          : 'NS_OPTIONS';
+NS_SWIFT_NAME       : 'NS_SWIFT_NAME';
+NS_NOESCAPE         : 'NS_NOESCAPE';
+NS_UNAVAILABLE      : 'NS_UNAVAILABLE';
+NS_SWIFT_UNAVAILABLE: 'NS_SWIFT_UNAVAILABLE';
+
+// API availablility macros
+API_AVAILABLE: 'API_AVAILABLE';
+API_UNAVAILABLE: 'API_UNAVAILABLE';
 
 // Property attributes
 
@@ -201,6 +216,7 @@ COMMA        : ',';
 DOT          : '.';
 STRUCTACCESS : '->';
 AT           : '@';
+UNDERSCORE   : '_';
 
 // Operators
 


### PR DESCRIPTION
**Overview**
- Borrowed C expression syntax: The expression syntax now is parsed in order of the operator precedence.
- Fixed an issue that array literal containing assignment isn't recognized: `@[ foo = bar ];` is valid
- Fixed an issue that spaces after `@` in `@   try {} @catch (...)` isn't allowed. Surprisingly they are valid.
- Fixed an issue that ellipsis in `@catch` isn't allowed.
- Add `direct` in `@property` attributes
- Stricter numeral type parsing: `long long long int` used to be valid, but now it isn't.

**Testing**
- [x] Test cases are added