### PR TITLE
[build] Fix for #4864: add weekly build against "dev" branch of the Antlr4 tool.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,189 +3,189 @@
   "isRoot": true,
   "tools": {
     "trcaret": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trcaret"
       ],
       "rollForward": false
     },
     "trcover": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trcover"
       ],
       "rollForward": false
     },
     "trgen": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trgen"
       ],
       "rollForward": false
     },
     "trglob": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trglob"
       ],
       "rollForward": false
     },
     "triconv": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "triconv"
       ],
       "rollForward": false
     },
     "trparse": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trparse"
       ],
       "rollForward": false
     },
     "trquery": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trquery"
       ],
       "rollForward": false
     },
     "trtext": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trtext"
       ],
       "rollForward": false
     },
     "trwdog": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trwdog"
       ],
       "rollForward": false
     },
     "trxgrep": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trxgrep"
       ],
       "rollForward": false
     },
     "trxml": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trxml"
       ],
       "rollForward": false
     },
     "trxml2": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trxml2"
       ],
       "rollForward": false
     },
     "trclonereplace": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trclonereplace"
       ],
       "rollForward": false
     },
     "trcombine": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trcombine"
       ],
       "rollForward": false
     },
     "trconvert": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trconvert"
       ],
       "rollForward": false
     },
     "trfoldlit": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trfoldlit"
       ],
       "rollForward": false
     },
     "tritext": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "tritext"
       ],
       "rollForward": false
     },
     "trjson": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trjson"
       ],
       "rollForward": false
     },
     "trperf": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trperf"
       ],
       "rollForward": false
     },
     "trrename": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trrename"
       ],
       "rollForward": false
     },
     "trsort": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trsort"
       ],
       "rollForward": false
     },
     "trsplit": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trsplit"
       ],
       "rollForward": false
     },
     "trsponge": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trsponge"
       ],
       "rollForward": false
     },
     "trtokens": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trtokens"
       ],
       "rollForward": false
     },
     "trtree": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trtree"
       ],
       "rollForward": false
     },
     "trunfold": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trunfold"
       ],
       "rollForward": false
     },
     "trunfoldlit": {
-      "version": "0.23.44",
+      "version": "0.23.45",
       "commands": [
         "trunfoldlit"
       ],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
       - "dependencies"
     ignore:
       - dependency-name: "tr*"
-        update-types: ["version-update:semver-patch"]
   # Java
   - package-ecosystem: "maven"
     directory: "/"

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -1,15 +1,16 @@
 name: Weekly Dev Build
 
-#on:
-#  schedule:
-#    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
-#  workflow_dispatch:        # allow manual triggering
-
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  schedule:
+    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
+  workflow_dispatch:        # allow manual triggering
+
+# Use for testing.
+#on:
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -65,12 +66,6 @@ jobs:
       run: |
         cd abb
         bash ../_scripts/test.sh -t Java --antlr-version dev
-        cat Generated-Java/test.sh
-    - name: What happened
-      if: always()
-      shell: bash
-      run: |
-        cd abb
         cat Generated-Java/test.sh
     - name: Upload dev ANTLR4 JAR
       uses: actions/upload-artifact@v7

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -66,6 +66,7 @@ jobs:
         bash ../_scripts/test.sh -t Java --antlr-version dev
         cat Generated-Java/test.sh
     - name: What happened
+      if: always()
       shell: bash
       run: |
         cd abb

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -1,0 +1,64 @@
+name: Weekly Dev Build
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
+  workflow_dispatch:        # allow manual triggering
+
+jobs:
+  test-java-dev:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        java-version: '17'
+        distribution: 'zulu'
+        cache: 'maven'
+    - name: Test Java
+      run: |
+        java --version
+        javac --version
+        mvn --version
+    - name: Install Python
+      uses: actions/setup-python@v6.2.0
+      with:
+        python-version: '3.10'
+    - name: Install antlr4-tools
+      run: |
+        python -m ensurepip --upgrade
+        pip install _scripts/antlr4-tools
+        pip show antlr4-tools
+    - name: Install Trash
+      shell: bash
+      run: |
+        dotnet tool restore
+    - name: Test Trash install
+      shell: bash
+      run: |
+        dotnet trgen --help
+    - name: Test all grammars with stable ANTLR4 (Java target)
+      shell: bash
+      run: |
+        bash _scripts/test.sh -t Java
+    - name: Clone and build ANTLR4 dev branch
+      shell: bash
+      run: |
+        ANTLR4_DEV_DIR="$HOME/.antlr4-dev/antlr4"
+        git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+        cd "$ANTLR4_DEV_DIR"
+        git checkout dev
+        mvn -DskipTests install
+    - name: Test all grammars with dev ANTLR4 (Java target)
+      shell: bash
+      run: |
+        bash _scripts/test.sh -t Java --antlr-version dev
+    - name: Upload dev ANTLR4 JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: antlr4-dev-complete
+        path: ~/.antlr4-dev/antlr4/tool/target/antlr4-*-complete.jar
+        retention-days: 90

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -54,8 +54,9 @@ jobs:
       shell: bash
       run: |
         ANTLR4_DEV_DIR="$HOME/.antlr4-dev/antlr4"
-        git clone --branch dev --depth 1 https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+        git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
         cd "$ANTLR4_DEV_DIR"
+        git checkout dev
         mvn -DskipTests install
         JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
         echo "ANTLR4_DEV_JAR=$JAR" >> "$GITHUB_ENV"

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -1,11 +1,15 @@
 name: Weekly Dev Build
 
+#on:
+#  schedule:
+#    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
+#  workflow_dispatch:        # allow manual triggering
+
 on:
-  schedule:
-    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
-  workflow_dispatch:        # allow manual triggering
   push:
-    branches: [ g4-4864 ]  # TODO: remove before merging
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test-java-dev:

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -61,6 +61,9 @@ jobs:
         mvn -DskipTests install
         JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
         echo "ANTLR4_DEV_JAR=$JAR" >> "$GITHUB_ENV"
+        dotnet build -c Release "$ANTLR4_DEV_DIR/runtime/CSharp/src"
+        CS_BIN=$(ls -d "$ANTLR4_DEV_DIR"/runtime/CSharp/src/bin/Release/*)
+        echo "ANTLR4_CS_BIN=$CS_BIN" >> "$GITHUB_ENV"
     - name: Test all grammars with dev ANTLR4 (Java target)
       shell: bash
       run: |
@@ -70,4 +73,10 @@ jobs:
       with:
         name: antlr4-dev-complete
         path: ${{ env.ANTLR4_DEV_JAR }}
+        retention-days: 90
+    - name: Upload dev ANTLR4 CSharp runtime bin
+      uses: actions/upload-artifact@v7
+      with:
+        name: antlr4-dev-csharp-runtime-bin
+        path: ${{ env.ANTLR4_CS_BIN }}
         retention-days: 90

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -48,10 +48,11 @@ jobs:
       shell: bash
       run: |
         ANTLR4_DEV_DIR="$HOME/.antlr4-dev/antlr4"
-        git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+        git clone --branch dev --depth 1 https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
         cd "$ANTLR4_DEV_DIR"
-        git checkout dev
         mvn -DskipTests install
+        JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+        echo "ANTLR4_DEV_JAR=$JAR" >> "$GITHUB_ENV"
     - name: Test all grammars with dev ANTLR4 (Java target)
       shell: bash
       run: |
@@ -60,5 +61,5 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: antlr4-dev-complete
-        path: ~/.antlr4-dev/antlr4/tool/target/antlr4-*-complete.jar
+        path: ${{ env.ANTLR4_DEV_JAR }}
         retention-days: 90

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -65,6 +65,11 @@ jobs:
         cd abb
         bash ../_scripts/test.sh -t Java --antlr-version dev
         cat Generated-Java/test.sh
+    - name: What happened
+      shell: bash
+      run: |
+        cd abb
+        cat Generated-Java/test.sh
     - name: Upload dev ANTLR4 JAR
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
   workflow_dispatch:        # allow manual triggering
+  push:
+    branches: [ g4-4864 ]  # TODO: remove before merging
 
 jobs:
   test-java-dev:

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -64,9 +64,7 @@ jobs:
     - name: Test all grammars with dev ANTLR4 (Java target)
       shell: bash
       run: |
-        cd abb
-        bash ../_scripts/test.sh -t Java --antlr-version dev
-        cat Generated-Java/test.sh
+        bash _scripts/test.sh -t Java --antlr-version dev
     - name: Upload dev ANTLR4 JAR
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -1,9 +1,15 @@
 name: Weekly Dev Build
 
+#on:
+#  schedule:
+#    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
+#  workflow_dispatch:        # allow manual triggering
+
 on:
-  schedule:
-    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
-  workflow_dispatch:        # allow manual triggering
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test-java-dev:
@@ -40,10 +46,6 @@ jobs:
       shell: bash
       run: |
         dotnet trgen --help
-    - name: Test all grammars with stable ANTLR4 (Java target)
-      shell: bash
-      run: |
-        bash _scripts/test.sh -t Java
     - name: Clone and build ANTLR4 dev branch
       shell: bash
       run: |
@@ -56,7 +58,9 @@ jobs:
     - name: Test all grammars with dev ANTLR4 (Java target)
       shell: bash
       run: |
-        bash _scripts/test.sh -t Java --antlr-version dev
+        cd abb
+        bash ../_scripts/test.sh -t Java --antlr-version dev
+        cat Generated-Java/test.sh
     - name: Upload dev ANTLR4 JAR
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -1,15 +1,9 @@
 name: Weekly Dev Build
 
-#on:
-#  schedule:
-#    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
-#  workflow_dispatch:        # allow manual triggering
-
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  schedule:
+    - cron: '0 9 * * 1'   # every Monday at 09:00 UTC (staggered from weekly-jar at 03:00)
+  workflow_dispatch:        # allow manual triggering
 
 jobs:
   test-java-dev:

--- a/.github/workflows/weekly-dev.yml
+++ b/.github/workflows/weekly-dev.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   test-java-dev:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![CI](https://github.com/antlr/grammars-v4/actions/workflows/main.yml/badge.svg)
+Last PR merge build: ![CI](https://github.com/antlr/grammars-v4/actions/workflows/main.yml/badge.svg)
+Weekly .jar build: ![Weekly JAR](https://github.com/antlr/grammars-v4/actions/workflows/weekly-jar.yml/badge.svg)
+Weekly dev build: ![Weekly Dev](https://github.com/antlr/grammars-v4/actions/workflows/weekly-dev.yml/badge.svg)
 
 # Grammars-v4
 

--- a/_scripts/templates/CSharp/Other.csproj
+++ b/_scripts/templates/CSharp/Other.csproj
@@ -1,8 +1,0 @@
-<Project>
-
-  <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version ="4.13.1" />
-	  <!--PackageReference Include="Antlr4BuildTasks" Version="12.10" PrivateAssets="all" -->
-  </ItemGroup>
-
-</Project>

--- a/_scripts/templates/CSharp/Test.csproj.st
+++ b/_scripts/templates/CSharp/Test.csproj.st
@@ -11,8 +11,15 @@
 } >  \</ItemGroup>
   \<ItemGroup>
     \<PackageReference Include="UTF.Unknown" Version="2.6.0" />
+<if(antlr_is_dev)>
+    \<Reference Include="Antlr4.Runtime.Standard">
+      \<HintPath>$(ANTLR4_CS_DLL)\</HintPath>
+    \</Reference>
+<else>
+    \<PackageReference Include="Antlr4.Runtime.Standard" Version="<antlr_version>" />
+<endif>
+	  \<!--PackageReference Include="Antlr4BuildTasks" Version="12.10" PrivateAssets="all" -->
   \</ItemGroup>
-  \<Import Project="Other.csproj">\</Import>
   \<PropertyGroup>
     \<RestoreProjectStyle>PackageReference\</RestoreProjectStyle>
   \</PropertyGroup>

--- a/_scripts/templates/CSharp/st.ErrorListener.cs
+++ b/_scripts/templates/CSharp/st.ErrorListener.cs
@@ -1,4 +1,4 @@
-// Generated from trgen <version>
+﻿// Generated from trgen <version>
 
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
@@ -77,6 +77,7 @@ public class MyDiagnosticErrorListener : DiagnosticErrorListener
         }
     }
 
+<if(antlr_has_diagnostic_overrides)>
     public override void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts,
         ATNConfigSet configs)
     {
@@ -96,6 +97,7 @@ public class MyDiagnosticErrorListener : DiagnosticErrorListener
         System.Console.WriteLine(msg);
         NewMethod(recognizer, dfa, startIndex, stopIndex, configs);
     }
+<endif>
 
     string OutIt(Parser recognizer, ATNConfig c, PredictionContext p)
     {

--- a/_scripts/templates/CSharp/st.build.ps1
+++ b/_scripts/templates/CSharp/st.build.ps1
@@ -8,25 +8,29 @@ npm init -y
 npm i antlr-ng
 <endif>
 
-$trxml2_output = dotnet trxml2 Other.csproj
-if (-not $trxml2_output -or ($trxml2_output -match '^\s*$')) {
-    Write-Host "trxml2 returned no output. Contents of Other.csproj:"
-    Get-Content Other.csproj | Write-Host
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
-$version = $trxml2_output | Select-String 'PackageReference/@Version' | ForEach-Object { ($_ -split '=')[1].Trim() }
-if (-not $version -or $version -eq '') {
-    Write-Host "version is empty, defaulting to 4.13.1"
-    $version = "4.13.1"
-}
-Write-Host "trxml2 output"
-dotnet trxml2 Other.csproj | Write-Host
-Write-Host "trxml2 plus select string output"
-dotnet trxml2 Other.csproj | Select-String 'PackageReference/@Version' | Write-Host
-Write-Host "version = '$version'"
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Set-Location runtime/CSharp
+dotnet build -c Release
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+$env:ANTLR4_CS_DLL = (Get-ChildItem "$ANTLR4_DEV_DIR/runtime/CSharp/src/bin/Release" -Recurse -Filter "Antlr4.Runtime.Standard.dll" | Select-Object -Last 1).FullName
+<else>
+$version = "<antlr_version>"
+<endif>
 
 <tool_grammar_files:{x |
 <if(antlrng_tool)>
 $(& tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=CSharp <antlr_tool_args:{y | <y> } >  <x> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<elseif(antlr_is_dev)>
+$(& java -jar "$JAR" <x> -encoding <antlr_encoding> -Dlanguage=CSharp <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <else>
 $(& antlr4 -v $version <x> -encoding <antlr_encoding> -Dlanguage=CSharp <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <endif>

--- a/_scripts/templates/CSharp/st.build.ps1
+++ b/_scripts/templates/CSharp/st.build.ps1
@@ -11,7 +11,7 @@ npm i antlr-ng
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/CSharp/st.build.sh
+++ b/_scripts/templates/CSharp/st.build.sh
@@ -10,7 +10,7 @@ npm i antlr-ng
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 (cd "$ANTLR4_DEV_DIR/runtime/CSharp/src" && dotnet build -c Release)

--- a/_scripts/templates/CSharp/st.build.sh
+++ b/_scripts/templates/CSharp/st.build.sh
@@ -7,11 +7,24 @@ npm init -y
 npm i antlr-ng
 <endif>
 
-version=`dotnet trxml2 Other.csproj | fgrep 'PackageReference/@Version' | awk -F= '{print $2}'`
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+(cd "$ANTLR4_DEV_DIR/runtime/CSharp/src" && dotnet build -c Release)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+export ANTLR4_CS_DLL=$(ls "$ANTLR4_DEV_DIR"/runtime/CSharp/src/bin/Release/*/Antlr4.Runtime.Standard.dll 2>/dev/null | head -1)
+<else>
+version=<antlr_version>
+<endif>
 
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=CSharp <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<elseif(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=CSharp <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <else>
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=CSharp <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <endif>

--- a/_scripts/templates/Cpp/st.CMakeLists.txt
+++ b/_scripts/templates/Cpp/st.CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required (VERSION 3.14)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 set(CMAKE_CXX_STANDARD 17)
-set(ANTLR4_TAG 4.13.1)
+set(ANTLR4_TAG <antlr_version>)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 #SET(GCC_COVERAGE_COMPILE_FLAGS "-g -pg")

--- a/_scripts/templates/Dart/st.build.ps1
+++ b/_scripts/templates/Dart/st.build.ps1
@@ -3,11 +3,24 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+}
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
 # Because there is no integrated build script for Dart targets, we need
 # to manually look at the version in pubspec.yaml and extract the
 # version number. We can then use this with antlr4 to generate the
 # parser and lexer.
 $version = Select-String -Path "pubspec.yaml" -Pattern "antlr4" | ForEach-Object {$_.Line.Split(" ")[3]}
+<endif>
 
 <if(antlrng_tool)>
 npm init -y
@@ -17,6 +30,8 @@ npm i antlr-ng
 <tool_grammar_files:{x |
 <if(antlrng_tool)>
 $(& tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Dart <antlr_tool_args:{y | <y> } > <x> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<elseif(antlr_is_dev)>
+$(& java -jar "$JAR" <x> -encoding <antlr_encoding> -Dlanguage=Dart <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <else>
 $(& antlr4 -v $version <x> -encoding <antlr_encoding> -Dlanguage=Dart <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <endif>

--- a/_scripts/templates/Dart/st.build.ps1
+++ b/_scripts/templates/Dart/st.build.ps1
@@ -6,7 +6,7 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/Dart/st.build.sh
+++ b/_scripts/templates/Dart/st.build.sh
@@ -3,11 +3,20 @@ set -e
 
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
 # Because there is no integrated build script for Dart targets, we need
 # to manually look at the version in pubspec.yaml and extract the
 # version number. We can then use this with antlr4 to generate the
 # parser and lexer.
 version=`grep antlr4 pubspec.yaml | awk '{print $2}' | tr -d '\r' | tr -d '\n'`
+<endif>
 
 <if(antlrng_tool)>
 npm init -y
@@ -17,6 +26,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Dart <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<elseif(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=Dart <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <else>
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=Dart <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <endif>

--- a/_scripts/templates/Dart/st.build.sh
+++ b/_scripts/templates/Dart/st.build.sh
@@ -6,7 +6,7 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)

--- a/_scripts/templates/Dart/st.clean.sh
+++ b/_scripts/templates/Dart/st.clean.sh
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-version=4.13.1
+version=<antlr_version>
 rm -f *.interp
 files=()
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`

--- a/_scripts/templates/Dart/st.pubspec.yaml
+++ b/_scripts/templates/Dart/st.pubspec.yaml
@@ -2,9 +2,9 @@
 name: cli
 description: A sample command-line application.
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 \<3.0.0'
 dependencies:
-  antlr4: 4.13.2
+  antlr4: <if(antlr_is_dev)>any<else><antlr_version><endif>
 dev_dependencies:
   pedantic: ^1.9.0
   test: ^1.14.4

--- a/_scripts/templates/Go/st.build.ps1
+++ b/_scripts/templates/Go/st.build.ps1
@@ -1,7 +1,29 @@
 # Generated from trgen <version>
 
-$version="4.13.1"
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+}
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
+$version="<antlr_version>"
+<endif>
 $env:GO111MODULE = "on"
+<if(antlr_is_dev)>
+For ($i=0; $i -le 5; $i++) {
+	$(& go get github.com/antlr4-go/antlr/v4@latest ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+	if($compile_exit_code -eq 0){
+		Break
+	}
+	Write-Host "go get failed. Trying again."
+}
+<else>
 For ($i=0; $i -le 5; $i++) {
 	$(& go get github.com/antlr4-go/antlr/v4@v$version ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 	if($compile_exit_code -eq 0){
@@ -9,6 +31,7 @@ For ($i=0; $i -le 5; $i++) {
 	}
 	Write-Host "go get failed. Trying again."
 }
+<endif>
 if($compile_exit_code -ne 0){
     exit $compile_exit_code
 }
@@ -35,6 +58,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 $(& tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Go --lib parser --package parser <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<elseif(antlr_is_dev)>
+$(& java -jar "$JAR" <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=Go <if(os_win)>-o parser<endif> -lib parser -package parser  <x.AntlrArgs>  <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <else>
 $(& antlr4 -v $version <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=Go <if(os_win)>-o parser<endif> -lib parser -package parser  <x.AntlrArgs>  <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <endif>

--- a/_scripts/templates/Go/st.build.ps1
+++ b/_scripts/templates/Go/st.build.ps1
@@ -3,7 +3,7 @@
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/Go/st.build.sh
+++ b/_scripts/templates/Go/st.build.sh
@@ -1,8 +1,21 @@
 # Generated from trgen <version>
 
-version="4.13.1"
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
+version="<antlr_version>"
+<endif>
 export GO111MODULE=on
+<if(antlr_is_dev)>
+for i in {1..5}; do go get github.com/antlr4-go/antlr/v4@latest; if [ "$?" = "0" ]; then break; fi; done; if [ "$?" != "0" ]; then exit 1; fi
+<else>
 for i in {1..5}; do go get github.com/antlr4-go/antlr/v4@v$version; if [ "$?" = "0" ]; then break; fi; done; if [ "$?" != "0" ]; then exit 1; fi
+<endif>
 for i in {1..5}; do go get golang.org/x/text@v0.26.0; if [ "$?" = "0" ]; then break; fi; done; if [ "$?" != "0" ]; then exit 1; fi
 
 set -e
@@ -23,6 +36,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Go --lib parser --package parser <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<elseif(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=Go <if(os_win)>-o parser<endif> -lib parser -package parser <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <else>
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=Go <if(os_win)>-o parser<endif> -lib parser -package parser  <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <endif>

--- a/_scripts/templates/Go/st.build.sh
+++ b/_scripts/templates/Go/st.build.sh
@@ -3,7 +3,7 @@
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)

--- a/_scripts/templates/Go/st.clean.sh
+++ b/_scripts/templates/Go/st.clean.sh
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-version=4.13.1
+version=<antlr_version>
 rm -f *.interp
 files=()
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`

--- a/_scripts/templates/Java/st.build.ps1
+++ b/_scripts/templates/Java/st.build.ps1
@@ -6,7 +6,7 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/Java/st.build.ps1
+++ b/_scripts/templates/Java/st.build.ps1
@@ -3,7 +3,21 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+}
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
 $version = Select-String -Path "build.sh" -Pattern "version=" | ForEach-Object { $_.Line -split "=" | Select-Object -Last 1 }
+$JAR = python -c "import os; from pathlib import Path; print(os.path.join(Path.home(), '.m2', 'repository', 'org', 'antlr', 'antlr4', '$version', ('antlr4-' + '$version' + '-complete.jar')))"
+<endif>
 
 <if(antlrng_tool)>
 npm init -y
@@ -14,6 +28,8 @@ npm i antlr-ng
 <if(antlrng_tool)>
 # Run tool.
 $(& tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } >  <x.GrammarFileNameTarget> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<elseif(antlr_is_dev)>
+$(& java -jar "$JAR" <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <else>
 $(& antlr4 -v $version <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <endif>
@@ -28,6 +44,5 @@ if($compile_exit_code -ne 0){
 # Antlr4 runtime wound up in the jar.
 $(& antlr4 -v $version ; $last = $LASTEXITCODE ) | Out-Null
 <endif>
-$JAR = python -c "import os; from pathlib import Path; print(os.path.join(Path.home(), '.m2', 'repository', 'org', 'antlr', 'antlr4', '$version', ('antlr4-' + '$version' + '-complete.jar')))"
 $(& javac -cp "${JAR}<if(path_sep_semi)>;<else>:<endif>." <tool_grammar_tuples:{x|<x.GeneratedFileName> }> Test.java ErrorListener.java ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 exit $compile_exit_code

--- a/_scripts/templates/Java/st.build.ps1
+++ b/_scripts/templates/Java/st.build.ps1
@@ -15,7 +15,7 @@ mvn -DskipTests install
 Pop-Location
 $JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
 <else>
-$version = Select-String -Path "build.sh" -Pattern "version=" | ForEach-Object { $_.Line -split "=" | Select-Object -Last 1 }
+$version = "<antlr_version>"
 $JAR = python -c "import os; from pathlib import Path; print(os.path.join(Path.home(), '.m2', 'repository', 'org', 'antlr', 'antlr4', '$version', ('antlr4-' + '$version' + '-complete.jar')))"
 <endif>
 

--- a/_scripts/templates/Java/st.build.sh
+++ b/_scripts/templates/Java/st.build.sh
@@ -6,7 +6,17 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 # to manually look at the version in pubspec.yaml and extract the
 # version number. We can then use this with antlr4 to generate the
 # parser and lexer.
-version=4.13.1
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
+version=<antlr_version>
+JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
+<endif>
 
 <if(antlrng_tool)>
 npm init -y
@@ -16,12 +26,13 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<elseif(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <else>
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=Java <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <endif>
 }>
 
-JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
 CLASSPATH="$JAR<if(path_sep_semi)>\;<else>:<endif>."
 javac -cp "$CLASSPATH" *.java
 

--- a/_scripts/templates/Java/st.build.sh
+++ b/_scripts/templates/Java/st.build.sh
@@ -9,7 +9,7 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)

--- a/_scripts/templates/Java/st.clean.sh
+++ b/_scripts/templates/Java/st.clean.sh
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-version=4.13.1
+version=<antlr_version>
 rm -f *.interp
 files=()
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`

--- a/_scripts/templates/Java/st.run.ps1
+++ b/_scripts/templates/Java/st.run.ps1
@@ -1,4 +1,9 @@
-$version = Select-String -Path "build.sh" -Pattern "version=" | ForEach-Object { $_.Line -split "=" | Select-Object -Last 1 }
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
+$version = "<antlr_version>"
 $JAR = python -c "import os; from pathlib import Path; print(os.path.join(Path.home(), '.m2', 'repository', 'org', 'antlr', 'antlr4', '$version', ('antlr4-' + '$version' + '-complete.jar')))"
+<endif>
 $CLASSPATH = "$JAR<if(path_sep_semi)>\;<else>:<endif>$pwd"
 java -cp "$CLASSPATH" Test $args

--- a/_scripts/templates/Java/st.run.sh
+++ b/_scripts/templates/Java/st.run.sh
@@ -1,5 +1,10 @@
 #
-version=`grep "version=" build.sh | awk -F= '{print $2}'`
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
+version=<antlr_version>
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
+<endif>
 CLASSPATH="$JAR<if(path_sep_semi)>\;<else>:<endif>."
 java -cp "$CLASSPATH" Test "$@"

--- a/_scripts/templates/Java/st.test.sh
+++ b/_scripts/templates/Java/st.test.sh
@@ -44,8 +44,13 @@ fi
 git clean -f ../<example_dir_unix>
 
 # Parse all input files.
-version=`grep "version=" build.sh | awk -F= '{print $2}'`
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
+version=<antlr_version>
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`
+<endif>
 CLASSPATH="$JAR<if(path_sep_semi)>\;<else>:<endif>."
 <if(individual_parsing)>
 # Individual parsing.

--- a/_scripts/templates/JavaScript/st.build.ps1
+++ b/_scripts/templates/JavaScript/st.build.ps1
@@ -6,7 +6,7 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/JavaScript/st.build.ps1
+++ b/_scripts/templates/JavaScript/st.build.ps1
@@ -3,11 +3,24 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+}
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
 # Because there is no integrated build script for Dart targets, we need
 # to manually look at the version in package.json and extract the
 # version number. We can then use this with antlr4 to generate the
 # parser and lexer.
 $version = (Select-String -Path "package.json" -Pattern "antlr4" | ForEach-Object {$_.Line.Split(" ")[5]}) -replace '"|,|\r|\n'
+<endif>
 
 <if(antlrng_tool)>
 npm i antlr-ng
@@ -16,6 +29,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 $(& tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<elseif(antlr_is_dev)>
+$(& java -jar "$JAR" <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <else>
 $(& antlr4 -v $version <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <endif>

--- a/_scripts/templates/JavaScript/st.build.sh
+++ b/_scripts/templates/JavaScript/st.build.sh
@@ -3,11 +3,20 @@ set -e
 
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
 # Because there is no integrated build script for Dart targets, we need
 # to manually look at the version in package.json and extract the
 # version number. We can then use this with antlr4 to generate the
 # parser and lexer.
 version=`grep antlr4 package.json | awk '{print $2}' | tr -d '"' | tr -d ',' | tr -d '\r' | tr -d '\n'`
+<endif>
 
 <if(antlrng_tool)>
 npm i antlr-ng
@@ -16,6 +25,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<elseif(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <else>
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=JavaScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <endif>

--- a/_scripts/templates/JavaScript/st.build.sh
+++ b/_scripts/templates/JavaScript/st.build.sh
@@ -6,7 +6,7 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)

--- a/_scripts/templates/JavaScript/st.clean.sh
+++ b/_scripts/templates/JavaScript/st.clean.sh
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-version=4.13.1
+version=<antlr_version>
 rm -f *.interp
 files=()
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`

--- a/_scripts/templates/JavaScript/st.package.json
+++ b/_scripts/templates/JavaScript/st.package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "4.13.2",
+    "antlr4": "<if(antlr_is_dev)>*<else><antlr_version><endif>",
     "fs-extra": "^11.1.0",
     "timer-node": "^5.0.6",
     "typescript-string-operations": "^1.4.1"

--- a/_scripts/templates/PHP/st.build.ps1
+++ b/_scripts/templates/PHP/st.build.ps1
@@ -3,6 +3,18 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+}
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
 # Find runtime version in composer.json file.
 $runtime_version = (Get-Content -Path composer.json | Select-String 'antlr4').ToString().Split(':')[1].Trim(' ",\r\n')
 
@@ -22,6 +34,7 @@ $version = (Get-Content -Path src/RuntimeMetaData.php | Select-String 'public co
 
 Set-Location ..
 Remove-Item -Recurse -Force antlr-php-runtime -ErrorAction SilentlyContinue
+<endif>
 
 <if(antlrng_tool)>
 npm init -y
@@ -31,6 +44,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 $(& tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<elseif(antlr_is_dev)>
+$(& java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <else>
 $(& antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <endif>

--- a/_scripts/templates/PHP/st.build.ps1
+++ b/_scripts/templates/PHP/st.build.ps1
@@ -6,7 +6,7 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/PHP/st.build.sh
+++ b/_scripts/templates/PHP/st.build.sh
@@ -3,6 +3,14 @@ set -e
 
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
 # Because there is no integrated build script for Dart targets, we need
 # to manually look at the version in pubspec.yaml and extract the
 # version number. We can then use this with antlr4 to generate the
@@ -29,6 +37,7 @@ git checkout $commit_version
 tool_version=`grep 'public const VERSION' src/RuntimeMetaData.php | awk '{print $NF}' | sed "s/'//g" | sed 's/;//'`
 cd ..
 rm -rf antlr4-php-runtime
+<endif>
 
 <if(antlrng_tool)>
 npm init -y
@@ -38,6 +47,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<elseif(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <else>
 antlr4 -v $tool_version -encoding <antlr_encoding> -Dlanguage=PHP <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <endif>

--- a/_scripts/templates/PHP/st.build.sh
+++ b/_scripts/templates/PHP/st.build.sh
@@ -6,7 +6,7 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)

--- a/_scripts/templates/PHP/st.clean.sh
+++ b/_scripts/templates/PHP/st.clean.sh
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-version=4.13.1
+version=<antlr_version>
 rm -f *.interp
 files=()
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`

--- a/_scripts/templates/Python3/requirements.txt
+++ b/_scripts/templates/Python3/requirements.txt
@@ -1,2 +1,0 @@
-antlr4-python3-runtime==4.13.2
-readchar

--- a/_scripts/templates/Python3/st.build.ps1
+++ b/_scripts/templates/Python3/st.build.ps1
@@ -8,7 +8,7 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/Python3/st.build.ps1
+++ b/_scripts/templates/Python3/st.build.ps1
@@ -5,11 +5,20 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
-# Because there is no integrated build script for Dart targets, we need
-# to manually look at the version in requirements.txt and extract the
-# version number. We can then use this with antlr4 to generate the
-# parser and lexer.
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+}
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
 $version = (Select-String -Path "requirements.txt" -Pattern "antlr4" | ForEach-Object {$_.Line.Split("=")[2]}) -replace '"|,|\r|\n'
+<endif>
 
 python3 -m venv .venv
 <if(test.IsWindows)>.venv\Scripts\Activate.ps1<else>.venv/bin/Activate.ps1<endif>
@@ -25,6 +34,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 $(& tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget> ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<elseif(antlr_is_dev)>
+$(& java -jar "$JAR" <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <else>
 $(& antlr4 -v $version <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
 <endif>

--- a/_scripts/templates/Python3/st.build.sh
+++ b/_scripts/templates/Python3/st.build.sh
@@ -3,11 +3,16 @@ set -e
 
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 
-# Because there is no integrated build script for Dart targets, we need
-# to manually look at the version in pubspec.yaml and extract the
-# version number. We can then use this with antlr4 to generate the
-# parser and lexer.
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
 version=`grep antlr4-python3-runtime requirements.txt | awk -F= '{print $3}' | tr -d '\r' | tr -d '\n'`
+<endif>
 
 python3 -m venv .venv
 source .venv/bin/activate
@@ -24,6 +29,8 @@ npm i antlr-ng
 <tool_grammar_tuples:{x |
 <if(antlrng_tool)>
 tsx $HOME/antlr-ng/cli/runner.ts --encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<elseif(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <else>
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=Python3 <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
 <endif>

--- a/_scripts/templates/Python3/st.build.sh
+++ b/_scripts/templates/Python3/st.build.sh
@@ -6,7 +6,7 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)

--- a/_scripts/templates/Python3/st.clean.sh
+++ b/_scripts/templates/Python3/st.clean.sh
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-version=4.13.1
+version=<antlr_version>
 rm -f *.interp
 files=()
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`

--- a/_scripts/templates/Python3/st.requirements.txt
+++ b/_scripts/templates/Python3/st.requirements.txt
@@ -1,0 +1,2 @@
+<if(antlr_is_dev)>antlr4-python3-runtime<else>antlr4-python3-runtime==<antlr_version><endif>
+readchar

--- a/_scripts/templates/TypeScript/st.build.ps1
+++ b/_scripts/templates/TypeScript/st.build.ps1
@@ -3,14 +3,31 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
     $(& python3 transformGrammar.py ) 2>&1 | Write-Host
 }
 
+<if(antlr_is_dev)>
+$ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
+if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
+    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+}
+Push-Location "$ANTLR4_DEV_DIR"
+git checkout dev
+git pull
+mvn -DskipTests install
+Pop-Location
+$JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Select-Object -Last 1).FullName
+<else>
 # Because there is no integrated build script for Dart targets, we need
 # to manually look at the version in package.json and extract the
 # version number. We can then use this with antlr4 to generate the
 # parser and lexer.
 $version = (Select-String -Path "package.json" -Pattern "antlr4" | ForEach-Object {$_.Line.Split(" ")[5]}) -replace '"|,|\r|\n'
+<endif>
 
 <tool_grammar_tuples:{x |
+<if(antlr_is_dev)>
+$(& java -jar "$JAR" <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<else>
 $(& antlr4 -v $version <x.GrammarFileNameTarget> -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > ; $compile_exit_code = $LASTEXITCODE) | Write-Host
+<endif>
 if($compile_exit_code -ne 0){
     exit $compile_exit_code
 \}

--- a/_scripts/templates/TypeScript/st.build.ps1
+++ b/_scripts/templates/TypeScript/st.build.ps1
@@ -6,7 +6,7 @@ if (Test-Path -Path transformGrammar.py -PathType Leaf) {
 <if(antlr_is_dev)>
 $ANTLR4_DEV_DIR = "<antlr_dev_dir>/antlr4"
 if (-not (Test-Path "$ANTLR4_DEV_DIR/.git")) {
-    git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+    git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 }
 Push-Location "$ANTLR4_DEV_DIR"
 git checkout dev

--- a/_scripts/templates/TypeScript/st.build.sh
+++ b/_scripts/templates/TypeScript/st.build.sh
@@ -6,7 +6,7 @@ if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 <if(antlr_is_dev)>
 ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
 if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
-  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+  git clone --quiet https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
 fi
 (cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
 JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)

--- a/_scripts/templates/TypeScript/st.build.sh
+++ b/_scripts/templates/TypeScript/st.build.sh
@@ -3,14 +3,27 @@ set -e
 
 if [ -f transformGrammar.py ]; then python3 transformGrammar.py ; fi
 
+<if(antlr_is_dev)>
+ANTLR4_DEV_DIR=<antlr_dev_dir>/antlr4
+if [ ! -d "$ANTLR4_DEV_DIR/.git" ]; then
+  git clone https://github.com/antlr/antlr4.git "$ANTLR4_DEV_DIR"
+fi
+(cd "$ANTLR4_DEV_DIR" && git checkout dev && git pull && mvn -DskipTests install)
+JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
+<else>
 # Because there is no integrated build script for Dart targets, we need
 # to manually look at the version in package.json and extract the
 # version number. We can then use this with antlr4 to generate the
 # parser and lexer.
 version=`grep antlr4 package.json | awk '{print $2}' | tr -d '"' | tr -d ',' | tr -d '\r' | tr -d '\n'`
+<endif>
 
 <tool_grammar_tuples:{x |
+<if(antlr_is_dev)>
+java -jar "$JAR" -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<else>
 antlr4 -v $version -encoding <antlr_encoding> -Dlanguage=TypeScript <x.AntlrArgs> <antlr_tool_args:{y | <y> } > <x.GrammarFileNameTarget>
+<endif>
 } >
 
 npm install -g typescript ts-node

--- a/_scripts/templates/TypeScript/st.clean.sh
+++ b/_scripts/templates/TypeScript/st.clean.sh
@@ -1,5 +1,5 @@
 # Generated from trgen <version>
-version=4.13.1
+version=<antlr_version>
 rm -f *.interp
 files=()
 JAR=`python -c "import os; from pathlib import Path; print(os.path.join(Path.home() , '.m2',  'repository', 'org', 'antlr', 'antlr4', '$version', 'antlr4-$version-complete.jar'))"`

--- a/_scripts/templates/TypeScript/st.package.json
+++ b/_scripts/templates/TypeScript/st.package.json
@@ -9,11 +9,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "4.13.2",
+    "antlr4": "<if(antlr_is_dev)>*<else><antlr_version><endif>",
     "buffer": "^6.0.3",
     "fs-extra": "^11.1.1",
     "timer-node": "^5.0.6",
-    "typescript-collections": "^1.3.3",
     "typescript-string-operations": "^1.5.0"
   },
   "type": "module",

--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -93,6 +93,27 @@ popd > /dev/null 2>&1
 
 rm -rf `find . -name 'Generated*' -type d`
 
+# Pre-process long options not handled by getopts.
+antlr_version=""
+_args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --antlr-version)
+            antlr_version="$2"
+            shift 2
+            ;;
+        --antlr-version=*)
+            antlr_version="${1#*=}"
+            shift
+            ;;
+        *)
+            _args+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${_args[@]}"
+
 # Parse args, and update computation to perform.
 order="grammars"
 additional=()
@@ -348,7 +369,7 @@ do
     # Generate driver source code.
 
     if [ $quiet != "true" ]; then echo "Generating driver for $testname."; fi
-    bad=`dotnet trgen -t "$target" --template-sources-directory "$full_path_templates" --antlr-tool-path $antlr4jar 2> /dev/null`
+    bad=`dotnet trgen -t "$target" --template-sources-directory "$full_path_templates"${antlr_version:+ --antlr-version "$antlr_version"} 2> /dev/null`
     for i in $bad; do failed+=( "$testname/$target" ); done
 
     for d in `echo Generated-$target-* Generated-$target`

--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -99,6 +99,10 @@ _args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --antlr-version)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: --antlr-version requires a non-option value." >&2
+                exit 2
+            fi
             antlr_version="$2"
             shift 2
             ;;

--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -181,6 +181,11 @@ OPTIONS
            "CSharp", "Cpp", "Dart", "Go", "Java", "JavaScript", "Python3".
            All targets are tested by default.
 
+       --antlr-version
+           Specifies the ANTLR4 tool and runtime version to use (e.g. "4.13.1"),
+           or "dev" to clone and build from the ANTLR4 dev branch. Passed
+           directly to trgen. If omitted, trgen's default version is used.
+
 EOF
             exit 0
             ;;
@@ -373,7 +378,9 @@ do
     # Generate driver source code.
 
     if [ $quiet != "true" ]; then echo "Generating driver for $testname."; fi
-    bad=`dotnet trgen -t "$target" --template-sources-directory "$full_path_templates" ${antlr_version:+ --antlr-version "$antlr_version"} 2> /dev/null`
+    trgen_opts=(-t "$target" --template-sources-directory "$full_path_templates" --antlr-tool-path "$antlr4jar")
+    [[ -n "$antlr_version" ]] && trgen_opts+=(--antlr-version "$antlr_version")
+    bad=$(dotnet trgen "${trgen_opts[@]}" 2>/dev/null)
     for i in $bad; do failed+=( "$testname/$target" ); done
 
     for d in `echo Generated-$target-* Generated-$target`

--- a/_scripts/test.sh
+++ b/_scripts/test.sh
@@ -369,7 +369,7 @@ do
     # Generate driver source code.
 
     if [ $quiet != "true" ]; then echo "Generating driver for $testname."; fi
-    bad=`dotnet trgen -t "$target" --template-sources-directory "$full_path_templates"${antlr_version:+ --antlr-version "$antlr_version"} 2> /dev/null`
+    bad=`dotnet trgen -t "$target" --template-sources-directory "$full_path_templates" ${antlr_version:+ --antlr-version "$antlr_version"} 2> /dev/null`
     for i in $bad; do failed+=( "$testname/$target" ); done
 
     for d in `echo Generated-$target-* Generated-$target`

--- a/abb/readme.md
+++ b/abb/readme.md
@@ -22,4 +22,3 @@ based on a set of ABB Rapid sys-files and the existing kuka-krl antlr file
 ## Issues
 
 Known ambiguity in dataList.
-


### PR DESCRIPTION
This PR is a fix for #4864.

This PR adds a workflow to test all grammars against the "dev" branch of antlr4 for the Java target. The top-level README.md page has updated badges displayed. There are two artifacts produced: one for the Antlr4 Tool .jar, which also functions as the runtime component for the Java target, and one for the CSharp runtime. These artifacts stay live for 90 days.

GitHub Dependabot should not be updated on a piecemeal basis because one could end up with a version skew between tools or templates. The change disables updates to the Trash Toolkit completely. I just submitted https://github.com/antlr/grammars-v4/pull/4875 to move Trash to a dispatch/sub-command tool, like git.