### PR TITLE
[acme] Fix for #4667: warnings from Antlr Tool for lexer symbol unreachable.

### DIFF
--- a/acme/acme.g4
+++ b/acme/acme.g4
@@ -883,7 +883,7 @@ OR
     : O R
     ;
 
-PATHSEPARATOR
+pathseparator
     : '.'
     | ':'
     | '-'


### PR DESCRIPTION
Fix for #4667. ANTLR grammars define lexer rules after first noting all string literals. If the lexer rules don't define a single lexer name for each string literal, then the folding is never performed by the Antlr Tool. The tool now provides a check and warning for lexer rules that overlap with other rules. I changed the rule to a parser rule, which avoids the problem.