### PR TITLE
Added DivAssign to theOperator in C++ parser

### DIFF
--- a/cpp/CPP14Parser.g4
+++ b/cpp/CPP14Parser.g4
@@ -1042,6 +1042,7 @@ theOperator
     | PlusAssign
     | MinusAssign
     | StarAssign
+    | DivAssign
     | ModAssign
     | XorAssign
     | AndAssign


### PR DESCRIPTION
I tried to update the C++ grammar in our project [JPlag](https://github.com/jplag/JPlag) and noticed the current C++ grammar is not able to pass one of our test files. Specifically the following code breaks the grammar:

```C++
    HDRColorA& operator/=(float f) noexcept
    {
        const float fInv = 1.0f / f;
        r *= fInv;
        g *= fInv;
        b *= fInv;
        a *= fInv;
        return *this;
    }
```

It seems to me that as mentioned in #1894 the DivAssign operator is simply missing in the "theOperator" rule. As far as I can tell there are no issues with just adding it. Please let me know if this is an issue.