### PR TITLE
[c] Fix stdin.c handling for string input to driver program

### DIFF
--- a/c/Antlr4ng/CLexerBase.ts
+++ b/c/Antlr4ng/CLexerBase.ts
@@ -1,8 +1,6 @@
 import { Lexer, CharStream } from "antlr4ng";
 import { execSync } from "child_process";
 import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
 
 export abstract class CLexerBase extends Lexer {
     constructor(input: CharStream) {
@@ -31,11 +29,9 @@ export abstract class CLexerBase extends Lexer {
         let sourceName = input.getSourceName();
         const inputText = input.getTextFromRange(0, input.size - 1);
 
-        // If source name is empty or not a .c file, we need to write to a temp file
+        // If source name is empty or not a .c file, use stdin.c
         if (!sourceName || sourceName === "" || !sourceName.endsWith(".c")) {
-            // Create a temp file for preprocessing
-            sourceName = path.join(os.tmpdir(), "antlr4ng_temp_" + Date.now() + ".c");
-            fs.writeFileSync(sourceName, inputText);
+            sourceName = "stdin.c";
         }
 
         const outputName = sourceName + ".p";
@@ -47,6 +43,10 @@ export abstract class CLexerBase extends Lexer {
                 // Ignore
             }
             return CharStream.fromString(inputText);
+        }
+
+        if (sourceName === "stdin.c") {
+            fs.writeFileSync(sourceName, inputText);
         }
 
         if (gcc) {

--- a/c/CSharp/CLexerBase.cs
+++ b/c/CSharp/CLexerBase.cs
@@ -36,7 +36,7 @@ public abstract class CLexerBase : Lexer
         var clang = args?.Where(a => a.IndexOf("--clang", StringComparison.OrdinalIgnoreCase) >= 0).Any() ?? false;
         var nopp = args?.Where(a => a.IndexOf("--nopp", StringComparison.OrdinalIgnoreCase) >= 0).Any() ?? false;
         if (!(vsc || gcc || clang))
-	    gcc = true;
+            gcc = true;
 
         // Extract preprocessor options (-D and -I)
         var ppOptions = ExtractPreprocessorOptions(args);
@@ -50,7 +50,7 @@ public abstract class CLexerBase : Lexer
             File.WriteAllText(output_name, x1);
             return CharStreams.fromString(x1);
         }
-        File.WriteAllText(output_name, x1);
+        if (source_name == "stdin.c") File.WriteAllText(source_name, x1);
 
         if (gcc)
         {
@@ -69,8 +69,8 @@ public abstract class CLexerBase : Lexer
             foreach (var opt in ppOptions)
             {
                 psi.ArgumentList.Add(opt);
-	    }
-	    psi.ArgumentList.Add(source_name);
+            }
+            psi.ArgumentList.Add(source_name);
             string? oldPath = psi.EnvironmentVariables["PATH"]; // inherits from parent
             using (var process = new Process { StartInfo = psi })
             {

--- a/c/Dart/CLexerBase.dart
+++ b/c/Dart/CLexerBase.dart
@@ -27,11 +27,9 @@ abstract class CLexerBase extends Lexer {
     var sourceName = input.sourceName;
     var inputText = input.getText(Interval(0, input.size - 1));
 
-    // If source name is empty or not a .c file, we need to write to a temp file
+    // If source name is empty or not a .c file, use stdin.c
     if (sourceName.isEmpty || !sourceName.endsWith(".c")) {
-      // Create a temp file for preprocessing
-      sourceName = "${Directory.systemTemp.path}/antlr4_temp_${DateTime.now().millisecondsSinceEpoch}.c";
-      File(sourceName).writeAsStringSync(inputText);
+      sourceName = "stdin.c";
     }
 
     var outputName = "$sourceName.p";
@@ -43,6 +41,10 @@ abstract class CLexerBase extends Lexer {
         // Ignore
       }
       return InputStream.fromString(inputText);
+    }
+
+    if (sourceName == "stdin.c") {
+      File(sourceName).writeAsStringSync(inputText);
     }
 
     if (gcc) {

--- a/c/Java/CLexerBase.java
+++ b/c/Java/CLexerBase.java
@@ -45,10 +45,12 @@ public abstract class CLexerBase extends Lexer {
             return CharStreams.fromString(inputText);
         }
 
-        try {
-            Files.writeString(Path.of(outputName), inputText);
-        } catch (IOException e) {
-            // Ignore
+        if ("stdin.c".equals(sourceName)) {
+            try {
+                Files.writeString(Path.of(sourceName), inputText);
+            } catch (IOException e) {
+                // Ignore
+            }
         }
 
         if (gcc) {

--- a/c/TypeScript/CLexerBase.ts
+++ b/c/TypeScript/CLexerBase.ts
@@ -1,8 +1,6 @@
 import { Lexer, CharStream, CharStreams } from "antlr4";
 import { execSync } from "child_process";
 import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
 
 export default abstract class CLexerBase extends Lexer {
     constructor(input: CharStream) {
@@ -31,11 +29,9 @@ export default abstract class CLexerBase extends Lexer {
         let sourceName = (input as any).name;  // (API does not exist) input.getSourceName(); HACK!!!
         const inputText = input.getText(0, input.size - 1);
 
-        // If source name is empty or not a .c file, we need to write to a temp file
+        // If source name is empty or not a .c file, use stdin.c
         if (!sourceName || sourceName === "" || !sourceName.endsWith(".c")) {
-            // Create a temp file for preprocessing
-            sourceName = path.join(os.tmpdir(), "antlr4ng_temp_" + Date.now() + ".c");
-            fs.writeFileSync(sourceName, inputText);
+            sourceName = "stdin.c";
         }
 
         const outputName = sourceName + ".p";
@@ -47,6 +43,10 @@ export default abstract class CLexerBase extends Lexer {
                 // Ignore
             }
             return CharStreams.fromString(inputText);
+        }
+
+        if (sourceName === "stdin.c") {
+            fs.writeFileSync(sourceName, inputText);
         }
 
         if (gcc) {


### PR DESCRIPTION
Fix for #4737. Only write input to stdin.c when the source comes from a string (not a file). Previously, temp files with timestamps were created unnecessarily.