### PR TITLE
[hypertalk] Clean up grammar start rule.

### DIFF
--- a/hypertalk/HyperTalk.g4
+++ b/hypertalk/HyperTalk.g4
@@ -30,25 +30,33 @@ grammar HyperTalk;
 // Start symbol accepting only well-formed HyperTalk scripts that consist of handlers, functions, whitespace and
 // comments (representing scripts that are assignable to objects like buttons, fields and cards). Disallows statements or
 // expressions that are not inside of a handler or function block.
+start_script
+    : script EOF
+    ;
+
+start_scriptlet
+    : scriptlet EOF
+    ;
+
 script
     : handler script
     | function_ script
     | NEWLINE script
-    | EOF
+    |
     ;
 
 // Start symbol accepting any sequence of HyperTalk statements, expressions, whitespace and comments. Suitable when
 // evaluating the message box or HyperTalk strings via the 'do' command and 'value of' function.
 scriptlet
-    : statement EOF
+    : statement
     | multilineScriptlet
     ;
 
 multilineScriptlet
     : statement NEWLINE multilineScriptlet
-    | statement EOF
+    | statement
     | NEWLINE multilineScriptlet
-    | EOF
+    |
     ;
 
 handler

--- a/hypertalk/desc.xml
+++ b/hypertalk/desc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <test>
       <entry-point>start_script</entry-point>
       <inputs>example-scripts/**/*.txt</inputs>

--- a/hypertalk/desc.xml
+++ b/hypertalk/desc.xml
@@ -2,7 +2,7 @@
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <test>
-      <entry-point>start_scripts</entry-point>
+      <entry-point>start_script</entry-point>
       <inputs>example-scripts/**/*.txt</inputs>
    </test>
    <test>

--- a/hypertalk/desc.xml
+++ b/hypertalk/desc.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
+   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <test>
-      <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
       <entry-point>start_script</entry-point>
       <inputs>example-scripts/**/*.txt</inputs>
-   </test>
-   <test>
-      <targets>Cpp</targets>
-      <entry-point>start_script</entry-point>
-      <inputs>example-scripts/**/*.txt</inputs>
-      <file-encoding>UTF-8</file-encoding>
    </test>
    <test>
       <entry-point>start_scriptlet</entry-point>

--- a/hypertalk/desc.xml
+++ b/hypertalk/desc.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
    <test>
+      <targets>CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
       <entry-point>start_script</entry-point>
       <inputs>example-scripts/**/*.txt</inputs>
+   </test>
+   <test>
+      <targets>Cpp</targets>
+      <entry-point>start_script</entry-point>
+      <inputs>example-scripts/**/*.txt</inputs>
+      <file-encoding>UTF-8</file-encoding>
    </test>
    <test>
       <entry-point>start_scriptlet</entry-point>

--- a/hypertalk/desc.xml
+++ b/hypertalk/desc.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
+   <test>
+      <entry-point>start_scripts</entry-point>
+      <inputs>example-scripts/**/*.txt</inputs>
+   </test>
+   <test>
+      <entry-point>start_scriptlet</entry-point>
+      <inputs>example-scriptlets/**/*.txt</inputs>
+   </test>
 </desc>

--- a/hypertalk/pom.xml
+++ b/hypertalk/pom.xml
@@ -44,7 +44,7 @@
                         <configuration>
                             <verbose>false</verbose>
                             <showTree>false</showTree>
-                            <entryPoint>script</entryPoint>
+                            <entryPoint>start_script</entryPoint>
                             <grammarName>HyperTalk</grammarName>
                             <exampleFiles>example-scripts/</exampleFiles>
                         </configuration>
@@ -57,7 +57,7 @@
                         <configuration>
                             <verbose>false</verbose>
                             <showTree>false</showTree>
-                            <entryPoint>scriptlet</entryPoint>
+                            <entryPoint>start_scriptlet</entryPoint>
                             <grammarName>HyperTalk</grammarName>
                             <exampleFiles>example-scriptlets/</exampleFiles>
                         </configuration>


### PR DESCRIPTION
This PR fixes the EOF-terminated start rules for hypertalk. I changed the desc.xml and pom.xml to test the two entry points.