### PR TITLE
[cobol85, glsl] Fix additional ambiguities of which grammar to test.

### DIFF
--- a/cobol85/desc.xml
+++ b/cobol85/desc.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
+   <grammar-name>Cobol85</grammar-name>
 </desc>

--- a/glsl/desc.xml
+++ b/glsl/desc.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <targets>CSharp;Dart;Java;JavaScript;Python3;TypeScript;Antlr4ng</targets>
+   <grammar-name>GLSL</grammar-name>
 </desc>


### PR DESCRIPTION
Trgen requires you to make a choice of what grammar to test when it is ambiguous. This happens when there are preprocessor grammars. This PR changes the desc.xml to say what grammar to test.