### PR TITLE
sql/mysql/Oracle: fix version comment state in Go lexer base

### DIFF
--- a/sql/mysql/Oracle/Go/MySQLLexerBase.go
+++ b/sql/mysql/Oracle/Go/MySQLLexerBase.go
@@ -216,7 +216,7 @@ func (m *MySQLLexerBase) checkMySQLVersion(text string) bool {
     }
 
     if version <= StaticMySQLLexerBase.serverVersion {
-        StaticMySQLLexerBase.inVersionComment = true
+        m.inVersionComment = true
         return true
     }
 


### PR DESCRIPTION
## Problem

In the Go support file `sql/mysql/Oracle/Go/MySQLLexerBase.go`, `checkMySQLVersion` records an active version comment on the **static** instance:

```go
if version <= StaticMySQLLexerBase.serverVersion {
    StaticMySQLLexerBase.inVersionComment = true
```

but the `VERSION_COMMENT_END` lexer rule's predicate and action (`isInVersionComment` / `endInVersionComment`) read and write the **instance** field `m.inVersionComment`. The flag set by `checkMySQLVersion` is therefore never observed: the closing `*/` of a satisfied version comment does not match `VERSION_COMMENT_END` and lexes as `MULT_OPERATOR` + `DIV_OPERATOR` instead, breaking the parse of any statement containing a version comment whose version gate passes.

## Repro (Go target, default serverVersion 80200)

```sql
SELECT 1 /*!50110 + 1*/;
```

Before: syntax errors at `*` `/`. After: parses. This affects virtually every statement in a mysqldump file (`/*!40101 SET ... */`, `/*!50013 DEFINER=... */`, trigger DDL spliced across `/*!50003 ... */`, etc.).

## Fix

Set the instance field, aligning the Go port with the TypeScript base, where `checkMySQLVersion` sets `this.inVersionComment = true` (`Antlr4ng/MySQLLexerBase.ts`). One line changed.

Found while integrating the grammar into a Go tool that rewrites mysqldump output; with this fix every DDL statement of a real ~1 GB production dump parses cleanly.