### PR TITLE
[Golang] fix operandName rule

### DIFF
--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -451,6 +451,7 @@ integer
 
 operandName
     : IDENTIFIER
+    | qualifiedIdent
     ;
 
 qualifiedIdent

--- a/golang/desc.xml
+++ b/golang/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.13.0</antlr-version>
-   <targets>Antlr4ng;Cpp;CSharp;Dart;Go;Java;JavaScript;Python3;TypeScript</targets>
+   <targets>Antlr4ng;Cpp;CSharp;Dart;Go;Java;JavaScript;Python3</targets>
 </desc>

--- a/golang/examples/operandName.go
+++ b/golang/examples/operandName.go
@@ -1,0 +1,10 @@
+package operandname
+
+import (
+	"github.com/cornelk/hashmap"
+)
+
+func foo()  {
+	// any package to get `identifier dot identifier` in operandName rule
+	x := hashmap.New[int, string]() 	
+}


### PR DESCRIPTION
Apply fix to operandName rule by go spec https://go.dev/ref/spec#OperandName