### PR TITLE
Fix #4725 function precedence in SQLite

### DIFF
--- a/sql/sqlite/SQLiteParser.g4
+++ b/sql/sqlite/SQLiteParser.g4
@@ -238,7 +238,8 @@ drop_stmt
 expr
     : literal_value
     | BIND_PARAMETER
-    | ((schema_name DOT)? table_name DOT)? column_name
+    | (schema_name DOT)? table_name DOT column_name
+    | column_name_excluding_string
     | (MINUS | PLUS | TILDE) expr
     | expr COLLATE_ collation_name
     | expr (PIPE2 | JPTR | JPTR2) expr
@@ -254,31 +255,22 @@ expr
         | (schema_name DOT)? table_name
         | (schema_name DOT)? table_function_name OPEN_PAR (expr (COMMA expr)*)? CLOSE_PAR
     )
-    | expr NOT_? ((LIKE_ expr (ESCAPE_ expr)?) | (GLOB_ | REGEXP_ | MATCH_) expr)
+    | expr NOT_? (LIKE_ expr (ESCAPE_ expr)? | (GLOB_ | REGEXP_ | MATCH_) expr)
     | expr (ISNULL_ | NOTNULL_ | NOT_ NULL_)
     | NOT_ expr
     | expr AND_ expr
     | expr OR_ expr
-    | function_name OPEN_PAR ((DISTINCT_? expr (COMMA expr)* order_clause?) | STAR)? CLOSE_PAR filter_clause? over_clause?
+    | function_name OPEN_PAR (DISTINCT_? expr (COMMA expr)* order_clause? | STAR)? CLOSE_PAR percentile_clause? filter_clause? over_clause?
     | OPEN_PAR expr (COMMA expr)* CLOSE_PAR
     | CAST_ OPEN_PAR expr AS_ type_name CLOSE_PAR
-    | ((NOT_)? EXISTS_)? OPEN_PAR select_stmt CLOSE_PAR
+    | (NOT_? EXISTS_)? OPEN_PAR select_stmt CLOSE_PAR
     | CASE_ expr? (WHEN_ expr THEN_ expr)+ (ELSE_ expr)? END_
     | raise_function
 ;
 */
 
 expr
-    : expr_recursive
-;
-
-expr_recursive
-    : function_name OPEN_PAR (DISTINCT_? expr (COMMA expr)* order_clause? | STAR)? CLOSE_PAR percentile_clause? filter_clause?
-        over_clause?
-    | OPEN_PAR expr (COMMA expr)* CLOSE_PAR
-    | CAST_ OPEN_PAR expr AS_ type_name CLOSE_PAR
-    | CASE_ expr? (WHEN_ expr THEN_ expr)+ (ELSE_ expr)? END_
-    | expr_or
+    : expr_or
 ;
 
 expr_or
@@ -350,6 +342,15 @@ expr_base
     | column_name_excluding_string
     | (NOT_? EXISTS_)? OPEN_PAR select_stmt CLOSE_PAR
     | raise_function
+    | expr_recursive
+;
+
+expr_recursive
+    : function_name OPEN_PAR (DISTINCT_? expr (COMMA expr)* order_clause? | STAR)? CLOSE_PAR percentile_clause? filter_clause?
+        over_clause?
+    | OPEN_PAR expr (COMMA expr)* CLOSE_PAR
+    | CAST_ OPEN_PAR expr AS_ type_name CLOSE_PAR
+    | CASE_ expr? (WHEN_ expr THEN_ expr)+ (ELSE_ expr)? END_
 ;
 
 raise_function

--- a/sql/sqlite/examples/sql3.sql
+++ b/sql/sqlite/examples/sql3.sql
@@ -18,3 +18,6 @@ SELECT UNBOUNDED FROM table_name;
 
 -- NATURAL and other join operator keywords can only work as aliases if preceeded by AS
 SELECT 1 FROM table_name AS NATURAL;
+
+-- Parse functions after binary exprs
+SELECT sql FROM sqlite_schema WHERE lower(name) = lower('MyTable');


### PR DESCRIPTION
Well, that was embarrassing. I was convinced I'd fixed everything in the last PR, but `expr_recursive` should have come *after* eveything else, not *before*. Just spotted this issue today.

By moving `expr_recursive`'s precedence, the issue is resolved, the automated tests still pass, and a manual inspection of the parse trees for the tests with `expr`s in them suggests that they are all parsing as intended, so I'm pretty sure everything should work as intended now.

Sorry for the regression!
