### PR TITLE
[build] Fixes for #4552: mvn clean test broken.

### DIFF
--- a/javacc/pom.xml
+++ b/javacc/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>antlr4</artifactId>
+	<artifactId>javacc</artifactId>
 	<packaging>jar</packaging>
 	<name>Javacc grammar</name>
 	<parent>

--- a/protobuf/protobuf3/pom.xml
+++ b/protobuf/protobuf3/pom.xml
@@ -38,10 +38,10 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>proto</entryPoint>
+					<entryPoint>twoPassParse</entryPoint>
 					<grammarName>Protobuf3</grammarName>
 					<packageName></packageName>
-					<exampleFiles>examples/</exampleFiles>
+					<exampleFiles></exampleFiles>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Fixed regression in build using Maven tester. `javacc/pom.xml` had a typo. `protobuf/protobuf3` has proto2 code, but can't be parsed using the protobuf3 grammar. Apparently, the protobuf compiler can dynamically switch to older syntaxes, but that wasn't the problem because the trgen tester can tell to test files in `examples/*.proto`, not recursively, so the proto2 code is not parsed. The Maven tester cannot be directed to test only `examples/*.proto`, i.e., only the examples in the directory, not sub-directories. So, parse testing with Maven was removed.

__Output from `mvn clean test`. Note, runtime is not realistic because I put my machine in sleep mode during the test. But, it does illustrate that the build works.__ 
[out.txt](https://github.com/user-attachments/files/21330765/out.txt)
