### PR TITLE
Fix duplicate artifactId (case-insensitive) (#4552)

### DIFF
--- a/bison/pom.xml
+++ b/bison/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>antlr4</artifactId>
+	<artifactId>bison</artifactId>
 	<packaging>jar</packaging>
-	<name>ANTLR4 grammar</name>
+	<name>Bison grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>antlrparent</artifactId>

--- a/blueprint/pom.xml
+++ b/blueprint/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>abb</artifactId>
+	<artifactId>blueprint</artifactId>
 	<packaging>jar</packaging>
-	<name>abb grammar</name>
+	<name>blueprint grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/ebnf/pom.xml
+++ b/ebnf/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>bnf</artifactId>
+	<artifactId>ebnf</artifactId>
 	<packaging>jar</packaging>
-	<name>khubla.com BNF grammar</name>
+	<name>khubla.com EBNF grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/javacc/pom.xml
+++ b/javacc/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>antlr4</artifactId>
+	<artifactId>javacc</artifactId>
 	<packaging>jar</packaging>
-	<name>Javacc grammar</name>
+	<name>JavaCC grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>grammarsv4</artifactId>

--- a/ocl/pom.xml
+++ b/ocl/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>java</artifactId>
+	<artifactId>ocl</artifactId>
 	<packaging>jar</packaging>
-	<name>Java</name>
+	<name>ocl</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>javaparent</artifactId>

--- a/python/python2_7_18/pom.xml
+++ b/python/python2_7_18/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>Python2</artifactId>
+	<artifactId>python2-7-18</artifactId>
 	<packaging>jar</packaging>
-	<name>Python2 grammar</name>
+	<name>Python2.7.18 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>pythonparent</artifactId>

--- a/python/python3_13/pom.xml
+++ b/python/python3_13/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>Python3</artifactId>
+	<artifactId>python3-13</artifactId>
 	<packaging>jar</packaging>
-	<name>Python3 grammar</name>
+	<name>Python3.13 grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>pythonparent</artifactId>

--- a/sql/mysql/Positive-Technologies/pom.xml
+++ b/sql/mysql/Positive-Technologies/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>mysql</artifactId>
+	<artifactId>mysql-positive-technologies</artifactId>
 	<packaging>jar</packaging>
-	<name>MySQL grammar</name>
+	<name>Positive Technologies MySQL grammar</name>
 	<parent>
 		<groupId>org.antlr.grammars</groupId>
 		<artifactId>mysqlparent</artifactId>


### PR DESCRIPTION
This PR fixes issues with duplicate `artifactId`s, including case-insensitive duplicates (e.g., `python3` vs `Python3`).
It addresses and includes the fix for #4552.

Note: According to [this page](https://maven.apache.org/guides/mini/guide-naming-conventions.html#Artifact_identifier), `artifactId`s should only consist of lowercase letters, digits, and hyphens. However, this PR does not modify `artifactId`s that contain uppercase letters and violate this convention.