### PR TITLE
[build] Fixes for 4510 and 4511.

### DIFF
--- a/_scripts/templates/TypeScript/tsconfig.json
+++ b/_scripts/templates/TypeScript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "ES2020",
     "moduleResolution": "node",
-    "target": "ES6",
+    "target": "ESNext",
     "noImplicitAny": true,
   },
   "ts-node": {

--- a/_scripts/test.ps1
+++ b/_scripts/test.ps1
@@ -70,8 +70,8 @@ function Test-Grammar {
     Write-Host "Building"
     # codegen
     Write-Host "dotnet trgen -t $Target --template-sources-directory $templates"
-    dotnet trgen -t $Target --template-sources-directory $templates | Write-Host
-    if ($LASTEXITCODE -ne 0) {
+    $(& dotnet trgen -t $Target --template-sources-directory $templates; $status = $LASTEXITCODE) | Write-Host
+    if ($status -ne 0) {
         $failStage = [FailStage]::CodeGeneration
         Write-Host "trgen failed" -ForegroundColor Red
     }


### PR DESCRIPTION
Changed test script call to trgen, and test proper exit code from it. Migrate to ESNext for TypeScript to fix build issue https://github.com/antlr/grammars-v4/pull/4508#issuecomment-2987546260.