### PR TITLE
[lua] Fix for #4494 -- adjust line numbering when newlines read.

### DIFF
--- a/lua/CSharp/LuaLexerBase.cs
+++ b/lua/CSharp/LuaLexerBase.cs
@@ -36,14 +36,14 @@ public abstract class LuaLexerBase : Lexer
         }
         while (cs.LA(1) != '\n' && cs.LA(1) != -1)
         {
-            cs.Consume();
+            this.Interpreter.Consume(cs);
         }
     }
 
     private void read_long_string(ICharStream cs, int sep)
     {
         bool done = false;
-        cs.Consume();
+        this.Interpreter.Consume(cs);
         for (; ; )
         {
             var c = cs.LA(1);
@@ -58,7 +58,7 @@ public abstract class LuaLexerBase : Lexer
                 case ']':
                     if (skip_sep(cs) == sep)
                     {
-                        cs.Consume();
+                        this.Interpreter.Consume(cs);
                         done = true;
                     }
                     break;
@@ -68,7 +68,7 @@ public abstract class LuaLexerBase : Lexer
                         done = true;
                         break;
                     }
-                    cs.Consume();
+                    this.Interpreter.Consume(cs);
                     break;
             }
             if (done) break;
@@ -80,10 +80,10 @@ public abstract class LuaLexerBase : Lexer
         int count = 0;
         int s = cs.LA(1);
         char ss = (char)s;
-        cs.Consume();
+        this.Interpreter.Consume(cs);
         while (cs.LA(1) == '=')
         {
-            cs.Consume();
+            this.Interpreter.Consume(cs);
             count++;
         }
         if (cs.LA(1) == s) count += 2;

--- a/lua/Cpp/LuaLexerBase.cpp
+++ b/lua/Cpp/LuaLexerBase.cpp
@@ -23,14 +23,14 @@ void LuaLexerBase::HandleComment()
     }
     while (cs->LA(1) != '\n' && cs->LA(1) != -1)
     {
-        cs->consume();
+        this->getInterpreter<antlr4::atn::LexerATNSimulator>()->consume(cs);
     }
 }
 
 void LuaLexerBase::read_long_string(antlr4::CharStream * cs, int sep)
 {
     bool done = false;
-    cs->consume();
+    this->getInterpreter<antlr4::atn::LexerATNSimulator>()->consume(cs);
     for (; ; )
     {
         auto c = cs->LA(1);
@@ -46,7 +46,7 @@ void LuaLexerBase::read_long_string(antlr4::CharStream * cs, int sep)
             case ']':
                 if (skip_sep(cs) == sep)
                 {
-                    cs->consume();
+                    this->getInterpreter<antlr4::atn::LexerATNSimulator>()->consume(cs);
                     done = true;
                 }
                 break;
@@ -56,7 +56,7 @@ void LuaLexerBase::read_long_string(antlr4::CharStream * cs, int sep)
                     done = true;
                     break;
                 }
-                cs->consume();
+                this->getInterpreter<antlr4::atn::LexerATNSimulator>()->consume(cs);
                 break;
         }
         if (done) break;
@@ -68,10 +68,10 @@ int LuaLexerBase::skip_sep(antlr4::CharStream * cs)
     int count = 0;
     size_t s = cs->LA(1);
     char ss = (char)s;
-    cs->consume();
+    this->getInterpreter<antlr4::atn::LexerATNSimulator>()->consume(cs);
     while (cs->LA(1) == '=')
     {
-        cs->consume();
+        this->getInterpreter<antlr4::atn::LexerATNSimulator>()->consume(cs);
         count++;
     }
     if (cs->LA(1) == s) count += 2;

--- a/lua/Dart/LuaLexerBase.dart
+++ b/lua/Dart/LuaLexerBase.dart
@@ -37,14 +37,14 @@ abstract class LuaLexerBase extends Lexer
             var yo2 = '\n'.codeUnitAt(0);
             if (c2 == yo2) break;
             if (c2 == -1) break;
-            cs.consume();
+            this.interpreter?.consume(cs);
         }
     }
 
     void read_long_string(CharStream cs, int sep)
     {
         bool done = false;
-        cs.consume();
+        this.interpreter?.consume(cs);
         for (; ; )
         {
             var c = cs.LA(1);
@@ -58,7 +58,7 @@ abstract class LuaLexerBase extends Lexer
             } else if (c == yo) {
                 if (skip_sep(cs) == sep)
                 {
-                    cs.consume();
+                    this.interpreter?.consume(cs);
                     done = true;
                 }
             } else {
@@ -66,7 +66,7 @@ abstract class LuaLexerBase extends Lexer
                 {
                     done = true;
                 } else {
-                    cs.consume();
+                    this.interpreter?.consume(cs);
                 }
             }
             if (done) break;
@@ -77,11 +77,11 @@ abstract class LuaLexerBase extends Lexer
     {
         int count = 0;
         var s = cs.LA(1);
-        cs.consume();
+        this.interpreter?.consume(cs);
         var yoeq = '='.codeUnitAt(0);
         while (cs.LA(1) == yoeq)
         {
-            cs.consume();
+            this.interpreter?.consume(cs);
             count++;
         }
         if (cs.LA(1) == s) count += 2;

--- a/lua/Go/LuaLexerBase.go
+++ b/lua/Go/LuaLexerBase.go
@@ -22,13 +22,13 @@ func (l *LuaLexerBase) HandleComment() {
         }
     }
     for cs.LA(1) != '\n' && cs.LA(1) != -1 {
-        cs.Consume()
+        l.Interpreter.Consume(cs)
     }
 }
 
 func (l *LuaLexerBase) read_long_string(cs antlr.CharStream, sep int) {
     done := false
-    cs.Consume()
+    l.Interpreter.Consume(cs)
     for {
         c := cs.LA(1)
         switch c {
@@ -38,7 +38,7 @@ func (l *LuaLexerBase) read_long_string(cs antlr.CharStream, sep int) {
             listener.SyntaxError(l, nil, l.start_line, l.start_col, "unfinished long comment", nil)
         case ']':
             if l.skip_sep(cs) == sep {
-                cs.Consume()
+                l.Interpreter.Consume(cs)
                 done = true
             }
         default:
@@ -46,7 +46,7 @@ func (l *LuaLexerBase) read_long_string(cs antlr.CharStream, sep int) {
                 done = true
                 break
             }
-            cs.Consume()
+            l.Interpreter.Consume(cs)
         }
         if done {
             break
@@ -57,9 +57,9 @@ func (l *LuaLexerBase) read_long_string(cs antlr.CharStream, sep int) {
 func (l *LuaLexerBase) skip_sep(cs antlr.CharStream) int {
     count := 0
     s := cs.LA(1)
-    cs.Consume()
+    l.Interpreter.Consume(cs)
     for cs.LA(1) == '=' {
-        cs.Consume()
+        l.Interpreter.Consume(cs)
         count++
     }
     if cs.LA(1) == s {

--- a/lua/Java/LuaLexerBase.java
+++ b/lua/Java/LuaLexerBase.java
@@ -27,14 +27,14 @@ public abstract class LuaLexerBase extends Lexer {
         }
         while (cs.LA(1) != '\n' && cs.LA(1) != -1)
         {
-            cs.consume();
+            this.getInterpreter().consume(cs);
         }
     }
 
     private void read_long_string(CharStream cs, int sep)
     {
         boolean done = false;
-        cs.consume();
+        this.getInterpreter().consume(cs);
         for (; ; )
         {
             var c = cs.LA(1);
@@ -49,7 +49,7 @@ public abstract class LuaLexerBase extends Lexer {
                 case ']':
                     if (skip_sep(cs) == sep)
                     {
-                        cs.consume();
+                        this.getInterpreter().consume(cs);
                         done = true;
                     }
                     break;
@@ -59,7 +59,7 @@ public abstract class LuaLexerBase extends Lexer {
                         done = true;
                         break;
                     }
-                    cs.consume();
+                    this.getInterpreter().consume(cs);
                     break;
             }
             if (done) break;
@@ -71,10 +71,10 @@ public abstract class LuaLexerBase extends Lexer {
         int count = 0;
         int s = cs.LA(1);
         char ss = (char)s;
-        cs.consume();
+        this.getInterpreter().consume(cs);
         while (cs.LA(1) == '=')
         {
-            cs.consume();
+            this.getInterpreter().consume(cs);
             count++;
         }
         if (cs.LA(1) == s) count += 2;

--- a/lua/JavaScript/LuaLexerBase.js
+++ b/lua/JavaScript/LuaLexerBase.js
@@ -15,12 +15,12 @@ export default class BisonLexerBase extends Lexer {
             }
         }
         while (cs.LA(1) !== 10 /* '\n' */ && cs.LA(1) !== -1) {
-            cs.consume();
+            this._interp.consume(cs);
         }
     }
     read_long_string(cs, sep) {
         let done = false;
-        cs.consume();
+        this._interp.consume(cs);
         for (;;) {
             let c = cs.LA(1);
             switch (c) {
@@ -31,7 +31,7 @@ export default class BisonLexerBase extends Lexer {
                     break;
                 case 93: /* ']' */
                     if (this.skip_sep(cs) === sep) {
-                        cs.consume();
+                        this._interp.consume(cs);
                         done = true;
                     }
                     break;
@@ -40,7 +40,7 @@ export default class BisonLexerBase extends Lexer {
                         done = true;
                         break;
                     }
-                    cs.consume();
+                    this._interp.consume(cs);
                     break;
             }
             if (done)
@@ -50,9 +50,9 @@ export default class BisonLexerBase extends Lexer {
     skip_sep(cs) {
         let count = 0;
         let s = cs.LA(1);
-        cs.consume();
+        this._interp.consume(cs);
         while (cs.LA(1) === 61 /* '=' */) {
-            cs.consume();
+            this._interp.consume(cs);
             count++;
         }
         if (cs.LA(1) === s)

--- a/lua/Python3/LuaLexerBase.py
+++ b/lua/Python3/LuaLexerBase.py
@@ -23,11 +23,11 @@ class LuaLexerBase(Lexer):
                 return
 
         while cs.LA(1) != 10 and cs.LA(1) != -1:  # '\n'
-            cs.consume()
+            self._interp.consume(cs)
 
     def read_long_string(self, cs:InputStream, sep:int):
         done = False
-        cs.consume()
+        self._interp.consume(cs)
 
         while not done:
             c = cs.LA(1)
@@ -35,21 +35,21 @@ class LuaLexerBase(Lexer):
                 done = True
             elif c == 93:  # ']'
                 if self.skip_sep(cs) == sep:
-                    cs.consume()
+                    self._interp.consume(cs)
                     done = True
             else:
                 if cs.LA(1) == -1:
                     done = True
                 else:
-                    cs.consume()
+                    self._interp.consume(cs)
 
     def skip_sep(self, cs:InputStream):
         count = 0
         s = cs.LA(1)
-        cs.consume()
+        self._interp.consume(cs)
 
         while cs.LA(1) == 61:  # '='
-            cs.consume()
+            self._interp.consume(cs)
             count += 1
 
         if cs.LA(1) == s:

--- a/lua/TypeScript/LuaLexerBase.ts
+++ b/lua/TypeScript/LuaLexerBase.ts
@@ -21,13 +21,13 @@ export default abstract class BisonLexerBase extends Lexer {
             }
         }
         while (cs.LA(1) !== 10 /* '\n' */ && cs.LA(1) !== -1) {
-            cs.consume();
+            this._interp.consume(cs);
         }
     }
 
     read_long_string(cs: CharStream, sep: number) {
         let done = false;
-        cs.consume();
+        this._interp.consume(cs);
         for (; ;) {
             let c = cs.LA(1);
             switch (c) {
@@ -38,7 +38,7 @@ export default abstract class BisonLexerBase extends Lexer {
                     break;
                 case 93: /* ']' */
                     if (this.skip_sep(cs) === sep) {
-                        cs.consume();
+                        this._interp.consume(cs);
                         done = true;
                     }
                     break;
@@ -47,7 +47,7 @@ export default abstract class BisonLexerBase extends Lexer {
                         done = true;
                         break;
                     }
-                    cs.consume();
+                    this._interp.consume(cs);
                     break;
             }
             if (done) break;
@@ -57,9 +57,9 @@ export default abstract class BisonLexerBase extends Lexer {
     skip_sep(cs: CharStream) {
         let count = 0;
         let s = cs.LA(1);
-        cs.consume();
+        this._interp.consume(cs);
         while (cs.LA(1) === 61 /* '=' */) {
-            cs.consume();
+            this._interp.consume(cs);
             count++;
         }
         if (cs.LA(1) === s) count += 2;


### PR DESCRIPTION
This PR fixes #4494.

It replace cs.consume() with interpreter.consume(cs) to have line numbering adjusted with newlines. This calls the lexer interpreter to adjust the line numbering.