### PR TITLE
[PlSql] Fix `selection_directive` parser rule

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -5903,9 +5903,9 @@ pipe_row_statement
     ;
 
 selection_directive
-    : DOLLAR_IF condition DOLLAR_THEN selection_directive_body (
-        DOLLAR_ELSIF selection_directive_body
-    )* (DOLLAR_ELSE selection_directive_body)? DOLLAR_END
+    : DOLLAR_IF condition DOLLAR_THEN selection_directive_body? (
+        DOLLAR_ELSIF condition DOLLAR_THEN selection_directive_body?
+    )* (DOLLAR_ELSE selection_directive_body?)? DOLLAR_END
     ;
 
 error_directive

--- a/sql/plsql/examples/selection_directive.sql
+++ b/sql/plsql/examples/selection_directive.sql
@@ -1,0 +1,41 @@
+begin
+    $if true $then
+        dbms_output.put_line(1);
+    $else
+    $end
+
+    $if false $then
+    $else
+        dbms_output.put_line(2);
+    $end
+
+    $if false $then
+    $elsif true $then
+        dbms_output.put_line(3);
+    $else
+    $end
+
+    $if false $then
+        dbms_output.put_line('if');
+    $elsif true $then
+        dbms_output.put_line('else if');
+    $else
+        dbms_output.put_line('else');
+    $end
+
+    $if true $then
+    $end
+
+    $if true $then
+    $else
+    $end
+
+    $if false $then
+    $elsif true $then
+    $end
+
+    $if false $then
+    $elsif true $then
+    $else
+    $end
+end;


### PR DESCRIPTION
Hello grammars-v4 team,

Here are some changes to fix the `selection_directive` rule of the PL/SQL parser.
In summary :
- The `selection_directive` rule was missing the `condition DOLLAR_THEN` part necessary to parse `... $elsif my_condition $then ...`.
- The `selection_directive_body` were required even if they really are optional.

I joined an example file which compiles successfully in an Oracle 26ai database.

Thank you for your work!