### PR TITLE
[build] Fix for #4499 -- Add parse tree validation via XPath predicates.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,189 +3,189 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trcaret"
       ],
       "rollForward": false
     },
     "trcover": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trcover"
       ],
       "rollForward": false
     },
     "trgen": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trgen"
       ],
       "rollForward": false
     },
     "trglob": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trglob"
       ],
       "rollForward": false
     },
     "triconv": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "triconv"
       ],
       "rollForward": false
     },
     "trparse": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trparse"
       ],
       "rollForward": false
     },
     "trquery": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trquery"
       ],
       "rollForward": false
     },
     "trtext": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trtext"
       ],
       "rollForward": false
     },
     "trwdog": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trwdog"
       ],
       "rollForward": false
     },
     "trxgrep": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trxgrep"
       ],
       "rollForward": false
     },
     "trxml": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trxml"
       ],
       "rollForward": false
     },
     "trxml2": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trxml2"
       ],
       "rollForward": false
     },
     "trclonereplace": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trclonereplace"
       ],
       "rollForward": false
     },
     "trcombine": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trcombine"
       ],
       "rollForward": false
     },
     "trconvert": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trconvert"
       ],
       "rollForward": false
     },
     "trfoldlit": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trfoldlit"
       ],
       "rollForward": false
     },
     "trgenvsc": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trgenvsc"
       ],
       "rollForward": false
     },
     "tritext": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "tritext"
       ],
       "rollForward": false
     },
     "trjson": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trjson"
       ],
       "rollForward": false
     },
     "trperf": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trperf"
       ],
       "rollForward": false
     },
     "trrename": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trrename"
       ],
       "rollForward": false
     },
     "trsort": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trsort"
       ],
       "rollForward": false
     },
     "trsplit": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trsplit"
       ],
       "rollForward": false
     },
     "trsponge": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trsponge"
       ],
       "rollForward": false
     },
     "trtokens": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trtokens"
       ],
       "rollForward": false
     },
     "trtree": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trtree"
       ],
       "rollForward": false
     },
     "trunfold": {
-      "version": "0.23.18",
+      "version": "0.23.19",
       "commands": [
         "trunfold"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,189 +3,189 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trcaret"
       ],
       "rollForward": false
     },
     "trcover": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trcover"
       ],
       "rollForward": false
     },
     "trgen": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trgen"
       ],
       "rollForward": false
     },
     "trglob": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trglob"
       ],
       "rollForward": false
     },
     "triconv": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "triconv"
       ],
       "rollForward": false
     },
     "trparse": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trparse"
       ],
       "rollForward": false
     },
     "trquery": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trquery"
       ],
       "rollForward": false
     },
     "trtext": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trtext"
       ],
       "rollForward": false
     },
     "trwdog": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trwdog"
       ],
       "rollForward": false
     },
     "trxgrep": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trxgrep"
       ],
       "rollForward": false
     },
     "trxml": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trxml"
       ],
       "rollForward": false
     },
     "trxml2": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trxml2"
       ],
       "rollForward": false
     },
     "trclonereplace": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trclonereplace"
       ],
       "rollForward": false
     },
     "trcombine": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trcombine"
       ],
       "rollForward": false
     },
     "trconvert": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trconvert"
       ],
       "rollForward": false
     },
     "trfoldlit": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trfoldlit"
       ],
       "rollForward": false
     },
     "trgenvsc": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trgenvsc"
       ],
       "rollForward": false
     },
     "tritext": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "tritext"
       ],
       "rollForward": false
     },
     "trjson": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trjson"
       ],
       "rollForward": false
     },
     "trperf": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trperf"
       ],
       "rollForward": false
     },
     "trrename": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trrename"
       ],
       "rollForward": false
     },
     "trsort": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trsort"
       ],
       "rollForward": false
     },
     "trsplit": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trsplit"
       ],
       "rollForward": false
     },
     "trsponge": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trsponge"
       ],
       "rollForward": false
     },
     "trtokens": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trtokens"
       ],
       "rollForward": false
     },
     "trtree": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trtree"
       ],
       "rollForward": false
     },
     "trunfold": {
-      "version": "0.23.19",
+      "version": "0.23.20",
       "commands": [
         "trunfold"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,189 +3,189 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trcaret"
       ],
       "rollForward": false
     },
     "trcover": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trcover"
       ],
       "rollForward": false
     },
     "trgen": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trgen"
       ],
       "rollForward": false
     },
     "trglob": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trglob"
       ],
       "rollForward": false
     },
     "triconv": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "triconv"
       ],
       "rollForward": false
     },
     "trparse": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trparse"
       ],
       "rollForward": false
     },
     "trquery": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trquery"
       ],
       "rollForward": false
     },
     "trtext": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trtext"
       ],
       "rollForward": false
     },
     "trwdog": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trwdog"
       ],
       "rollForward": false
     },
     "trxgrep": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trxgrep"
       ],
       "rollForward": false
     },
     "trxml": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trxml"
       ],
       "rollForward": false
     },
     "trxml2": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trxml2"
       ],
       "rollForward": false
     },
     "trclonereplace": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trclonereplace"
       ],
       "rollForward": false
     },
     "trcombine": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trcombine"
       ],
       "rollForward": false
     },
     "trconvert": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trconvert"
       ],
       "rollForward": false
     },
     "trfoldlit": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trfoldlit"
       ],
       "rollForward": false
     },
     "trgenvsc": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trgenvsc"
       ],
       "rollForward": false
     },
     "tritext": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "tritext"
       ],
       "rollForward": false
     },
     "trjson": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trjson"
       ],
       "rollForward": false
     },
     "trperf": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trperf"
       ],
       "rollForward": false
     },
     "trrename": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trrename"
       ],
       "rollForward": false
     },
     "trsort": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trsort"
       ],
       "rollForward": false
     },
     "trsplit": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trsplit"
       ],
       "rollForward": false
     },
     "trsponge": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trsponge"
       ],
       "rollForward": false
     },
     "trtokens": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trtokens"
       ],
       "rollForward": false
     },
     "trtree": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trtree"
       ],
       "rollForward": false
     },
     "trunfold": {
-      "version": "0.23.20",
+      "version": "0.23.21",
       "commands": [
         "trunfold"
       ],

--- a/_scripts/templates/Antlr4cs/st.test.ps1
+++ b/_scripts/templates/Antlr4cs/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob -- '$Tests' ; $last = $LASTEXITCODE ) | Out-Null
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/Antlr4cs/st.test.sh
+++ b/_scripts/templates/Antlr4cs/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/Antlr4ng/st.test.ps1
+++ b/_scripts/templates/Antlr4ng/st.test.ps1
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/Antlr4ng/st.test.sh
+++ b/_scripts/templates/Antlr4ng/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/CSharp/st.test-ambiguity.sh
+++ b/_scripts/templates/CSharp/st.test-ambiguity.sh
@@ -6,7 +6,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/CSharp/st.test-cover.sh
+++ b/_scripts/templates/CSharp/st.test-cover.sh
@@ -6,7 +6,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/Cpp/st.test.ps1
+++ b/_scripts/templates/Cpp/st.test.ps1
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/Cpp/st.test.sh
+++ b/_scripts/templates/Cpp/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/Dart/st.test.ps1
+++ b/_scripts/templates/Dart/st.test.ps1
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/Dart/st.test.sh
+++ b/_scripts/templates/Dart/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/Go/st.test.ps1
+++ b/_scripts/templates/Go/st.test.ps1
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/Go/st.test.sh
+++ b/_scripts/templates/Go/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/Java/st.test.ps1
+++ b/_scripts/templates/Java/st.test.ps1
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/Java/st.test.sh
+++ b/_scripts/templates/Java/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/JavaScript/st.test.ps1
+++ b/_scripts/templates/JavaScript/st.test.ps1
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/JavaScript/st.test.sh
+++ b/_scripts/templates/JavaScript/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob '$Tests' ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/PHP/st.test.ps1
+++ b/_scripts/templates/PHP/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob '$Tests' ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/PHP/st.test.sh
+++ b/_scripts/templates/PHP/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob '$Tests' ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/Python3/st.test.ps1
+++ b/_scripts/templates/Python3/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob '$Tests' ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/Python3/st.test.sh
+++ b/_scripts/templates/Python3/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob '$Tests' ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {
@@ -19,15 +19,27 @@ foreach ($file in $allFiles) {
         continue
     } elseif ($ext -eq ".tree") {
         continue
+    } elseif ($ext -eq ".trq") {
+        continue
     } else {
         $files.Add($file)
         Write-Host "Test case: $file"
     }
 }
+
+$filePath = "tests.txt"
+$writer = New-Object System.IO.StreamWriter($filePath, $true) # $true for append
 foreach ($file in $files) {
-    Add-Content "tests.txt" $file
+    $writer.WriteLine($file)
 }
+$writer.Dispose()
+
 if (-not(Test-Path -Path "tests.txt" -PathType Leaf)) {
+    Write-Host "No test cases provided."
+    exit 0
+}
+$size = (Get-Item -Path "tests.txt").Length
+if ( $size -eq 0 ) {
     Write-Host "No test cases provided."
     exit 0
 }

--- a/_scripts/templates/TypeScript/st.test.ps1
+++ b/_scripts/templates/TypeScript/st.test.ps1
@@ -10,7 +10,7 @@ if (Test-Path -Path "tests.txt" -PathType Leaf) {
     Remove-Item "tests.txt"
 }
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trglob '$Tests' ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trglob "$Tests" ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/_scripts/templates/TypeScript/st.test.sh
+++ b/_scripts/templates/TypeScript/st.test.sh
@@ -9,7 +9,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trglob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trglob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/lua/Go/LuaLexerBase.go
+++ b/lua/Go/LuaLexerBase.go
@@ -73,9 +73,9 @@ func (l *LuaLexerBase) skip_sep(cs antlr.CharStream) int {
 }
 
 func (l *LuaLexerBase) IsLine1Col0() bool {
-	cs := l.GetInputStream().(antlr.CharStream)
-	if cs.Index() == 1 {
-		return true
-	}
-	return false
+    cs := l.GetInputStream().(antlr.CharStream)
+    if cs.Index() == 1 {
+        return true
+    }
+    return false
 }

--- a/lua/examples/stats.lua
+++ b/lua/examples/stats.lua
@@ -1,0 +1,2 @@
+a = b + c
+(print or io.write)('done')

--- a/lua/examples/stats.lua.trq
+++ b/lua/examples/stats.lua.trq
@@ -1,0 +1,11 @@
+(: Check whether there are a correct number of "stat".
+
+    NB!!! This is a placeholder to implement a requirement on
+    the number of stat-nodes. This is known to be incorrect for
+    the current version of the lua grammar. When tree structure
+    is corrected, this file must be fixed.
+
+    For now, the count is 2.
+:)
+
+assert count(//stat) = 2, "Invalid number of 'stat' nodes.";


### PR DESCRIPTION
I'm really excited about this PR! It introduces a new way to validate the parse tree outputted from a parse.

This PR introduces a new approach to validating parse trees with the latest Trash toolkit. It can be used in conjunction with the old Maven-tester style `.tree` validation, or it can be used as an alternative. The only caveat is that the grammar has to work for the `CSharp` target, because trparse only works with a `CSharp` parser app.

The old Maven-tester style of validating parse trees is declarative by the existence of a companion `.tree` file to an input test file. When the tester is run, the parser driver outputs a .tree file of the parse. The .tree file is compared to the previous version of the file, and if it has changed, the test fails.

The tree displayed in the .tree file is the output from the Antlr4 runtime `ToStringTree()`. This output is a Lisp-like expression containing internal and leaf nodes of the parse tree. When someone changes the grammar, we'd expect the parse tree to change. The developer is then required to go through the .tree file and verify that the change is correct.

The problem with this validation approach is that small changes in the grammar will cause the whole file to change. Some of these changes may not be important, such as renaming a parser rule. But the developer must meticulously compare the trees and make sure it is valid.

With the latest version of Trash, [trquery](https://github.com/kaby76/Trash/tree/main/src/trquery) has the `assert` command, which validates the parse tree using a predicate as an XPath expression. This PR includes an example in the Lua grammar to demonstrate the test, as described below.

Consider input stats.lua.
```
a = b + c
(print or io.write)('done')
```

The parse tree for this file is:
```
start_
├── chunk
│   └── block
│       ├── stat
│       │   ├── varlist
│       │   │   └── var
│       │   │       └── NAME
│       │   │           └── "a"
│       │   ├── Attribute WS Value ' ' chnl:HIDDEN
│       │   ├── EQ
│       │   │   └── "="
│       │   └── explist
│       │       └── exp
│       │           ├── exp
│       │           │   └── prefixexp
│       │           │       ├── Attribute WS Value ' ' chnl:HIDDEN
│       │           │       └── NAME
│       │           │           └── "b"
│       │           ├── Attribute WS Value ' ' chnl:HIDDEN
│       │           ├── PLUS
│       │           │   └── "+"
│       │           └── exp
│       │               └── prefixexp
│       │                   ├── Attribute WS Value ' ' chnl:HIDDEN
│       │                   └── NAME
│       │                       └── "c"
│       └── stat
│           └── functioncall
│               ├── Attribute WS Value '\r' chnl:HIDDEN
│               ├── Attribute NL Value '\n'
│               ├── OP
│               │   └── "("
│               ├── exp
│               │   ├── exp
│               │   │   └── prefixexp
│               │   │       └── NAME
│               │   │           └── "print"
│               │   ├── Attribute WS Value ' ' chnl:HIDDEN
│               │   ├── OR
│               │   │   └── "or"
│               │   └── exp
│               │       └── prefixexp
│               │           ├── Attribute WS Value ' ' chnl:HIDDEN
│               │           ├── NAME
│               │           │   └── "io"
│               │           ├── DOT
│               │           │   └── "."
│               │           └── NAME
│               │               └── "write"
│               ├── CP
│               │   └── ")"
│               └── args
│                   ├── OP
│                   │   └── "("
│                   ├── explist
│                   │   └── exp
│                   │       └── string
│                   │           └── CHARSTRING
│                   │               └── "'done'"
│                   └── CP
│                       └── ")"
├── Attribute WS Value '\r' chnl:HIDDEN
├── Attribute NL Value '\n'
└── EOF
    └── ""
```

_NB: This parse tree contains two `stat` nodes. As explained in the Lua manual, the parse tree should contain one `stat` node. This is caused by the ambiguity in the grammar. Unfortunately, the Antlr parser makes the wrong choice. This problem will be addressed in another PR. https://github.com/antlr/grammars-v4/pull/4502_

We know that the parser should output two `stat` nodes (until we fix the grammar). We can test whether this is expected by adding a companion `.trq` file for the input.

stat.lua.trq:
```
(: Check whether there is a correct number of "stat".

    NB!!! This is a placeholder to implement a requirement on
    the number of stat-nodes. This is known to be incorrect for
    the current version of the lua grammar. When tree structure
    is corrected, this file must be fixed.

    For now, the count is 2.
:)

assert count(//stat) = 2, "Invalid number of 'stat' nodes.";
```
The test is performed in the test scripts thus: `dotnet trparse stats.lua | dotnet trquery -c stats.lua.trq`.

Note that we can write multiple tests in one file, and the .trq can include comments that explain the purpose of the predicate. The predicate is followed by a string to print when the predicate fails.

Trash requires a `CSharp` port, so we only validate using the .trq for the `CSharp` target.
