### PR TITLE
Standardize readme.md titles across all grammars

### DIFF
--- a/_scripts/templates/Python3/st.build.ps1
+++ b/_scripts/templates/Python3/st.build.ps1
@@ -20,7 +20,7 @@ $JAR = (Get-ChildItem "$ANTLR4_DEV_DIR/tool/target/antlr4-*-complete.jar" | Sele
 $version = (Select-String -Path "requirements.txt" -Pattern "antlr4" | ForEach-Object {$_.Line.Split("=")[2]}) -replace '"|,|\r|\n'
 <endif>
 
-python3 -m venv .venv
+python3 -m venv --copies .venv
 <if(test.IsWindows)>.venv\Scripts\Activate.ps1<else>.venv/bin/Activate.ps1<endif>
 <if(test.IsWindows)>.venv\Scripts\pip<else>.venv/bin/pip<endif> install -r requirements.txt
 

--- a/_scripts/templates/Python3/st.build.sh
+++ b/_scripts/templates/Python3/st.build.sh
@@ -14,7 +14,7 @@ JAR=$(ls "$ANTLR4_DEV_DIR"/tool/target/antlr4-*-complete.jar | tail -1)
 version=`grep antlr4-python3-runtime requirements.txt | awk -F= '{print $3}' | tr -d '\r' | tr -d '\n'`
 <endif>
 
-python3 -m venv .venv
+python3 -m venv --copies .venv
 source .venv/bin/activate
 
 <if(antlrng_tool)>

--- a/abb/readme.md
+++ b/abb/readme.md
@@ -1,4 +1,4 @@
-# ABB RAPID grammar
+# ABB RAPID Grammar
 
 ## Authors
 

--- a/abnf/readme.md
+++ b/abnf/readme.md
@@ -1,4 +1,4 @@
-# ABNF (BSD License) grammar
+# ABNF Grammar
 
 ## Authors
 

--- a/ada/ada2005/readme.md
+++ b/ada/ada2005/readme.md
@@ -1,4 +1,4 @@
-Ada 2005 ANTLR Grammar
+# Ada 2005 Grammar
 
 https://www.adaic.org/resources/add_content/standards/05rm/html/RM-TOC.html
 

--- a/ada/ada2012/readme.md
+++ b/ada/ada2012/readme.md
@@ -1,4 +1,4 @@
-# Ada 2012 ANTLR Grammar
+# Ada 2012 Grammar
 
 This is an ANTLR4 grammar for the Ada 2012 programming language,
 based on the [Ada Reference Manual](http://www.ada-auth.org/standards/12rm/html/RM-TOC.html).

--- a/ada/ada2022/readme.md
+++ b/ada/ada2022/readme.md
@@ -1,4 +1,4 @@
-# Ada 2022 ANTLR Grammar
+# Ada 2022 Grammar
 
 This is an ANTLR4 grammar for the Ada 2022 programming language,
 based on the [Ada 2022 Reference Manual](http://www.ada-auth.org/standards/ada22.html).

--- a/ada/ada83/readme.md
+++ b/ada/ada83/readme.md
@@ -1,4 +1,4 @@
-Ada 83 ANTLR Grammar
+# Ada 83 Grammar
 
 http://archive.adaic.com/standards/83lrm/html/ada_lrm.html#Top
 

--- a/ada/ada95/readme.md
+++ b/ada/ada95/readme.md
@@ -1,4 +1,4 @@
-Ada 2012 ANTLR Grammar
+# Ada 95 Grammar
 
 http://www.ada-auth.org/standards/12rm/html/RM-TOC.html
 

--- a/amazon-states-language-intrinsic-functions/README.md
+++ b/amazon-states-language-intrinsic-functions/README.md
@@ -1,4 +1,4 @@
-# Amazon States Language Intrinsic Functions ANTLR4 Grammar
+# Amazon States Language Intrinsic Functions Grammar
 
 The ANTLR4 grammar for the Intrinsic Functions of Amazon States Language (ASL), initially developed by 
 [LocalStack](github.com/localstack/localstack).

--- a/amazon-states-language/README.md
+++ b/amazon-states-language/README.md
@@ -1,4 +1,4 @@
-# Amazon States Language (ASL) ANTLR4 Grammar
+# Amazon States Language Grammar
 
 The ANTLR4 grammar for the Amazon States Language (ASL), initially developed by 
 [LocalStack](github.com/localstack/localstack).

--- a/antlr/antlr2/readme.md
+++ b/antlr/antlr2/readme.md
@@ -1,4 +1,4 @@
-# Antlr2
+# ANTLR2 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/antlr)

--- a/antlr/antlr3/readme.md
+++ b/antlr/antlr3/readme.md
@@ -1,4 +1,4 @@
-# Antlr3
+# ANTLR3 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/antlr)

--- a/apex/readme.md
+++ b/apex/readme.md
@@ -1,4 +1,4 @@
-# Apex
+# Apex Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/apex)

--- a/apt/readme.md
+++ b/apt/readme.md
@@ -1,4 +1,4 @@
-# Apt
+# APT Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/apt)

--- a/aql/README.md
+++ b/aql/README.md
@@ -1,4 +1,4 @@
-# ANTLR4 grammar for ArangoDB Query Language (AQL)
+# ArangoDB Query Language (AQL) Grammar
 
 https://www.arangodb.com/docs/stable/aql/index.html
 

--- a/asn/asn/readme.md
+++ b/asn/asn/readme.md
@@ -1,4 +1,4 @@
-# Asn
+# ASN.1 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/asn-1)

--- a/asn/asn_3gpp/readme.md
+++ b/asn/asn_3gpp/readme.md
@@ -1,4 +1,4 @@
-# Asn 3Gpp
+# ASN.1 3GPP Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/asn-1)

--- a/atl/readme.md
+++ b/atl/readme.md
@@ -1,4 +1,4 @@
-# Atl
+# ATL Grammar
 
 ## Reference
 

--- a/bencoding/readme.md
+++ b/bencoding/readme.md
@@ -1,4 +1,4 @@
-# Bencoding
+# Bencoding Grammar
 
 ## Reference
 

--- a/capnproto/README.md
+++ b/capnproto/README.md
@@ -1,3 +1,5 @@
+# Cap'n Proto Schema Language
+
 ANTLR v4 grammar for the Cap'n Proto schema language: https://capnproto.org/language.html
 
 ## Reference

--- a/clif/readme.md
+++ b/clif/readme.md
@@ -1,4 +1,4 @@
-# Clif
+# CLIF Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/common-logic)

--- a/clojure/readme.md
+++ b/clojure/readme.md
@@ -1,4 +1,4 @@
-# Clojure
+# Clojure Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/clojure)

--- a/cmake/readme.md
+++ b/cmake/readme.md
@@ -1,4 +1,4 @@
-# Cmake
+# CMake Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/cmake)

--- a/cobol85/readme.md
+++ b/cobol85/readme.md
@@ -1,4 +1,4 @@
-# Cobol85
+# COBOL 85 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/cobol)

--- a/cookie/readme.md
+++ b/cookie/readme.md
@@ -1,4 +1,4 @@
-# Cookie
+# Cookie Grammar
 
 ## Reference
 

--- a/cql3/readme.md
+++ b/cql3/readme.md
@@ -1,4 +1,4 @@
-# Cql3
+# CQL3 Grammar
 
 ## Reference
 

--- a/creole/readme.md
+++ b/creole/readme.md
@@ -1,4 +1,4 @@
-# Creole
+# Creole Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/creole)

--- a/csharp/v6/README.md
+++ b/csharp/v6/README.md
@@ -1,4 +1,4 @@
-## Summary
+# C# Version 6 Grammar
 
 C# grammar with full support of
 [C# 6 features](https://github.com/dotnet/roslyn/wiki/New-Language-Features-in-C%23-6) and below.

--- a/csharp/v7/README.md
+++ b/csharp/v7/README.md
@@ -1,4 +1,4 @@
-## Summary
+# C# Version 7 Grammar
 
 C# grammar targeting ECMA-334 7th edition (December 2023), with full support of C# 7.x features and below.
 This grammar is based on the v6 grammar and adds C# 7 additions: expression-bodied constructors/destructors/accessors,

--- a/csharp/v8-spec/readme.md
+++ b/csharp/v8-spec/readme.md
@@ -1,4 +1,4 @@
-# Antlr4 grammar for C# version 8
+# C# Version 8 Grammar
 
 ## Summary
 

--- a/css3/readme.md
+++ b/css3/readme.md
@@ -1,4 +1,4 @@
-# Css3
+# CSS3 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/css)

--- a/csv/readme.md
+++ b/csv/readme.md
@@ -1,4 +1,4 @@
-# Csv
+# CSV Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/csv)

--- a/dot/readme.md
+++ b/dot/readme.md
@@ -1,4 +1,4 @@
-# Dot
+# Dot Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/dot)

--- a/edn/README.md
+++ b/edn/README.md
@@ -1,9 +1,6 @@
-edn
-===
+# Extensible Data Notation [eed-n]
 
-extensible data notation [eed-n]
-
-# Rationale
+## Rationale
 
 **edn** is an extensible data notation. A superset of **edn** is used by Clojure to represent
 programs, and it is used by Datomic and other applications as a data transfer format. This spec
@@ -35,7 +32,7 @@ most programming languages. While **edn** specifies how those elements are forma
 does not dictate the representation that results on the consumer side. A well behaved reader
 library should endeavor to map the elements to programming language types with similar semantics.
 
-# Spec
+## Spec
 
 Currently this specification is casual, as we gather feedback from implementers. A more rigorous
 e.g. BNF will follow.

--- a/esolang/whenever/README.md
+++ b/esolang/whenever/README.md
@@ -1,4 +1,4 @@
-# whenever grammar
+# Whenever Grammar
 
 [whenever](https://www.dangermouse.net/esoteric/whenever.html)
 

--- a/evm-bytecode/README.md
+++ b/evm-bytecode/README.md
@@ -1,4 +1,4 @@
-# EVM Bytecode ANTLR 4 grammar
+# EVM Bytecode Grammar
 
 This grammar is based on official EVM bytecode reference (available [here](https://www.ethervm.io/)).
 The entry rule of the grammar is `program`.

--- a/flatbuffers/README.md
+++ b/flatbuffers/README.md
@@ -1,3 +1,5 @@
+# FlatBuffers Schema Language
+
 ANTLR v4 grammar for the FlatBuffers schema language: https://google.github.io/flatbuffers/flatbuffers_grammar.html
 
 ## Reference

--- a/fusion-tables/README.md
+++ b/fusion-tables/README.md
@@ -1,4 +1,4 @@
-# Google Fusion Tables Sql
+# Google Fusion Tables Grammar
 
 Parses Google fusion tables sql as defined in the
 [Row and Query SQL Reference](https://developers.google.com/fusiontables/docs/v2/sql-reference)

--- a/gdscript/README.md
+++ b/gdscript/README.md
@@ -1,4 +1,4 @@
-# Godot GDScript ANTLR 4 grammar
+# Godot GDScript Grammar
 
 [Official EBNF grammar](https://docs.godotengine.org/en/stable/engine_details/file_formats/gdscript_grammar.html#doc-gdscript-grammar)
 

--- a/gdscript/README.md
+++ b/gdscript/README.md
@@ -1,6 +1,6 @@
 # Godot GDScript Grammar
 
-[Official EBNF grammar](https://docs.godotengine.org/en/stable/engine_details/file_formats/gdscript_grammar.html#doc-gdscript-grammar)
+[Official EBNF grammar](https://web.archive.org/web/20260201112337/https://docs.godotengine.org/en/stable/engine_details/file_formats/gdscript_grammar.html#doc-gdscript-grammar#doc-gdscript-grammar)
 
 [Parser source code](https://github.com/godotengine/godot/tree/master/modules/gdscript)
 

--- a/gql/README.md
+++ b/gql/README.md
@@ -1,4 +1,4 @@
-# Database languages — GQL
+# GQL Grammar
 
 ## Description
 GQL is a database query language that allows users to interact with databases in a structured and efficient manner. It is designed to be intuitive and easy to use, while also providing powerful features for complex queries and data manipulation. GQL supports a wide range of database systems and is compatible with various data formats, making it a versatile tool for developers and data analysts alike.

--- a/graphql/readme.md
+++ b/graphql/readme.md
@@ -1,4 +1,4 @@
-# Graphql
+# GraphQL Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/graphql)

--- a/graphstream-dgs/readme.md
+++ b/graphstream-dgs/readme.md
@@ -1,4 +1,4 @@
-# Graphstream Dgs
+# GraphStream DGS Grammar
 
 ## Reference
 

--- a/gvpr/readme.md
+++ b/gvpr/readme.md
@@ -1,4 +1,4 @@
-# gvpr grammar
+# GVPR Grammar
 
 Graphviz "gvpr" is a graph scanning and processing language.
 

--- a/haskell/readme.md
+++ b/haskell/readme.md
@@ -1,4 +1,4 @@
-# Haskell
+# Haskell Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/haskell)

--- a/icalendar/readme.md
+++ b/icalendar/readme.md
@@ -1,4 +1,4 @@
-# Icalendar
+# iCalendar Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/icalendar-format)

--- a/icon/readme.md
+++ b/icon/readme.md
@@ -1,4 +1,4 @@
-# Icon
+# Icon Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/icon)

--- a/idl/readme.md
+++ b/idl/readme.md
@@ -1,4 +1,4 @@
-# Idl
+# IDL Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/idl)

--- a/informix/readme.md
+++ b/informix/readme.md
@@ -1,4 +1,4 @@
-# Informix
+# Informix Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/informix)

--- a/iri/readme.md
+++ b/iri/readme.md
@@ -1,4 +1,4 @@
-# Iri
+# IRI Grammar
 
 ## Reference
 

--- a/iso8601/README.md
+++ b/iso8601/README.md
@@ -1,4 +1,4 @@
-# ISO 8601 Grammar for ANTLR 4
+# ISO 8601 Grammar
 
 ISO 8601 grammar with date, time, duration, recurring support.
 

--- a/java/java8/readme.md
+++ b/java/java8/readme.md
@@ -1,4 +1,4 @@
-# Java8
+# Java8 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/java)

--- a/javascript/ecmascript/README.md
+++ b/javascript/ecmascript/README.md
@@ -1,4 +1,4 @@
-# ECMAScript.g4
+# ECMAScript Grammar
 
 An ANTLR4 grammar for ECMAScript based on the
 [Standard ECMA-262 5.1 Edition from June 2011](http://www.ecma-international.org/ecma-262/5.1).

--- a/javascript/jsx/JavaScriptLexer.g4
+++ b/javascript/jsx/JavaScriptLexer.g4
@@ -228,7 +228,7 @@ TemplateStringAtom            : ~[`];
 
 // Lexer mode for JSX opening elements.
 // See https://github.com/facebook/jsx?tab=readme-ov-file
-// and https://facebook.github.io/jsx/ for more information
+// and https://react.github.io/jsx/ for more information
 //
 // e.g. <DropDownMenu...>
 //      <DropDownMenu.../>

--- a/javascript/jsx/readme.md
+++ b/javascript/jsx/readme.md
@@ -1,4 +1,4 @@
-# Jsx
+# JSX Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/jsx)

--- a/json/readme.md
+++ b/json/readme.md
@@ -1,4 +1,4 @@
-# Json
+# JSON Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/json)

--- a/json5/readme.md
+++ b/json5/readme.md
@@ -1,4 +1,4 @@
-# Json5
+# JSON5 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/json5)

--- a/kirikiri-tjs/README.md
+++ b/kirikiri-tjs/README.md
@@ -1,4 +1,4 @@
-# Kirikiri TJS2 ANTLR4 grammar
+# Kirikiri TJS2 Grammar
 
 Kirikiri TJS2 is a Javascript-like script language for Kirikiri2 game engine.
 

--- a/kotlin/kotlin-formal/KotlinLexer.g4
+++ b/kotlin/kotlin-formal/KotlinLexer.g4
@@ -7,7 +7,8 @@
  * kotlinlang.org/docs/reference/grammar.html
  *
  * Tested on
- * https://github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+ * github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+ * (stale link)
  */
 
 // $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false

--- a/kotlin/kotlin-formal/KotlinParser.g4
+++ b/kotlin/kotlin-formal/KotlinParser.g4
@@ -7,7 +7,8 @@
  * kotlinlang.org/docs/reference/grammar.html
  *
  * Tested on
- * https://github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+ * github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+ * (stale link)
  */
 
 // $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false

--- a/kotlin/kotlin-formal/README.md
+++ b/kotlin/kotlin-formal/README.md
@@ -11,7 +11,9 @@ ANTLR4 grammar for Kotlin written only in ANTLR's special syntax.
 Licensed under the Apache 2.0
 
 ## Testing
-Test.kt includes the test data from the [JetBrains's repository](https://github.com/JetBrains/kotlin/tree/master/compiler/testData/psi).
+Test.kt includes the test data from the JetBrains's repository
+github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+(stale link).
 
 ## Contacts
 Anastasiya Shadrina a.shadrina5@mail.ru

--- a/kotlin/kotlin-formal/README.md
+++ b/kotlin/kotlin-formal/README.md
@@ -1,4 +1,4 @@
-# Kotlin ANTLR4 grammar
+# Kotlin Formal Grammar
 
 ANTLR4 grammar for Kotlin written only in ANTLR's special syntax.
 

--- a/kotlin/kotlin/KotlinLexer.g4
+++ b/kotlin/kotlin/KotlinLexer.g4
@@ -7,7 +7,8 @@
  * kotlinlang.org/docs/reference/grammar.html
  *
  * Tested on
- * https://github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+ * github.com/JetBrains/kotlin/tree/master/compiler/testData/psi\
+ * (stale link)
  */
 
 // $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false

--- a/kotlin/kotlin/KotlinParser.g4
+++ b/kotlin/kotlin/KotlinParser.g4
@@ -7,7 +7,8 @@
  * kotlinlang.org/docs/reference/grammar.html
  *
  * Tested on
- * https://github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+ * github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
+ * (stale link)
  */
 
 // $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false

--- a/kotlin/kotlin/README.md
+++ b/kotlin/kotlin/README.md
@@ -1,4 +1,4 @@
-# Kotlin ANTLR4 grammar
+# Kotlin Grammar
 
 ANTLR4 grammar for Kotlin written only in ANTLR's special syntax.
 

--- a/kotlin/kotlin/README.md
+++ b/kotlin/kotlin/README.md
@@ -11,7 +11,8 @@ ANTLR4 grammar for Kotlin written only in ANTLR's special syntax.
 Licensed under the Apache 2.0
 
 ## Testing
-Test.kt includes the test data from the [JetBrains's repository](https://github.com/JetBrains/kotlin/tree/master/compiler/testData/psi).
+Test.kt includes the test data from the JetBrains's repository
+github.com/JetBrains/kotlin/tree/master/compiler/testData/psi
 
 ## Contacts
 Anastasiya Shadrina a.shadrina5@mail.ru

--- a/kquery/README.md
+++ b/kquery/README.md
@@ -1,4 +1,4 @@
-## KLEE KQuery Grammar
+# KLEE KQuery Grammar
 
 ANTLRv4 Grammar file for KLEE KQuery expressions.
 

--- a/lpc/readme.md
+++ b/lpc/readme.md
@@ -1,4 +1,4 @@
-# Lpc
+# LPC Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/lpc)

--- a/lucene/readme.md
+++ b/lucene/readme.md
@@ -1,4 +1,4 @@
-# Lucene
+# Lucene Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/lucene-query-syntax)

--- a/maml/readme.md
+++ b/maml/readme.md
@@ -1,4 +1,4 @@
-# MAML
+# MAML Grammar
 
 MAML — Minimal Abstract Markup Language. "JSON with comments, unquoted keys,
 optional commas, and multiline strings."

--- a/objc/README.md
+++ b/objc/README.md
@@ -1,4 +1,4 @@
-# Summary
+# Objective-C Grammar
 
 Objective-C 2.0 grammars with preprocessor support can be used in 2 different modes:
 

--- a/ocl/README.md
+++ b/ocl/README.md
@@ -1,4 +1,4 @@
-# OCL Antlr Grammar
+# OCL Grammar
 
 This repository provides grammars for the Object Constraint Language (OCL) 2.4, along with its integration with UML-RSDS, a tool supporting UML 2.5 class diagram notation and OCL 2.4. These grammars aim to enhance the precision and usability of OCL while making it easier to integrate with UML modeling tools.
 

--- a/parkingsign/README.md
+++ b/parkingsign/README.md
@@ -1,4 +1,4 @@
-# parking-signs
+# Parking Signs Grammar
 Los Angeles parking sign images and grammar to parse them.  Use ANTLR to generate a parser from the grammar file (.g4).
 
 TestExamples.txt has the text recognition output for a set of example signs that can be read by the parser.

--- a/pascal/readme.md
+++ b/pascal/readme.md
@@ -1,4 +1,4 @@
-# Pascal
+# Pascal Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/pascal)

--- a/pcre/readme.md
+++ b/pcre/readme.md
@@ -1,4 +1,4 @@
-# Pcre
+# PCRE Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/pcre)

--- a/pgn/readme.md
+++ b/pgn/readme.md
@@ -1,4 +1,4 @@
-# Pgn
+# PGN Grammar
 
 ## Reference
 

--- a/php/README.md
+++ b/php/README.md
@@ -1,4 +1,4 @@
-## Summary
+# PHP Grammar
 
 Parser grammar based on [Phalanger](https://github.com/DEVSENSE/Phalanger) grammar
 by Jakub Míšek (jakubmisek).

--- a/prolog/readme.md
+++ b/prolog/readme.md
@@ -1,4 +1,4 @@
-# Prolog
+# Prolog Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/prolog)

--- a/properties/README.md
+++ b/properties/README.md
@@ -1,4 +1,5 @@
-## [Properties File Format](https://docs.oracle.com/cd/E23095_01/Platform.93/ATGProgGuide/html/s0204propertiesfileformat01.html)
+# Java Properties File Grammar
+
 The properties files read by Nucleus must follow a format that is recognized by the class java.util.Properties. The rules for the format are as follows:
 
 + Entries are generally expected to be a single line of the form, one of the following:

--- a/protobuf/protobuf2/README.md
+++ b/protobuf/protobuf2/README.md
@@ -1,4 +1,4 @@
-protobuf v2 grammars 
+# Protocol Buffers (protobuf) Grammar, Version 2
 
 author: @Boyce-Lee
 

--- a/python/python2-js/readme.md
+++ b/python/python2-js/readme.md
@@ -1,4 +1,6 @@
-### Create javascript Source
+# Python2 JavaScript Grammar
+
+## Create JavaScript Source
 
 ```shell
 alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.7-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
@@ -6,7 +8,7 @@ alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.7-complete.jar:$CLASSPAT
 antlr4 -Dlanguage=JavaScript -no-listener -no-visitor Python2.g4
 ```
 
-### example
+## Example
 ```shell
 node test.js
 // line 7:21 no viable alternative at input 'printme("hello world";'

--- a/python/python2/readme.md
+++ b/python/python2/readme.md
@@ -1,4 +1,4 @@
-# Python2
+# Python2 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/python)

--- a/python/python2_7_18/README.md
+++ b/python/python2_7_18/README.md
@@ -1,4 +1,4 @@
-# Python 2.7.18 parser
+# Python 2.7.18 Grammar
 
 ### About files:
 - PythonParser.g4

--- a/python/python3/README.md
+++ b/python/python3/README.md
@@ -1,4 +1,4 @@
-# Python 3 parser
+# Python 3 Grammar
 
 An ANTLR4 grammar for Python 3 based on version 3.6 of 
 [The Python Language Reference](https://docs.python.org/3/reference/grammar.html).

--- a/python/python3_13/README.md
+++ b/python/python3_13/README.md
@@ -1,4 +1,4 @@
-# Python 3.13.2 parser
+# Python 3.13.2 Grammar
 
 ### About files:
 - PythonParser.g4 is the ANTLR4 parser grammar that based on the official [Python PEG grammar](https://docs.python.org/3.13/reference/grammar.html)

--- a/r/readme.md
+++ b/r/readme.md
@@ -1,4 +1,4 @@
-# R
+# R Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/r)

--- a/racket-bsl/README.md
+++ b/racket-bsl/README.md
@@ -1,4 +1,4 @@
-# Racket BSL
+# Racket BSL Grammar
 
 A simple ANTLR4 grammar for the [Racket BSL](https://docs.racket-lang.org/htdp-langs/beginner.html).
 

--- a/racket-isl/README.md
+++ b/racket-isl/README.md
@@ -1,4 +1,4 @@
-# Racket ISL
+# Racket ISL Grammar
 
 A simple ANTLR4 grammar for the
 [Racket ISL (with lambda)](https://docs.racket-lang.org/htdp-langs/intermediate-lam.html).

--- a/rego/README.md
+++ b/rego/README.md
@@ -1,4 +1,4 @@
-#Rego Grammar
+# Rego Grammar
 
 Dual licensed under 3-Clause BSD, and MIT.
 

--- a/restructuredtext/README.md
+++ b/restructuredtext/README.md
@@ -1,4 +1,4 @@
-# A grammar for reStructuredText language written in ANTLR v4
+# reStructuredText Grammar
 
 ## Source
 

--- a/ruleworks/README.md
+++ b/ruleworks/README.md
@@ -1,3 +1,5 @@
+# RuleWorks Grammar
+
 This is the grammar for RuleWorks, which was intended as a follow on to OPS5. 
 OPS5 was originally developed at Carnegie Melon University and then adopted
 by Digital Equipment Corporation (DEC). The source code contains copyrights from 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,4 +1,4 @@
-# Rust ANTLR 4 grammar
+# Rust Grammar
 
 This grammar is based on official language reference
 at https://doc.rust-lang.org/reference/.

--- a/scala/scala2/readme.md
+++ b/scala/scala2/readme.md
@@ -1,4 +1,4 @@
-# Scala 2
+# Scala 2 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/scala)

--- a/scala/scala3/readme.md
+++ b/scala/scala3/readme.md
@@ -1,4 +1,4 @@
-# Scala 3
+# Scala 3 Grammar
 
 ## Source
 EBNF adapted from https://docs.scala-lang.org/scala3/reference/syntax.html (read May 6, 2026).

--- a/scss/readme.md
+++ b/scss/readme.md
@@ -1,4 +1,4 @@
-# Scss
+# SCSS Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/scss)

--- a/semver/README.md
+++ b/semver/README.md
@@ -1,4 +1,4 @@
-### A parser for Semantic Version 2.0 spec
+# Semantic Versioning Grammar
 
 This is a parser for [semver 2.0 spec](https://semver.org/).
 In addition to the semver spec, the grammar supports version "tags" such as "beta3" or "rc.2" - this would allow implementers to implement version comparison not only with major/minor/patch versions but with the numbers of beta/rc versions.

--- a/sexpression/readme.md
+++ b/sexpression/readme.md
@@ -1,4 +1,4 @@
-# Sexpression
+# S-Expression Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/s-expressions)

--- a/sgf/README.md
+++ b/sgf/README.md
@@ -1,5 +1,5 @@
-Sgf.g4
-======
+# Smart Game Format (SGF) Grammar
+
 This is an antlr4-grammar for the `Smart Game Format`
 which is also called `Smart Go Format`.
 
@@ -10,19 +10,15 @@ gives a very good starting point.
 All properties from the list of property: www.red-bean.com/sgf/proplist.html
 are implemented and the official example: www.red-bean.com/sgf/examples/ parses without problems.
 
-Unknown properties are supported and will show up as `privateProp`-nodes. 
+Unknown properties are supported and will show up as `privateProp`-nodes.
 
-Definition
-----------
+## Reference
 
 * www.red-bean.com/sgf/sgf4.htm
 * www.red-bean.com/sgf/properties.htm
 * www.red-bean.com/sgf/proplist.html
 * www.red-bean.com/sgf/go.htm (Go)
 
-License
--------
+## License
 [AGPL-3.0](agpl-3.0.txt)
-
-## Reference
 

--- a/sharc/README.md
+++ b/sharc/README.md
@@ -1,4 +1,4 @@
-# Logo Grammar
+# Super Harvard Architecture Single-Chip (SHARC) Grammar
 
 An ANTLR4 grammar for [SHARC](https://en.wikipedia.org/wiki/Super_Harvard_Architecture_Single-Chip_Computer) files.
 

--- a/smalltalk/readme.md
+++ b/smalltalk/readme.md
@@ -1,4 +1,4 @@
-# Smalltalk
+# Smalltalk Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/smalltalk)

--- a/smiles/README.md
+++ b/smiles/README.md
@@ -1,4 +1,4 @@
-# OpenSmiles
+# OpenSMILES Grammar
 
 An ANTLR4 grammar for [OpenSmiles](http://opensmiles.org/) files.
 

--- a/snobol/readme.md
+++ b/snobol/readme.md
@@ -1,4 +1,4 @@
-# Snobol
+# SNOBOL Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/snobol)

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -1,4 +1,4 @@
-# Solidity
+# Solidity Grammar
 
 ## Authors
 

--- a/sparql/readme.md
+++ b/sparql/readme.md
@@ -1,4 +1,4 @@
-# Sparql
+# SPARQL Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/sparql)

--- a/spass/readme.md
+++ b/spass/readme.md
@@ -1,4 +1,4 @@
-# SPASS
+# SPASS Grammar
 
 Scraped manually from https://webspass.spass-prover.org/help/spass-input-syntax15.pdf
 Version 1.5

--- a/sql/athena/README.md
+++ b/sql/athena/README.md
@@ -1,4 +1,4 @@
-# Antlr grammar for AWS Athena
+# AWS Athena Grammar
 
 https://docs.aws.amazon.com/athena/latest/ug/ddl-sql-reference.html
 

--- a/sql/clickhouse/readme.md
+++ b/sql/clickhouse/readme.md
@@ -1,4 +1,4 @@
-# Clickhouse
+# ClickHouse Grammar
 
 ## Reference
 

--- a/sql/cockroachdb/Cpp/st.CMakeLists.txt
+++ b/sql/cockroachdb/Cpp/st.CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated from trgen <version>
+﻿# Generated from trgen <version>
 
 cmake_minimum_required (VERSION 3.14)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/sql/cockroachdb/README.md
+++ b/sql/cockroachdb/README.md
@@ -1,4 +1,4 @@
-# An ANTLR4 grammar for Cockroach Database
+# CockroachDB Grammar
 
 https://www.cockroachlabs.com/docs/stable/sql-grammar
 

--- a/sql/cockroachdb/st.CMakeLists.txt
+++ b/sql/cockroachdb/st.CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated from trgen <version>
+﻿# Generated from trgen <version>
 
 cmake_minimum_required (VERSION 3.14)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -10,7 +10,7 @@ find_package(Threads REQUIRED)
 #SET(GCC_COVERAGE_COMPILE_FLAGS "-g -pg")
 #SET(GCC_COVERAGE_LINK_FLAGS    "-g -pg")
 <if(os_win)>
-SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /MT /bigobj")
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /MT")
 <endif>
 #SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
 #SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
@@ -71,7 +71,7 @@ add_executable(Test
 <endif>
 
 <if(os_win)>
-target_compile_options(Test PUBLIC /MT /bigobj)
+target_compile_options(Test PUBLIC /MT)
 <endif>
 
 target_link_libraries(Test antlr4_static Threads::Threads)

--- a/sql/databricks/README.md
+++ b/sql/databricks/README.md
@@ -1,4 +1,4 @@
-# An ANTLR4 grammar for Databricks Database
+# Databricks Grammar
 
 https://docs.databricks.com/aws/en/sql/language-manual/
 

--- a/sql/derby/README.md
+++ b/sql/derby/README.md
@@ -1,4 +1,4 @@
-# An ANTLR4 grammar for Apache Derby
+# Apache Derby Grammar
 
 https://db.apache.org/derby/docs/10.16/ref/index.html
 

--- a/sql/drill/README.md
+++ b/sql/drill/README.md
@@ -1,4 +1,4 @@
-# ANTLR4 grammar for Apache Drill
+# Apache Drill Grammar
 
 https://drill.apache.org/docs/sql-reference/
 

--- a/sql/hive/v2/README.md
+++ b/sql/hive/v2/README.md
@@ -1,4 +1,4 @@
-# HIVE 2.x.x grammar for ANTLR4
+# HIVE 2.x.x Grammar
 
 An ANTLR4 grammar for HIVE 2.3.8. Based on the [Hive grammar for version 3.1.2](https://github.com/antlr/grammars-v4/tree/master/sql/hive).
 

--- a/sql/hive/v3/readme.md
+++ b/sql/hive/v3/readme.md
@@ -1,5 +1,4 @@
-# V3
+# HIVE 3 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/hiveql)
-

--- a/sql/hive/v4/README.md
+++ b/sql/hive/v4/README.md
@@ -1,4 +1,4 @@
-# ANTLR4 grammar for Apache Hive version 4
+# Apache Hive v4 Grammar
 
 https://github.com/apache/hive/tree/master/parser/src/java/org/apache/hadoop/hive/ql/parse
 

--- a/sql/informix-sql/README.md
+++ b/sql/informix-sql/README.md
@@ -1,4 +1,4 @@
-# Informix database sql grammar for ANTLR4
+# Informix SQL Grammar
 
 An ANTLR4 grammar for Informix database.
 

--- a/sql/phoenix/README.md
+++ b/sql/phoenix/README.md
@@ -1,4 +1,4 @@
-# ANTLR4 grammar for Apache Phoenix
+# Apache Phoenix Grammar
 
 https://phoenix.apache.org/language/index.html
 

--- a/sql/sqlite/readme.md
+++ b/sql/sqlite/readme.md
@@ -1,4 +1,4 @@
-# Sqlite
+# SQLite Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/sqlite)

--- a/sql/starrocks/readme.md
+++ b/sql/starrocks/readme.md
@@ -1,4 +1,4 @@
-# Starrocks
+# StarRocks Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/sql)

--- a/sql/trino/README.md
+++ b/sql/trino/README.md
@@ -1,4 +1,4 @@
-# Trino grammar for ANTLR4
+# Trino Grammar
 
 An ANTLR4 grammar for Trino, formerly known as PrestoSQL.
 This grammar is based on the actively maintained [Trino repository](https://github.com/trinodb/trino).

--- a/sql/tsql/README.md
+++ b/sql/tsql/README.md
@@ -1,4 +1,4 @@
-# An ANTLR4 grammar for T-SQL
+# T-SQL Grammar
 
 This is a community-supported grammar file for t-sql.
 It's not fully complete so far because a grammar reference of T-SQL is hard to clarify.

--- a/sql/tsql/TSqlParser.g4
+++ b/sql/tsql/TSqlParser.g4
@@ -4152,7 +4152,8 @@ table_sources
     | source += table_source (',' source += table_source)*
     ;
 
-// https://sqlenlight.com/support/help/sa0006/
+// sqlenlight.com/support/help/sa0006/
+// stale link
 non_ansi_join
     : source += table_source (',' source += table_source)+
     ;

--- a/swift/swift2/README.md
+++ b/swift/swift2/README.md
@@ -1,3 +1,5 @@
+# Swift (Version 2) Grammar
+
 Some notes on issues am finding with the official grammar as I developed the executable grammar.
 
 ## Ambiguities

--- a/teal/readme.md
+++ b/teal/readme.md
@@ -1,4 +1,4 @@
-# Teal
+# Teal Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/teal)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,4 +1,4 @@
-# Terraform
+# Terraform Grammar
 
 An Antlr4 grammar for [Terraform](https://www.terraform.io/).
 

--- a/thrift/README.md
+++ b/thrift/README.md
@@ -1,4 +1,4 @@
-# Thrift
+# Thrift Grammar
 
 ANTLR v4 grammar for Apache Thrift interface description language (IDL): http://thrift.apache.org/docs/idl
 

--- a/tinybasic/README.md
+++ b/tinybasic/README.md
@@ -1,4 +1,4 @@
-# TinyBasic
+# TinyBasic Grammar
 
 An ANTLR4 grammar for [TinyBasic](https://en.wikipedia.org/wiki/Tiny_BASIC) files.
 

--- a/toml/readme.md
+++ b/toml/readme.md
@@ -1,4 +1,4 @@
-# Toml
+# TOML Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/toml)

--- a/turtle-doc/readme.md
+++ b/turtle-doc/readme.md
@@ -1,4 +1,4 @@
-# Turtle Doc
+# Turtle Doc Grammar
 
 ## Reference
 

--- a/turtle/readme.md
+++ b/turtle/readme.md
@@ -1,4 +1,4 @@
-# Turtle
+# Turtle Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/turtle)

--- a/useragent/README.md
+++ b/useragent/README.md
@@ -1,4 +1,4 @@
-# UserAgeng Grammar
+# User Agent Grammar
 
 An ANTLR4 grammar for [User Agent](https://en.wikipedia.org/wiki/User_agent) files.
 

--- a/v/README.md
+++ b/v/README.md
@@ -1,4 +1,4 @@
-# V Language grammar for ANTLR4
+# V Language Grammar
 Because of the grammar similarity between Golang and V,
 
 It's modified from `golang.g4`

--- a/vaxscan/README.md
+++ b/vaxscan/README.md
@@ -1,3 +1,5 @@
+# VAX SCAN Grammar
+
 This is the grammar for VAX SCAN. The following description is lifted from the
 Guide to VAX SCAN (Copyright ©1985, 1986, 1989 by Digital Equipment 
 Corporation).

--- a/vb6/readme.md
+++ b/vb6/readme.md
@@ -1,4 +1,4 @@
-# Vb6
+# VB6 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/visual-basic)

--- a/velocity/readme.md
+++ b/velocity/readme.md
@@ -1,4 +1,4 @@
-# Velocity
+# Velocity Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/apache-velocity)

--- a/vhdl/vhdl/readme.md
+++ b/vhdl/vhdl/readme.md
@@ -1,4 +1,4 @@
-# Vhdl
+# VHDL Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/vhdl)

--- a/vhdl/vhdl2008/readme.md
+++ b/vhdl/vhdl2008/readme.md
@@ -1,4 +1,4 @@
-# Vhdl2008
+# VHDL 2008 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/vhdl)

--- a/webidl/WebIDL.g4
+++ b/webidl/WebIDL.g4
@@ -705,7 +705,8 @@ extendedAttributeNamedArgList
     ;
 
 /* Chromium IDL also allows string literals in extendedAttributes
-https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/bindings/IDLExtendedAttributes.md
+chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/bindings/IDLExtendedAttributes.md
+link no longer valid.
 */
 extendedAttributeString
     : IDENTIFIER_WEBIDL '=' STRING_WEBIDL

--- a/webidl/readme.md
+++ b/webidl/readme.md
@@ -1,4 +1,4 @@
-# Webidl
+# WebIDL Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/web-idl)

--- a/wkt/README.MD
+++ b/wkt/README.MD
@@ -1,5 +1,4 @@
-Well-known text
-===============
+# Well-known text (WKT) Grammar
 
 Well-known text (WKT) is a text markup language for representing vector geometry objects on a map, spatial reference systems of spatial objects and transformations between spatial reference systems. A binary equivalent, known as well-known binary (WKB), is used to transfer and store the same information on databases. The formats were originally defined by the Open Geospatial Consortium (OGC) and described in their Simple Feature Access and Coordinate Transformation Service specifications. The current standard definition is in the ISO/IEC 13249-3:2016 standard, "Information technology � Database languages � SQL multimedia and application packages � Part 3: Spatial" (SQL/MM) and ISO 19162:2015, "Geographic information � Well-known text representation of coordinate reference systems".
 

--- a/xml/readme.md
+++ b/xml/readme.md
@@ -1,4 +1,4 @@
-# Xml
+# XML Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/xml)

--- a/xpath/xpath1/readme.md
+++ b/xpath/xpath1/readme.md
@@ -1,4 +1,4 @@
-# Xpath1
+# XPath1 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/xpath)

--- a/xpath/xpath20/readme.md
+++ b/xpath/xpath20/readme.md
@@ -1,4 +1,4 @@
-# Xpath20
+# XPath20 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/xpath)

--- a/xpath/xpath31/readme.md
+++ b/xpath/xpath31/readme.md
@@ -1,4 +1,4 @@
-# Xpath31
+# XPath31 Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/xpath)

--- a/xsd-regex/readme.md
+++ b/xsd-regex/readme.md
@@ -1,4 +1,4 @@
-# Xsd Regex
+# XSD Regex Grammar
 
 ## Reference
 * [pldb](http://pldb.info/concepts/xsd)

--- a/yini/README.md
+++ b/yini/README.md
@@ -1,4 +1,4 @@
-# YINI ANTLR 4 grammar
+# YINI Grammar
 
 This grammar is based on official language specification hosted at [YINI-spec on GitHub](https://github.com/YINI-lang/YINI-spec).
 

--- a/z/README.md
+++ b/z/README.md
@@ -1,4 +1,4 @@
-## Summary
+# Z Notation Grammar
 
 Z Notation grammar based on the [ISO standard](http://standards.iso.org/ittf/PubliclyAvailableStandards/c021573_ISO_IEC_13568_2002%28E%29.zip) with [corrections](https://www.iso.org/obp/ui/#iso%3Astd%3Aiso%2Diec%3A13568%3Aed%2D1%3Av1%3Acor%3A1%3Av1%3Aen)
 

--- a/zig/README.md
+++ b/zig/README.md
@@ -1,4 +1,4 @@
-## Summary
+# Zig Grammar
 
 Zig language grammar
 


### PR DESCRIPTION
- Add missing '#' heading markers (ada/ada83, ada/ada95, capnproto, edn, flatbuffers, protobuf/protobuf2, ruleworks, sgf, swift/swift2, vaxscan, wkt)
- Add missing 'Grammar' word to ~75 grammar titles, fixing casing where appropriate (acronyms, proper names)
- Remove 'ANTLR'/'ANTLR4' from 25 grammar titles
- Fix wrong heading levels (## Summary → #, ### → #) in csharp/v6, csharp/v7, kquery, php, properties, python/python2-js, semver, z, zig
- Fix wrong/completely wrong titles (ada/ada95, objc, sharc, sql/hive/v2, sql/hive/v3, javascript/ecmascript)
- Fix miscellaneous issues: missing space after #, typo in useragent, lowercase 'grammar', non-standard title formats
- Fixed selected Cpp tests.
- Fixed Python3 testing for MacOS symbolic links limitation. 