### PR TITLE
promql: add mad_over_time function to the lexer

### DIFF
--- a/promql/PromQLLexer.g4
+++ b/promql/PromQLLexer.g4
@@ -163,6 +163,7 @@ FUNCTION options {
     | 'quantile_over_time'
     | 'stddev_over_time'
     | 'stdvar_over_time'
+    | 'mad_over_time'
     | 'last_over_time'
     | 'present_over_time'
     | 'acos'

--- a/promql/examples/mad_over_time.txt
+++ b/promql/examples/mad_over_time.txt
@@ -1,0 +1,1 @@
+mad_over_time(demo_cpu_usage_seconds_total[5m])


### PR DESCRIPTION
Prometheus supports `mad_over_time` (median absolute deviation over time; experimental, gated by `--enable-feature=promql-experimental-functions`, implemented in [promql/functions.go as `funcMadOverTime`](https://github.com/prometheus/prometheus/blob/main/promql/functions.go)). The lexer's function list is missing it, so such queries fail to parse.

Adds the token alongside the other `*_over_time` functions, plus an example query.