### PR TITLE
[vhdl] Added correct signature rule to VHDL2008 Grammar

### DIFF
--- a/vhdl/vhdl2008/examples/test_pkg.vhd
+++ b/vhdl/vhdl2008/examples/test_pkg.vhd
@@ -38,10 +38,12 @@ package test_pkg is
   end component component_with_trailing_label;
 
   function signature_test(data : unsigned) return integer;
-
+  
   function signature_test(data : signed) return integer;
-
+  
   function signature_test(data : integer) return integer;
+
+  alias signature_test_alias is signature_test [unsigned return integer];
 
 end package;
 

--- a/vhdl/vhdl2008/vhdl2008.g4
+++ b/vhdl/vhdl2008/vhdl2008.g4
@@ -552,8 +552,7 @@ aggregate
     ;
 
 alias_declaration
-    // : ALIAS alias_designator (COLON subtype_indication)? IS name (signature)? SEMI
-    : ALIAS alias_designator (COLON subtype_indication)? IS name SEMI
+    : ALIAS alias_designator (COLON subtype_indication)? IS name (signature)? SEMI
     ;
 
 alias_designator
@@ -1929,11 +1928,9 @@ signal_list
     | ALL
     ;
 
-// Signatures never get matched before other rules,
-// and no-one uses them in most HDL designs
-// signature
-//     : ( (type_mark (COMMA type_mark)?) (RETURN type_mark)? )?
-//     ;
+signature
+    : LBRACKET (name (COMMA name)?) (RETURN name)? RBRACKET
+    ;
 
 // simple_configuration_specification // Only used in one other rule
 //     : FOR component_specification binding_indication SEMI (END FOR SEMI)?


### PR DESCRIPTION
Added signature rule to VHDL2008 Grammar, in accordance with IEEE 1076-2008:

4.5.3 Signatures
A signature distinguishes between overloaded subprograms and overloaded enumeration literals based on
their parameter and result type profiles. A signature can be used in a subprogram instantiation declaration,
attribute name, entity designator, or alias declaration.
signature ::= [ [ type_mark { , type_mark } ] [ return type_mark ] ]
(Note that the initial and terminal brackets are part of the syntax of signatures and do not indicate that the
entire right-hand side of the production is optional.)

The old signature rule never worked because of the confusion regarding the enclosing LBRACKET and RBRACKET. 