### PR TITLE
[c] Fix #4463 -- unused rule removed.

### DIFF
--- a/c/C.g4
+++ b/c/C.g4
@@ -346,10 +346,6 @@ gccAttribute
     ('(' argumentExpressionList? ')')?
     ;
 
-nestedParenthesesBlock
-    : (~('(' | ')') | '(' nestedParenthesesBlock ')')*
-    ;
-
 pointer
     : (('*' | '^') typeQualifierList?)+ // ^ - Blocks language extension
     ;


### PR DESCRIPTION
This PR removes an unused rule, fixing #4463.

There should be a check in Trash to find rules that take part of a recursive cycle but are unused in any rules outside of the cycle (i.e., disconnected cycles from the start rule).