### PR TITLE
[PlSql] Fixed merge_statement 

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6461,7 +6461,7 @@ merge_statement
     : MERGE INTO selected_tableview USING selected_tableview ON '(' condition ')' (
         merge_update_clause merge_insert_clause?
         | merge_insert_clause merge_update_clause?
-    )? error_logging_clause?
+    ) error_logging_clause?
     ;
 
 // Merge Specific Clauses

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6458,7 +6458,7 @@ values_clause
     ;
 
 merge_statement
-    : MERGE INTO selected_tableview table_alias? USING selected_tableview ON '(' condition ')' (
+    : MERGE INTO selected_tableview USING selected_tableview ON '(' condition ')' (
         merge_update_clause merge_insert_clause?
         | merge_insert_clause merge_update_clause?
     )? error_logging_clause?


### PR DESCRIPTION
Hello grammars-v4 team,

While reviewing recent changes to the PL/SQL grammar, I noticed some problems with `merge_statement`. I made a commit for each to facilitate review.

1. The switch from `tableview_name` to `selected_tableview`  in `merge_statement` made in commit 70c13e7 introduced a bug by allowing two consecutive `table_alias` because `table_alias?` was already part of `selected_tableview`.
2. According to [Oracle 26 merge::=](https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/MERGE.html), "You must specify at least one of the clauses merge_update_clause or merge_insert_clause". The current grammar does not detect this error.
_Side note: The documentation shows an optional "returning_clause" but does not mention it in the following description. It is absent from the current implementation of `merge_statement`. I decided not to add it in this PR but to open #4830 for later._

As an example for 1 and 2, `merge into my_table alias1 alias2 using my_other_table on (my_table.id = my_other_table.id)` was falsely recognized as a valid `merge_statement`.
<img width="865" height="658" alt="image" src="https://github.com/user-attachments/assets/816e68f2-023e-477d-93ee-c1a0d10fbbb5" />

Thank you for your work!