### PR TITLE
Fix link to perf data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The root directory name is the all-lowercase name of the language or file format
 
 ## Performance
 
-[Grammar performance table](https://htmlpreview.github.io/?https://github.com/antlr/grammars-v4/blob/performance.html) (sortable by column header).
+[Grammar performance table](https://htmlpreview.github.io/?https://github.com/antlr/grammars-v4/blob/master/performance.html) (sortable by column header).
 
 ## FAQ
 

--- a/performance.html
+++ b/performance.html
@@ -34,6 +34,10 @@
 </tbody>
 </table>
 <h3>Results</h3>
+<p>Runtime of examples/ on AMD Ryzen 7 2700 Eight-Core Processor;
+   16GB DDR4; Samsung SSD 990 EVO Plus 2TB; Windows: Version
+   10.0.26200.7623 (this is a Windows 11 Insider Preview build); .NET
+   SDK: 10.0.301.</p>
 <table id="perf-table">
 <thead><tr>
   <th onclick="sortTable('perf-table',0)">Grammar</th>


### PR DESCRIPTION
This PR fixes the link to the performance table. I had to test using my cloned repo, but didn't update the link correctly when submitting https://github.com/antlr/grammars-v4/pull/4919.