### PR TITLE
[PlSql] Fixed test directory path for more-examples

### DIFF
--- a/sql/plsql/desc.xml
+++ b/sql/plsql/desc.xml
@@ -9,7 +9,7 @@
    <test>
       <name>more-examples</name>
       <targets>Antlr4ng;Cpp;CSharp;Dart;Go;Java</targets>
-      <inputs>more/**/*.sql</inputs>
+      <inputs>more-examples/**/*.sql</inputs>
    </test>
 </desc>
 


### PR DESCRIPTION
I noticed that the tests contained in `sql/plsql/more-examples` were not found. I fixed the issue using the instruction from [this comment](https://github.com/antlr/grammars-v4/pull/4451#issuecomment-2764777883).