### PR TITLE
[PlSql] Fix `index_properties` multiplicity

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -1646,9 +1646,10 @@ index_expr
     ;
 
 index_properties
-    : ( (global_partitioned_index | local_partitioned_index | index_attributes)+
+    : (
+        (global_partitioned_index | local_partitioned_index | index_attributes)+
         | INDEXTYPE IS (domain_index_clause | xmlindex_clause)
-    )*
+    )?
     ;
 
 domain_index_clause


### PR DESCRIPTION
As mentioned in #4947, the correct multiplicity for the `index_properties` rule is `?` instead of `*` as shown in [its documentation](https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/CREATE-INDEX.html#GUID-1F89BBC0-825F-4215-AF71-7588E31D8BFE__I2138869).
<img width="393" height="178" alt="image" src="https://github.com/user-attachments/assets/0efd0981-5ec9-434e-8f11-1f3890591e77" />

I also notice that the following warning `warning(154): PlSqlParser.g4:1633:0: rule table_index_clause contains an optional block with at least one alternative that can match an empty string` was introduced. I did not fix it because every rule involved is described as is in Oracle's documentation and I believe it may be better to stick to those descriptions to avoid potential future issues.