### PR TITLE
[java20 and java] Fix for #4391

### DIFF
--- a/java/java/examples/Foo4391.java
+++ b/java/java/examples/Foo4391.java
@@ -1,0 +1,1 @@
+class Foo4391 { void bar () { boolean; } }

--- a/java/java/examples/Foo4391.java.errors
+++ b/java/java/examples/Foo4391.java.errors
@@ -1,0 +1,1 @@
+line 1:37 no viable alternative at input 'boolean;'

--- a/java/java20/Java20Parser.g4
+++ b/java/java20/Java20Parser.g4
@@ -885,7 +885,7 @@ localClassOrInterfaceDeclaration
 // --------------
 
 localVariableDeclaration
-    : variableModifier* localVariableType variableDeclaratorList?
+    : variableModifier* localVariableType variableDeclaratorList
     ;
 
 localVariableType

--- a/java/java20/examples/Foo4391.java
+++ b/java/java20/examples/Foo4391.java
@@ -1,0 +1,1 @@
+class Foo4391 { void bar () { boolean; } }

--- a/java/java20/examples/Foo4391.java.errors
+++ b/java/java20/examples/Foo4391.java.errors
@@ -1,0 +1,1 @@
+line 1:37 no viable alternative at input 'boolean;'


### PR DESCRIPTION
This PR fixes #4391, a problem specifically in the Java 20 grammar. Note, I checked the java/java grammar and it works correctly, reporting the parse error.

I corrected Java 20 grammar and added a test for the problem. I copied the test to the [java/java grammar](https://github.com/antlr/grammars-v4/tree/master/java/java) as well.