### PR TITLE
[PlSql] fix for alter type * ATTRIBUTE-keyword support

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -974,6 +974,7 @@ alter_type
         compile_type_clause
         | replace_type_clause
         | alter_method_spec
+        | alter_attribute_definition
         | alter_collection_clauses
         | modifier_clause
         | overriding_subprogram_spec
@@ -996,6 +997,11 @@ alter_method_spec
 
 alter_method_element
     : (ADD | DROP) (map_order_function_spec | subprogram_spec)
+    ;
+
+alter_attribute_definition
+    : (ADD | MODIFY) ATTRIBUTE (identifier type_spec? | '(' identifier type_spec (',' identifier type_spec)* ')')
+    | DROP ATTRIBUTE (identifier | '(' identifier (',' identifier)* ')')
     ;
 
 alter_collection_clauses

--- a/sql/plsql/examples/alter_type.sql
+++ b/sql/plsql/examples/alter_type.sql
@@ -1,0 +1,6 @@
+alter type my_type add attribute my_new_attr varchar2(200) invalidate;
+
+alter type my_type modify attribute my_new_attr varchar2(400) cascade;
+alter type my_type modify attribute my_new_attr varchar2(800);
+
+alter type my_type drop attribute my_new_attr invalidate;


### PR DESCRIPTION
Hello ANTLR-team.
Looks like the "alter_attribute_definition" rule is missing in the "alter_type" rule:
https://docs.oracle.com/en/database/oracle/oracle-database/19/lnpls/ALTER-TYPE-statement.html#GUID-A8B449E7-E3A8-48F4-A4C6-5BB87B1841CD__I2112566

<img width="499" height="208" alt="image" src="https://github.com/user-attachments/assets/0f34706e-4459-418e-aa53-c33d6a4d4b17" />


So false posittive diagnostics generated:
<img width="703" height="74" alt="image" src="https://github.com/user-attachments/assets/5e825ae4-38db-474b-a18f-0b7109e8f37d" />
