### PR TITLE
the optiona keyword "FIELDS" inside insert statements was not accepted by PL/SQL parser

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -1051,9 +1051,11 @@ func_decl_in_type
     ;
 
 constructor_declaration
-    : FINAL? INSTANTIABLE? CONSTRUCTOR FUNCTION type_spec (
-        '(' (SELF IN OUT type_spec ',') type_elements_parameter (',' type_elements_parameter)* ')'
-    )? RETURN SELF AS RESULT (IS | AS) (call_spec | DECLARE? seq_of_declare_specs? body ';')
+    : FINAL? INSTANTIABLE? CONSTRUCTOR FUNCTION function_name
+        (
+            '(' (SELF IN OUT type_spec ',')? (type_elements_parameter (',' type_elements_parameter)*)? ')'
+        )?
+      RETURN SELF AS RESULT (IS | AS) (call_spec | DECLARE? seq_of_declare_specs? body ';')
     ;
 
 // Common Type Clauses


### PR DESCRIPTION
Oracle accepts an optional (and useless...) keyword "FIELDS" in insert statements, like in this example

INSERT INTO mytable FIELDS (myfield) VALUES ('myvalue');

the grammar did not accept this FIELDS keyword.

Moreover: it is actually possible do declare a plsql variable named "AUDIT" even if AUDIT is a keyword: this compiles just fine for oracle:
declare
   audit CLOB;
begin
   ....
end;

but this wasn't accepted by the grammar. I fixed it too