### PR TITLE
[angelscript] Clean up grammar start rule.

### DIFF
--- a/angelscript/angelscript.g4
+++ b/angelscript/angelscript.g4
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 grammar angelscript;
 
-start
+start_
     : script EOF
     ;
 

--- a/angelscript/angelscript.g4
+++ b/angelscript/angelscript.g4
@@ -35,6 +35,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 grammar angelscript;
 
+start
+    : script EOF
+    ;
+
 script
     : (
         import_
@@ -49,7 +53,7 @@ script
         | func_
         | namespace
         | ';'
-    )+ EOF
+    )+
     ;
 
 class_

--- a/angelscript/pom.xml
+++ b/angelscript/pom.xml
@@ -38,7 +38,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>start</entryPoint>
+					<entryPoint>start_</entryPoint>
 					<grammarName>angelscript</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>

--- a/angelscript/pom.xml
+++ b/angelscript/pom.xml
@@ -38,7 +38,7 @@
 				<configuration>
 					<verbose>false</verbose>
 					<showTree>false</showTree>
-					<entryPoint>script</entryPoint>
+					<entryPoint>start</entryPoint>
 					<grammarName>angelscript</grammarName>
 					<packageName></packageName>
 					<exampleFiles>examples/</exampleFiles>


### PR DESCRIPTION
This PR fixes the EOF-terminated start rule for angelscript. The [script rule](https://github.com/antlr/grammars-v4/blob/37146747969be81255787b80d476873ec24d2626/angelscript/angelscript.g4#L38) was used in [another rule](https://github.com/antlr/grammars-v4/blob/37146747969be81255787b80d476873ec24d2626/angelscript/angelscript.g4#L67), so it should not have been labeled as the start rule. I added `start_` as the corrected start rule.