### PR TITLE
[JavaScript] Optional chaining fixes

### DIFF
--- a/javascript/javascript/JavaScriptParser.g4
+++ b/javascript/javascript/JavaScriptParser.g4
@@ -356,16 +356,15 @@ expressionSequence
     ;
 
 singleExpression
-    : anonymousFunction                                 # FunctionExpression
-    | Class identifier? classTail                       # ClassExpression
-    | singleExpression '?.' singleExpression            # OptionalChainExpression
-    | singleExpression '?.'? '[' expressionSequence ']' # MemberIndexExpression
-    | singleExpression '?'? '.' '#'? identifierName     # MemberDotExpression
+    : anonymousFunction                                                    # FunctionExpression
+    | Class identifier? classTail                                          # ClassExpression
+    | singleExpression '?.'? '[' expressionSequence ']'                    # MemberIndexExpression
+    | singleExpression ('?.' | '.') '#'? identifierName                    # MemberDotExpression
     // Split to try `new Date()` first, then `new Date`.
     | New identifier arguments                                             # NewExpression
     | New singleExpression arguments                                       # NewExpression
     | New singleExpression                                                 # NewExpression
-    | singleExpression arguments                                           # ArgumentsExpression
+    | singleExpression '?.'? arguments                                     # ArgumentsExpression
     | New '.' identifier                                                   # MetaExpression // new.target
     | singleExpression {this.notLineTerminator()}? '++'                    # PostIncrementExpression
     | singleExpression {this.notLineTerminator()}? '--'                    # PostDecreaseExpression


### PR DESCRIPTION
As described in MDN [Optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) there are 3 cases of optional chaining:
1) obj?.prop - accessing object's property by name
2) obj?.[expr] - accessing object's property by index
3) func?.(args) - calling function if it is non null

So the 1st case is now caught by modified `MemberDotExpression` rule:
`singleExpression ('?.' | '.') '#'? identifierName`
(The lexer defines a `QuestionMarkDot` token for '?.', but the parser rule for member dot used '?'? '.' which expects two tokens: an optional `QuestionMark` followed by a `Dot`. The lexer produces a single `QuestionMarkDot` token, so the parser couldn't match the token sequence.)

The 2nd case is caught by unmodified `MemberIndexExpression`.

The 3rd case is caught by modified `ArgumentsExpression` with optional `QuestionMarkDot`:
`singleExpression '?.'? arguments`

The `OptionalChainExpression` rule is now unuseful.