### PR TITLE
Fix typo in protobuf grammar definitions

### DIFF
--- a/protobuf/protobuf2/Protobuf2.g4
+++ b/protobuf/protobuf2/Protobuf2.g4
@@ -20,7 +20,7 @@ proto
 // Syntax
 
 syntax
-    : SYNTAX EQ (PROTO2_LIT_SINGLE | PROTO2_LIT_DOBULE) SEMI
+    : SYNTAX EQ (PROTO2_LIT_SINGLE | PROTO2_LIT_DOUBLE) SEMI
     ;
 
 // Import Statement
@@ -335,7 +335,7 @@ intLit
 strLit
     : STR_LIT
     | PROTO2_LIT_SINGLE
-    | PROTO2_LIT_DOBULE
+    | PROTO2_LIT_DOUBLE
     ;
 
 boolLit
@@ -503,7 +503,7 @@ PROTO2_LIT_SINGLE
     : '"proto2"'
     ;
 
-PROTO2_LIT_DOBULE
+PROTO2_LIT_DOUBLE
     : '\'proto2\''
     ;
 

--- a/protobuf/protobuf3/Protobuf3.g4
+++ b/protobuf/protobuf3/Protobuf3.g4
@@ -34,7 +34,7 @@ proto
 // Syntax
 
 syntax
-    : SYNTAX EQ (PROTO3_LIT_SINGLE | PROTO3_LIT_DOBULE) SEMI
+    : SYNTAX EQ (PROTO3_LIT_SINGLE | PROTO3_LIT_DOUBLE) SEMI
     ;
 
 // Import Statement
@@ -317,7 +317,7 @@ intLit
 strLit
     : STR_LIT
     | PROTO3_LIT_SINGLE
-    | PROTO3_LIT_DOBULE
+    | PROTO3_LIT_DOUBLE
     ;
 
 boolLit
@@ -474,7 +474,7 @@ PROTO3_LIT_SINGLE
     : '"proto3"'
     ;
 
-PROTO3_LIT_DOBULE
+PROTO3_LIT_DOUBLE
     : '\'proto3\''
     ;
 


### PR DESCRIPTION
Spelling mistake DOBULE -> DOUBLE