### PR TITLE
[mariadb] Fix DECLARE .. HANDLER syntax to allow for bare return, #4948

### DIFF
--- a/sql/mariadb/MariaDBParser.g4
+++ b/sql/mariadb/MariaDBParser.g4
@@ -1528,7 +1528,7 @@ declareCursor
 declareHandler
     : DECLARE handlerAction = (CONTINUE | EXIT | UNDO) HANDLER FOR handlerConditionValue (
         ',' handlerConditionValue
-    )* routineBody
+    )* (compoundStatement | sqlStatement)
     ;
 
 handlerConditionValue

--- a/sql/mariadb/examples/fast/ddl_create.sql
+++ b/sql/mariadb/examples/fast/ddl_create.sql
@@ -791,3 +791,13 @@ SELECT
      ,@N_latin;
 END
 #end
+
+#begin
+-- Create function with exit handler containing a bare RETURN statement
+-- src: https://mariadb.com/docs/server/reference/sql-statements/programmatic-compound-statements/declare-handler#syntax
+CREATE FUNCTION f() RETURNS INT
+BEGIN
+  DECLARE EXIT HANDLER FOR NOT FOUND RETURN NULL;
+  RETURN 0;
+END
+#end


### PR DESCRIPTION
This fixes the MariaDB grammar to allow for bare return (and other control-flow statements) as the body for a handler declaration.

Note that `routineBody` is defined as `blockStatement | sqlStatement`, and `compoundStatement` includes `blockStatement`, so this is a superset of the previous rules. I am open to alternative approaches, however.

Fixes #4948