### PR TITLE
[c] Fix lexer typo of C23 typeof_unqual keyword

### DIFF
--- a/c/CLexer.g4
+++ b/c/CLexer.g4
@@ -264,8 +264,8 @@ Typeof
     ;
 
 Typeof_unqual
-    : 'typeof_unequal'
-    | '__typeof_unequal__' //GNU
+    : 'typeof_unqual'
+    | '__typeof_unqual__' //GNU
     ;
 
 Union


### PR DESCRIPTION
In  `CLexer.g4` the C23 keyword `typeof_unqual` (as in unqualified) was misspelt as `typeof_unequal`.

Previously, this was falsely accepted

```c
int main(void) {
    int x = 5;
    typeof_unequal(x) y = 10;
    return 0;
}
```

And this was falsely rejected

```c
int main(void) {
    int x = 5;
    typeof_unqual(x) y = 10;
    return 0;
}
```

This patch correctly rejects the first input and accepts the second input.

Verified no regressions with the Maven test suite.