### PR TITLE
[MariaDB] Support `IF EXISTS` in `RENAME COLUMN` clause

### DIFF
--- a/sql/mariadb/MariaDBParser.g4
+++ b/sql/mariadb/MariaDBParser.g4
@@ -733,7 +733,7 @@ alterSpecification
     | ALTER COLUMN? uid (SET DEFAULT defaultValue | DROP DEFAULT)            # alterByChangeDefault
     | CHANGE COLUMN? ifExists? oldColumn = uid // here ifExists is MariaDB-specific only
     newColumn = uid columnDefinition (FIRST | AFTER afterColumn = uid)? # alterByChangeColumn
-    | RENAME COLUMN oldColumn = uid TO newColumn = uid                  # alterByRenameColumn
+    | RENAME COLUMN ifExists? oldColumn = uid TO newColumn = uid        # alterByRenameColumn
     | LOCK '='? lockType = (DEFAULT | NONE | SHARED | EXCLUSIVE)        # alterByLock
     | MODIFY COLUMN? ifExists? // here ifExists is MariaDB-specific only
     uid columnDefinition (FIRST | AFTER uid)?                             # alterByModifyColumn

--- a/sql/mariadb/examples/fast/ddl_alter.sql
+++ b/sql/mariadb/examples/fast/ddl_alter.sql
@@ -53,6 +53,7 @@ alter table default.task add column xxxx varchar(200) comment 'cdc test';
 alter table `some_table` add unique if not exists `id_unique` (`id`)
 alter table if exists `add_test` add column if not exists `new_col` text default 'my_default';
 alter table user_details add index if not exists `country_id_index` (country_id), algorithm=NOCOPY;
+alter table if exists T1 modify column if exists status ENUM ('PENDING', 'SENDING', 'SENT', 'SUCCESS', 'FAILED', 'FATAL') NOT NULL, rename column if exists col to new_col;
 #end
 #begin
 -- Alter database


### PR DESCRIPTION
Adds the ability to specify the `IF EXISTS` clause as part of the `alterSpecification` during column renaming.