### PR TITLE
[Cypher] Add QPP (Quantified Path Patterns) syntax to grammar

### DIFF
--- a/cypher/CypherParser.g4
+++ b/cypher/CypherParser.g4
@@ -272,12 +272,31 @@ patternPart
     ;
 
 patternElem
-    : nodePattern patternElemChain*
-    | LPAREN patternElem RPAREN
+    : nodePattern (patternElemChain | qppElemChain)*
+    | LPAREN patternElem RPAREN qppQuantifier?
     ;
 
 patternElemChain
     : relationshipPattern nodePattern
+    ;
+
+qppElemChain
+    : LPAREN patternElem RPAREN qppQuantifier nodePattern
+    ;
+
+qppQuantifier
+    : LBRACE qppInt COMMA qppInt RBRACE
+    | LBRACE qppInt RBRACE
+    | LBRACE qppInt COMMA RBRACE
+    | LBRACE COMMA qppInt RBRACE
+    | LBRACE COMMA RBRACE
+    | PLUS
+    | MULT
+    ;
+
+qppInt
+    : DIGIT
+    | ID
     ;
 
 properties

--- a/cypher/examples/match39.txt
+++ b/cypher/examples/match39.txt
@@ -1,0 +1,1 @@
+MATCH ((a)-[r]->(b)){3} RETURN a

--- a/cypher/examples/match40.txt
+++ b/cypher/examples/match40.txt
@@ -1,0 +1,1 @@
+MATCH ((a)-[r]->(b)){1,3} RETURN a

--- a/cypher/examples/match41.txt
+++ b/cypher/examples/match41.txt
@@ -1,0 +1,1 @@
+MATCH (s) ((a)-[r]->(b)){1,3} (e) RETURN s, e

--- a/cypher/examples/match42.txt
+++ b/cypher/examples/match42.txt
@@ -1,0 +1,1 @@
+MATCH (s)-[x]->(t) ((a)-[r]->(b)){1,5} (e) RETURN s, e

--- a/cypher/examples/match43.txt
+++ b/cypher/examples/match43.txt
@@ -1,0 +1,1 @@
+MATCH (s) ((a)-[r]->(b))+ (e) RETURN s, e

--- a/cypher/examples/match44.txt
+++ b/cypher/examples/match44.txt
@@ -1,0 +1,1 @@
+MATCH (s) ((a)-[r]->(b))* (e) RETURN s, e

--- a/cypher/examples/match45.txt
+++ b/cypher/examples/match45.txt
@@ -1,0 +1,1 @@
+MATCH (s) ((a)-[r]->(b)){,3} (e) RETURN s, e

--- a/cypher/examples/match46.txt
+++ b/cypher/examples/match46.txt
@@ -1,0 +1,1 @@
+MATCH (s) ((a)-[r]->(b)){2,} (e) RETURN s, e

--- a/cypher/examples/match47.txt
+++ b/cypher/examples/match47.txt
@@ -1,0 +1,1 @@
+MATCH (s) ((a)-[r]->(b)){,} (e) RETURN s, e


### PR DESCRIPTION
## Summary
This Pull Request adds support for Cypher's QPP (Quantified Path Patterns) syntax (documented [here](https://neo4j.com/docs/cypher-manual/current/patterns/reference/#quantified-path-patterns)).

Also adds enough examples to cover multiple rules:
```
MATCH ((a)-[r]->(b)){3} RETURN a
MATCH ((a)-[r]->(b)){1,3} RETURN a
MATCH (s) ((a)-[r]->(b)){1,3} (e) RETURN s, e
MATCH (s)-[x]->(t) ((a)-[r]->(b)){1,5} (e) RETURN s, e
MATCH (s) ((a)-[r]->(b))+ (e) RETURN s, e
MATCH (s) ((a)-[r]->(b))* (e) RETURN s, e
MATCH (s) ((a)-[r]->(b)){,3} (e) RETURN s, e
MATCH (s) ((a)-[r]->(b)){2,} (e) RETURN s, e
MATCH (s) ((a)-[r]->(b)){,} (e) RETURN s, e
```