### PR TITLE
[clickhouse] Fix for #4562: Add CSharp, and other. targets.

### DIFF
--- a/sql/clickhouse/desc.xml
+++ b/sql/clickhouse/desc.xml
@@ -4,6 +4,6 @@
     <antlr-version>^4.10</antlr-version>
     <entry-point>queryStmt</entry-point>
 
+    <targets>CSharp;Java</targets>
     <!-- Works only with Java because of symbol conflicts. -->
-    <targets>Java</targets>
 </desc>


### PR DESCRIPTION
The CSharp target is a very important target to have. It is used to obtain critical information on the grammar that people use to review changes to the grammar.