### PR TITLE
[PLSql] DATE_FORMAT - valid constant name

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -7855,6 +7855,7 @@ regular_id
     | VAR_
     | VALUE
     | COVAR_
+    | DATE_FORMAT
     ;
 
 non_reserved_keywords_in_18c


### PR DESCRIPTION
I have faced with parsing errors during testing my plsql linter on real codebase and prepared minor fix for plsql grammar