### PR TITLE
Add missing REQUIRED keyword to Protobuf3.g4

### DIFF
--- a/protobuf3/Protobuf3.g4
+++ b/protobuf3/Protobuf3.g4
@@ -53,6 +53,7 @@ optionName
 // Normal Field
 fieldLabel
     : OPTIONAL
+    | REQUIRED
     | REPEATED
     ;
 
@@ -346,6 +347,10 @@ OPTIONAL
     : 'optional'
     ;
 
+REQUIRED
+    : 'required'
+    ;
+
 REPEATED
     : 'repeated'
     ;
@@ -630,6 +635,7 @@ keywords
     | PACKAGE
     | OPTION
     | OPTIONAL
+    | REQUIRED
     | REPEATED
     | ONEOF
     | MAP


### PR DESCRIPTION
Fields in proto3 can be "optional" or "required" or "repeated". One of those appears to be missing in the sample.