### PR TITLE
Fixed errors in TypeScriptParser.g4

### DIFF
--- a/javascript/typescript/TypeScriptParser.g4
+++ b/javascript/typescript/TypeScriptParser.g4
@@ -345,6 +345,7 @@ sourceElement
 
 statement
     : block
+    | namespaceDeclaration //ADDED
     | variableStatement
     | importStatement
     | exportStatement
@@ -352,9 +353,7 @@ statement
     | abstractDeclaration //ADDED
     | classDeclaration
     | functionDeclaration
-    | expressionStatement
     | interfaceDeclaration //ADDED
-    | namespaceDeclaration //ADDED
     | ifStatement
     | iterationStatement
     | continueStatement
@@ -372,6 +371,7 @@ statement
     | typeAliasDeclaration //ADDED
     | enumDeclaration      //ADDED
     | Export statement
+    | expressionStatement
     ;
 
 block

--- a/javascript/typescript/examples/allTokensJPlag.ts
+++ b/javascript/typescript/examples/allTokensJPlag.ts
@@ -1,0 +1,70 @@
+import {test} from 'test';
+
+namespace Name {
+    enum Values {
+        val1 = 3,
+        val2
+    }
+}
+
+interface Inter {
+    value: number;
+}
+
+class Class {
+    private x;
+
+    constructor(x) {
+        this.x = x;
+    }
+
+    public test(y: number) {
+        return this.x + y;
+    }
+}
+
+let a = 3;
+const d = 4;
+
+function c() {
+    let b;
+    b = 8;
+    return a - b;
+}
+
+switch (c()) {
+    case 1:
+        break;
+    default:
+        console.log(c())
+}
+
+try {
+    throw "Error"
+} catch (e) {
+    console.log('Error', e);
+} finally {
+    console.log()
+}
+
+for (let i = 0; i < a; i++) {
+
+}
+
+while(a > 3) {
+    a--;
+    if (d > 5) {
+        continue;
+    }
+}
+
+export default Name;
+export { c };
+
+if (d) {
+
+} else if (d < 10) {
+
+} else {
+    
+}

--- a/javascript/typescript/examples/forLoops.ts
+++ b/javascript/typescript/examples/forLoops.ts
@@ -1,0 +1,13 @@
+const are = ["Test", "Test2"];
+
+for (let i = 0; i < are.length; i++) {
+    console.log(are[i])
+}
+
+for (const a in are) {
+    console.log(a)
+}
+
+for (const a of are) {
+    console.log(a)
+}

--- a/javascript/typescript/examples/methods.ts
+++ b/javascript/typescript/examples/methods.ts
@@ -1,0 +1,11 @@
+function add1(a: number, b: number) {
+    return a + b;
+}
+
+const add2 = function (a: number, b: number) {
+    return a + b;
+}
+
+const add3 = (a: number, b: number) => {
+    return a + b;
+}


### PR DESCRIPTION
Using the current version of the [typescript grammar](https://github.com/antlr/grammars-v4/tree/master/javascript/typescript) the AST generated for the test files found [here](https://github.com/jplag/JPlag/tree/main/languages/typescript/src/test/resources/de/jplag/typescript) seem to be wrong in some cases:

[forLoops.ts](https://github.com/jplag/JPlag/blob/main/languages/typescript/src/test/resources/de/jplag/typescript/forLoops.ts): The second and third for loops get turned into an expression rule instead of the iteration rule
[methods.ts](https://github.com/jplag/JPlag/blob/main/languages/typescript/src/test/resources/de/jplag/typescript/methods.ts): The second and third methods get turned into expression rules instead of function declarations
[allTokens.ts](https://github.com/jplag/JPlag/blob/main/languages/typescript/src/test/resources/de/jplag/typescript/allTokens.ts): The namespace gets turned into a variable declaration instead of a namespace declaration

I was able to fix those errors by changing the order of the rules. I'm not sure if the current order is perfect, but it seems to work for the test files. If someone knows more about this grammar I'd appreciate some feedback.