### PR TITLE
Optional last comma for `typeParameters`

### DIFF
--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -105,7 +105,7 @@ typeDef
     ;
 
 typeParameters
-    : L_BRACKET typeParameterDecl (COMMA typeParameterDecl)* R_BRACKET
+    : L_BRACKET (typeParameterDecl (COMMA typeParameterDecl)* COMMA?) R_BRACKET
     ;
 
 typeParameterDecl

--- a/golang/GoParser.g4
+++ b/golang/GoParser.g4
@@ -105,7 +105,7 @@ typeDef
     ;
 
 typeParameters
-    : L_BRACKET (typeParameterDecl (COMMA typeParameterDecl)* COMMA?) R_BRACKET
+    : L_BRACKET typeParameterDecl (COMMA typeParameterDecl)* COMMA? R_BRACKET
     ;
 
 typeParameterDecl


### PR DESCRIPTION
current `typeParameters` rule can not properly parse the following struct declarations:
```go
type ConfigProviderFactory[
	C any,
	Config *C, // because of this colon
] interface {
	New(ctx context.Context, cfg Config) ConfigProvider[C, Config]
}
```

This PR introducing fix similar to how default parameters are handled:
```
parameters
    : L_PAREN (parameterDecl (COMMA parameterDecl)* COMMA?)? R_PAREN
    ;
```