### PR TITLE
[protobuf2] Fix for #4635: `start` symbol is optional.

### DIFF
--- a/protobuf/protobuf2/Protobuf2.g4
+++ b/protobuf/protobuf2/Protobuf2.g4
@@ -14,7 +14,7 @@
 grammar Protobuf2;
 
 proto
-    : syntax (importStatement | packageStatement | optionStatement | topLevelDef | emptyStatement_)* EOF
+    : syntax? (importStatement | packageStatement | optionStatement | topLevelDef | emptyStatement_)* EOF
     ;
 
 // Syntax

--- a/protobuf/protobuf2/examples/demo-without-syntax.proto
+++ b/protobuf/protobuf2/examples/demo-without-syntax.proto
@@ -1,0 +1,16 @@
+package demo;
+
+service Demo {
+    // Sends a greeting
+    rpc Demo(DemoReq) returns (DemoResp) {}
+}
+
+// The request message containing the user's name.
+message DemoReq {
+    optional string name = 1;
+}
+
+// The response message containing the greetings
+message DemoResp {
+    optional string message = 1;
+}


### PR DESCRIPTION
As mentioned in the comment in #4635, the grammar deviates from the spec. This change resolves the issue, and the tests now include an additional test to verify its effectiveness.