### PR TITLE
[PlSql] CHARACTERSET is valid identifier name

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -7939,6 +7939,7 @@ regular_id
     | COVAR_
     | DATE_FORMAT
     | CSV
+    | CHARACTERSET
     ;
 
 non_reserved_keywords_in_18c


### PR DESCRIPTION
Hello, ANTLR team
small fix: CHARACTERSET is also valid identifier name