### PR TITLE
[lua and z] Changes to fix ambiguity in Z grammar, and unnecessary "using" in lua.

### DIFF
--- a/lua/CSharp/LuaLexerBase.cs
+++ b/lua/CSharp/LuaLexerBase.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using Antlr4.Runtime;
-using Microsoft.Build.Utilities;
 
 public abstract class LuaLexerBase : Lexer
 {

--- a/z/desc.xml
+++ b/z/desc.xml
@@ -2,4 +2,5 @@
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
    <targets>Java</targets>
+   <grammar-name>Z</grammar-name>
 </desc>


### PR DESCRIPTION
The lua grammar contained a "using" to something that is not needed for the CSharp target of the grammar. If not removed, a build error will occur for the new Antlr-ng tool.

For the Z grammar, there is an additional preprocessor grammar. The desc.xml is required to disambiguate which grammar for building and testing.