### PR TITLE
Add MAML

### DIFF
--- a/maml/MAML.g4
+++ b/maml/MAML.g4
@@ -1,0 +1,141 @@
+/*
+ MAML - Minimal Abstract Markup Language.
+
+ "JSON with comments, unquoted keys, optional commas, and multiline strings."
+
+ Derived from the MAML v0.1 specification: https://maml.dev/spec/v0.1
+ See also https://maml.dev/ and ../json5/JSON5.g4 for prior art.
+
+ Note on separators: per the spec, members and items are separated by a comma
+ OR a newline (separator = "," / newline). A comma is "optional" only in the
+ sense that a newline may stand in for it - two values on the SAME line with
+ only spaces between them are NOT valid. Newlines are therefore significant
+ tokens here, not skipped whitespace.
+ */
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+grammar MAML;
+
+// maml = ws-comment-newline value ws-comment-newline
+maml
+    : NL* value NL* EOF
+    ;
+
+value
+    : object
+    | array
+    | STRING
+    | RAW_STRING
+    | NUMBER
+    | TRUE
+    | FALSE
+    | NULL
+    ;
+
+// object = "{" [ members ] ws-comment-newline "}"
+object
+    : '{' NL* (member (separator member)* separator?)? '}'
+    ;
+
+// key-value = key ws-comment-newline ":" ws-comment-newline value
+member
+    : key NL* ':' NL* value
+    ;
+
+key
+    : IDENTIFIER
+    | STRING
+    | NUMBER // digits-only keys are allowed (interpreted as strings)
+    | TRUE
+    | FALSE
+    | NULL
+    ;
+
+// array = "[" [ items ] ws-comment-newline "]"
+array
+    : '[' NL* (value (separator value)* separator?)? ']'
+    ;
+
+// separator = "," / newline. A comma may be followed by further newlines
+// (insignificant filler), but a newline-separator may not be followed by a
+// comma, and two commas in a row are not allowed.
+separator
+    : ',' NL*
+    | NL+
+    ;
+
+// Lexer
+
+TRUE
+    : 'true'
+    ;
+
+FALSE
+    : 'false'
+    ;
+
+NULL
+    : 'null'
+    ;
+
+// A hash marks the rest of the line as a comment, except inside a string. The
+// terminating newline is left for NL so it can still act as a separator.
+COMMENT
+    : '#' ~[\r\n]* -> skip
+    ;
+
+// Raw strings are bounded by """ and preserve their contents literally. Listed
+// before STRING so the """ delimiter is never read as an empty "" plus a quote.
+// At least one character is required: empty single-line raw strings are not
+// supported by the spec (use "" instead).
+RAW_STRING
+    : '"""' . .*? '"""'
+    ;
+
+STRING
+    : '"' CHAR* '"'
+    ;
+
+// Any char but ", backslash, or a control char; tab is allowed.
+fragment CHAR
+    : ESCAPE
+    | ~["\\\u0000-\u0008\u000A-\u001F]
+    ;
+
+fragment ESCAPE
+    : '\\' (["\\tnr] | 'u{' HEX HEX? HEX? HEX? HEX? HEX? '}')
+    ;
+
+NUMBER
+    : '-'? INT ('.' [0-9]+)? EXP?
+    ;
+
+fragment INT
+    : '0'
+    | [1-9] [0-9]*
+    ;
+
+fragment EXP
+    : [eE] [+-]? [0-9]+
+    ;
+
+fragment HEX
+    : [0-9a-fA-F]
+    ;
+
+// Identifier keys contain only A-Z, a-z, 0-9, _ and -.
+IDENTIFIER
+    : [A-Za-z0-9_-]+
+    ;
+
+// Newline (LF or CRLF) is significant: it separates members and items.
+NL
+    : ('\r'? '\n')+
+    ;
+
+// Spaces and tabs are insignificant.
+WS
+    : [ \t]+ -> skip
+    ;

--- a/maml/MAML.g4
+++ b/maml/MAML.g4
@@ -83,7 +83,7 @@ NULL
 // A hash marks the rest of the line as a comment, except inside a string. The
 // terminating newline is left for NL so it can still act as a separator.
 COMMENT
-    : '#' ~[\r\n]* -> skip
+    : '#' ~[\r\n]* -> channel(HIDDEN)
     ;
 
 // Raw strings are bounded by """ and preserve their contents literally. Listed
@@ -137,5 +137,5 @@ NL
 
 // Spaces and tabs are insignificant.
 WS
-    : [ \t]+ -> skip
+    : [ \t]+ -> channel(HIDDEN)
     ;

--- a/maml/desc.xml
+++ b/maml/desc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
+   <antlr-version>^4.7</antlr-version>
+   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
+</desc>

--- a/maml/desc.xml
+++ b/maml/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
    <antlr-version>^4.7</antlr-version>
-   <targets>CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript;Antlr4ng</targets>
+   <targets>Antlr4ng;CSharp;Cpp;Dart;Go;Java;JavaScript;PHP;Python3;Rust;TypeScript</targets>
 </desc>

--- a/maml/examples/basic.maml
+++ b/maml/examples/basic.maml
@@ -1,0 +1,13 @@
+# A basic MAML document
+{
+  project: "MAML"
+  tags: ["minimal", "readable"]  # comma-separated
+  langs: [                       # or newline-separated, no commas
+    "json"
+    "maml"
+  ]
+  count: 42
+  enabled: true
+  disabled: false
+  nothing: null
+}

--- a/maml/examples/nested.maml
+++ b/maml/examples/nested.maml
@@ -1,0 +1,14 @@
+{
+  items: [
+    { name: "Item1", value: 1 },
+    { name: "Item2", value: 2 },
+  ]
+  server: {
+    host: "localhost"
+    port: 8080
+    ratios: [0.5, 1.5e3, -2, -3.14, 0]
+  }
+  "quoted key": "value"
+  42: "digit-only key"
+  kebab-case_key: true
+}

--- a/maml/examples/scalar.maml
+++ b/maml/examples/scalar.maml
@@ -1,0 +1,2 @@
+# Top-level value need not be an object
+[1, 2, 3]

--- a/maml/examples/strings.maml
+++ b/maml/examples/strings.maml
@@ -1,0 +1,10 @@
+{
+  escaped: "line1\nline2\ttabbed \"quoted\" back\\slash"
+  unicode: "snowman \u{2603} and emoji \u{1F600}"
+  notes: """
+This preserves
+formatting "as-is" and even ""double quotes""
+"""
+  oneline: """raw single line"""
+  inline: "value"  # inline comment after a value
+}

--- a/maml/pom.xml
+++ b/maml/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>maml</artifactId>
+	<packaging>jar</packaging>
+	<name>ANTLR MAML grammar</name>
+	<parent>
+		<groupId>org.antlr.grammars</groupId>
+		<artifactId>grammarsv4</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr.version}</version>
+				<configuration>
+					<sourceDirectory>${basedir}</sourceDirectory>
+					<includes>
+					   <include>MAML.g4</include>
+					</includes>
+					<visitor>true</visitor>
+					<listener>true</listener>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.khubla.antlr</groupId>
+				<artifactId>antlr4test-maven-plugin</artifactId>
+				<version>${antlr4test-maven-plugin.version}</version>
+				<configuration>
+					<verbose>false</verbose>
+					<showTree>false</showTree>
+					<entryPoint>maml</entryPoint>
+					<grammarName>MAML</grammarName>
+					<packageName></packageName>
+					<exampleFiles>examples/</exampleFiles>
+					<testFileExtension>.maml</testFileExtension>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maml/readme.md
+++ b/maml/readme.md
@@ -1,0 +1,9 @@
+# MAML
+
+MAML — Minimal Abstract Markup Language. "JSON with comments, unquoted keys,
+optional commas, and multiline strings."
+
+## Reference
+
+* [maml.dev](https://maml.dev/)
+* [Specification v0.1](https://maml.dev/spec/v0.1)

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,7 @@
 				<module>ltl</module>
 				<module>lua</module>
 				<module>lucene</module>
+				<module>maml</module>
 				<module>matlab</module>
 				<module>mckeeman-form</module>
 				<module>mdx</module>


### PR DESCRIPTION
Hi! This adds a grammar for [MAML](https://maml.dev), which is basically JSON
with comments, unquoted keys, optional commas, and multiline strings.

One thing worth knowing: newlines are significant, so a comma or a newline
separates items. I kept newlines as real tokens for that reason.

Tested with ANTLR 4.13.2 and the examples all parse cleanly. Thanks!