### PR TITLE
Fixes to bring sql/mysql/Oracle up to date.

### DIFF
--- a/sql/mysql/Oracle/Antlr4ng/MySQLLexerBase.ts
+++ b/sql/mysql/Oracle/Antlr4ng/MySQLLexerBase.ts
@@ -245,273 +245,67 @@ export abstract class MySQLLexerBase extends Lexer {
         return t;
     }
 
-    public isServerVersionLt80024(): boolean
-    {
-        return this.serverVersion < 80024;
-    }
-
-    public isServerVersionGe80024(): boolean
-    {
-        return this.serverVersion >= 80024;
-    }
-
-    public isServerVersionGe80011(): boolean
-    {
-        return this.serverVersion >= 80011;
-    }
-
-    public isServerVersionGe80013(): boolean
-    {
-        return this.serverVersion >= 80013;
-    }
-
-    public isServerVersionLt80014(): boolean
-    {
-        return this.serverVersion < 80014;
-    }
-
-    public isServerVersionGe80014(): boolean
-    {
-        return this.serverVersion >= 80014;
-    }
-
-    public isServerVersionGe80017(): boolean
-    {
-        return this.serverVersion >= 80017;
-    }
-
-
-    public isServerVersionGe80018(): boolean { return this.serverVersion >= 80018; }
-
     public isMasterCompressionAlgorithm(): boolean { return this.serverVersion >= 80018 && this.isServerVersionLt80024(); }
-
-    public isServerVersionLt80031(): boolean
-    {
-        return this.serverVersion < 80031;
-    }
-
-    public doLogicalOr(): void
-    {
-        this.type = this.isSqlModeActive(SqlMode.PipesAsConcat) ? MySQLLexer.CONCAT_PIPES_SYMBOL : MySQLLexer.LOGICAL_OR_OPERATOR;
-    }
-
-    public doIntNumber(): void
-    {
-        this.type = this.determineNumericType(this.text);
-    }
-
-    public doAdddate(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.ADDDATE_SYMBOL);
-    }
-
-    public doBitAnd(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.BIT_AND_SYMBOL);
-    }
-
-    public doBitOr(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.BIT_OR_SYMBOL);
-    }
-
-    public doBitXor(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.BIT_XOR_SYMBOL);
-    }
-
-    public doCast(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.CAST_SYMBOL);
-    }
-
-    public doCount(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.COUNT_SYMBOL);
-    }
-
-    public doCurdate(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL);
-    }
-
-    public doCurrentDate(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL);
-    }
-
-    public doCurrentTime(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL);
-    }
-
-    public doCurtime(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL);
-    }
-
-    public doDateAdd(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.DATE_ADD_SYMBOL);
-    }
-
-    public doDateSub(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.DATE_SUB_SYMBOL);
-    }
-
-    public doExtract(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.EXTRACT_SYMBOL);
-    }
-
-    public doGroupConcat(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.GROUP_CONCAT_SYMBOL);
-    }
-
-    public doMax(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.MAX_SYMBOL);
-    }
-
-    public doMid(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-
-    public doMin(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.MIN_SYMBOL);
-    }
-
-    public doNot(): void
-    {
-        this.type = this.isSqlModeActive(SqlMode.HighNotPrecedence) ? MySQLLexer.NOT2_SYMBOL: MySQLLexer.NOT_SYMBOL;
-    }
-
-    public doNow(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.NOW_SYMBOL);
-    }
-
-    public doPosition(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.POSITION_SYMBOL);
-    }
-
-    public doSessionUser(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.USER_SYMBOL);
-    }
-
-    public doStddevSamp(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.STDDEV_SAMP_SYMBOL);
-    }
-
-    public doStddev(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-
-    public doStddevPop(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-
-    public doStd(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-
-    public doSubdate(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.SUBDATE_SYMBOL);
-    }
-
-    public doSubstr(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-
-    public doSubstring(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-
-    public doSum(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.SUM_SYMBOL);
-    }
-
-    public doSysdate(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.SYSDATE_SYMBOL);
-    }
-
-    public doSystemUser(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.USER_SYMBOL);
-    }
-
-    public doTrim(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.TRIM_SYMBOL);
-    }
-
-    public doVariance(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL);
-    }
-
-    public doVarPop(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL);
-    }
-
-    public doVarSamp(): void
-    {
-        this.type = this.determineFunction(MySQLLexer.VAR_SAMP_SYMBOL);
-    }
-
-    public doUnderscoreCharset(): void
-    {
-        this.type = this.checkCharset(this.text);
-    }
-
-    public isVersionComment(): boolean
-    {
-        return this.checkMySQLVersion(this.text);
-    }
-
-    public isBackTickQuotedId(): boolean
-    {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-
-    public isDoubleQuotedText(): boolean
-    {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-
-    public isSingleQuotedText(): boolean
-    {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-
-    public startInVersionComment(): void
-    {
-        this.inVersionComment = true;
-    }
-
-    public endInVersionComment(): void
-    {
-        this.inVersionComment = false;
-    }
-
-    public isInVersionComment(): boolean
-    {
-        return this.inVersionComment;
-    }
+    public isServerVersionGe80011(): boolean { return this.serverVersion >= 80011; }
+    public isServerVersionGe80013(): boolean { return this.serverVersion >= 80013; }
+    public isServerVersionLt80014(): boolean { return this.serverVersion < 80014; }
+    public isServerVersionGe80014(): boolean { return this.serverVersion >= 80014; }
+    public isServerVersionGe80016(): boolean { return this.serverVersion >= 80016; }
+    public isServerVersionGe80017(): boolean { return this.serverVersion >= 80017; }
+    public isServerVersionGe80018(): boolean { return this.serverVersion >= 80018; }
+    public isServerVersionLt80021(): boolean { return this.serverVersion < 80021; }
+    public isServerVersionGe80021(): boolean { return this.serverVersion >= 80021; }
+    public isServerVersionLt80022(): boolean { return this.serverVersion < 80022; }
+    public isServerVersionGe80022(): boolean { return this.serverVersion >= 80022; }
+    public isServerVersionLt80023(): boolean { return this.serverVersion < 80023; }
+    public isServerVersionGe80023(): boolean { return this.serverVersion >= 80023; }
+    public isServerVersionLt80024(): boolean { return this.serverVersion < 80024; }
+    public isServerVersionGe80024(): boolean { return this.serverVersion >= 80024; }
+    public isServerVersionLt80031(): boolean { return this.serverVersion < 80031; }
+    public doLogicalOr(): void { this.type = this.isSqlModeActive(SqlMode.PipesAsConcat) ? MySQLLexer.CONCAT_PIPES_SYMBOL : MySQLLexer.LOGICAL_OR_OPERATOR; }
+    public doIntNumber(): void { this.type = this.determineNumericType(this.text); }
+    public doAdddate(): void { this.type = this.determineFunction(MySQLLexer.ADDDATE_SYMBOL); }
+    public doBitAnd(): void { this.type = this.determineFunction(MySQLLexer.BIT_AND_SYMBOL); }
+    public doBitOr(): void { this.type = this.determineFunction(MySQLLexer.BIT_OR_SYMBOL); }
+    public doBitXor(): void { this.type = this.determineFunction(MySQLLexer.BIT_XOR_SYMBOL); }
+    public doCast(): void { this.type = this.determineFunction(MySQLLexer.CAST_SYMBOL); }
+    public doCount(): void { this.type = this.determineFunction(MySQLLexer.COUNT_SYMBOL); }
+    public doCurdate(): void { this.type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL); }
+    public doCurrentDate(): void { this.type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL); }
+    public doCurrentTime(): void { this.type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL); }
+    public doCurtime(): void { this.type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL); }
+    public doDateAdd(): void { this.type = this.determineFunction(MySQLLexer.DATE_ADD_SYMBOL); }
+    public doDateSub(): void { this.type = this.determineFunction(MySQLLexer.DATE_SUB_SYMBOL); }
+    public doExtract(): void { this.type = this.determineFunction(MySQLLexer.EXTRACT_SYMBOL); }
+    public doGroupConcat(): void { this.type = this.determineFunction(MySQLLexer.GROUP_CONCAT_SYMBOL); }
+    public doMax(): void { this.type = this.determineFunction(MySQLLexer.MAX_SYMBOL); }
+    public doMid(): void { this.type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    public doMin(): void { this.type = this.determineFunction(MySQLLexer.MIN_SYMBOL); }
+    public doNot(): void { this.type = this.isSqlModeActive(SqlMode.HighNotPrecedence) ? MySQLLexer.NOT2_SYMBOL: MySQLLexer.NOT_SYMBOL; }
+    public doNow(): void { this.type = this.determineFunction(MySQLLexer.NOW_SYMBOL); }
+    public doPosition(): void { this.type = this.determineFunction(MySQLLexer.POSITION_SYMBOL); }
+    public doSessionUser(): void { this.type = this.determineFunction(MySQLLexer.USER_SYMBOL); }
+    public doStddevSamp(): void { this.type = this.determineFunction(MySQLLexer.STDDEV_SAMP_SYMBOL); }
+    public doStddev(): void { this.type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    public doStddevPop(): void { this.type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    public doStd(): void { this.type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    public doSubdate(): void { this.type = this.determineFunction(MySQLLexer.SUBDATE_SYMBOL); }
+    public doSubstr(): void { this.type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    public doSubstring(): void { this.type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    public doSum(): void { this.type = this.determineFunction(MySQLLexer.SUM_SYMBOL); }
+    public doSysdate(): void { this.type = this.determineFunction(MySQLLexer.SYSDATE_SYMBOL); }
+    public doSystemUser(): void { this.type = this.determineFunction(MySQLLexer.USER_SYMBOL); }
+    public doTrim(): void { this.type = this.determineFunction(MySQLLexer.TRIM_SYMBOL); }
+    public doVariance(): void { this.type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL); }
+    public doVarPop(): void { this.type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL); }
+    public doVarSamp(): void { this.type = this.determineFunction(MySQLLexer.VAR_SAMP_SYMBOL); }
+    public doUnderscoreCharset(): void { this.type = this.checkCharset(this.text); }
+    public doDollarQuotedStringText(): boolean { return this.serverVersion >= 80034 && this.supportMle; }
+    public isVersionComment(): boolean { return this.checkMySQLVersion(this.text); }
+    public isBackTickQuotedId(): boolean { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    public isDoubleQuotedText(): boolean { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    public isSingleQuotedText(): boolean { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    public startInVersionComment(): void { this.inVersionComment = true; }
+    public endInVersionComment(): void { this.inVersionComment = false; }
+    public isInVersionComment(): boolean { return this.inVersionComment; }
 }

--- a/sql/mysql/Oracle/CSharp/MySQLLexerBase.cs
+++ b/sql/mysql/Oracle/CSharp/MySQLLexerBase.cs
@@ -278,14 +278,21 @@ public class MySQLLexerBase : Lexer {
     }
 
     // Version-related methods
-    public bool isServerVersionLt80024() => serverVersion < 80024;
-    public bool isServerVersionGe80024() => serverVersion >= 80024;
     public bool isServerVersionGe80011() => serverVersion >= 80011;
     public bool isServerVersionGe80013() => serverVersion >= 80013;
     public bool isServerVersionLt80014() => serverVersion < 80014;
     public bool isServerVersionGe80014() => serverVersion >= 80014;
+    public bool isServerVersionGe80016() => serverVersion >= 80016;
     public bool isServerVersionGe80017() => serverVersion >= 80017;
     public bool isServerVersionGe80018() => serverVersion >= 80018;
+    public bool isServerVersionLt80021() => serverVersion < 80021;
+    public bool isServerVersionGe80021() => serverVersion >= 80021;
+    public bool isServerVersionLt80022() => serverVersion < 80022;
+    public bool isServerVersionGe80022() => serverVersion >= 80022;
+    public bool isServerVersionLt80023() => serverVersion < 80023;
+    public bool isServerVersionGe80023() => serverVersion >= 80023;
+    public bool isServerVersionLt80024() => serverVersion < 80024;
+    public bool isServerVersionGe80024() => serverVersion >= 80024;
 
     public bool isMasterCompressionAlgorithm() => serverVersion >= 80018 && isServerVersionLt80024();
 
@@ -338,7 +345,8 @@ public class MySQLLexerBase : Lexer {
     public void doVarPop() => Type = determineFunction(MySQLLexer.VARIANCE_SYMBOL);
     public void doVarSamp() => Type = determineFunction(MySQLLexer.VAR_SAMP_SYMBOL);
     public void doUnderscoreCharset() => Type = checkCharset(Text);
-
+    public bool doDollarQuotedStringText() => this.serverVersion >= 80034 && this.supportMle;
+    
     public bool isVersionComment() => checkMySQLVersion(Text);
 
     public bool isBackTickQuotedId()

--- a/sql/mysql/Oracle/Cpp/MySQLLexerBase.cpp
+++ b/sql/mysql/Oracle/Cpp/MySQLLexerBase.cpp
@@ -162,273 +162,69 @@ antlr4::Token* MySQLLexerBase::emit() {
     return t;
 }
 
-bool MySQLLexerBase::isServerVersionLt80024()
-{
-    return this->serverVersion < 80024;
-
-}
-
-bool MySQLLexerBase::isServerVersionGe80024()
-{
-    return this->serverVersion >= 80024;
-}
-
-bool MySQLLexerBase::isServerVersionGe80011()
-{
-    return this->serverVersion >= 80011;
-}
-
-bool MySQLLexerBase::isServerVersionGe80013()
-{
-    return this->serverVersion >= 80013;
-}
-
-bool MySQLLexerBase::isServerVersionLt80014()
-{
-    return this->serverVersion < 80014;
-}
-
-bool MySQLLexerBase::isServerVersionGe80014()
-{
-    return this->serverVersion >= 80014;
-}
-
-bool MySQLLexerBase::isServerVersionGe80017()
-{
-    return this->serverVersion >= 80017;
-}
-
-bool MySQLLexerBase::isServerVersionGe80018() { return this->serverVersion >= 80018; }
-
 bool MySQLLexerBase::isMasterCompressionAlgorithm() { return this->serverVersion >= 80018 && this->isServerVersionLt80024(); }
-
-bool MySQLLexerBase::isServerVersionLt80031()    {
-    return this->serverVersion < 80031;
-}
-
-void MySQLLexerBase::doLogicalOr()    {
-    this->type = this->isSqlModeActive(SqlMode::PipesAsConcat) ? MySQLLexer::CONCAT_PIPES_SYMBOL : MySQLLexer::LOGICAL_OR_OPERATOR;
-}
-
-void MySQLLexerBase::doIntNumber()
-{
-    this->type = this->determineNumericType(this->getText());
-}
-
-void MySQLLexerBase::doAdddate()
-{
-    this->type = this->determineFunction(MySQLLexer::ADDDATE_SYMBOL);
-}
-
-void MySQLLexerBase::doBitAnd()
-{
-    this->type = this->determineFunction(MySQLLexer::BIT_AND_SYMBOL);
-}
-
-void MySQLLexerBase::doBitOr()
-{
-    this->type = this->determineFunction(MySQLLexer::BIT_OR_SYMBOL);
-}
-
-void MySQLLexerBase::doBitXor()
-{
-    this->type = this->determineFunction(MySQLLexer::BIT_XOR_SYMBOL);
-}
-
-void MySQLLexerBase::doCast()
-{
-    this->type = this->determineFunction(MySQLLexer::CAST_SYMBOL);
-}
-
-void MySQLLexerBase::doCount()
-{
-    this->type = this->determineFunction(MySQLLexer::COUNT_SYMBOL);
-}
-
-void MySQLLexerBase::doCurdate()
-{
-    this->type = this->determineFunction(MySQLLexer::CURDATE_SYMBOL);
-}
-
-void MySQLLexerBase::doCurrentDate()
-{
-    this->type = this->determineFunction(MySQLLexer::CURDATE_SYMBOL);
-}
-
-void MySQLLexerBase::doCurrentTime()
-{
-    this->type = this->determineFunction(MySQLLexer::CURTIME_SYMBOL);
-}
-
-void MySQLLexerBase::doCurtime()
-{
-    this->type = this->determineFunction(MySQLLexer::CURTIME_SYMBOL);
-}
-
-void MySQLLexerBase::doDateAdd()
-{
-    this->type = this->determineFunction(MySQLLexer::DATE_ADD_SYMBOL);
-}
-
-void MySQLLexerBase::doDateSub()
-{
-    this->type = this->determineFunction(MySQLLexer::DATE_SUB_SYMBOL);
-}
-
-void MySQLLexerBase::doExtract()
-{
-    this->type = this->determineFunction(MySQLLexer::EXTRACT_SYMBOL);
-}
-
-void MySQLLexerBase::doGroupConcat()
-{
-    this->type = this->determineFunction(MySQLLexer::GROUP_CONCAT_SYMBOL);
-}
-
-void MySQLLexerBase::doMax()
-{
-    this->type = this->determineFunction(MySQLLexer::MAX_SYMBOL);
-}
-
-void MySQLLexerBase::doMid()
-{
-    this->type = this->determineFunction(MySQLLexer::SUBSTRING_SYMBOL);
-}
-
-void MySQLLexerBase::doMin()
-{
-    this->type = this->determineFunction(MySQLLexer::MIN_SYMBOL);
-}
-
-void MySQLLexerBase::doNot()
-{
-    this->type = this->isSqlModeActive(SqlMode::HighNotPrecedence) ? MySQLLexer::NOT2_SYMBOL: MySQLLexer::NOT_SYMBOL;
-}
-
-void MySQLLexerBase::doNow()
-{
-    this->type = this->determineFunction(MySQLLexer::NOW_SYMBOL);
-}
-
-void MySQLLexerBase::doPosition()
-{
-    this->type = this->determineFunction(MySQLLexer::POSITION_SYMBOL);
-}
-
-void MySQLLexerBase::doSessionUser()
-{
-    this->type = this->determineFunction(MySQLLexer::USER_SYMBOL);
-}
-
-void MySQLLexerBase::doStddevSamp()
-{
-    this->type = this->determineFunction(MySQLLexer::STDDEV_SAMP_SYMBOL);
-}
-
-void MySQLLexerBase::doStddev()
-{
-    this->type = this->determineFunction(MySQLLexer::STD_SYMBOL);
-}
-
-void MySQLLexerBase::doStddevPop()
-{
-    this->type = this->determineFunction(MySQLLexer::STD_SYMBOL);
-}
-
-void MySQLLexerBase::doStd()
-{
-    this->type = this->determineFunction(MySQLLexer::STD_SYMBOL);
-}
-
-void MySQLLexerBase::doSubdate()
-{
-    this->type = this->determineFunction(MySQLLexer::SUBDATE_SYMBOL);
-}
-
-void MySQLLexerBase::doSubstr()
-{
-    this->type = this->determineFunction(MySQLLexer::SUBSTRING_SYMBOL);
-}
-
-void MySQLLexerBase::doSubstring()
-{
-    this->type = this->determineFunction(MySQLLexer::SUBSTRING_SYMBOL);
-}
-
-void MySQLLexerBase::doSum()
-{
-    this->type = this->determineFunction(MySQLLexer::SUM_SYMBOL);
-}
-
-void MySQLLexerBase::doSysdate()
-{
-    this->type = this->determineFunction(MySQLLexer::SYSDATE_SYMBOL);
-}
-
-void MySQLLexerBase::doSystemUser()
-{
-    this->type = this->determineFunction(MySQLLexer::USER_SYMBOL);
-}
-
-void MySQLLexerBase::doTrim()
-{
-    this->type = this->determineFunction(MySQLLexer::TRIM_SYMBOL);
-}
-
-void MySQLLexerBase::doVariance()
-{
-    this->type = this->determineFunction(MySQLLexer::VARIANCE_SYMBOL);
-}
-
-void MySQLLexerBase::doVarPop()
-{
-    this->type = this->determineFunction(MySQLLexer::VARIANCE_SYMBOL);
-}
-
-void MySQLLexerBase::doVarSamp()
-{
-    this->type = this->determineFunction(MySQLLexer::VAR_SAMP_SYMBOL);
-}
-
-void MySQLLexerBase::doUnderscoreCharset()
-{
-    this->type = this->checkCharset(this->getText());
-}
-
-bool MySQLLexerBase::isVersionComment() {
-    return inVersionComment;
-}
-
-bool MySQLLexerBase::isBackTickQuotedId()
-{
-    return !this->isSqlModeActive(SqlMode::NoBackslashEscapes);
-}
-
-bool MySQLLexerBase::isDoubleQuotedText()
-{
-    return !this->isSqlModeActive(SqlMode::NoBackslashEscapes);
-}
-
-bool MySQLLexerBase::isSingleQuotedText()
-{
-    return !this->isSqlModeActive(SqlMode::NoBackslashEscapes);
-}
-
-void MySQLLexerBase::startInVersionComment()
-{
-    inVersionComment = true;
-}
-
-void MySQLLexerBase::endInVersionComment()
-{
-    inVersionComment = false;
-}
-
-bool MySQLLexerBase::isInVersionComment()
-{
-    return inVersionComment;
-}
-
+bool MySQLLexerBase::isServerVersionGe80011() { return this->serverVersion >= 80011; }
+bool MySQLLexerBase::isServerVersionGe80013() { return this->serverVersion >= 80013; }
+bool MySQLLexerBase::isServerVersionLt80014() { return this->serverVersion < 80014; }
+bool MySQLLexerBase::isServerVersionGe80014() { return this->serverVersion >= 80014; }
+bool MySQLLexerBase::isServerVersionGe80016() { return this->serverVersion >= 80016; }
+bool MySQLLexerBase::isServerVersionGe80017() { return this->serverVersion >= 80017; }
+bool MySQLLexerBase::isServerVersionGe80018() { return this->serverVersion >= 80018; }
+bool MySQLLexerBase::isServerVersionLt80021() { return this->serverVersion < 80021; }
+bool MySQLLexerBase::isServerVersionGe80021() { return this->serverVersion >= 80021; }
+bool MySQLLexerBase::isServerVersionLt80022() { return this->serverVersion < 80022; }
+bool MySQLLexerBase::isServerVersionGe80022() { return this->serverVersion >= 80022; }
+bool MySQLLexerBase::isServerVersionLt80023() { return this->serverVersion < 80023; }
+bool MySQLLexerBase::isServerVersionGe80023() { return this->serverVersion >= 80023; }
+bool MySQLLexerBase::isServerVersionLt80024() { return this->serverVersion < 80024; }
+bool MySQLLexerBase::isServerVersionGe80024() { return this->serverVersion >= 80024; }
+bool MySQLLexerBase::isServerVersionLt80031() { return this->serverVersion < 80031; }
+void MySQLLexerBase::doLogicalOr() { this->type = this->isSqlModeActive(SqlMode::PipesAsConcat) ? MySQLLexer::CONCAT_PIPES_SYMBOL : MySQLLexer::LOGICAL_OR_OPERATOR; }
+void MySQLLexerBase::doIntNumber() { this->type = this->determineNumericType(this->getText()); }
+void MySQLLexerBase::doAdddate() { this->type = this->determineFunction(MySQLLexer::ADDDATE_SYMBOL); }
+void MySQLLexerBase::doBitAnd() { this->type = this->determineFunction(MySQLLexer::BIT_AND_SYMBOL); }
+void MySQLLexerBase::doBitOr() { this->type = this->determineFunction(MySQLLexer::BIT_OR_SYMBOL); }
+void MySQLLexerBase::doBitXor() { this->type = this->determineFunction(MySQLLexer::BIT_XOR_SYMBOL); }
+void MySQLLexerBase::doCast() { this->type = this->determineFunction(MySQLLexer::CAST_SYMBOL); }
+void MySQLLexerBase::doCount() { this->type = this->determineFunction(MySQLLexer::COUNT_SYMBOL); }
+void MySQLLexerBase::doCurdate() { this->type = this->determineFunction(MySQLLexer::CURDATE_SYMBOL); }
+void MySQLLexerBase::doCurrentDate() { this->type = this->determineFunction(MySQLLexer::CURDATE_SYMBOL); }
+void MySQLLexerBase::doCurrentTime() { this->type = this->determineFunction(MySQLLexer::CURTIME_SYMBOL); }
+void MySQLLexerBase::doCurtime() { this->type = this->determineFunction(MySQLLexer::CURTIME_SYMBOL); }
+void MySQLLexerBase::doDateAdd() { this->type = this->determineFunction(MySQLLexer::DATE_ADD_SYMBOL); }
+void MySQLLexerBase::doDateSub() { this->type = this->determineFunction(MySQLLexer::DATE_SUB_SYMBOL); }
+void MySQLLexerBase::doExtract() { this->type = this->determineFunction(MySQLLexer::EXTRACT_SYMBOL); }
+void MySQLLexerBase::doGroupConcat() { this->type = this->determineFunction(MySQLLexer::GROUP_CONCAT_SYMBOL); }
+void MySQLLexerBase::doMax() { this->type = this->determineFunction(MySQLLexer::MAX_SYMBOL); }
+void MySQLLexerBase::doMid() { this->type = this->determineFunction(MySQLLexer::SUBSTRING_SYMBOL); }
+void MySQLLexerBase::doMin() { this->type = this->determineFunction(MySQLLexer::MIN_SYMBOL); }
+void MySQLLexerBase::doNot() { this->type = this->isSqlModeActive(SqlMode::HighNotPrecedence) ? MySQLLexer::NOT2_SYMBOL: MySQLLexer::NOT_SYMBOL; }
+void MySQLLexerBase::doNow() { this->type = this->determineFunction(MySQLLexer::NOW_SYMBOL); }
+void MySQLLexerBase::doPosition() { this->type = this->determineFunction(MySQLLexer::POSITION_SYMBOL); }
+void MySQLLexerBase::doSessionUser() { this->type = this->determineFunction(MySQLLexer::USER_SYMBOL); }
+void MySQLLexerBase::doStddevSamp() { this->type = this->determineFunction(MySQLLexer::STDDEV_SAMP_SYMBOL); }
+void MySQLLexerBase::doStddev() { this->type = this->determineFunction(MySQLLexer::STD_SYMBOL); }
+void MySQLLexerBase::doStddevPop() { this->type = this->determineFunction(MySQLLexer::STD_SYMBOL);}
+void MySQLLexerBase::doStd() { this->type = this->determineFunction(MySQLLexer::STD_SYMBOL); }
+void MySQLLexerBase::doSubdate() { this->type = this->determineFunction(MySQLLexer::SUBDATE_SYMBOL); }
+void MySQLLexerBase::doSubstr() { this->type = this->determineFunction(MySQLLexer::SUBSTRING_SYMBOL); }
+void MySQLLexerBase::doSubstring() { this->type = this->determineFunction(MySQLLexer::SUBSTRING_SYMBOL); }
+void MySQLLexerBase::doSum() { this->type = this->determineFunction(MySQLLexer::SUM_SYMBOL); }
+void MySQLLexerBase::doSysdate() { this->type = this->determineFunction(MySQLLexer::SYSDATE_SYMBOL); }
+void MySQLLexerBase::doSystemUser() { this->type = this->determineFunction(MySQLLexer::USER_SYMBOL); }
+void MySQLLexerBase::doTrim() { this->type = this->determineFunction(MySQLLexer::TRIM_SYMBOL); }
+void MySQLLexerBase::doVariance() { this->type = this->determineFunction(MySQLLexer::VARIANCE_SYMBOL); }
+void MySQLLexerBase::doVarPop() { this->type = this->determineFunction(MySQLLexer::VARIANCE_SYMBOL); }
+void MySQLLexerBase::doVarSamp() { this->type = this->determineFunction(MySQLLexer::VAR_SAMP_SYMBOL); }
+void MySQLLexerBase::doUnderscoreCharset() { this->type = this->checkCharset(this->getText()); }
+bool MySQLLexerBase::doDollarQuotedStringText() { return this->serverVersion >= 80034 && this->supportMle; }
+bool MySQLLexerBase::isVersionComment() { return inVersionComment; }
+bool MySQLLexerBase::isBackTickQuotedId() { return !this->isSqlModeActive(SqlMode::NoBackslashEscapes); }
+bool MySQLLexerBase::isDoubleQuotedText() { return !this->isSqlModeActive(SqlMode::NoBackslashEscapes); }
+bool MySQLLexerBase::isSingleQuotedText() { return !this->isSqlModeActive(SqlMode::NoBackslashEscapes); }
+void MySQLLexerBase::startInVersionComment() { inVersionComment = true; }
+void MySQLLexerBase::endInVersionComment() { inVersionComment = false; }
+bool MySQLLexerBase::isInVersionComment() { return inVersionComment; }
 std::string MySQLLexerBase::longString = "2147483647";
 int MySQLLexerBase::longLength = 10;
 std::string MySQLLexerBase::signedLongString = "-2147483648";

--- a/sql/mysql/Oracle/Cpp/MySQLLexerBase.h
+++ b/sql/mysql/Oracle/Cpp/MySQLLexerBase.h
@@ -64,15 +64,22 @@ class MySQLLexerBase : public antlr4::Lexer
         void emitDot();
 
     public:
-        bool isServerVersionLt80024();
-        bool isServerVersionGe80024();
+        bool isMasterCompressionAlgorithm();
         bool isServerVersionGe80011();
         bool isServerVersionGe80013();
         bool isServerVersionLt80014();
         bool isServerVersionGe80014();
+        bool isServerVersionGe80016();
         bool isServerVersionGe80017();
         bool isServerVersionGe80018();
-        bool isMasterCompressionAlgorithm();
+        bool isServerVersionLt80021();
+        bool isServerVersionGe80021();
+        bool isServerVersionLt80022();
+        bool isServerVersionGe80022();
+        bool isServerVersionLt80023();
+        bool isServerVersionGe80023();
+        bool isServerVersionLt80024();
+        bool isServerVersionGe80024();
         bool isServerVersionLt80031();
         void doLogicalOr();
         void doIntNumber();
@@ -112,6 +119,7 @@ class MySQLLexerBase : public antlr4::Lexer
         void doVarPop();
         void doVarSamp();
         void doUnderscoreCharset();
+        bool doDollarQuotedStringText();
         bool isVersionComment();
         bool isBackTickQuotedId();
         bool isDoubleQuotedText();

--- a/sql/mysql/Oracle/Dart/MySQLLexerBase.dart
+++ b/sql/mysql/Oracle/Dart/MySQLLexerBase.dart
@@ -252,15 +252,22 @@ abstract class MySQLLexerBase extends Lexer
         return t;
     }
 
-    bool isServerVersionLt80024() => serverVersion < 80024;
-    bool isServerVersionGe80024() => serverVersion >= 80024;
+    bool isMasterCompressionAlgorithm() => serverVersion >= 80018 && isServerVersionLt80024();
     bool isServerVersionGe80011() => serverVersion >= 80011;
     bool isServerVersionGe80013() => serverVersion >= 80013;
     bool isServerVersionLt80014() => serverVersion < 80014;
     bool isServerVersionGe80014() => serverVersion >= 80014;
+    bool isServerVersionGe80016() => serverVersion >= 80016;
     bool isServerVersionGe80017() => serverVersion >= 80017;
     bool isServerVersionGe80018() => serverVersion >= 80018;
-    bool isMasterCompressionAlgorithm() => serverVersion >= 80018 && isServerVersionLt80024();
+    bool isServerVersionLt80021() => serverVersion < 80021;
+    bool isServerVersionGe80021() => serverVersion >= 80021;
+    bool isServerVersionLt80022() => serverVersion < 80022;
+    bool isServerVersionGe80022() => serverVersion >= 80022;
+    bool isServerVersionLt80023() => serverVersion < 80023;
+    bool isServerVersionGe80023() => serverVersion >= 80023;
+    bool isServerVersionLt80024() => serverVersion < 80024;
+    bool isServerVersionGe80024() => serverVersion >= 80024;
     bool isServerVersionLt80031() => serverVersion < 80031;
     void doLogicalOr() { this.type = isSqlModeActive(SqlMode.pipesAsConcat) ? MySQLLexer.TOKEN_CONCAT_PIPES_SYMBOL : MySQLLexer.TOKEN_LOGICAL_OR_OPERATOR; }
     void doIntNumber() { this.type = determineNumericType(this.text); }
@@ -300,6 +307,7 @@ abstract class MySQLLexerBase extends Lexer
     void doVarPop() => this.type = determineFunction(MySQLLexer.TOKEN_VARIANCE_SYMBOL);
     void doVarSamp() => this.type = determineFunction(MySQLLexer.TOKEN_VAR_SAMP_SYMBOL);
     void doUnderscoreCharset() => this.type = checkCharset(this.text);
+    bool doDollarQuotedStringText() => this.serverVersion >= 80034 && this.supportMle;
     bool isVersionComment() => checkMySQLVersion(this.text);
     bool isBackTickQuotedId() { return !this.isSqlModeActive(SqlMode.noBackslashEscapes); }
     bool isDoubleQuotedText() { return !this.isSqlModeActive(SqlMode.noBackslashEscapes); }

--- a/sql/mysql/Oracle/Go/MySQLLexerBase.go
+++ b/sql/mysql/Oracle/Go/MySQLLexerBase.go
@@ -97,15 +97,22 @@ func (m *MySQLLexerBase) emitDot() {
     m.TokenStartCharIndex = m.TokenStartCharIndex + 1
 }
 
-func (m *MySQLLexerBase) isServerVersionLt80024() bool { return StaticMySQLLexerBase.serverVersion < 80024 }
-func (m *MySQLLexerBase) isServerVersionGe80024() bool { return StaticMySQLLexerBase.serverVersion >= 80024 }
+func (m *MySQLLexerBase) isMasterCompressionAlgorithm() bool { return StaticMySQLLexerBase.serverVersion >= 80018 && m.isServerVersionLt80024() }
 func (m *MySQLLexerBase) isServerVersionGe80011() bool { return StaticMySQLLexerBase.serverVersion >= 80011 }
 func (m *MySQLLexerBase) isServerVersionGe80013() bool { return StaticMySQLLexerBase.serverVersion >= 80013 }
 func (m *MySQLLexerBase) isServerVersionLt80014() bool { return StaticMySQLLexerBase.serverVersion < 80014 }
 func (m *MySQLLexerBase) isServerVersionGe80014() bool { return StaticMySQLLexerBase.serverVersion >= 80014 }
+func (m *MySQLLexerBase) isServerVersionGe80016() bool { return StaticMySQLLexerBase.serverVersion >= 80016 }
 func (m *MySQLLexerBase) isServerVersionGe80017() bool { return StaticMySQLLexerBase.serverVersion >= 80017 }
 func (m *MySQLLexerBase) isServerVersionGe80018() bool { return StaticMySQLLexerBase.serverVersion >= 80018 }
-func (m *MySQLLexerBase) isMasterCompressionAlgorithm() bool { return StaticMySQLLexerBase.serverVersion >= 80018 && m.isServerVersionLt80024() }
+func (m *MySQLLexerBase) isServerVersionLt80021() bool { return StaticMySQLLexerBase.serverVersion < 80021 }
+func (m *MySQLLexerBase) isServerVersionGe80021() bool { return StaticMySQLLexerBase.serverVersion >= 80021 }
+func (m *MySQLLexerBase) isServerVersionLt80022() bool { return StaticMySQLLexerBase.serverVersion < 80022 }
+func (m *MySQLLexerBase) isServerVersionGe80022() bool { return StaticMySQLLexerBase.serverVersion >= 80022 }
+func (m *MySQLLexerBase) isServerVersionLt80023() bool { return StaticMySQLLexerBase.serverVersion < 80023 }
+func (m *MySQLLexerBase) isServerVersionGe80023() bool { return StaticMySQLLexerBase.serverVersion >= 80023 }
+func (m *MySQLLexerBase) isServerVersionLt80024() bool { return StaticMySQLLexerBase.serverVersion < 80024 }
+func (m *MySQLLexerBase) isServerVersionGe80024() bool { return StaticMySQLLexerBase.serverVersion >= 80024 }
 func (m *MySQLLexerBase) isServerVersionLt80031() bool { return StaticMySQLLexerBase.serverVersion < 80031 }
 
 func (m *MySQLLexerBase) doLogicalOr() {
@@ -116,14 +123,8 @@ func (m *MySQLLexerBase) doLogicalOr() {
     }
 }
 
-func (m *MySQLLexerBase) isSqlModeActive(mode SqlMode) bool {
-    return StaticMySQLLexerBase.sqlModes[mode]
-}
-
- 
-func (m *MySQLLexerBase) doIntNumber() {
-    m.SetType(m.determineNumericType(m.GetText()));
-}
+func (m *MySQLLexerBase) isSqlModeActive(mode SqlMode) bool { return StaticMySQLLexerBase.sqlModes[mode]; }
+func (m *MySQLLexerBase) doIntNumber() { m.SetType(m.determineNumericType(m.GetText())); }
 
 func (m *MySQLLexerBase) determineNumericType(text string) int {
     length := len(text) - 1
@@ -256,7 +257,6 @@ func (m *MySQLLexerBase) doCurtime() { m.SetType(m.determineFunction(MySQLLexerC
 func (m *MySQLLexerBase) doDateAdd() { m.SetType(m.determineFunction(MySQLLexerDATE_ADD_SYMBOL)) }
 func (m *MySQLLexerBase) doDateSub() { m.SetType(m.determineFunction(MySQLLexerDATE_SUB_SYMBOL)) }
 func (m *MySQLLexerBase) doExtract() { m.SetType(m.determineFunction(MySQLLexerEXTRACT_SYMBOL)) }
-
 func (m *MySQLLexerBase) doGroupConcat() { m.SetType(m.determineFunction(MySQLLexerGROUP_CONCAT_SYMBOL)) }
 func (m *MySQLLexerBase) doMax() { m.SetType(m.determineFunction(MySQLLexerMAX_SYMBOL)) }
 func (m *MySQLLexerBase) doMid() { m.SetType(m.determineFunction(MySQLLexerSUBSTRING_SYMBOL)) }
@@ -288,6 +288,7 @@ func (m *MySQLLexerBase) doVariance() { m.SetType(m.determineFunction(MySQLLexer
 func (m *MySQLLexerBase) doVarPop() { m.SetType(m.determineFunction(MySQLLexerVARIANCE_SYMBOL)) }
 func (m *MySQLLexerBase) doVarSamp() { m.SetType(m.determineFunction(MySQLLexerVAR_SAMP_SYMBOL)) }
 func (m *MySQLLexerBase) doUnderscoreCharset() { m.SetType(m.checkCharset(m.GetText())) }
+func (m *MySQLLexerBase) doDollarQuotedStringText() bool { return StaticMySQLLexerBase.serverVersion >= 80034 && StaticMySQLLexerBase.supportMle; }
 func (m *MySQLLexerBase) isVersionComment() bool { return m.checkMySQLVersion(m.GetText()) }
 func (m *MySQLLexerBase) isBackTickQuotedId() bool { return ! m.isSqlModeActive(NoBackslashEscapes) }
 func (m *MySQLLexerBase) isDoubleQuotedText() bool { return !m.isSqlModeActive(NoBackslashEscapes) }

--- a/sql/mysql/Oracle/Java/MySQLLexerBase.java
+++ b/sql/mysql/Oracle/Java/MySQLLexerBase.java
@@ -188,15 +188,22 @@ public abstract class MySQLLexerBase extends Lexer {
         return t;
     }
 
-    public boolean isServerVersionLt80024() { return serverVersion < 80024; }
-    public boolean isServerVersionGe80024() { return serverVersion >= 80024; }
+    public boolean isMasterCompressionAlgorithm() { return serverVersion >= 80018 && isServerVersionLt80024(); }
     public boolean isServerVersionGe80011() { return serverVersion >= 80011; }
     public boolean isServerVersionGe80013() { return serverVersion >= 80013; }
     public boolean isServerVersionLt80014() { return serverVersion < 80014; }
     public boolean isServerVersionGe80014() { return serverVersion >= 80014; }
+    public boolean isServerVersionGe80016() { return serverVersion >= 80016; }
     public boolean isServerVersionGe80017() { return serverVersion >= 80017; }
     public boolean isServerVersionGe80018() { return serverVersion >= 80018; }
-    public boolean isMasterCompressionAlgorithm() { return serverVersion >= 80018 && isServerVersionLt80024(); }
+    public boolean isServerVersionLt80021() { return serverVersion < 80021; }
+    public boolean isServerVersionGe80021() { return serverVersion >= 80021; }
+    public boolean isServerVersionLt80022() { return serverVersion < 80022; }
+    public boolean isServerVersionGe80022() { return serverVersion >= 80022; }
+    public boolean isServerVersionLt80023() { return serverVersion < 80023; }
+    public boolean isServerVersionGe80023() { return serverVersion >= 80023; }
+    public boolean isServerVersionLt80024() { return serverVersion < 80024; }
+    public boolean isServerVersionGe80024() { return serverVersion >= 80024; }
     public boolean isServerVersionLt80031() { return serverVersion < 80031; }
     public void doLogicalOr() { this._type = isSqlModeActive(SqlMode.PipesAsConcat) ? MySQLLexer.CONCAT_PIPES_SYMBOL : MySQLLexer.LOGICAL_OR_OPERATOR; }
     public void doIntNumber() { this._type = determineNumericType(this.getText()); }
@@ -236,6 +243,7 @@ public abstract class MySQLLexerBase extends Lexer {
     public void doVarPop() { this._type = determineFunction(MySQLLexer.VARIANCE_SYMBOL); }
     public void doVarSamp() { this._type = determineFunction(MySQLLexer.VAR_SAMP_SYMBOL); }
     public void doUnderscoreCharset() { this._type = checkCharset(this.getText()); }
+    public boolean doDollarQuotedStringText() { return this.serverVersion >= 80034 && this.supportMle; }
     public boolean isVersionComment() { return checkMySQLVersion(this.getText()); }
     public boolean isBackTickQuotedId() { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
     public boolean isDoubleQuotedText() { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }

--- a/sql/mysql/Oracle/JavaScript/MySQLLexerBase.js
+++ b/sql/mysql/Oracle/JavaScript/MySQLLexerBase.js
@@ -221,167 +221,69 @@ class MySQLLexerBase extends Lexer {
         }
         return t;
     }
-    isServerVersionLt80024() {
-        return this.serverVersion < 80024;
-    }
-    isServerVersionGe80024() {
-        return this.serverVersion >= 80024;
-    }
-    isServerVersionGe80011() {
-        return this.serverVersion >= 80011;
-    }
-    isServerVersionGe80013() {
-        return this.serverVersion >= 80013;
-    }
-    isServerVersionLt80014() {
-        return this.serverVersion < 80014;
-    }
-    isServerVersionGe80014() {
-        return this.serverVersion >= 80014;
-    }
-    isServerVersionGe80017() {
-        return this.serverVersion >= 80017;
-    }
-    isServerVersionGe80018() { return this.serverVersion >= 80018; }
     isMasterCompressionAlgorithm() { return this.serverVersion >= 80018 && this.isServerVersionLt80024(); }
-    isServerVersionLt80031() {
-        return this.serverVersion < 80031;
-    }
-    doLogicalOr() {
-        this._type = this.isSqlModeActive(SqlMode.PipesAsConcat) ? MySQLLexer.CONCAT_PIPES_SYMBOL : MySQLLexer.LOGICAL_OR_OPERATOR;
-    }
-    doIntNumber() {
-        this._type = this.determineNumericType(this.text);
-    }
-    doAdddate() {
-        this._type = this.determineFunction(MySQLLexer.ADDDATE_SYMBOL);
-    }
-    doBitAnd() {
-        this._type = this.determineFunction(MySQLLexer.BIT_AND_SYMBOL);
-    }
-    doBitOr() {
-        this._type = this.determineFunction(MySQLLexer.BIT_OR_SYMBOL);
-    }
-    doBitXor() {
-        this._type = this.determineFunction(MySQLLexer.BIT_XOR_SYMBOL);
-    }
-    doCast() {
-        this._type = this.determineFunction(MySQLLexer.CAST_SYMBOL);
-    }
-    doCount() {
-        this._type = this.determineFunction(MySQLLexer.COUNT_SYMBOL);
-    }
-    doCurdate() {
-        this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL);
-    }
-    doCurrentDate() {
-        this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL);
-    }
-    doCurrentTime() {
-        this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL);
-    }
-    doCurtime() {
-        this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL);
-    }
-    doDateAdd() {
-        this._type = this.determineFunction(MySQLLexer.DATE_ADD_SYMBOL);
-    }
-    doDateSub() {
-        this._type = this.determineFunction(MySQLLexer.DATE_SUB_SYMBOL);
-    }
-    doExtract() {
-        this._type = this.determineFunction(MySQLLexer.EXTRACT_SYMBOL);
-    }
-    doGroupConcat() {
-        this._type = this.determineFunction(MySQLLexer.GROUP_CONCAT_SYMBOL);
-    }
-    doMax() {
-        this._type = this.determineFunction(MySQLLexer.MAX_SYMBOL);
-    }
-    doMid() {
-        this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-    doMin() {
-        this._type = this.determineFunction(MySQLLexer.MIN_SYMBOL);
-    }
-    doNot() {
-        this._type = this.isSqlModeActive(SqlMode.HighNotPrecedence) ? MySQLLexer.NOT2_SYMBOL : MySQLLexer.NOT_SYMBOL;
-    }
-    doNow() {
-        this._type = this.determineFunction(MySQLLexer.NOW_SYMBOL);
-    }
-    doPosition() {
-        this._type = this.determineFunction(MySQLLexer.POSITION_SYMBOL);
-    }
-    doSessionUser() {
-        this._type = this.determineFunction(MySQLLexer.USER_SYMBOL);
-    }
-    doStddevSamp() {
-        this._type = this.determineFunction(MySQLLexer.STDDEV_SAMP_SYMBOL);
-    }
-    doStddev() {
-        this._type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-    doStddevPop() {
-        this._type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-    doStd() {
-        this._type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-    doSubdate() {
-        this._type = this.determineFunction(MySQLLexer.SUBDATE_SYMBOL);
-    }
-    doSubstr() {
-        this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-    doSubstring() {
-        this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-    doSum() {
-        this._type = this.determineFunction(MySQLLexer.SUM_SYMBOL);
-    }
-    doSysdate() {
-        this._type = this.determineFunction(MySQLLexer.SYSDATE_SYMBOL);
-    }
-    doSystemUser() {
-        this._type = this.determineFunction(MySQLLexer.USER_SYMBOL);
-    }
-    doTrim() {
-        this._type = this.determineFunction(MySQLLexer.TRIM_SYMBOL);
-    }
-    doVariance() {
-        this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL);
-    }
-    doVarPop() {
-        this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL);
-    }
-    doVarSamp() {
-        this._type = this.determineFunction(MySQLLexer.VAR_SAMP_SYMBOL);
-    }
-    doUnderscoreCharset() {
-        this._type = this.checkCharset(this.text);
-    }
-    isVersionComment() {
-        return this.checkMySQLVersion(this.text);
-    }
-    isBackTickQuotedId() {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-    isDoubleQuotedText() {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-    isSingleQuotedText() {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-    startInVersionComment() {
-        this.inVersionComment = true;
-    }
-    endInVersionComment() {
-        this.inVersionComment = false;
-    }
-    isInVersionComment() {
-        return this.inVersionComment;
-    }
+    isServerVersionGe80011() { return this.serverVersion >= 80011; }
+    isServerVersionGe80013() { return this.serverVersion >= 80013; }
+    isServerVersionLt80014() { return this.serverVersion < 80014; }
+    isServerVersionGe80014() { return this.serverVersion >= 80014; }
+    isServerVersionGe80016() { return this.serverVersion >= 80016; }
+    isServerVersionGe80017() { return this.serverVersion >= 80017; }
+    isServerVersionGe80018() { return this.serverVersion >= 80018; }
+    isServerVersionLt80021() { return this.serverVersion < 80021; }
+    isServerVersionGe80021() { return this.serverVersion >= 80021; }
+    isServerVersionLt80022() { return this.serverVersion < 80022; }
+    isServerVersionGe80022() { return this.serverVersion >= 80022; }
+    isServerVersionLt80023() { return this.serverVersion < 80023; }
+    isServerVersionGe80023() { return this.serverVersion >= 80023; }
+    isServerVersionLt80024() { return this.serverVersion < 80024; }
+    isServerVersionGe80024() { return this.serverVersion >= 80024; }
+    isServerVersionLt80031() { return this.serverVersion < 80031; }
+    doLogicalOr() { this._type = this.isSqlModeActive(SqlMode.PipesAsConcat) ? MySQLLexer.CONCAT_PIPES_SYMBOL : MySQLLexer.LOGICAL_OR_OPERATOR; }
+    doIntNumber() { this._type = this.determineNumericType(this.text); }
+    doAdddate() { this._type = this.determineFunction(MySQLLexer.ADDDATE_SYMBOL); }
+    doBitAnd() { this._type = this.determineFunction(MySQLLexer.BIT_AND_SYMBOL); }
+    doBitOr() { this._type = this.determineFunction(MySQLLexer.BIT_OR_SYMBOL); }
+    doBitXor() { this._type = this.determineFunction(MySQLLexer.BIT_XOR_SYMBOL); }
+    doCast() { this._type = this.determineFunction(MySQLLexer.CAST_SYMBOL); }
+    doCount() { this._type = this.determineFunction(MySQLLexer.COUNT_SYMBOL); }
+    doCurdate() { this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL); }
+    doCurrentDate() { this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL); }
+    doCurrentTime() { this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL); }
+    doCurtime() { this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL); }
+    doDateAdd() { this._type = this.determineFunction(MySQLLexer.DATE_ADD_SYMBOL); }
+    doDateSub() { this._type = this.determineFunction(MySQLLexer.DATE_SUB_SYMBOL); }
+    doExtract() { this._type = this.determineFunction(MySQLLexer.EXTRACT_SYMBOL); }
+    doGroupConcat() { this._type = this.determineFunction(MySQLLexer.GROUP_CONCAT_SYMBOL); }
+    doMax() { this._type = this.determineFunction(MySQLLexer.MAX_SYMBOL); }
+    doMid() { this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    doMin() { this._type = this.determineFunction(MySQLLexer.MIN_SYMBOL); }
+    doNot() { this._type = this.isSqlModeActive(SqlMode.HighNotPrecedence) ? MySQLLexer.NOT2_SYMBOL : MySQLLexer.NOT_SYMBOL; }
+    doNow() { this._type = this.determineFunction(MySQLLexer.NOW_SYMBOL); }
+    doPosition() { this._type = this.determineFunction(MySQLLexer.POSITION_SYMBOL); }
+    doSessionUser() { this._type = this.determineFunction(MySQLLexer.USER_SYMBOL); }
+    doStddevSamp() { this._type = this.determineFunction(MySQLLexer.STDDEV_SAMP_SYMBOL); }
+    doStddev() { this._type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    doStddevPop() { this._type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    doStd() { this._type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    doSubdate() { this._type = this.determineFunction(MySQLLexer.SUBDATE_SYMBOL); }
+    doSubstr() { this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    doSubstring() { this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    doSum() { this._type = this.determineFunction(MySQLLexer.SUM_SYMBOL); }
+    doSysdate() { this._type = this.determineFunction(MySQLLexer.SYSDATE_SYMBOL); }
+    doSystemUser() { this._type = this.determineFunction(MySQLLexer.USER_SYMBOL); }
+    doTrim() { this._type = this.determineFunction(MySQLLexer.TRIM_SYMBOL); }
+    doVariance() { this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL); }
+    doVarPop() { this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL); }
+    doVarSamp() { this._type = this.determineFunction(MySQLLexer.VAR_SAMP_SYMBOL); }
+    doUnderscoreCharset() { this._type = this.checkCharset(this.text); }
+    doDollarQuotedStringText() { return this.serverVersion >= 80034 && this.supportMle; }
+    isVersionComment() {  return this.checkMySQLVersion(this.text); }
+    isBackTickQuotedId() { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    isDoubleQuotedText() { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    isSingleQuotedText() { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    startInVersionComment() { this.inVersionComment = true; }
+    endInVersionComment() { this.inVersionComment = false; }
+    isInVersionComment() { return this.inVersionComment; }
 }
 _a = MySQLLexerBase;
 _MySQLLexerBase_longString = { value: "2147483647" };

--- a/sql/mysql/Oracle/MySQLLexer.g4
+++ b/sql/mysql/Oracle/MySQLLexer.g4
@@ -353,6 +353,8 @@ DOT_IDENTIFIER
 
 // $antlr-format groupedAlignments off, alignTrailers on
 
+// Version information for keywords was taken from https://dev.mysql.com/doc/mysqld-version-reference/en/keywords.html.
+
 ACCESSIBLE_SYMBOL
     : A C C E S S I B L E
     ;
@@ -3153,7 +3155,7 @@ OPTIONAL_SYMBOL
     ;                                                                                     // MYSQL
 
 SECONDARY_SYMBOL
-    : S E C O N D A R Y                                                                   {this.isServerVersionGe80013()}?
+    : S E C O N D A R Y                                                                   {this.isServerVersionGe80016()}?
     ;                                                                                     // MYSQL
 
 SECONDARY_ENGINE_SYMBOL
@@ -3245,7 +3247,7 @@ REQUIRE_TABLE_PRIMARY_KEY_CHECK_SYMBOL
     ;                                                                                     // MYSQL
 
 STREAM_SYMBOL
-    : S T R E A M                                                                         {this.serverVersion >= 80019}?
+    : S T R E A M                                                                         {this.serverVersion >= 80020}?
     ;                                                                                     // MYSQL
 
 OFF_SYMBOL
@@ -3253,7 +3255,7 @@ OFF_SYMBOL
     ;                                                                                     // SQL-1999-R
 
 RETURNING_SYMBOL
-    : R E T U R N I N G                                                                   {this.isServerVersionGe80024()}?
+    : R E T U R N I N G                                                                   {this.isServerVersionGe80021()}?
     ;                                                                                     // SQL-2016-N
 
 JSON_VALUE_SYMBOL
@@ -3261,7 +3263,7 @@ JSON_VALUE_SYMBOL
     ;                                                                                     // SQL-2016-R
 
 TLS_SYMBOL
-    : T L S                                                                               {this.isServerVersionGe80024()}?
+    : T L S                                                                               {this.isServerVersionGe80021()}?
     ;                                                                                     // MYSQL
 
 ATTRIBUTE_SYMBOL
@@ -3281,7 +3283,7 @@ SOURCE_CONNECTION_AUTO_FAILOVER_SYMBOL
     ;                                                                                     // MYSQL
 
 ZONE_SYMBOL
-    : Z O N E                                                                             {this.isServerVersionGe80024()}?
+    : Z O N E                                                                             {this.isServerVersionGe80022()}?
     ;                                                                                     // SQL-2003-N
 
 GRAMMAR_SELECTOR_DERIVED_EXPR
@@ -3289,11 +3291,11 @@ GRAMMAR_SELECTOR_DERIVED_EXPR
     ;                                                                                     // synthetic token: starts derived table expressions.
 
 REPLICA_SYMBOL
-    : R E P L I C A                                                                       {this.isServerVersionGe80024()}?
+    : R E P L I C A                                                                       {this.isServerVersionGe80022()}?
     ;
 
 REPLICAS_SYMBOL
-    : R E P L I C A S                                                                     {this.isServerVersionGe80024()}?
+    : R E P L I C A S                                                                     {this.isServerVersionGe80022()}?
     ;
 
 ASSIGN_GTIDS_TO_ANONYMOUS_TRANSACTIONS_SYMBOL
@@ -3305,107 +3307,107 @@ GET_SOURCE_PUBLIC_KEY_SYMBOL
     ;                                                                                     // MYSQL
 
 SOURCE_AUTO_POSITION_SYMBOL
-    : S O U R C E '_' A U T O '_' P O S I T I O N                                         {this.isServerVersionGe80024()}?
+    : S O U R C E '_' A U T O '_' P O S I T I O N                                         {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_BIND_SYMBOL
-    : S O U R C E '_' B I N D                                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' B I N D                                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_COMPRESSION_ALGORITHM_SYMBOL
-    : S O U R C E '_' C O M P R E S S I O N '_' A L G O R I T H M                         {this.isServerVersionGe80024()}?
+    : S O U R C E '_' C O M P R E S S I O N '_' A L G O R I T H M                         {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_CONNECT_RETRY_SYMBOL
-    : S O U R C E '_' C O N N E C T '_' R E T R Y                                         {this.isServerVersionGe80024()}?
+    : S O U R C E '_' C O N N E C T '_' R E T R Y                                         {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_DELAY_SYMBOL
-    : S O U R C E '_' D E L A Y                                                           {this.isServerVersionGe80024()}?
+    : S O U R C E '_' D E L A Y                                                           {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_HEARTBEAT_PERIOD_SYMBOL
-    : S O U R C E '_' H E A R T B E A T '_' P E R I O D                                   {this.isServerVersionGe80024()}?
+    : S O U R C E '_' H E A R T B E A T '_' P E R I O D                                   {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_HOST_SYMBOL
-    : S O U R C E '_' H O S T                                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' H O S T                                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_LOG_FILE_SYMBOL
-    : S O U R C E '_' L O G '_' F I L E                                                   {this.isServerVersionGe80024()}?
+    : S O U R C E '_' L O G '_' F I L E                                                   {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_LOG_POS_SYMBOL
-    : S O U R C E '_' L O G '_' P O S                                                     {this.isServerVersionGe80024()}?
+    : S O U R C E '_' L O G '_' P O S                                                     {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_PASSWORD_SYMBOL
-    : S O U R C E '_' P A S S W O R D                                                     {this.isServerVersionGe80024()}?
+    : S O U R C E '_' P A S S W O R D                                                     {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_PORT_SYMBOL
-    : S O U R C E '_' P O R T                                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' P O R T                                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_PUBLIC_KEY_PATH_SYMBOL
-    : S O U R C E '_' P U B L I C '_' K E Y '_' P A T H                                   {this.isServerVersionGe80024()}?
+    : S O U R C E '_' P U B L I C '_' K E Y '_' P A T H                                   {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_RETRY_COUNT_SYMBOL
-    : S O U R C E '_' R E T R Y '_' C O U N T                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' R E T R Y '_' C O U N T                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_SYMBOL
-    : S O U R C E '_' S S L                                                               {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L                                                               {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_CA_SYMBOL
-    : S O U R C E '_' S S L '_' C A                                                       {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' C A                                                       {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_CAPATH_SYMBOL
-    : S O U R C E '_' S S L '_' C A P A T H                                               {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' C A P A T H                                               {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_CERT_SYMBOL
-    : S O U R C E '_' S S L '_' C E R T                                                   {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' C E R T                                                   {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_CIPHER_SYMBOL
-    : S O U R C E '_' S S L '_' C I P H E R                                               {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' C I P H E R                                               {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_CRL_SYMBOL
-    : S O U R C E '_' S S L '_' C R L                                                     {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' C R L                                                     {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_CRLPATH_SYMBOL
-    : S O U R C E '_' S S L '_' C R L P A T H                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' C R L P A T H                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_KEY_SYMBOL
-    : S O U R C E '_' S S L '_' C R L P A T H                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' C R L P A T H                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_SSL_VERIFY_SERVER_CERT_SYMBOL
-    : S O U R C E '_' S S L '_' V E R I F Y '_' S E R V E R '_' C E R T                   {this.isServerVersionGe80024()}?
+    : S O U R C E '_' S S L '_' V E R I F Y '_' S E R V E R '_' C E R T                   {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_TLS_CIPHERSUITES_SYMBOL
-    : S O U R C E '_' T L S '_' C I P H E R S U I T E S                                   {this.isServerVersionGe80024()}?
+    : S O U R C E '_' T L S '_' C I P H E R S U I T E S                                   {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_TLS_VERSION_SYMBOL
-    : S O U R C E '_' T L S '_' V E R S I O N                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' T L S '_' V E R S I O N                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_USER_SYMBOL
-    : S O U R C E '_' U S E R                                                             {this.isServerVersionGe80024()}?
+    : S O U R C E '_' U S E R                                                             {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 SOURCE_ZSTD_COMPRESSION_LEVEL_SYMBOL
-    : S O U R C E '_' Z S T D '_' C O M P R E S S I O N '_' L E V E L                     {this.isServerVersionGe80024()}?
+    : S O U R C E '_' Z S T D '_' C O M P R E S S I O N '_' L E V E L                     {this.isServerVersionGe80023()}?
     ;                                                                                     // MYSQL
 
 ST_COLLECT_SYMBOL
@@ -3457,11 +3459,11 @@ INTERSECT_SYMBOL
     ;                                                                                     // SQL-1992-R
 
 BULK_SYMBOL
-    : B U L K                                                                             {this.serverVersion >= 80200}?
+    : B U L K                                                                             {this.serverVersion >= 80032}?
     ;                                                                                     // MYSQL
 
 URL_SYMBOL
-    : U R L                                                                               {this.serverVersion >= 80200}?
+    : U R L                                                                               {this.serverVersion >= 80032}?
     ;                                                                                     // MYSQL
 
 GENERATE_SYMBOL
@@ -3588,6 +3590,10 @@ UNDERSCORE_CHARSET
     : UNDERLINE_SYMBOL [a-z0-9]+ { this.doUnderscoreCharset(); }
     ;
 
+// TODO: check in the semantic phase that starting and ending tags are the same.
+DOLLAR_QUOTED_STRING_TEXT
+   : '$' DOLLAR_QUOTE_TAG_CHAR* '$' .*? '$' DOLLAR_QUOTE_TAG_CHAR* '$' {this.doDollarQuotedStringText()}?;
+
 // Identifiers might start with a digit, even though it is discouraged, and may not consist entirely of digits only.
 // All keywords above are automatically excluded.
 IDENTIFIER
@@ -3631,11 +3637,6 @@ SINGLE_QUOTED_TEXT
     : (
         SINGLE_QUOTE (({this.isSingleQuotedText()}? '\\')? .)*? SINGLE_QUOTE
     )+
-    ;
-
-// TODO: check in the semantic phase that starting and ending tags are the same.
-DOLLAR_QUOTED_STRING_TEXT
-    : '$' DOLLAR_QUOTE_TAG_CHAR* '$' .*? '$' DOLLAR_QUOTE_TAG_CHAR* '$' {this.supportMle}?
     ;
 
 // There are 3 types of block comments:

--- a/sql/mysql/Oracle/Python3/MySQLLexerBase.py
+++ b/sql/mysql/Oracle/Python3/MySQLLexerBase.py
@@ -145,11 +145,8 @@ class MySQLLexerBase(Lexer):
             self.justEmitedDot = False
         return t
 
-    def isServerVersionLt80024(self):
-        return self.serverVersion < 80024
-
-    def isServerVersionGe80024(self):
-        return self.serverVersion >= 80024
+    def isMasterCompressionAlgorithm(self):
+        return self.serverVersion >= 80018 and self.isServerVersionLt80024();
 
     def isServerVersionGe80011(self):
         return self.serverVersion >= 80011
@@ -163,14 +160,38 @@ class MySQLLexerBase(Lexer):
     def isServerVersionGe80014(self):
         return self.serverVersion >= 80014
 
+    def isServerVersionGe80016(self):
+        return self.serverVersion >= 80016
+
     def isServerVersionGe80017(self):
         return self.serverVersion >= 80017
 
     def isServerVersionGe80018(self):
         return self.serverVersion >= 80018
 
-    def isMasterCompressionAlgorithm(self):
-        return self.serverVersion >= 80018 and self.isServerVersionLt80024();
+    def isServerVersionLt80021(self):
+        return self.serverVersion < 80021
+
+    def isServerVersionGe80021(self):
+        return self.serverVersion >= 80021
+
+    def isServerVersionLt80022(self):
+        return self.serverVersion < 80022
+
+    def isServerVersionGe80022(self):
+        return self.serverVersion >= 80022
+
+    def isServerVersionLt80023(self):
+        return self.serverVersion < 80023
+
+    def isServerVersionGe80023(self):
+        return self.serverVersion >= 80023
+
+    def isServerVersionLt80024(self):
+        return self.serverVersion < 80024
+
+    def isServerVersionGe80024(self):
+        return self.serverVersion >= 80024
 
     def isServerVersionLt80031(self):
         return self.serverVersion < 80031
@@ -289,6 +310,9 @@ class MySQLLexerBase(Lexer):
 
     def doUnderscoreCharset(self):
         self._type = self.checkCharset(self._text)
+
+    def doDollarQuotedStringText(self):
+        return self.serverVersion >= 80034 and self.supportMle;
 
     def isVersionComment(self):
         return self.checkMySQLVersion(self._text)

--- a/sql/mysql/Oracle/README.md
+++ b/sql/mysql/Oracle/README.md
@@ -8,6 +8,8 @@ https://github.com/mysql/mysql-shell-plugins/tree/8928ada7d9e37a4075291880738983
 
 This grammar is set to recognize version "8.0.200".
 
+Includes updates to commit https://github.com/mysql/mysql-shell-plugins/commit/d0271b1244d9686c30ce95bae92f4cf4c135d36d.
+
 ## License
 
 Like all of Oracle's open source, this grammar is released under the GPLv2.

--- a/sql/mysql/Oracle/TypeScript/MySQLLexerBase.ts
+++ b/sql/mysql/Oracle/TypeScript/MySQLLexerBase.ts
@@ -252,273 +252,67 @@ export default abstract class MySQLLexerBase extends Lexer {
         return t;
     }
 
-    public isServerVersionLt80024(): boolean
-    {
-        return this.serverVersion < 80024;
-    }
-
-    public isServerVersionGe80024(): boolean
-    {
-        return this.serverVersion >= 80024;
-    }
-
-    public isServerVersionGe80011(): boolean
-    {
-        return this.serverVersion >= 80011;
-    }
-
-    public isServerVersionGe80013(): boolean
-    {
-        return this.serverVersion >= 80013;
-    }
-
-    public isServerVersionLt80014(): boolean
-    {
-        return this.serverVersion < 80014;
-    }
-
-    public isServerVersionGe80014(): boolean
-    {
-        return this.serverVersion >= 80014;
-    }
-
-    public isServerVersionGe80017(): boolean
-    {
-        return this.serverVersion >= 80017;
-    }
-
-
-    public isServerVersionGe80018(): boolean { return this.serverVersion >= 80018; }
-
     public isMasterCompressionAlgorithm(): boolean { return this.serverVersion >= 80018 && this.isServerVersionLt80024(); }
-
-    public isServerVersionLt80031(): boolean
-    {
-        return this.serverVersion < 80031;
-    }
-
-    public doLogicalOr(): void
-    {
-        this._type = this.isSqlModeActive(SqlMode.PipesAsConcat) ? MySQLLexer.CONCAT_PIPES_SYMBOL : MySQLLexer.LOGICAL_OR_OPERATOR;
-    }
-
-    public doIntNumber(): void
-    {
-        this._type = this.determineNumericType(this.text);
-    }
-
-    public doAdddate(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.ADDDATE_SYMBOL);
-    }
-
-    public doBitAnd(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.BIT_AND_SYMBOL);
-    }
-
-    public doBitOr(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.BIT_OR_SYMBOL);
-    }
-
-    public doBitXor(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.BIT_XOR_SYMBOL);
-    }
-
-    public doCast(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.CAST_SYMBOL);
-    }
-
-    public doCount(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.COUNT_SYMBOL);
-    }
-
-    public doCurdate(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL);
-    }
-
-    public doCurrentDate(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL);
-    }
-
-    public doCurrentTime(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL);
-    }
-
-    public doCurtime(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL);
-    }
-
-    public doDateAdd(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.DATE_ADD_SYMBOL);
-    }
-
-    public doDateSub(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.DATE_SUB_SYMBOL);
-    }
-
-    public doExtract(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.EXTRACT_SYMBOL);
-    }
-
-    public doGroupConcat(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.GROUP_CONCAT_SYMBOL);
-    }
-
-    public doMax(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.MAX_SYMBOL);
-    }
-
-    public doMid(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-
-    public doMin(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.MIN_SYMBOL);
-    }
-
-    public doNot(): void
-    {
-        this._type = this.isSqlModeActive(SqlMode.HighNotPrecedence) ? MySQLLexer.NOT2_SYMBOL: MySQLLexer.NOT_SYMBOL;
-    }
-
-    public doNow(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.NOW_SYMBOL);
-    }
-
-    public doPosition(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.POSITION_SYMBOL);
-    }
-
-    public doSessionUser(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.USER_SYMBOL);
-    }
-
-    public doStddevSamp(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.STDDEV_SAMP_SYMBOL);
-    }
-
-    public doStddev(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-
-    public doStddevPop(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-
-    public doStd(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.STD_SYMBOL);
-    }
-
-    public doSubdate(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.SUBDATE_SYMBOL);
-    }
-
-    public doSubstr(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-
-    public doSubstring(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL);
-    }
-
-    public doSum(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.SUM_SYMBOL);
-    }
-
-    public doSysdate(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.SYSDATE_SYMBOL);
-    }
-
-    public doSystemUser(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.USER_SYMBOL);
-    }
-
-    public doTrim(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.TRIM_SYMBOL);
-    }
-
-    public doVariance(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL);
-    }
-
-    public doVarPop(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL);
-    }
-
-    public doVarSamp(): void
-    {
-        this._type = this.determineFunction(MySQLLexer.VAR_SAMP_SYMBOL);
-    }
-
-    public doUnderscoreCharset(): void
-    {
-        this._type = this.checkCharset(this.text);
-    }
-
-    public isVersionComment(): boolean
-    {
-        return this.checkMySQLVersion(this.text);
-    }
-
-    public isBackTickQuotedId(): boolean
-    {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-
-    public isDoubleQuotedText(): boolean
-    {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-
-    public isSingleQuotedText(): boolean
-    {
-        return !this.isSqlModeActive(SqlMode.NoBackslashEscapes);
-    }
-
-    public startInVersionComment(): void
-    {
-        this.inVersionComment = true;
-    }
-
-    public endInVersionComment(): void
-    {
-        this.inVersionComment = false;
-    }
-
-    public isInVersionComment(): boolean
-    {
-        return this.inVersionComment;
-    }
+    public isServerVersionGe80011(): boolean { return this.serverVersion >= 80011; }
+    public isServerVersionGe80013(): boolean { return this.serverVersion >= 80013; }
+    public isServerVersionLt80014(): boolean { return this.serverVersion < 80014; }
+    public isServerVersionGe80014(): boolean { return this.serverVersion >= 80014; }
+    public isServerVersionGe80016(): boolean { return this.serverVersion >= 80016; }
+    public isServerVersionGe80017(): boolean { return this.serverVersion >= 80017; }
+    public isServerVersionGe80018(): boolean { return this.serverVersion >= 80018; }
+    public isServerVersionLt80021(): boolean { return this.serverVersion < 80021; }
+    public isServerVersionGe80021(): boolean { return this.serverVersion >= 80021; }
+    public isServerVersionLt80022(): boolean { return this.serverVersion < 80022; }
+    public isServerVersionGe80022(): boolean { return this.serverVersion >= 80022; }
+    public isServerVersionLt80023(): boolean { return this.serverVersion < 80023; }
+    public isServerVersionGe80023(): boolean { return this.serverVersion >= 80023; }
+    public isServerVersionLt80024(): boolean { return this.serverVersion < 80024; }
+    public isServerVersionGe80024(): boolean { return this.serverVersion >= 80024; }
+    public isServerVersionLt80031(): boolean { return this.serverVersion < 80031; }
+    public doLogicalOr(): void { this._type = this.isSqlModeActive(SqlMode.PipesAsConcat) ? MySQLLexer.CONCAT_PIPES_SYMBOL : MySQLLexer.LOGICAL_OR_OPERATOR; }
+    public doIntNumber(): void { this._type = this.determineNumericType(this.text); }
+    public doAdddate(): void { this._type = this.determineFunction(MySQLLexer.ADDDATE_SYMBOL); }
+    public doBitAnd(): void { this._type = this.determineFunction(MySQLLexer.BIT_AND_SYMBOL); }
+    public doBitOr(): void { this._type = this.determineFunction(MySQLLexer.BIT_OR_SYMBOL); }
+    public doBitXor(): void { this._type = this.determineFunction(MySQLLexer.BIT_XOR_SYMBOL); }
+    public doCast(): void { this._type = this.determineFunction(MySQLLexer.CAST_SYMBOL); }
+    public doCount(): void { this._type = this.determineFunction(MySQLLexer.COUNT_SYMBOL); }
+    public doCurdate(): void { this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL); }
+    public doCurrentDate(): void { this._type = this.determineFunction(MySQLLexer.CURDATE_SYMBOL); }
+    public doCurrentTime(): void { this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL); }
+    public doCurtime(): void { this._type = this.determineFunction(MySQLLexer.CURTIME_SYMBOL); }
+    public doDateAdd(): void { this._type = this.determineFunction(MySQLLexer.DATE_ADD_SYMBOL); }
+    public doDateSub(): void { this._type = this.determineFunction(MySQLLexer.DATE_SUB_SYMBOL); }
+    public doExtract(): void { this._type = this.determineFunction(MySQLLexer.EXTRACT_SYMBOL); }
+    public doGroupConcat(): void { this._type = this.determineFunction(MySQLLexer.GROUP_CONCAT_SYMBOL); }
+    public doMax(): void { this._type = this.determineFunction(MySQLLexer.MAX_SYMBOL); }
+    public doMid(): void { this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    public doMin(): void { this._type = this.determineFunction(MySQLLexer.MIN_SYMBOL); }
+    public doNot(): void { this._type = this.isSqlModeActive(SqlMode.HighNotPrecedence) ? MySQLLexer.NOT2_SYMBOL: MySQLLexer.NOT_SYMBOL; }
+    public doNow(): void { this._type = this.determineFunction(MySQLLexer.NOW_SYMBOL); }
+    public doPosition(): void { this._type = this.determineFunction(MySQLLexer.POSITION_SYMBOL); }
+    public doSessionUser(): void { this._type = this.determineFunction(MySQLLexer.USER_SYMBOL); }
+    public doStddevSamp(): void { this._type = this.determineFunction(MySQLLexer.STDDEV_SAMP_SYMBOL); }
+    public doStddev(): void { this._type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    public doStddevPop(): void { this._type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    public doStd(): void { this._type = this.determineFunction(MySQLLexer.STD_SYMBOL); }
+    public doSubdate(): void { this._type = this.determineFunction(MySQLLexer.SUBDATE_SYMBOL); }
+    public doSubstr(): void { this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    public doSubstring(): void { this._type = this.determineFunction(MySQLLexer.SUBSTRING_SYMBOL); }
+    public doSum(): void { this._type = this.determineFunction(MySQLLexer.SUM_SYMBOL); }
+    public doSysdate(): void { this._type = this.determineFunction(MySQLLexer.SYSDATE_SYMBOL); }
+    public doSystemUser(): void { this._type = this.determineFunction(MySQLLexer.USER_SYMBOL); }
+    public doTrim(): void { this._type = this.determineFunction(MySQLLexer.TRIM_SYMBOL); }
+    public doVariance(): void { this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL); }
+    public doVarPop(): void { this._type = this.determineFunction(MySQLLexer.VARIANCE_SYMBOL); }
+    public doVarSamp(): void { this._type = this.determineFunction(MySQLLexer.VAR_SAMP_SYMBOL); }
+    public doUnderscoreCharset(): void { this._type = this.checkCharset(this.text); }
+    public doDollarQuotedStringText(): boolean { return this.serverVersion >= 80034 && this.supportMle; }
+    public isVersionComment(): boolean { return this.checkMySQLVersion(this.text); }
+    public isBackTickQuotedId(): boolean { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    public isDoubleQuotedText(): boolean { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    public isSingleQuotedText(): boolean { return !this.isSqlModeActive(SqlMode.NoBackslashEscapes); }
+    public startInVersionComment(): void { this.inVersionComment = true; }
+    public endInVersionComment(): void { this.inVersionComment = false; }
+    public isInVersionComment(): boolean { return this.inVersionComment; }
 }


### PR DESCRIPTION
This PR is a change to bring the [sql/mysql/Oracle grammar](https://github.com/antlr/grammars-v4/tree/master/sql/mysql/Oracle) up to date with the one in the [Oracle MySQL Shell for VS Code extension](https://github.com/mysql/mysql-shell-plugins/tree/f35d371f3290fefc224ed474e1d9766adeec71c2/gui/frontend/src/parsing/mysql). Many of the changes are reformatting. This was done because this grammar will be automatically generated from the Oracle repo sources, which will be pre-formatted with one line per Antlr4 grammar action. I'm not sure when I'll get around to writing the script that scrapes the grammar directly from the Oracle repo, but soon.