### PR TITLE
[Plsql] pivot_clause and unpivot_clause can have own alias

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -5988,7 +5988,7 @@ flashback_query_clause
     ;
 
 pivot_clause
-    : PIVOT XML? '(' pivot_element (',' pivot_element)* pivot_for_clause pivot_in_clause ')'
+    : PIVOT XML? '(' pivot_element (',' pivot_element)* pivot_for_clause pivot_in_clause ')' table_alias?
     ;
 
 pivot_element
@@ -6013,7 +6013,7 @@ pivot_in_clause_elements
     ;
 
 unpivot_clause
-    : UNPIVOT ((INCLUDE | EXCLUDE) NULLS)? '(' (column_name | paren_column_list) pivot_for_clause unpivot_in_clause ')'
+    : UNPIVOT ((INCLUDE | EXCLUDE) NULLS)? '(' (column_name | paren_column_list) pivot_for_clause unpivot_in_clause ')' table_alias?
     ;
 
 unpivot_in_clause

--- a/sql/plsql/examples/pivot14.sql
+++ b/sql/plsql/examples/pivot14.sql
@@ -1,0 +1,9 @@
+SELECT s2.id, name, subject, score
+FROM scores2 s1
+    UNPIVOT (
+    score FOR subject IN (
+        chinese_score AS 'Chinese',
+        math_score AS 'Math',
+        english_score AS 'English'
+    )
+) s2;

--- a/sql/plsql/examples/pivot15.sql
+++ b/sql/plsql/examples/pivot15.sql
@@ -1,0 +1,6 @@
+SELECT *
+FROM (SELECT id, name, subject, score FROM scores) s1
+    PIVOT (
+    MAX(score)
+    FOR subject IN ('Chinese', 'Math', 'English')
+) s2;


### PR DESCRIPTION
```sql
SELECT s2.id, name, subject, score
FROM scores2 s1
    UNPIVOT (
    score FOR subject IN (
        chinese_score AS 'Chinese',
        math_score AS 'Math',
        english_score AS 'English'
    )
) s2;
```
Here it is, pivot_clause and unpivot_clause can have own alias.
Previous query and its pivot_clause can both have an alias, but pivot_clause's alias will replace previous query alias.
which meas
```sql
SELECT s1.id, name, subject, score
FROM scores2 s1
    UNPIVOT (
    score FOR subject IN (
        chinese_score AS 'Chinese',
        math_score AS 'Math',
        english_score AS 'English'
    )
) s2;
```
if you use s1 to be the identifier will be wrong.
i tried these sql on livesql.oracle.com