### PR TITLE
[c] Fixes for C grammar (#4885)

### DIFF
--- a/c/CLexer.g4
+++ b/c/CLexer.g4
@@ -203,7 +203,7 @@ Long
     : 'long'
     ;
 
-Nulptr
+Nullptr_
     : 'nullptr'
     ;
 

--- a/c/readme.md
+++ b/c/readme.md
@@ -3,6 +3,9 @@
 ## Introduction
 
 This is an ANTLR4 grammar for the C programming language, based on the ISO/IEC 9899:2024 specification (C23). The grammar is organized into two files: `CLexer.g4` for lexical analysis and `CParser.g4` for parsing. Parser rules are ordered to correspond with the sections in the ISO C specification.
+Note, the EBNF of the draft
+[N3320](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf) 2024-02-22, early C2y draft,
+differs only in rule numbering from the C23 Spec.
 
 ### Preprocessor Integration
 

--- a/c/readme.md
+++ b/c/readme.md
@@ -4,7 +4,7 @@
 
 This is an ANTLR4 grammar for the C programming language, based on the ISO/IEC 9899:2024 specification (C23). The grammar is organized into two files: `CLexer.g4` for lexical analysis and `CParser.g4` for parsing. Parser rules are ordered to correspond with the sections in the ISO C specification.
 Note, the EBNF of the draft
-[N3320](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf) 2024-02-22, early C2y draft,
+[N3220](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf) 2024-02-22, early C2y draft,
 differs only in rule numbering from the C23 Spec.
 
 ### Preprocessor Integration


### PR DESCRIPTION
* Change Nulptr to Nullptr_. This is the standard way to rename a symbol to avoid symbol conflict.
* Update readme.md with additional information on where to get the spec.