### PR TITLE
[various grammars] Correct spellings (#4890)

### DIFF
--- a/_scripts/readme.md
+++ b/_scripts/readme.md
@@ -13,7 +13,7 @@ you want to test. You will also need to set the Antlr4 tool.
 
 Both scripts use trgen to generate a program from the pom.xml file
 in the grammar source. The tool generates a parser program for one of the target
-langauges, currently CSharp, Java, Cpp, Dart, Go, and Python. The generated
+languages, currently CSharp, Java, Cpp, Dart, Go, and Python. The generated
 code contains makefiles and Powershell files to present an idealized interface
 to build and run the parse with the examples, so you do not need to memorize how
 to build and run the parser for the given target.

--- a/ada/ada2012/readme.md
+++ b/ada/ada2012/readme.md
@@ -51,7 +51,7 @@ The parser base class implements the following command-line options:
 | `--output-symbol-table` | Output the symbol table to stderr after parsing completes. Shows all non-predefined symbols with their classification and source location. |
 | `--output-applied-occurrences` | Output applied occurrences (identifier references) to stderr as they are resolved. |
 
-## Peformance
+## Performance
 
 <img src="./times.svg">
 

--- a/asm/asm6502/README.md
+++ b/asm/asm6502/README.md
@@ -1,6 +1,6 @@
 # 6502 Grammar
 
-An ANTLR4 grammar for [6502 Assember](http://en.wikipedia.org/wiki/6502) files.
+An ANTLR4 grammar for [6502 Assembler](http://en.wikipedia.org/wiki/6502) files.
 
 You can download appropriate example files at [http://6502.org/](http://6502.org/).
 

--- a/c/readme.md
+++ b/c/readme.md
@@ -306,7 +306,7 @@ The following table maps the EBNF nonterminal names from the ISO C specification
 * [sqlite](https://github.com/sqlite/sqlite)
 * [writing-a-c-compiler-tests](https://github.com/nlsandler/writing-a-c-compiler-tests)
 
-## Peformance
+## Performance
 
 <img src="./times.svg">
 

--- a/dcm/README.md
+++ b/dcm/README.md
@@ -2,7 +2,7 @@
 
 An ANTLR4 grammar for DCM files.
 
-Ported to Antlr4 by Tom Everett from the Antlr3 Grammer by Donn Shull.
+Ported to Antlr4 by Tom Everett from the Antlr3 Grammar by Donn Shull.
 
 ## Reference
 

--- a/edn/README.md
+++ b/edn/README.md
@@ -37,7 +37,7 @@ library should endeavor to map the elements to programming language types with s
 
 # Spec
 
-Currently this specification is casual, as we gather feedback from implementors. A more rigorous
+Currently this specification is casual, as we gather feedback from implementers. A more rigorous
 e.g. BNF will follow.
 
 ## General considerations

--- a/erlang/README.md
+++ b/erlang/README.md
@@ -14,7 +14,7 @@ It is merely extracted from the [official non-standard grammar from Erlang/OTP s
 It is meant for students and people who work on Erlang's syntax.
 
 
-## Requierements
+## Requirements
 
 * Erlang's **erlc** for preprocessing purposes.
 

--- a/java/java9/readme.md
+++ b/java/java9/readme.md
@@ -2,7 +2,7 @@
 
 ## Source
 The source for the grammar is the
-[Java Langauage Specification, version 9](https://docs.oracle.com/javase/specs/jls/se9/html/index.html).
+[Java Language Specification, version 9](https://docs.oracle.com/javase/specs/jls/se9/html/index.html).
 Please note that this grammar is unoptimized: the runtimes for parses will
 be significantly slower than the [optimized Java grammar](https://github.com/antlr/grammars-v4/tree/master/java/java).
 

--- a/javascript/ecmascript/README.md
+++ b/javascript/ecmascript/README.md
@@ -11,7 +11,7 @@ files.
 
 The parser needs to read certain tokens from the `HIDDEN` channel
 for proper *semi colon insertion*. The following method signatures
-are therefor embedded inside `@parser::members`:
+are therefore embedded inside `@parser::members`:
 
 ```java
 /**

--- a/javascript/javascript/Cpp/README.md
+++ b/javascript/javascript/Cpp/README.md
@@ -18,6 +18,6 @@
     }
     ```
 
-* In both `JavaScriptLexer.g4` and `JavaScriptParser.g4`, replace all `this.` ocurrences with `this->`
+* In both `JavaScriptLexer.g4` and `JavaScriptParser.g4`, replace all `this.` occurrences with `this->`
 
 Or you can use `pitch.sed` to do convert.

--- a/javascript/javascript/README.md
+++ b/javascript/javascript/README.md
@@ -44,7 +44,7 @@ Grammar supports the following list of ECMAScript 6 features taken from
 * Map/Set& WeakMap/WeakSet
 * Meta-Programming
 * Modules
-* New Build-In Methods
+* New Built-In Methods
 * Promises
 * Scoping
 * Strict Functions
@@ -59,7 +59,7 @@ See [examples](examples) directory with test data files.
 
 * HashBang Comment
 * `**` and `**=`
-* Numeric Literal Seprator (`1_23`)
+* Numeric Literal Separator (`1_23`)
 * BigInt (`123456n`)
 * Async Await 
 * Async Iteration (`for await`)

--- a/javascript/typescript/Cpp/README.md
+++ b/javascript/typescript/Cpp/README.md
@@ -18,4 +18,4 @@
     }
     ```
 
-* In both `TypeScriptLexer.g4` and `TypeScriptParser.g4`, replace all `this.` ocurrences with `this->`
+* In both `TypeScriptLexer.g4` and `TypeScriptParser.g4`, replace all `this.` occurrences with `this->`

--- a/langium/readme.md
+++ b/langium/readme.md
@@ -18,7 +18,7 @@ the equivalent of a label is called a "property", which--surprisingly--is requir
 children of the tree node must be explicitly named.
 
 The regular expression
-rules are roughly equivalent to that for JavaScript, but I cannot guarentee that it is
+rules are roughly equivalent to that for JavaScript, but I cannot guarantee that it is
 completely correct. The use of the semantic predicate for RegexLiteral is to make sure
 comments are not lexed as regular expressions.
 

--- a/logo/ucb-logo/README.md
+++ b/logo/ucb-logo/README.md
@@ -33,7 +33,7 @@ print {1+2}
 ## Parser
 
 There are no strict delimiters that act as the end or procedure calls in Logo.
-The following two snippets are therefor valid Logo sources:
+The following two snippets are therefore valid Logo sources:
 
 ```
 print "a print "b
@@ -75,7 +75,7 @@ initial pass over the input collecting all user defined procedures and macros:
  * parse.
  *
  * @param input
- *         the inout stream containing the UCB Logo source
+ *         the input stream containing the UCB Logo source
  *         to parse.
  */
 public UCBLogoParser(ANTLRInputStream input) {

--- a/mumath/README.md
+++ b/mumath/README.md
@@ -2,7 +2,7 @@
 
 An ANTLR4 grammar for [MuMath](https://en.wikipedia.org/wiki/MuMATH) files.
 
-Ported to Antlr4 by Tom Everett from the Antlr3 Grammer by Dan Stanger.
+Ported to Antlr4 by Tom Everett from the Antlr3 Grammar by Dan Stanger.
 
 ## Reference
 * [pldb](http://pldb.info/concepts/mumath)

--- a/pddl/README.md
+++ b/pddl/README.md
@@ -2,7 +2,7 @@
 
 An ANTLR4 grammar for [PDDL](https://en.wikipedia.org/wiki/Planning_Domain_Definition_Language) files.
 
-Ported to Antlr4 by Tom Everett from the Antlr3 Grammer by Zeyn Saigol.
+Ported to Antlr4 by Tom Everett from the Antlr3 Grammar by Zeyn Saigol.
 
 ## Reference
 

--- a/peoplecode/README.md
+++ b/peoplecode/README.md
@@ -1,6 +1,6 @@
 # PeopleCode Grammar
 
-This grammer was developed for use by [the OpenPplSoft Runtime Project](http://openpplsoft.org).
+This grammar was developed for use by [the OpenPplSoft Runtime Project](http://openpplsoft.org).
 
 Example PeopleCode programs are included in the `examples/` subdirectory.
 Run `mvn clean test` at a bash prompt to test the grammar with these examples.

--- a/pf/README.md
+++ b/pf/README.md
@@ -2,4 +2,4 @@
 
 A simple ANTLR4 grammar for [pf](https://man.openbsd.org/pf.conf).  
 
-Grammer is not fully complete, but can parse simple pf.conf files.
+Grammar is not fully complete, but can parse simple pf.conf files.

--- a/php/Antlr4ng/PhpLexerBase.ts
+++ b/php/Antlr4ng/PhpLexerBase.ts
@@ -65,11 +65,13 @@ export default abstract class PhpLexerBase extends Lexer {
         else if (this.mode === PhpLexer.HereDoc) {
             // Heredoc and Nowdoc syntax support: http://php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
             if (token.type === PhpLexer.StartHereDoc || token.type === PhpLexer.StartNowDoc) {
-                this._heredocIdentifier = token.text.slice(3).trim().replace(/\'/, '').replace(/\'/, '');
+                if (token.text != null) {
+                    this._heredocIdentifier = token.text.slice(3).trim().replace(/\'/, '').replace(/\'/, '');
+                }
             }
 
             else if (token.type === PhpLexer.HereDocText) {
-                if (this.CheckHeredocEnd(token.text)) {
+                if (token.text != null && this.CheckHeredocEnd(token.text)) {
                     this.popMode()
                     const heredocIdentifier = this.GetHeredocIdentifier(token.text)
                     if (token.text.trim().endsWith(';')) {

--- a/php/Cpp/README.md
+++ b/php/Cpp/README.md
@@ -18,4 +18,4 @@
     }
     ```
 
-* In both `PhpLexer.g4` and `PhpParser.g4`, replace all `this.` ocurrences with `this->`
+* In both `PhpLexer.g4` and `PhpParser.g4`, replace all `this.` occurrences with `this->`

--- a/protobuf/protobuf3/readme.md
+++ b/protobuf/protobuf3/readme.md
@@ -1,4 +1,4 @@
-# Protocal Buffers (protobuf) Grammar, Version 3
+# Protocol Buffers (protobuf) Grammar, Version 3
 
 This is an Antlr4 grammar for protobuf. This grammar
 contains contains a symbol table to remove ambiguity
@@ -22,7 +22,7 @@ https://protobuf.dev/programming-guides/proto3/
 
 ## Notes
 Apparently, the Dart port for this grammar cannot be done. This is because the parser
-calls for file reading synchronously, whcih cannot be done.
+calls for file reading synchronously, which cannot be done.
 
 ## Reference
 * [pldb](http://pldb.info/concepts/protobuf)

--- a/python/python3_13/README.md
+++ b/python/python3_13/README.md
@@ -15,7 +15,7 @@
 - parser grammar update for Python 3.13.2
 - added ENCODING token
 - complete rewrite of fstring tokenizer in lexer grammar and PythonLexerBase class
-    - now correctly tokenizes the followings in fstring:
+    - now correctly tokenizes the following in fstring:
         - escape sequences
         - walrus operator
         - dictionary comprehension

--- a/rcs/README.md
+++ b/rcs/README.md
@@ -2,7 +2,7 @@
 
 An ANTLR4 grammar for RCS files.
 
-Ported to Antlr4 by Tom Everett from the Antlr3 Grammer by Lucas Bruand.
+Ported to Antlr4 by Tom Everett from the Antlr3 Grammar by Lucas Bruand.
 
 ## Reference
 * [pldb](http://pldb.info/concepts/rcs)

--- a/scala/scala3/readme.md
+++ b/scala/scala3/readme.md
@@ -5,7 +5,7 @@ EBNF adapted from https://docs.scala-lang.org/scala3/reference/syntax.html (read
 NB: https://scala-lang.org/files/archive/spec/3.4/13-syntax-summary.html seems incomplete (e.g., Import).
 So, I decided to not use that, but the "docs" version instead. Note, the "docs" grammar
 contains several problems with newlines, semicolons, and statements. I tried to mirror what
-the Dotty compiler does rather than assume blind allegience to a human-scraped EBNF.
+the Dotty compiler does rather than assume blind allegiance to a human-scraped EBNF.
 
 ## Options
 

--- a/sgf/README.md
+++ b/sgf/README.md
@@ -3,7 +3,7 @@ Sgf.g4
 This is an antlr4-grammar for the `Smart Game Format`
 which is also called `Smart Go Format`.
 
-Sgf is a context dependend format, which means a standard parser is
+Sgf is a context dependent format, which means a standard parser is
 of limited use. The format however is pretty simple and this parser
 gives a very good starting point.
 

--- a/sharc/README.md
+++ b/sharc/README.md
@@ -2,7 +2,7 @@
 
 An ANTLR4 grammar for [SHARC](https://en.wikipedia.org/wiki/Super_Harvard_Architecture_Single-Chip_Computer) files.
 
-Ported to Antlr4 by Tom Everett from the Antlr3 Grammer by topmint@gmail.com
+Ported to Antlr4 by Tom Everett from the Antlr3 Grammar by topmint@gmail.com
 
 ## Reference
 

--- a/smtlibv2/readme.md
+++ b/smtlibv2/readme.md
@@ -4,7 +4,7 @@
 Julian Thome <julian.thome.de@gmail.com>
 
 ## Description
-Grammar is baesd on the following specification: http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf.
+Grammar is based on the following specification: http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf.
 
 ## Reference
 * [pldb](http://pldb.info/concepts/smt)
@@ -16,7 +16,7 @@ Grammar is baesd on the following specification: http://smtlib.cs.uiowa.edu/pape
 
 ## Known Issues
 This grammar is ambiguous in rules
-`general_response`, `logic_attribue` (mispelled),
+`general_response`, `logic_attribue` (misspelled),
 `option`, `specific_success_response`, `start_`,
 and `theory_attribute`.
 

--- a/sql/trino/README.md
+++ b/sql/trino/README.md
@@ -3,10 +3,10 @@
 An ANTLR4 grammar for Trino, formerly known as PrestoSQL.
 This grammar is based on the actively maintained [Trino repository](https://github.com/trinodb/trino).
 
-The lexer and parser are referenced from the [offical base antlr file](https://github.com/trinodb/trino/blob/master/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4).
+The lexer and parser are referenced from the [official base antlr file](https://github.com/trinodb/trino/blob/master/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4).
 Changes are made to accommodate various language targets as the official one is being developed for Java only.
 
-The examples are extracted from the [offical test file](https://github.com/trinodb/trino/blob/master/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java).
+The examples are extracted from the [official test file](https://github.com/trinodb/trino/blob/master/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java).
 
 ## Reference
 

--- a/swift-fin/README.md
+++ b/swift-fin/README.md
@@ -2,7 +2,7 @@
 
 Grammar parses SWIFT FIN exchange messages between financial institutions.
 It is based on experience gained when working on core banking system.
-It is sufficient for current needs and therefor should be improved.
+It is sufficient for current needs and therefore should be improved.
 See links for structure description.
 
 ## Reference


### PR DESCRIPTION
Corrected several misspelled words.  Updated the grammar for PHP because the TypeScript compiler was updated.