### PR TITLE
[bibtex] Fix for #4539: pom.xml wrong for bibtex.

### DIFF
--- a/bibtex/pom.xml
+++ b/bibtex/pom.xml
@@ -18,7 +18,7 @@
 				<configuration>
 					<sourceDirectory>${basedir}</sourceDirectory>
 					<includes>
-					   <include>BibTeX.g4</include>
+					   <include>BibTeXParser.g4</include>
 					   <include>BibTeXLexer.g4</include>
 					</includes>
 					<visitor>true</visitor>


### PR DESCRIPTION
The pom.xml was wrong. The parser grammar file name was fixed.