### PR TITLE
[build] Fix for #4590: Remove PHP setup.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,12 +63,6 @@ jobs:
       uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    - name: Setup PHP
-      id: setup-php
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.4'
-        ini-values: xdebug.max_nesting_level=1000
     - name: Print PHP version
       run: |
         echo ${{ steps.setup-php.outputs.php-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,10 +63,6 @@ jobs:
       uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    - name: Print PHP version
-      run: |
-        echo ${{ steps.setup-php.outputs.php-version }}
-        php --version
     - name: Test Dotnet
       run: |
         dotnet --version


### PR DESCRIPTION
MacOS testing is broken because it uses [setup-php](https://github.com/shivammathur/setup-php), which doesn't seem to work anymore at least on the Mac.
```
2025-08-15T14:22:06.6638920Z [command]/bin/bash /Users/runner/work/_actions/shivammathur/setup-php/v2/src/scripts/run.sh
2025-08-15T14:22:06.6948900Z 
2025-08-15T14:22:06.6964450Z [90;1m==> [0m[37;1mSetup PHP[0m
2025-08-15T14:22:36.2582450Z sed: : No such file or directory
2025-08-15T14:22:36.2660160Z grep: : No such file or directory
2025-08-15T14:22:36.2687690Z /Users/runner/work/_actions/shivammathur/setup-php/v2/src/scripts/../scripts/unix.sh: line 260: php: command not found
2025-08-15T14:22:36.2854700Z mkdir: : No such file or directory
2025-08-15T14:22:36.2953480Z chmod: /php.ini: No such file or directory
2025-08-15T14:22:36.2966400Z /Users/runner/work/_actions/shivammathur/setup-php/v2/src/scripts/../scripts/unix.sh: line 255: php_config: parameter null or not set
2025-08-15T14:22:36.3077800Z cp: /php.ini: No such file or directory
2025-08-15T14:22:36.3163460Z cp: /php.ini-production: No such file or directory
2025-08-15T14:22:36.3380570Z [31;1m✗ [0m[34;1mPHP [0m[90;1mCould not setup PHP 8.4[0m
2025-08-15T14:22:36.3689110Z ##[error]The process '/bin/bash' failed with exit code 1
```
This PR removes the setup of PHP, fixing #4590. This causes no problems because we don't test the PHP target (the Antlr4 target is unreliable).