### PR TITLE
[antlr/antlr4] Fix for #4576 (duplicate TOKEN_REF).

### DIFF
--- a/antlr/antlr4/ANTLRv4Lexer.g4
+++ b/antlr/antlr4/ANTLRv4Lexer.g4
@@ -72,7 +72,6 @@ tokens {
     SEMPRED,
     STRING_LITERAL,
     TOKEN_REF,
-    TOKEN_REF,
     UNICODE_ESC,
     UNICODE_EXTENDED_ESC,
     WS,


### PR DESCRIPTION
This PR fixes #4576. There is a duplicate for `TOKEN_REF` in the Antlr4 lexer grammar. It should not be there. As noted in the comments in the grammar (see `options { tokenVocab ... }`), the order of the tokens is important, but the values are not. So, the gap in token values is not necessary.