### PR TITLE
[sql/db2] Fix ANSI JOIN, CTE body, and zero-arg function calls

### DIFF
--- a/sql/db2/Db2Parser.g4
+++ b/sql/db2/Db2Parser.g4
@@ -2735,7 +2735,7 @@ sql_routine_statement
     ;
 
 common_table_expression
-    : table_name column_name_list_paren? AS '(' (WITH common_table_expression)? ')'
+    : table_name column_name_list_paren? AS '(' (WITH common_table_expression_list)? fullselect ')'
     ;
 
 create_alias_statement
@@ -4657,7 +4657,10 @@ from_clause
     ;
 
 table_reference
-    : singles_table_reference
+    : table_reference (INNER | outer)? JOIN table_reference (ON join_condition | USING '(' column_name_list ')')
+    | table_reference CROSS JOIN table_reference
+    | '(' table_reference ')'
+    | singles_table_reference
     | single_view_reference
     | single_nickname_reference
     | only_table_reference
@@ -4668,7 +4671,6 @@ table_reference
     | table_function_reference
     | collection_derived_table
     | xmltable_expression
-    //| joined_table
     | external_table_reference
     ;
 
@@ -4794,12 +4796,6 @@ xmltable_expression
 
 xmltable_function
     : todo
-    ;
-
-joined_table
-    : table_reference (INNER | outer)? JOIN table_reference (ON join_condition | USING '(' column_name_list ')')
-    | table_reference CROSS JOIN table_reference
-    | '(' joined_table ')'
     ;
 
 join_condition
@@ -5218,7 +5214,7 @@ expression
     ;
 
 function_invocation
-    : function_name '(' all_distinct? arg_list ')'
+    : function_name '(' all_distinct? arg_list? ')'
     ;
 
 all_distinct


### PR DESCRIPTION
Fixes #4937.

## Context

I'm using this grammar in a static-analysis tool that parses real-world DB2 LUW SQL files. While testing it against actual production queries, I ran into three constructs that failed to parse even though they're extremely common DB2 SQL — ANSI `JOIN ... ON`/`USING`, CTEs, and zero-argument function calls.

## What I found

- `joined_table` is fully written but its only reference site in `table_reference` is commented out (`//| joined_table`), so `FROM t1 a JOIN t2 b ON a.x = b.y` never reaches a JOIN node — the parser resyncs and only `FROM t1 a` forms a valid subtree, `t2 b ON a.x=b.y` is left dangling. Uncommenting it as-is doesn't work: it throws ANTLR4's "mutually left-recursive" error for `[table_reference, joined_table]`, since `joined_table`'s first alternative starts with `table_reference` while `joined_table` is itself an alternative of `table_reference` — indirect left recursion, which ANTLR4 doesn't eliminate automatically (only direct self-recursion within one rule is supported). I'd guess that's why it ended up commented out rather than fixed.
- `common_table_expression`'s body is `(WITH common_table_expression)?` — self-referential, never reaching `fullselect`. A CTE's own SELECT body has no parse path into the tree at all, so `WITH cte AS (SELECT id FROM t1) SELECT * FROM cte;` fails to parse as one statement.
- `function_invocation` requires a non-empty `arg_list`, so a zero-arg call like `NOW()` has no parse path.

## What I did

- Merged the `JOIN`/`CROSS JOIN` alternatives directly into `table_reference` as *direct* left recursion instead of routing through a separate `joined_table` rule — ANTLR4 supports this and correctly left-associates chained joins (`t1 JOIN t2 JOIN t3` becomes `(t1 JOIN t2) JOIN t3`). Removed the now-dead standalone `joined_table` rule.
- Pointed `common_table_expression`'s body at `(WITH common_table_expression_list)? fullselect`, matching the pattern already used everywhere else in this grammar (`select_statement`, `nested_table_reference`, etc. all follow this exact shape).
- Made `arg_list` optional in `function_invocation`.

## Result

Regenerated the Python3 target from the patched grammar and confirmed all three constructs now parse with zero syntax errors and the correct tree shape:

```
SELECT * FROM t1 a JOIN t2 b ON a.x = b.y;
SELECT * FROM t1 a LEFT OUTER JOIN t2 b ON a.x=b.y JOIN t3 c ON b.z=c.w;   -- 3-table chain left-associates correctly
WITH cte AS (SELECT id FROM t1) SELECT * FROM cte;
SELECT NOW() FROM t1;
```

Given the grammar's own PR description flagged it as "98% complete," these read like gaps rather than intentional omissions, but happy to adjust if there's a reason any of them were left out on purpose.
