### PR TITLE
Fix: identifier name cannot include '<' or '>'

### DIFF
--- a/vba/vba6/vba.g4
+++ b/vba/vba6/vba.g4
@@ -1991,7 +1991,7 @@ WS
 
 // identifier
 IDENTIFIER
-    : ~[\]()\r\n\t.,'"|!@#$%^&*\-+:=; ]+
+    : ~[\]()\r\n\t.,'"|!@#$%^&*\-+:=; <>]+
     | L_SQUARE_BRACKET (~[!\]\r\n])+ R_SQUARE_BRACKET
     ;
 


### PR DESCRIPTION
Expressions like "Abc<>Cde" (without spaces) is considered as a single identifier