### PR TITLE
antlr/grammars-v4#4833 Add support for OPTIMIZE TABLES (plural form) to Oracle mysql grammar

### DIFF
--- a/sql/mysql/Oracle/MySQLParser.g4
+++ b/sql/mysql/Oracle/MySQLParser.g4
@@ -2244,7 +2244,7 @@ tableAdministrationStatement
         QUICK_SYMBOL
         | EXTENDED_SYMBOL
     )?
-    | type = OPTIMIZE_SYMBOL noWriteToBinLog? TABLE_SYMBOL tableRefList
+    | type = OPTIMIZE_SYMBOL noWriteToBinLog? (TABLE_SYMBOL | TABLES_SYMBOL) tableRefList
     | type = REPAIR_SYMBOL noWriteToBinLog? TABLE_SYMBOL tableRefList repairType*
     ;
 


### PR DESCRIPTION
closes https://github.com/antlr/grammars-v4/issues/4833

Fixes grammar to accept both `OPTIMIZE TABLE` (singular) and `OPTIMIZE TABLES` (plural) syntax, which are both valid in MySQL 8.0+ and 9.0+.

## Issue

The Oracle MySQL grammar currently only accepts:
```sql
OPTIMIZE TABLE t1;
OPTIMIZE TABLE t1, t2;
```

But rejects the valid plural form:
```sql
OPTIMIZE TABLES t1;
OPTIMIZE TABLES t1, t2;
```

**Error:**
```
line 1:9 mismatched input 'TABLES' expecting {LOCAL_SYMBOL, NO_WRITE_TO_BINLOG_SYMBOL, TABLE_SYMBOL}
```

## Verification

Tested against MySQL 8.0.46 and MySQL 9.0.1 - both forms work correctly:

```sql
-- Both forms work in real MySQL
mysql> OPTIMIZE TABLE t1;
+---------------+----------+----------+----------+
| Table         | Op       | Msg_type | Msg_text |
+---------------+----------+----------+----------+
| testdb.t1     | optimize | status   | OK       |
+---------------+----------+----------+----------+
1 row in set (0.02 sec)

mysql> OPTIMIZE TABLES t1;
+---------------+----------+----------+----------+
| Table         | Op       | Msg_type | Msg_text |
+---------------+----------+----------+----------+
| testdb.t1     | optimize | status   | OK       |
+---------------+----------+----------+----------+
1 row in set (0.01 sec)
```

## Verification

Before fix:
```sql
OPTIMIZE TABLE t1;   -- ✅ Passes
OPTIMIZE TABLES t1;  -- ❌ Fails with parse error
```

After fix:
```sql
OPTIMIZE TABLE t1;   -- ✅ Passes
OPTIMIZE TABLES t1;  -- ✅ Passes
```

