### PR TITLE
sql/snowflake: support PARTITION BY EXCLUDING in window function metrics

### DIFF
--- a/sql/snowflake/SnowflakeLexer.g4
+++ b/sql/snowflake/SnowflakeLexer.g4
@@ -327,6 +327,7 @@ ESCAPE_UNENCLOSED_FIELD          : 'ESCAPE_UNENCLOSED_FIELD';
 EVENT                            : 'EVENT';
 EXCEPT                           : 'EXCEPT';
 EXCLUDE                          : 'EXCLUDE';
+EXCLUDING                        : 'EXCLUDING';
 EXCHANGE                         : 'EXCHANGE';
 EXECUTE                          : 'EXEC' 'UTE'?;
 EXECUTION                        : 'EXECUTION';

--- a/sql/snowflake/SnowflakeParser.g4
+++ b/sql/snowflake/SnowflakeParser.g4
@@ -4100,6 +4100,7 @@ non_reserved_words
     | EVENT
     | EXCHANGE
     | EXCLUDE
+    | EXCLUDING
     | EXECUTION
     | EXPIRY_DATE
     | EXPR
@@ -4499,9 +4500,15 @@ asc_desc
     ;
 
 over_clause
-    : OVER '(' partition_by order_by_expr? ')'
+    : OVER '(' window_partition_by order_by_expr? ')'
     | OVER '(' order_by_expr ')'
     | OVER '(' ')'
+    ;
+
+// Kept separate from partition_by, the unrelated file-layout clause of COPY INTO <location>,
+// CREATE EXTERNAL TABLE and MATCH_RECOGNIZE, none of which accept EXCLUDING.
+window_partition_by
+    : PARTITION BY EXCLUDING? expr_list
     ;
 
 function_call

--- a/sql/snowflake/examples/ids.sql
+++ b/sql/snowflake/examples/ids.sql
@@ -12,3 +12,5 @@ select 0 as interval;
 create table interval(internal int);
 
 select 0 as include, 0 as exclude, 0 as nulls;
+select 0 as excluding;
+create table excluding(excluding int);

--- a/sql/snowflake/examples/semantic_views.sql
+++ b/sql/snowflake/examples/semantic_views.sql
@@ -47,3 +47,37 @@ CREATE SEMANTIC VIEW tpch_rev_analysis
   )
 
   COMMENT = 'Semantic view for revenue analysis';
+
+CREATE SEMANTIC VIEW daily_sales_trends
+
+  TABLES (
+    daily_sales AS SALES.PUBLIC.DAILY_SALES
+      PRIMARY KEY (sale_date, channel)
+  )
+
+  DIMENSIONS (
+    daily_sales.date AS sale_date,
+    daily_sales.channel AS channel,
+    daily_sales.year AS YEAR(sale_date)
+  )
+
+  METRICS (
+    daily_sales.total_revenue AS SUM(revenue),
+    -- PARTITION BY EXCLUDING partitions by every dimension requested in the query
+    -- except the listed ones, so this window walks forward in time within channel.
+    daily_sales.revenue_30d_ago AS
+      LAG(daily_sales.total_revenue, 30) OVER (
+        PARTITION BY EXCLUDING daily_sales.date
+        ORDER BY daily_sales.date),
+    daily_sales.revenue_rank AS
+      RANK() OVER (
+        PARTITION BY EXCLUDING daily_sales.date, daily_sales.channel
+        ORDER BY daily_sales.total_revenue DESC),
+    -- An explicit partition list stays valid.
+    daily_sales.running_total AS
+      SUM(daily_sales.total_revenue) OVER (
+        PARTITION BY daily_sales.year
+        ORDER BY daily_sales.date)
+  )
+
+  COMMENT = 'Window function metrics, including PARTITION BY EXCLUDING';


### PR DESCRIPTION
The Snowflake documentation defines window function metrics in `CREATE SEMANTIC VIEW`
as accepting either an expression list or `EXCLUDING <dimensions>` as the window
partition:

```
windowFunctionMetricExpression ::=
  [ { PRIVATE | PUBLIC } ] <table_alias>.<metric> AS
  <window_function>( <metric> ) OVER (
    [ PARTITION BY { <exprs_using_dimensions_or_metrics> | EXCLUDING <dimensions> } ]
    [ ORDER BY <exprs_using_dimensions_or_metrics> [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
    [ <windowFrameClause> ]
  )
```

`EXCLUDING <dimensions>` partitions by every dimension requested in the query except
the ones listed. The grammar had no `EXCLUDING` token at all, so a semantic view
containing such a metric fails to parse at that keyword.

Changes:

* `SnowflakeLexer.g4`: new `EXCLUDING` token.
* `SnowflakeParser.g4`: `EXCLUDING` added to `non_reserved_words`. It is a non-reserved
  keyword in Snowflake and stays valid as an unquoted identifier, which would otherwise
  regress now that the lexer recognizes it.
* `SnowflakeParser.g4`: new `window_partition_by` rule, `PARTITION BY EXCLUDING? expr_list`,
  used by `over_clause` in place of `partition_by`.

`over_clause` previously shared the `partition_by` rule with `copy_into_location`,
`create_external_table` and `match_recognize`. Those are file-layout and pattern-matching
clauses unrelated to window partitioning, and none of them accept `EXCLUDING`. Adding the
modifier to `partition_by` would have made it grammatical in all three, so window
partitioning gets its own rule here and `partition_by` is left untouched.

The documentation further notes that `EXCLUDING` is accepted only in semantic view metric
definitions and "is not supported in window function calls in any other context".
Enforcing it that precisely would mean duplicating the expression grammar reachable from
the `METRICS` clause, so `window_partition_by` accepts it in any `OVER (...)`; a comment
on the rule records the real restriction.

Reference: https://docs.snowflake.com/en/sql-reference/sql/create-semantic-view
(section "Parameters for window function metrics")

Examples:

* `examples/semantic_views.sql`: a second semantic view whose metrics use
  `PARTITION BY EXCLUDING <dim>`, `PARTITION BY EXCLUDING <dim>, <dim>` and a plain
  `PARTITION BY <expr>` alongside one another.
* `examples/ids.sql`: `excluding` as a column alias, a table name and a column name,
  covering the `non_reserved_words` entry.

`mvn clean test` in `sql/snowflake` passes over all 51 example files. This change is
visible to the existing CI, which checks that inputs parse: reverting the two grammar
files while keeping the examples makes `semantic_views.sql` fail with three syntax errors
at `PARTITION BY EXCLUDING`.
