### PR TITLE
[Snowflake] allow EXISTS(subquery) as a boolean expr

### DIFF
--- a/sql/snowflake/SnowflakeParser.g4
+++ b/sql/snowflake/SnowflakeParser.g4
@@ -4364,6 +4364,7 @@ expr
     | expr OR expr  //bool operation
     | arr_literal
     //    | expr time_zone
+    | EXISTS LR_BRACKET subquery RR_BRACKET // EXISTS as a boolean expression (e.g. row access policy body)
     | expr over_clause
     | cast_expr
     | expr COLON_COLON data_type // Cast also

--- a/sql/snowflake/examples/row_access_policy.sql
+++ b/sql/snowflake/examples/row_access_policy.sql
@@ -1,0 +1,33 @@
+--SQL test for ROW ACCESS policy related
+CREATE OR REPLACE ROW ACCESS POLICY rap_simple
+    AS (code_organisation VARCHAR) RETURNS BOOLEAN ->
+    CURRENT_ROLE() = 'ADMIN';
+
+-- body wrapped in CASE (already worked)
+CREATE ROW ACCESS POLICY IF NOT EXISTS rap_case
+    AS (code_organisation VARCHAR) RETURNS BOOLEAN ->
+    CASE
+        WHEN CURRENT_ROLE() = 'ADMIN' THEN TRUE
+        ELSE FALSE
+    END;
+
+-- EXISTS(subquery) as the bare policy body (the case this PR fixes)
+CREATE ROW ACCESS POLICY rap_exists
+    AS (code_organisation VARCHAR) RETURNS BOOLEAN ->
+    EXISTS (
+        SELECT 1
+        FROM mapping_table AS m
+        WHERE m.user_code = LEFT(CURRENT_USER(), 6)
+          AND m.code_organisation = code_organisation
+    );
+
+-- EXISTS combined with other boolean operators
+CREATE ROW ACCESS POLICY rap_exists_combined
+    AS (val VARCHAR) RETURNS BOOLEAN ->
+    CURRENT_ROLE() = 'ADMIN'
+    OR EXISTS (SELECT 1 FROM allowlist WHERE allowlist.val = val);
+
+-- NOT EXISTS as a boolean expression
+CREATE ROW ACCESS POLICY rap_not_exists
+    AS (val VARCHAR) RETURNS BOOLEAN ->
+    NOT EXISTS (SELECT 1 FROM blocklist WHERE blocklist.val = val);


### PR DESCRIPTION
create_row_access_policy (and masking policy bodies) use `expr` after `RETURNS BOOLEAN ->`. A bare `EXISTS (SELECT ...)` body fails to parse because EXISTS is only reachable via predicate/search_condition, not from `expr`. This is valid Snowflake: EXISTS(...) is a boolean expression usable anywhere. Add the alternative to `expr` and a row_access_policy.sql example covering the bare-EXISTS, CASE-wrapped, and combined-operator forms.