### PR TITLE
[build] Disable PHP target because it fails on Ubuntu.

### DIFF
--- a/_scripts/what-to-test.sh
+++ b/_scripts/what-to-test.sh
@@ -1,7 +1,8 @@
 #
 #set -x
 declare -A targets
-for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "PHP" "Python3" "TypeScript" "Antlr4ng"
+# remove temporarily TODO add back: "PHP"
+for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "Python3" "TypeScript" "Antlr4ng"
 do
     targets[$t]=0
 done
@@ -44,8 +45,8 @@ do
 done
 
 ttargets=""
-# remove temporarily TODO add back: "TypeScript"
-for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "PHP" "Python3" "TypeScript" "Antlr4ng"
+# remove temporarily TODO add back: "PHP"
+for t in "Cpp" "CSharp" "Dart" "Go" "Java" "JavaScript" "Python3" "TypeScript" "Antlr4ng"
 do
     if [ ${targets[$t]} -ne 0 ]
     then


### PR DESCRIPTION
For the build, there are messages on Ubuntu saying "Could not open input file: memory_limit=1G". This doesn't happen on the other OSes tested, and doesn't happen on my Ubuntu box. I'm also noticing a lot of dependabot failures in updating the PHP templates. 
```
+------------------------------------------------+
|         Dependencies failed to update          |
+-------------------+----------------------------+
| psr/log           | unknown_error              |
| phpunit/php-timer | tool_version_not_supported |
+-------------------+----------------------------+
```
I think it has to do with Github "latest" changes to PHP and/or the PHP Github plugin not working--not unusual because I had to remove the dotnet plugin.

So I am just disabling the PHP target testing.