### PR TITLE
[PlSql] Improved SqlPlus `start_cmd` rule

### DIFF
--- a/sql/plsql/PlSqlLexer.g4
+++ b/sql/plsql/PlSqlLexer.g4
@@ -1753,7 +1753,7 @@ SQLDATA                        : 'SQLDATA';
 SQLERROR                       : 'SQLERROR';
 SQLLDR                         : 'SQLLDR';
 SQL                            : 'SQL';
-FILE_EXT                       : 'PKB' | 'PKS';
+FILE_EXT                       : 'FNC' | 'PKB' | 'PKS' | 'PRC' | 'TRG' | 'VW';
 SQL_MACRO                      : 'SQL_MACRO';
 SQL_TRACE                      : 'SQL_TRACE';
 SQL_TRANSLATION_PROFILE        : 'SQL_TRANSLATION_PROFILE';
@@ -2554,6 +2554,7 @@ PLUS_SIGN       : '+';
 MINUS_SIGN      : '-';
 COMMA           : ',';
 SOLIDUS         : '/';
+RSOLIDUS        : '\\';
 AT_SIGN         : '@';
 ASSIGN_OP       : ':=';
 HASH_OP         : '#';
@@ -2598,11 +2599,6 @@ REMARK_COMMENT:
 
 // https://docs.oracle.com/cd/E11882_01/server.112/e16604/ch_twelve032.htm#SQPUG052
 PROMPT_MESSAGE: 'PRO' {this.IsNewlineAtPos(-4)}? 'MPT'? (' ' ~('\r' | '\n')*)? NEWLINE_EOF;
-
-// TODO: should starts with newline
-START_CMD: // https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12002.htm
-    '@' '@'?
-; // https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12003.htm
 
 REGULAR_ID: SIMPLE_LETTER (SIMPLE_LETTER | '$' | '_' | '#' | [0-9])*;
 

--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -7205,7 +7205,13 @@ sql_plus_command
     ;
 
 start_command
-    : START_CMD id_expression PERIOD (SQL | FILE_EXT)
+    : (START | AT_SIGN AT_SIGN?) sql_plus_filepath
+    ;
+
+sql_plus_filepath
+    : (id_expression COLON)? (SOLIDUS | RSOLIDUS)? (
+        id_expression (SOLIDUS | RSOLIDUS)
+    )* id_expression PERIOD (SQL | FILE_EXT)
     ;
 
 whenever_command

--- a/sql/plsql/examples/examples-sql-script/green_run.sql
+++ b/sql/plsql/examples/examples-sql-script/green_run.sql
@@ -4,3 +4,8 @@
 @@green_tools.pkb;
 
 @@green_tools_review.sql;
+
+@my_procedure.prc
+@my_directory/my_trigger.trg
+@/from_root/my_trigger.trg
+@V:\my_directory\my_function.fnc


### PR DESCRIPTION
I updated the `start_cmd` rule to recognize more valid SqlPlus commands (see added examples).

Here is a summary of the changes :
- Added missing file extensions to `FILE_EXT` lexical unit;
- Fixed support for single "@" by replacing the `START_CMD` lexical unit by explicit `AT_SIGN` calls in parser;
- Added support for file paths (Unix and Windows styles) by introducing the `sql_plus_filepath` rule and `RSOLIDUS` lexical token.