### PR TITLE
[antlr4, maven testing] Fix for #4569: predefined.tokens interfering with testing.

### DIFF
--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -51,16 +51,45 @@ options {
     // Using a predefined list of tokens here to ensure the same order of the tokens as they were defined
     // in the old ANTLR3 tree parsers (to avoid having to change the tree parsers code).
     // The actual values of the tokens doesn't matter, but the order does.
-    tokenVocab = predefined;
+    // tokenVocab = predefined;
+    //
+    // Instead of declaring predefined.tokens, which messes up the Maven tester for grammars-v4,
+    // we define the total order of token type values. This should work because it was stated
+    // that the "actual values of the tokens doesn't matter, but the order does." Declaring them
+    // in the tokensSpec section preserves the total order.
 }
 
 // Insert here @header for lexer.
 
 // Standard set of fragments
 tokens {
-    TOKEN_REF,
+    ACTION,
+    ARG_ACTION,
+    ARG_OR_CHARSET,
+    ASSIGN,
+    LEXER_CHAR_SET,
     RULE_REF,
-    LEXER_CHAR_SET
+    SEMPRED,
+    STRING_LITERAL,
+    TOKEN_REF,
+    TOKEN_REF,
+    UNICODE_ESC,
+    UNICODE_EXTENDED_ESC,
+    WS,
+    ALT,
+    BLOCK,
+    CLOSURE,
+    ELEMENT_OPTIONS,
+    EPSILON,
+    LEXER_ACTION_CALL,
+    LEXER_ALT_ACTION,
+    OPTIONAL,
+    POSITIVE_CLOSURE,
+    RULE,
+    RULEMODIFIERS,
+    RULES,
+    SET,
+    WILDCARD
 }
 
 channels {


### PR DESCRIPTION
This is a fix for #4569.

The file predefined.tokens, introduced in https://github.com/antlr/grammars-v4/pull/4424, breaks Maven testing. People still use the tester, so we are trying to reintroduce it but in a way that is more "incremental".

The predefined.tokens file is replaced with an ordered list of tokens in the grammar. I would recommend the file be removed, but kept it for reference. In addition, I noticed an error in the file: `TOKEN_REF` is listed twice. https://github.com/antlr/grammars-v4/blob/1dc19f1279cb6a74d2b2c7c87a052e731a81b37f/antlr/antlr4/predefined.tokens#L9-L10