### PR TITLE
Minor update OCL.g4 - "\\u+XXXX"

### DIFF
--- a/ocl/OCL.g4
+++ b/ocl/OCL.g4
@@ -348,7 +348,7 @@ MULTILINE_COMMENT
 fragment EscapeSequence
     : '\\' [btnfr"'\\]
     | '\\' ([0-3]? [0-7])? [0-7]
-    | '\\' 'u' '+' HexDigit HexDigit HexDigit HexDigit
+    | '\\' 'u' HexDigit HexDigit HexDigit HexDigit
     ;
 
 fragment HexDigits

--- a/ocl/OCL.g4
+++ b/ocl/OCL.g4
@@ -348,7 +348,7 @@ MULTILINE_COMMENT
 fragment EscapeSequence
     : '\\' [btnfr"'\\]
     | '\\' ([0-3]? [0-7])? [0-7]
-    | '\\' 'u'+ HexDigit HexDigit HexDigit HexDigit
+    | '\\' 'u' '+' HexDigit HexDigit HexDigit HexDigit
     ;
 
 fragment HexDigits


### PR DESCRIPTION
I was referring to @kevinlano 's grammar for building another OCL tool ([USE](https://github.com/useocl/use)), and I did side by side comparison between the grammars. Overall, the grammar by Lano is more clear and concise, comparing to the USE's grammar (see more at [this](https://github.com/useocl/use/blob/master/use-core/src/main/resources/grammars/base/OCLBase.gpart) and [this](https://github.com/useocl/use/blob/master/use-core/src/main/resources/grammars/base/OCLLexerRules.gpart)).

For now, I found a typo in the grammar, that describe the wrong escape code (which allows for u, uu, uuuu, uuuuuuu, ..., instead of u+some hex code). This was fixed in my PR here. I plan to continue my survey on both grammars as references (and will make another PR if needed).

As this grammar is based on [AgileUML](https://github.com/eclipse/agileuml/blob/master/OCL.g4), if Lano confirms that my fix is correct, I would submit another fix to that repository as well.