### PR TITLE
[postgresql] Fix NOTICE identifier parsing (#4960)

### DIFF
--- a/sql/postgresql/PostgreSQLParser.g4
+++ b/sql/postgresql/PostgreSQLParser.g4
@@ -4637,6 +4637,7 @@ unreserved_keyword
     | NORMALIZED
     | NOTHING
     | NOTIFY
+    | NOTICE
     | NOWAIT
     | NULLS_P
     | OBJECT_P
@@ -5255,6 +5256,7 @@ bare_label_keyword
     | NOT
     | NOTHING
     | NOTIFY
+    | NOTICE
     | NOWAIT
     | NULL_P
     | NULLIF

--- a/sql/postgresql/examples/notice_as_identifier.sql
+++ b/sql/postgresql/examples/notice_as_identifier.sql
@@ -1,0 +1,3 @@
+ALTER TABLE studio.notice ADD COLUMN display_flags TEXT[];
+CREATE TABLE notice (notice text);
+SELECT 1 notice;


### PR DESCRIPTION
## Summary

- classify `NOTICE` as an unreserved keyword so it can be used as a relation or column identifier
- classify `NOTICE` as a bare-label keyword so it can be used as an alias without `AS`
- add PostgreSQL examples covering relation names, column names, and bare aliases

## Why

`PostgreSQLLexer.g4` tokenizes `notice` as `NOTICE`, but `PostgreSQLParser.g4` did not include that token in any identifier-compatible keyword category. PostgreSQL accepts `notice` as an unquoted identifier, while the grammar rejected inputs such as:

```sql
ALTER TABLE studio.notice ADD COLUMN display_flags TEXT[];
```

Closes #4960.

## Testing

- `mvn clean test` in `sql/postgresql`: passed
