### PR TITLE
snowflake: allow ACCOUNTS as an identifier

### DIFF
--- a/sql/snowflake/SnowflakeParser.g4
+++ b/sql/snowflake/SnowflakeParser.g4
@@ -4075,6 +4075,7 @@ non_reserved_words
     //List here lexer token referenced by rules which is not a keyword (SnowSQL Meaning) and allowed has object name
     // please add in alphabetic order for easy reading
     : ACCOUNTADMIN
+    | ACCOUNTS
     | AES
     | ALLOW_OVERLAPPING_EXECUTION
     | ARRAY_AGG

--- a/sql/snowflake/examples/select.sql
+++ b/sql/snowflake/examples/select.sql
@@ -172,3 +172,6 @@ SELECT * FROM t PIVOT(SUM(amount) FOR quarter IN (
 WITH LOCATION as ( SELECT 1 as LOCATION)
 SELECT LOCATION.LOCATION as LOCATION
 FROM LOCATION;
+
+SELECT COUNT(accounts.account_id) FROM accounts;
+SELECT accounts.name FROM db1.public.accounts AS accounts WHERE accounts.id > 0;


### PR DESCRIPTION
`ACCOUNTS` is a non-reserved keyword in Snowflake, so it is valid as an unquoted identifier — table name, alias, or column qualifier. The grammar listed it only as a lexer token used in keyword positions (`SHOW GLOBAL ACCOUNTS`, `ALTER SHARE ... SET ACCOUNTS = ...`, `ALTER DATABASE ... ENABLE REPLICATION TO ACCOUNTS`) and never included it in `id_`, so any query using it as a name fails to parse:

```sql
SELECT COUNT(accounts.account_id) FROM accounts;
-- line 1:13 no viable alternative at input 'SELECT COUNT(accounts'
```

This turned up on a real schema whose table is named `accounts`.

## Change

Added `ACCOUNTS` to `non_reserved_words`, which `id_` already includes, keeping the list in alphabetical order as that rule's comment asks. This is the same shape of fix as the recent `LOCATION` example added in `examples/select.sql`.

The existing keyword uses of `ACCOUNTS` are unaffected — none of them place `ACCOUNTS` adjacent to an `id_` position, so no new ambiguity is introduced.

## Verification

`mvn test` in `sql/snowflake` passes over all examples. Reverting just the grammar line makes it fail with the `no viable alternative` error above, so the new examples genuinely gate the change rather than merely documenting it.

I also parsed an ad-hoc file covering every keyword use of `ACCOUNTS` in the grammar — `ALTER SHARE ... ADD/REMOVE/SET ACCOUNTS =`, all four `SHOW ... ACCOUNTS` forms, and `ALTER DATABASE ... DISABLE FAILOVER TO ACCOUNTS` — and all still parse.

## Examples

Added two queries to `sql/snowflake/examples/select.sql` exercising the fix, per House_Rules.md.

## Unrelated pre-existing gap, not touched here

While testing I noticed `ALTER DATABASE d1 ENABLE REPLICATION TO ACCOUNTS org1.acc1` does not parse: `account_id_list` is a plain `id_` list with no `DOT`, so it cannot express the `org.account` form used in the Snowflake docs, even though the neighboring `alter_failover_group` rules do accept `id_ DOT id_`. Independent of this change — mentioning it in case it is of interest as a separate fix.

Reference: https://docs.snowflake.com/en/sql-reference/reserved-keywords