### PR TITLE
[plsql] using_index_clause should use index_properties instead of index_attributes

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -4927,7 +4927,7 @@ enable_disable_clause
     ;
 
 using_index_clause
-    : USING INDEX (index_name | '(' create_index ')' | index_attributes)?
+    : USING INDEX (index_name | '(' create_index ')' | index_properties)
     ;
 
 index_attributes


### PR DESCRIPTION
According to [Oracle latest SQL Language Reference](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/constraint.html#GUID-1055EA97-BA6F-4764-A15F-1024FD5B6DFE__CJAIEIDI), using_index_clause for constraint is illustrated as following: 
**using_index_clause**：
![using_index_clause](https://github.com/user-attachments/assets/cf7ad092-ab4d-4059-9897-0461b569d38b)
**index_properties**：
![image](https://github.com/user-attachments/assets/a1bb0f14-aef2-4833-abe7-c6f515535f03)

However, in `PlSqlParser.g4`,`using_index_clause`:
https://github.com/antlr/grammars-v4/blob/7f917add1199e8b050a7117814899ebab50a3c3b/sql/plsql/PlSqlParser.g4#L4927-L4929

Actually it should be modified to:
```
using_index_clause
    : USING INDEX (index_name | '(' create_index ')' | index_properties)
    ;
```