### PR TITLE
Fix R lexer: Unicode escapes, hex escapes, and EOF comment handling

### DIFF
--- a/r/R.g4
+++ b/r/R.g4
@@ -212,19 +212,21 @@ COMPLEX
 STRING
     : '"' (ESC | ~[\\"])*? '"'
     | '\'' ( ESC | ~[\\'])*? '\''
-    | '`' ( ESC | ~[\\'])*? '`'
+    | '`' ( ESC | ~[\\`])*? '`'
     ;
 
 fragment ESC
-    : '\\' [abtnfrv"'\\]
+    : '\\' [abtnfrv"'\\`]
     | UNICODE_ESCAPE
-    | HEX_ESCAPE
     | OCTAL_ESCAPE
+    | HEX_XHH
+    | '\\' .
     ;
 
 fragment UNICODE_ESCAPE
     : '\\' 'u' HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
-    | '\\' 'u' '{' HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT '}'
+    | '\\' 'u' '{' HEXDIGIT+ '}'
+    | '\\' 'U' HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
     ;
 
 fragment OCTAL_ESCAPE
@@ -233,8 +235,8 @@ fragment OCTAL_ESCAPE
     | '\\' [0-7]
     ;
 
-fragment HEX_ESCAPE
-    : '\\' HEXDIGIT HEXDIGIT?
+fragment HEX_XHH
+    : '\\' 'x' HEXDIGIT HEXDIGIT
     ;
 
 ID
@@ -251,7 +253,7 @@ USER_OP
     ;
 
 COMMENT
-    : '#' .*? '\r'? '\n' -> type(NL)
+    : '#' ~[\r\n]* '\r'? '\n'? -> type(NL)
     ;
 
 // Match both UNIX and Windows newlines


### PR DESCRIPTION
## Fix and improve R lexer compliance

### Summary

This PR fixes several issues in the R lexer and improves compatibility with the R language specification, particularly around escape sequences and comment handling.

The changes ensure correct handling of valid escape sequences and prevent lexer failures in edge cases such as truncated comments at the end of a file.

---

# Problems Addressed

### 1. Missing escape sequence for backtick

The escape sequence ``` is valid in R but was not recognized by the lexer.

This PR:

* Adds support for escaping backticks.
* Fixes parsing of backtick-delimited identifiers.

---

### 2. Truncated comments at end of file

Comments at the end of the file without a trailing newline were not handled correctly.

Example that previously failed:

```
# comment at EOF
```

The updated rule now accepts comments that end without a newline.

---

### 3. Incorrect handling of hexadecimal escape sequences

The grammar previously allowed incomplete hexadecimal escapes.

This PR replaces the rule with the correct R form:

```
\xHH
```

where `H` is a hexadecimal digit and **both digits are mandatory**.

---

### 4. Missing support for long Unicode escape sequences

R supports Unicode escapes of the form:

```
\UXXXXXXXX
```

where `XXXXXXXX` is an 8-digit hexadecimal code point.

This PR adds lexer support for that syntax.

---

# Key Grammar Changes

### STRING rule fix

Backtick strings were incorrectly excluding escaped backticks.

Updated:

```
'`' ( ESC | ~[\\`] )*? '`'
```

---

### ESC fragment improvements

Changes include:

* Added support for escaped backtick
* Added strict hex escape rule
* Added fallback escape handling

---

### Unicode escape improvements

Supported forms now include:

```
\uXXXX
\u{XXXX}
\UXXXXXXXX
```

---

### Hex escape correction

Replaced permissive rule:

```
\ HEXDIGIT HEXDIGIT?
```

with the correct R syntax:

```
\xHH
```

---

### Comment handling fix

Old rule required newline termination:

```
# ... \n
```

New rule allows EOF termination:

```
# ~[\r\n]* '\r'? '\n'?
```

This prevents lexer errors on files ending with comments.

---

# Notes

The changes are intentionally minimal and localized to the lexer rules affecting escape sequences and comment parsing.
