### PR TITLE
[javascript]: Allow only single variable bindings in `for in` and `for of` loops

### DIFF
--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -181,8 +181,8 @@ iterationStatement
     : Do statement While '(' expressionSequence ')' eos                                                                     # DoStatement
     | While '(' expressionSequence ')' statement                                                                            # WhileStatement
     | For '(' (expressionSequence | variableDeclarationList)? ';' expressionSequence? ';' expressionSequence? ')' statement # ForStatement
-    | For '(' (singleExpression | singleVariableDeclaration) In expressionSequence ')' statement                              # ForInStatement
-    | For Await? '(' (singleExpression | singleVariableDeclaration) Of expressionSequence ')' statement                       # ForOfStatement
+    | For '(' (singleExpression | singleVariableDeclaration) In expressionSequence ')' statement                            # ForInStatement
+    | For Await? '(' (singleExpression | singleVariableDeclaration) Of expressionSequence ')' statement                     # ForOfStatement
     ;
 
 varModifier // let, const - ECMAScript 6

--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -157,6 +157,10 @@ variableDeclarationList
     : varModifier variableDeclaration (',' variableDeclaration)*
     ;
 
+singleVariableDeclaration
+    : varModifier variableDeclaration
+    ;
+
 variableDeclaration
     : assignable ('=' singleExpression)? // ECMAScript 6: Array & Object Matching
     ;
@@ -177,8 +181,8 @@ iterationStatement
     : Do statement While '(' expressionSequence ')' eos                                                                     # DoStatement
     | While '(' expressionSequence ')' statement                                                                            # WhileStatement
     | For '(' (expressionSequence | variableDeclarationList)? ';' expressionSequence? ';' expressionSequence? ')' statement # ForStatement
-    | For '(' (singleExpression | variableDeclarationList) In expressionSequence ')' statement                              # ForInStatement
-    | For Await? '(' (singleExpression | variableDeclarationList) Of expressionSequence ')' statement                       # ForOfStatement
+    | For '(' (singleExpression | singleVariableDeclaration) In expressionSequence ')' statement                              # ForInStatement
+    | For Await? '(' (singleExpression | singleVariableDeclaration) Of expressionSequence ')' statement                       # ForOfStatement
     ;
 
 varModifier // let, const - ECMAScript 6
@@ -559,7 +563,7 @@ keyword
     | Protected
     | Static
     | Yield
-    | YieldStar    
+    | YieldStar
     | Async
     | Await
     | From


### PR DESCRIPTION
Current grammar is too permissive - it allows passing multiple `var` declarations in the `for in` and `for of` loop variants:

```js
for (var a, b, c in someObject) // ...
```

```js
for (var a, b, c of someIterable) // ...
```

It is not supported by the runtime and spec in both cases:
```
Uncaught SyntaxError: Invalid left-hand side in for-of loop: Must have a single binding.
```
Moreover, such syntax doesn't make any sense.

So only single binding is meaningful and should be supported:
```js
for (var a of someIterable) // ...
```

Which is covered by this change.

Let me know if you want me to cover it with an example in `examples/` folder or something.