### PR TITLE
fix: remove nuget entry from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,6 @@ updates:
     labels:
       - "infrastructure"
       - "dependencies"
-  - package-ecosystem: "nuget"
-    directory: "/_scripts/templates/CSharp"
-    schedule:
-      interval: "daily"
-    labels:
-      - "infrastructure"
-      - "dependencies"
-      - "target:csharp-standard"
   # Go
   - package-ecosystem: "gomod"
     directory: "/_scripts/templates/Go"


### PR DESCRIPTION
Dependabot's NuGet scanner also picks up `.config/dotnet-tools.json` at the repo root regardless of the specified directory, causing it to continuously open PRs to update the pinned Trash Toolkit (`trash`). Example: https://github.com/antlr/grammars-v4/pull/4973. Removed the nuget entry entirely to stop these unwanted PRs. Fixes https://github.com/antlr/grammars-v4/issues/4978.