### PR TITLE
PL/SQL: add NOT? IN support to relational_expression

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6594,6 +6594,7 @@ multiset_expression
 
 relational_expression
     : relational_expression relational_operator relational_expression
+    | relational_expression NOT? IN in_elements
     | compound_expression
     ;
 


### PR DESCRIPTION
This PR updates the `relational_expression` rule in `PlSqlParser.g4` to support the `NOT? IN` construct, which is valid in Oracle PL/SQL but currently not handled by the grammar.

**Before**

```g4
relational_expression
    : relational_expression relational_operator relational_expression
    | compound_expression
    ;
```

**After**

```g4
relational_expression
    : relational_expression relational_operator relational_expression
    | relational_expression NOT? IN in_elements
    | compound_expression
    ;
```

**Why**

* The current grammar fails to parse valid Oracle expressions like:

  ```plsql
  IF NOT internal AND
      object_category IN (VEC_CAT_OBJECT_LIST, VEC_CAT_FEEDBACK) AND
      (allowed_categories IS NULL OR
       object_category NOT MEMBER OF allowed_categories)
  THEN
  ```
* `IN` and `NOT IN` are not covered by `relational_operator`, so they need an explicit alternative.

That's all. Thanks!
