### PR TITLE
Update WatParser.g4 to accept element segments in the WAT format.

### DIFF
--- a/wat/WatParser.g4
+++ b/wat/WatParser.g4
@@ -246,7 +246,7 @@ offset
     ;
 
 elem
-    : LPAR ELEM var_? offset var_* RPAR
+    : LPAR ELEM var_? offset (FUNC var_)* RPAR
     ;
 
 table


### PR DESCRIPTION
The grammar in the repo does not accept 

```(elem (;0;) (i32.const 1) func 9)```