### PR TITLE
[PlSql] Fix for #4758, slow parse.

### DIFF
--- a/sql/plsql/Antlr4ng/PlSqlParserBase.ts
+++ b/sql/plsql/Antlr4ng/PlSqlParserBase.ts
@@ -1,4 +1,5 @@
 import { Parser, TokenStream, CommonTokenStream, Recognizer } from 'antlr4ng';
+import { PlSqlLexer } from './PlSqlLexer.js';
 
 export abstract class PlSqlParserBase extends Parser {
 
@@ -35,6 +36,21 @@ export abstract class PlSqlParserBase extends Parser {
 
   setVersion12(value: boolean): void {
     this._isVersion12 = value;
+  }
+
+  IsNotNumericFunction(): boolean {
+    const lt1 = (this.tokenStream as CommonTokenStream).LT(1);
+    const lt2 = (this.tokenStream as CommonTokenStream).LT(2);
+    if ((lt1!.type === PlSqlLexer.SUM ||
+      lt1!.type === PlSqlLexer.COUNT ||
+      lt1!.type === PlSqlLexer.AVG ||
+      lt1!.type === PlSqlLexer.MIN ||
+      lt1!.type === PlSqlLexer.MAX ||
+      lt1!.type === PlSqlLexer.ROUND ||
+      lt1!.type === PlSqlLexer.LEAST ||
+      lt1!.type === PlSqlLexer.GREATEST) && lt2!.type === PlSqlLexer.LEFT_PAREN)
+      return false;
+    return true;
   }
 
 }

--- a/sql/plsql/CSharp/PlSqlParserBase.cs
+++ b/sql/plsql/CSharp/PlSqlParserBase.cs
@@ -30,4 +30,19 @@ public abstract class PlSqlParserBase : Parser
     public bool setVersion11(bool value) => _isVersion11 = value;
 
     public bool setVersion12(bool value) => _isVersion12 = value;
+
+    public bool IsNotNumericFunction() {
+	    var lt1 = (this.InputStream as CommonTokenStream).LT(1);
+	    var lt2 = (this.InputStream as CommonTokenStream).LT(2);
+	    if ( (lt1.Type == PlSqlParser.SUM ||
+		lt1.Type == PlSqlParser.COUNT ||
+		lt1.Type == PlSqlParser.AVG ||
+		lt1.Type == PlSqlParser.MIN ||
+		lt1.Type == PlSqlParser.MAX ||
+		lt1.Type == PlSqlParser.ROUND ||
+		lt1.Type == PlSqlParser.LEAST ||
+		  lt1.Type == PlSqlParser.GREATEST) && lt2.Type == PlSqlParser.LEFT_PAREN)
+		    return false;
+	    return true;
+    }
 }

--- a/sql/plsql/Cpp/PlSqlParserBase.cpp
+++ b/sql/plsql/Cpp/PlSqlParserBase.cpp
@@ -1,0 +1,19 @@
+#include "PlSqlParserBase.h"
+#include "PlSqlParser.h"
+
+bool PlSqlParserBase::IsNotNumericFunction() {
+    auto* stream = dynamic_cast<antlr4::CommonTokenStream*>(getTokenStream());
+    auto* lt1 = stream->LT(1);
+    auto* lt2 = stream->LT(2);
+    if ((lt1->getType() == PlSqlParser::SUM ||
+         lt1->getType() == PlSqlParser::COUNT ||
+         lt1->getType() == PlSqlParser::AVG ||
+         lt1->getType() == PlSqlParser::MIN ||
+         lt1->getType() == PlSqlParser::MAX ||
+         lt1->getType() == PlSqlParser::ROUND ||
+         lt1->getType() == PlSqlParser::LEAST ||
+         lt1->getType() == PlSqlParser::GREATEST) &&
+         lt2->getType() == PlSqlParser::LEFT_PAREN)
+        return false;
+    return true;
+}

--- a/sql/plsql/Cpp/PlSqlParserBase.h
+++ b/sql/plsql/Cpp/PlSqlParserBase.h
@@ -41,6 +41,8 @@ class PlSqlParserBase : public antlr4::Parser
     {
         _isVersion10 = value;
     }
+
+    bool IsNotNumericFunction();
 };
 
 #endif

--- a/sql/plsql/Dart/PlSqlParserBase.dart
+++ b/sql/plsql/Dart/PlSqlParserBase.dart
@@ -1,6 +1,7 @@
 import 'package:antlr4/antlr4.dart';
 import 'dart:io';
 import 'dart:convert';
+import 'PlSqlLexer.dart';
 
 abstract class PlSqlParserBase extends Parser
 {
@@ -34,5 +35,21 @@ abstract class PlSqlParserBase extends Parser
 
     void setVersion10(bool value) {
         _isVersion10 = value;
+    }
+
+    bool IsNotNumericFunction() {
+        var stream = tokenStream as CommonTokenStream;
+        var lt1 = stream.LT(1);
+        var lt2 = stream.LT(2);
+        if ((lt1!.type == PlSqlLexer.TOKEN_SUM ||
+             lt1.type == PlSqlLexer.TOKEN_COUNT ||
+             lt1.type == PlSqlLexer.TOKEN_AVG ||
+             lt1.type == PlSqlLexer.TOKEN_MIN ||
+             lt1.type == PlSqlLexer.TOKEN_MAX ||
+             lt1.type == PlSqlLexer.TOKEN_ROUND ||
+             lt1.type == PlSqlLexer.TOKEN_LEAST ||
+             lt1.type == PlSqlLexer.TOKEN_GREATEST) && lt2!.type == PlSqlLexer.TOKEN_LEFT_PAREN)
+            return false;
+        return true;
     }
 }

--- a/sql/plsql/Go/plsql_parser_base.go
+++ b/sql/plsql/Go/plsql_parser_base.go
@@ -45,3 +45,21 @@ func (p *PlSqlParserBase) isVersion10() bool {
 func (p *PlSqlParserBase) setVersion10(value bool) {
     StaticConfig._isVersion10 = value;
 }
+
+func (p *PlSqlParserBase) IsNotNumericFunction() bool {
+    stream := p.GetTokenStream().(*antlr.CommonTokenStream)
+    lt1 := stream.LT(1)
+    lt2 := stream.LT(2)
+    if (lt1.GetTokenType() == PlSqlParserSUM ||
+        lt1.GetTokenType() == PlSqlParserCOUNT ||
+        lt1.GetTokenType() == PlSqlParserAVG ||
+        lt1.GetTokenType() == PlSqlParserMIN ||
+        lt1.GetTokenType() == PlSqlParserMAX ||
+        lt1.GetTokenType() == PlSqlParserROUND ||
+        lt1.GetTokenType() == PlSqlParserLEAST ||
+        lt1.GetTokenType() == PlSqlParserGREATEST) &&
+        lt2.GetTokenType() == PlSqlParserLEFT_PAREN {
+        return false
+    }
+    return true
+}

--- a/sql/plsql/Java/PlSqlParserBase.java
+++ b/sql/plsql/Java/PlSqlParserBase.java
@@ -35,4 +35,20 @@ public abstract class PlSqlParserBase extends Parser
     public void setVersion10(boolean value) {
         _isVersion10 = value;
     }
+
+    public boolean IsNotNumericFunction() {
+        Token lt1 = _input.LT(1);
+        Token lt2 = _input.LT(2);
+        if ((lt1.getType() == PlSqlParser.SUM ||
+             lt1.getType() == PlSqlParser.COUNT ||
+             lt1.getType() == PlSqlParser.AVG ||
+             lt1.getType() == PlSqlParser.MIN ||
+             lt1.getType() == PlSqlParser.MAX ||
+             lt1.getType() == PlSqlParser.ROUND ||
+             lt1.getType() == PlSqlParser.LEAST ||
+             lt1.getType() == PlSqlParser.GREATEST) &&
+             lt2.getType() == PlSqlParser.LEFT_PAREN)
+            return false;
+        return true;
+    }
 }

--- a/sql/plsql/JavaScript/PlSqlParserBase.js
+++ b/sql/plsql/JavaScript/PlSqlParserBase.js
@@ -1,5 +1,6 @@
 import antlr4 from 'antlr4';
 import JavaScriptLexer from './PlSqlParser.js';
+import PlSqlLexer from './PlSqlLexer.js';
 
 export default class PlSqlParserBase extends antlr4.Parser {
   _isVersion10;
@@ -35,5 +36,20 @@ export default class PlSqlParserBase extends antlr4.Parser {
 
   setVersion12(value) {
     this._isVersion12 = value;
+  }
+
+  IsNotNumericFunction() {
+    const lt1 = this.getTokenStream().LT(1);
+    const lt2 = this.getTokenStream().LT(2);
+    if ((lt1.type === PlSqlLexer.SUM ||
+      lt1.type === PlSqlLexer.COUNT ||
+      lt1.type === PlSqlLexer.AVG ||
+      lt1.type === PlSqlLexer.MIN ||
+      lt1.type === PlSqlLexer.MAX ||
+      lt1.type === PlSqlLexer.ROUND ||
+      lt1.type === PlSqlLexer.LEAST ||
+      lt1.type === PlSqlLexer.GREATEST) && lt2.type === PlSqlLexer.LEFT_PAREN)
+      return false;
+    return true;
   }
 }

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6659,7 +6659,6 @@ concatenation
 interval_expression
     : DAY ('(' concatenation ')')? TO SECOND ('(' concatenation ')')?
     | YEAR ('(' concatenation ')')? TO MONTH
-    | concatenation (SECOND | DAY | MONTH | YEAR)
     ;
 
 model_expression
@@ -6700,7 +6699,7 @@ unary_expression
     )
     | quantified_expression
     | standard_function
-    | atom
+    | {this.IsNotNumericFunction()}? atom
     | implicit_cursor_expression
     ;
 
@@ -6795,7 +6794,7 @@ standard_function
     : string_function
     | numeric_function_wrapper
     | json_function
-    | other_function
+    | {this.IsNotNumericFunction()}? other_function
     ;
 
 //see as https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/JSON_ARRAY.html#GUID-46CDB3AF-5795-455B-85A8-764528CEC43B

--- a/sql/plsql/Python3/PlSqlParserBase.py
+++ b/sql/plsql/Python3/PlSqlParserBase.py
@@ -23,3 +23,14 @@ class PlSqlParserBase(Parser):
 
     def setVersion12(self, value):
         self._isVersion12 = value
+
+    def IsNotNumericFunction(self):
+        from PlSqlLexer import PlSqlLexer as _Lexer
+        lt1 = self._input.LT(1)
+        lt2 = self._input.LT(2)
+        if (lt1.type in (_Lexer.SUM, _Lexer.COUNT, _Lexer.AVG,
+                         _Lexer.MIN, _Lexer.MAX, _Lexer.ROUND,
+                         _Lexer.LEAST, _Lexer.GREATEST) and
+                lt2.type == _Lexer.LEFT_PAREN):
+            return False
+        return True

--- a/sql/plsql/TypeScript/PlSqlParserBase.ts
+++ b/sql/plsql/TypeScript/PlSqlParserBase.ts
@@ -1,4 +1,5 @@
 import { Parser, TokenStream } from "antlr4";
+import PlSqlLexer from './PlSqlLexer.js';
 
 export default abstract class PlSqlParserBase extends Parser {
 
@@ -37,6 +38,21 @@ export default abstract class PlSqlParserBase extends Parser {
 
   setVersion12(value: boolean): void {
     this._isVersion12 = value;
+  }
+
+  IsNotNumericFunction(): boolean {
+    const lt1 = this.getTokenStream().LT(1);
+    const lt2 = this.getTokenStream().LT(2);
+    if ((lt1!.type === PlSqlLexer.SUM ||
+      lt1!.type === PlSqlLexer.COUNT ||
+      lt1!.type === PlSqlLexer.AVG ||
+      lt1!.type === PlSqlLexer.MIN ||
+      lt1!.type === PlSqlLexer.MAX ||
+      lt1!.type === PlSqlLexer.ROUND ||
+      lt1!.type === PlSqlLexer.LEAST ||
+      lt1!.type === PlSqlLexer.GREATEST) && lt2!.type === PlSqlLexer.LEFT_PAREN)
+      return false;
+    return true;
   }
 
 }


### PR DESCRIPTION
Fix for #4758, extremely slow parse, which involves aggregate function ambiguity with IsNotNumericFunction predicate.

Add semantic predicate IsNotNumericFunction() to all target base classes to prevent SUM/COUNT/AVG/MIN/MAX/ROUND/LEAST/GREATEST followed by '(' from being parsed as atom or other_function instead of numeric_function_wrapper.

In addition to fixing ambiguity, the parse times are slightly faster.