### PR TITLE
Fix TSqlParser.g4 to Support OpenQuery Format for Table Names

### DIFF
--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -5120,6 +5120,7 @@ full_table_name
         | database = id_ '.' schema = id_? '.'
         | schema = id_ '.'
     )? table = id_
+    | openquery
     ;
 
 table_name

--- a/sql/tsql/examples/openQuery_tableName.sql
+++ b/sql/tsql/examples/openQuery_tableName.sql
@@ -1,0 +1,29 @@
+
+WITH abcd as(
+    SELECT
+        *
+    FROM OPENQUERY(mysqldg,'
+        select
+      * from abcd
+        ') AS b
+             LEFT JOIN test.dbo.abcde AS p ON
+        b.inco=p.gco
+),
+     plucount as(
+         select
+             j.loc,
+             COUNT(j.plu) as plucount
+         from jhdata as j
+         group by
+             j.loc
+         having
+             COUNT(j.plu)>1
+     )
+select
+    *
+from jhdata as a
+         inner join plucount as p on
+    a.loc=p.loc
+order by
+    a.dept asc,
+    a.loc asc


### PR DESCRIPTION
Affected File:
- [TSqlParser.g4](https://github.com/antlr/grammars-v4/blob/master/sql/tsql/TSqlParser.g4)

The parser now correctly processes queries in the OPENQUERY format, ensuring smooth parsing of remote queries in SQL Server.
<img width="1375" alt="image" src="https://github.com/user-attachments/assets/e5b87b2b-3704-446d-a04f-d97cee01fef2" />

Test Sql:
```sql

WITH abcd as(
    SELECT
      *
    FROM OPENQUERY(mysqldg,'
        select
      * from abcd
        ') AS b
    LEFT JOIN test.dbo.abcde AS p ON
        b.inco=p.gco
),
plucount as(
select  
    j.loc,
    COUNT(j.plu) as plucount
from jhdata as j
group by
    j.loc
having 
    COUNT(j.plu)>1
)
select
*
from jhdata as a
inner join plucount as p on
    a.loc=p.loc
order by
    a.dept asc,
    a.loc asc
```

