### PR TITLE
Fix: Make PlantUML more lenient

### DIFF
--- a/plantUML/PlantUML.g4
+++ b/plantUML/PlantUML.g4
@@ -10,218 +10,87 @@
 * SPDX-License-Identifier: EPL-2.0
 * *****************************/
 
-grammar PlantUML;	
-	
-classDiagram
-  : '@startuml' cdelement* '@enduml' EOF
-  ;
 
-cdelement
-    : 'class' identifier stereotype? classDefinition?
-    | 'interface' identifier stereotype? classDefinition?
-    | 'abstract' 'class' identifier stereotype? classDefinition?
-    | 'abstract' identifier stereotype? classDefinition?
-    | 'entity' identifier stereotype? classDefinition?
-    | 'enum' identifier stereotype? enumDefinition?
-    | 'annotation' identifier
-    | inheritance
-    | association
-    | aggregation
-    | attribute
-    | composition
-    | dependency
-    | method
+parser grammar PlantUML;
+
+options { tokenVocab=PlantUMLLexer; }  // tokens from lexer file
+
+uml:
+    (NEWLINE | COMMENT)* STARTUML (IDENT)? (NEWLINE | class_dclr | enum_dclr | association_dclr | associative_class_dclr | COMMENT)* ENDUML (NEWLINE | COMMENT)*
     ;
 
-classDefinition
-    : '{' classElement* '}'
-    ; 
-
-classElement
-    : internalMethod
-    | internalAttribute
-    ; 
-
-enumDefinition
-    : '{' identifier+ '}'
-    ; 
-
-attribute
-    : identifier ':' type visibility? identifier 
-    ; 
-
-internalAttribute 
-    : ('{' modifier '}')? type? visibility? identifier
-    | ('{' modifier '}')? visibility? identifier ':' type
-    ; 
-
-method
-    : identifier ':' visibility? identifier '(' parameters? ')' 
+class_dclr:
+    class_type? CLASS ident stereotype? extension_dclr? (NEWLINE? class_body)?
     ;
 
-internalMethod 
-    : ('{' modifier '}')? type? visibility? identifier '(' parameters? ')'
-    | ('{' modifier '}')? visibility? identifier '(' parameters? ')' ':' type 
-    ; 
-
-parameters
-      : (identifier ',')* identifier
-      ;
-
-stereotype 
-      : '<<' identifier '>>'
-      ; 
-
-visibility
-      : '+' 
-      | '-' 
-      | '#'
-      | '~'
-      ; 
-
-modifier
-      : 'static'
-      | 'classifier' 
-      | 'abstract'
-      ; 
-
-type
-    : 'Sequence' '(' type ')'  
-    | 'Set' '(' type ')'  
-    | 'Bag' '(' type ')' 
-    | 'OrderedSet' '(' type ')' 
-    | 'SortedSet' '(' type ')' 
-    | identifier '[' integerLiteral? ']'  
-    | 'Map' '(' type ',' type ')' 
-    | 'SortedMap' '(' type ',' type ')' 
-    | 'Function' '(' type ',' type ')' 
-    | identifier
-    ; 
-
-inheritance
-    : identifier (leftAncestorSymbol | rightAncestorSymbol) identifier
-    ; 
-
-leftAncestorSymbol
-    : '<|--'
-    | '<|-'
-    | '<|---' 
-    | '<|..' 
-    | '^--' 
-    ; 
-
-rightAncestorSymbol
-    : '--|>' 
-    | '-|>' 
-    | '---|>'
-    | '..|>' 
-    | '--^' 
-    ; 
-
-association
-    : identifier stringExpression? associationSymbol stringExpression? identifier lineAnnotation?
-    ; 
-
-associationSymbol
-    : '-'
-    | '--'
-    | '---' 
-    | '-->' 
-    | '->' 
-    | '<--'
-    | '<-'
-    ; 
-
-aggregation
-    : identifier stringExpression? aggregationSymbol stringExpression? identifier lineAnnotation?
-    ; 
-
-aggregationSymbol
-    : 'o--' 
-    | '--o' 
-    | 'o-->'
-    | '<--o'
-    ; 
-
-composition
-    : identifier stringExpression? compositionSymbol stringExpression? identifier lineAnnotation?
-    ; 
-
-compositionSymbol
-    : '*--' 
-    | '*-' 
-    | '--*'
-    | '-*'
-    | '*-->'
-    | '*->'
-    | '<--*'
-    | '<-*'
-    ; 
-
-dependency
-    : identifier stringExpression? dependencySymbol stringExpression? identifier lineAnnotation?
-    ; 
-
-dependencySymbol
-    : '..'
-    | '..>'
-    | '<..'
-    | '...'
-    | '...>'
-    | '<...'
-    ; 
-
-lineAnnotation
-    : ':' direction? identifier
-    | ':' identifier direction
-    ; 
-
-direction
-    : '>'
-    | '<'
-    ; 
-
-
-identifier: ID ;
-
-stringExpression : STRING1_LITERAL | STRING2_LITERAL ;
-
-integerLiteral : INT ; 
-
-FLOAT_LITERAL:  Digits '.' Digits ;
-
-STRING1_LITERAL:     '"' (~["\\\r\n] | EscapeSequence)* '"';
-
-STRING2_LITERAL:     '\'' (~['\\\r\n] | EscapeSequence)* '\'';
-
-NULL_LITERAL:       'null';
-
-MULTILINE_COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
-
-
-fragment EscapeSequence
-    : '\\' [btnfr"'\\]
-    | '\\' ([0-3]? [0-7])? [0-7]
-    | '\\' 'u' HexDigit HexDigit HexDigit HexDigit
+class_body:
+    CLASS_BODY_START body_content* BODY_CLOSE
     ;
 
-fragment HexDigits
-    : HexDigit ((HexDigit | '_')* HexDigit)?
+body_content:
+    BODY_INLINE_BRACES
+    | BODY_OPEN
+    | BODY_CONTENT
+    | BODY_NL
+    | nested_body
     ;
 
-fragment HexDigit
-    : [0-9a-fA-F]
+nested_body:
+    BODY_OPEN body_content* BODY_CLOSE
     ;
 
-
-fragment Digits
-    : [0-9]+
+class_type:
+    (ABSTRACT|INTERFACE)
     ;
 
-INTEGRAL : '\u222B'; 
-SIGMA : '\u2211';
+stereotype: STEREOTYPE_TEXT;
 
-NEWLINE : [\r\n]+ -> skip ;
-INT     : [0-9]+ ;
-ID  :   [a-zA-Z_$]+[a-zA-Z0-9_$]* ;      // match identifiers
-WS  :   [ \t\n\r]+ -> skip ;
+extension_dclr:
+    EXTENDS ident
+    ;
+
+ident:
+    IDENT
+    ;
+
+enum_dclr:
+    ENUM ident stereotype? class_body?
+    ;
+
+association_dclr:
+    left=association_left
+    relation
+    right=association_right
+    association_name?
+    ;
+
+relation:
+    (GT | LT)? DASH (DASH)* (GT | LT)?
+    | (LT)? (DASH)+ STAR
+    | STAR (DASH)+ (GT)?
+    | (LT)? (DASH)+ O
+    | O (DASH)+ (GT)?
+    | (LT_PIPE | CARET) (DASH)+ (GT)?
+    | (LT)? (DASH)+ (CARET | PIPE_GT)
+    ;
+
+association_left:
+    ident association_detail?
+    ;
+
+association_right:
+    association_detail? ident
+    ;
+
+association_detail:
+    ASSOC_DETAIL
+    ;
+
+association_name:
+    AFTER_COLON_TEXT
+    ;
+
+associative_class_dclr:
+    LPAREN left=ident COMMA right=ident RPAREN (DOT | DOUBLE_DOT) target=ident association_name?
+    | target=ident (DOT | DOUBLE_DOT) LPAREN left=ident COMMA right=ident RPAREN association_name?
+    ;

--- a/plantUML/PlantUMLLexer.g4
+++ b/plantUML/PlantUMLLexer.g4
@@ -1,0 +1,68 @@
+lexer grammar PlantUMLLexer;
+
+ENUM: 'enum';
+CLASS: 'class';
+STARTUML: '@startuml';
+ENDUML: '@enduml';
+INTERFACE: 'interface';
+ABSTRACT: 'abstract';
+MANY: 'many';
+ONE: 'one';
+EXTENDS: 'extends';
+STATIC: 'static';
+LIST: 'List';
+
+GT: '>';
+LT: '<';
+PLUS: '+';
+DASH: '-';
+DOT: '.';
+DOUBLE_DOT: '..';
+STAR: '*';
+O: 'o';
+CARET: '^';
+PIPE_GT: '|>';
+LT_PIPE: '<|';
+COMMA: ',';
+LPAREN: '(';
+RPAREN: ')';
+LBRACK: '[';
+RBRACK: ']';
+AMP: '#';
+EQUALS: '=';
+NULL_LITERAL: 'null' ;
+CLASS_BODY_START: '{' -> pushMode(BODY);
+
+STEREOTYPE_TEXT: '<<' ~[\r\n>]* '>>';
+ASSOC_DETAIL: '"' ~[\r\n"]* '"';
+NOTE: ('note' ~[\r\n]*) ->channel(HIDDEN);
+DIAMOND: ('<>' ~[\r\n]*) ->channel(HIDDEN);
+
+AFTER_COLON_TEXT
+    : ':' ~[\r\n]* // Match ':' followed by any characters except line breaks
+    ;
+
+NEWLINE: '\r'? '\n';
+WS  : [ \t]+ -> skip ;
+COMMENT : ('/' '/' ~[\r\n]* | '/*' .*? '*/' | '\'' ~[\r\n]* ) -> channel(HIDDEN);
+
+FLOAT_LITERAL: [0-9]+ '.' [0-9]+ ;
+NUMBER: [0-9]+ ;
+
+IDENT: [a-zA-Z] [a-zA-Z0-9_]* ;
+
+
+mode BODY;
+BODY_INLINE_BRACES: '{' ~[{}\r\n]+ '}';
+BODY_OPEN: '{';
+BODY_CLOSE: '}' -> popMode;
+BODY_CONTENT: ~[{}\r\n]+;
+BODY_NL: [\r\n];
+
+mode ENUM_FREE_TEXT;
+ENUM_FREE_TEXT_CLOSE: '>>' -> popMode;
+ENUM_FREE_TEXT_CONTENT : ~[\r\n>]+ ;
+
+mode ASSOC_DETAIL_TEXT;
+ASSOC_DETAIL_TEXT_CLOSE: '"' -> popMode;
+ASSOC_DETAIL_TEXT_CONTENT : ~[\r\n"]+ ;


### PR DESCRIPTION
## Summary

Relax the grammar so it matches the level of permissiveness accepted by PlantUML.

The current grammar is stricter than the actual language and rejects inputs that PlantUML parses successfully. It should not prematurely restrict inputs that are valid according to PlantUML.

The parser should focus on recognizing the high-level structure of the diagram while remaining tolerant of loosely structured content. 

Detailed interpretation (attributes, types, modifiers, etc.) should be performed in a later semantic analysis phase based on an AST rather than directly from the parse tree.


## Example

The following diagram is valid PlantUML and can be parsed using the online server:
https://www.plantuml.com/

```plantuml
@startuml

enum Position <<enum>> {
    Goalkeeper
    LeftBack
    ...
}

enum Recommendation <<enum example of allowed commentary>> {
    KeyPlayer
    FirstTeamPlayer
    ReserveTeamPlayer
    ProspectivePlayer
    NotRecommended
}

enum ScoutingStatus <<enum>> {
    LongListed
    ShortListed {another} example of allowed input here
    RecommendedForSigning
    OfferMade
}

enum ScoutKind <<enum>> {
    RegularScout
    HeadScout
}

abstract class Person {
    String FirstName
    String LastName
}

class Player {
    ScoutingStatus Status
}

class HeadCoach {}

class Director {}

class Scout {
    ScoutKind ScoutKind
}

class Club {}

class Offer {
    Int Value
}

class ScoutingAssignment {}

class ScoutReport {
    {String} Pro
    [String] I can write whatever I want {String}
    Recommendation Recommendation
}

class PlayerProfile {
    Position Position
}

class PlayerAttribute {
    Name: String
    Int Value
}

Person <|-- Player
Person <|-- HeadCoach
Person <|-- Director
Person <|-- Scout

Director *--> "0..*" Offer
Club *--> "0..1" Director
Club *--> "0..1" HeadCoach
Club *--> "0..*" Player
Club *--> "0..*" Scout
Scout *--> "0..*" ScoutingAssignment
ScoutingAssignment *--> "0..1" ScoutReport 
HeadCoach *--> "0..*" PlayerProfile
PlayerProfile *--> "0..*" PlayerAttribute

Player "0..1" <--> "0..* another comment here" Offer
Player "0..1" <--> "0..1" PlayerProfile
Player "1..1" <--> "0..*" ScoutingAssignment
ScoutReport "0..1" <--> "0..1" ScoutReport : nextReport example comment
Player "1..1" <--> "0..*" ScoutingAssignment

@enduml
```

It produces the following diagram:

<img width="1356" height="616" alt="example" src="https://github.com/user-attachments/assets/ccd22eae-34b3-4c58-baaf-167876cd429b" />

The example shows that the PlantUML domain-specific language allows additional text in several places where the existing ANTLR PlantUML grammar is too strict and fails to parse the input.

## Changes

* Make enum names more permissive (allow spaces and inline text).
* Allow arbitrary content inside class bodies.
* Relax parsing of association cardinalities and labels to allow free text.
* Introduce a lexer using ANTLR modes to tolerate free-form text in these contexts.

## Notes

The parser should focus on structural recognition. Detailed interpretation (attributes, types, etc.) should happen later using an AST.

This level of tolerance is also necessary for constructs embedding other syntaxes such as HTML or CSS.