### PR TITLE
[mysql/Oracle] Specialize Cpp/CMakeLists.txt for mysql grammar because the grammar is large for MS compiler (#4964).

### DIFF
--- a/sql/mysql/Oracle/Cpp/st.CMakeLists.txt
+++ b/sql/mysql/Oracle/Cpp/st.CMakeLists.txt
@@ -1,0 +1,77 @@
+﻿# Generated from trgen <version>
+
+cmake_minimum_required (VERSION 3.14)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+set(CMAKE_CXX_STANDARD 17)
+set(ANTLR4_TAG <antlr_version>)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+#SET(GCC_COVERAGE_COMPILE_FLAGS "-g -pg")
+#SET(GCC_COVERAGE_LINK_FLAGS    "-g -pg")
+<if(os_win)>
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /MT /bigobj")
+<endif>
+#SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
+#SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
+
+add_definitions(-DANTLR4CPP_STATIC)
+
+include(ExternalAntlr4Cpp)
+include_directories(${ANTLR4_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/)
+find_package(ANTLR REQUIRED)
+
+<if(is_combined_grammar)>
+antlr_target(
+    <grammar_name>
+    <grammar_file>
+    )
+
+include_directories(${ANTLR4_INCLUDE_DIRS})
+include_directories(${ANTLR_<grammar_name>_OUTPUT_DIR})
+
+add_executable(Test
+    Test.cpp
+    ErrorListener.cpp
+    ErrorListener.h
+    EncodingInputStream.cpp
+    EncodingInputStream.h
+    <additional_sources:{x | <x>
+    } >${ANTLR_<grammar_name>_CXX_OUTPUTS}
+    )
+
+<else>
+antlr_target(
+    <lexer_name>
+    <lexer_grammar_file>
+    LEXER
+    )
+antlr_target(
+    <parser_name>
+    <parser_grammar_file>
+    PARSER
+    DEPENDS_ANTLR <lexer_name>
+    COMPILE_FLAGS -lib ${ANTLR_<lexer_name>_OUTPUT_DIR}
+    )
+
+include_directories(${ANTLR_<lexer_name>_OUTPUT_DIR})
+include_directories(${ANTLR_<parser_name>_OUTPUT_DIR})
+
+add_executable(Test
+    Test.cpp
+    ErrorListener.cpp
+    ErrorListener.h
+    EncodingInputStream.cpp
+    EncodingInputStream.h
+    <additional_sources:{x | <x>
+    } >${ANTLR_<lexer_name>_CXX_OUTPUTS}
+    ${ANTLR_<parser_name>_CXX_OUTPUTS}
+    )
+
+<endif>
+
+<if(os_win)>
+target_compile_options(Test PUBLIC /MT /bigobj)
+<endif>
+
+target_link_libraries(Test antlr4_static Threads::Threads)


### PR DESCRIPTION
The grammar is getting larger, and MS changed Cpp code generation for Visual Studio C++ so that it now produces even bigger object code. Added `/bigobj` to fix the problem.