### PR TITLE
R - Fixed compiler error for RFilter.g4

### DIFF
--- a/r/Java/RFilter.g4
+++ b/r/Java/RFilter.g4
@@ -46,7 +46,7 @@ stream
     ;
 
 eat
-    : (NL {this.hideToken($NL)})+
+    : (NL {this.hideToken($NL);})+
     ;
 
 elem


### PR DESCRIPTION
When updating the R grammar I noticed that the RFilter.g4 does not compile due to a missing semicolon. This PR adds it.