### PR TITLE
[mysql/Oracle] Fixing "mvn clean test" for Oracle MySQL grammar.

### DIFF
--- a/sql/mysql/Oracle/pom.xml
+++ b/sql/mysql/Oracle/pom.xml
@@ -39,7 +39,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>root</entryPoint>
+					<entryPoint>queries</entryPoint>
 					<grammarName>MySQL</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples</exampleFiles>


### PR DESCRIPTION
This PR fixes "mvn clean test" for the Oracle MySQL grammar. The start symbol was incorrectly specified.