### PR TITLE
[PlSql] Support multiple rows in `values_clause`

### DIFF
--- a/sql/plsql/PlSqlParser.g4
+++ b/sql/plsql/PlSqlParser.g4
@@ -6524,7 +6524,11 @@ insert_into_clause
     ;
 
 values_clause
-    : VALUES (REGULAR_ID | '(' expressions_ ')' | collection_expression)
+    : VALUES (
+        REGULAR_ID
+        | '(' expressions_ ')' (COMMA '(' expressions_ ')')*
+        | collection_expression
+    )
     ;
 
 merge_statement

--- a/sql/plsql/README.md
+++ b/sql/plsql/README.md
@@ -8,12 +8,12 @@ Various
 
 ## Reference
 
-Oracle� Database; Database PL/SQL Language Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/index.html) [pdf](https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/database-pl-sql-language-reference.pdf)
+Oracle� Database; Database PL/SQL Language Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/26/lnpls/index.html) [pdf](https://docs.oracle.com/en/database/oracle/oracle-database/26/lnpls/database-pl-sql-language-reference.pdf)
 
-SQL Language Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/index.html) [pdf](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/sql-language-reference.pdf)
+SQL Language Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/index.html)
 
 Oracle's SQL*Plus�
-User's Guide and Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqpug/index.html#SQL*Plus%C2%AE)
+User's Guide and Reference [html](https://docs.oracle.com/en/database/oracle/oracle-database/26/sqpug/index.html#SQL*Plus%C2%AE)
 
 [wikipedia](https://en.wikipedia.org/wiki/PL/SQL)
 

--- a/sql/plsql/more-examples/insert_statement.sql
+++ b/sql/plsql/more-examples/insert_statement.sql
@@ -4,3 +4,10 @@ BEGIN
    SELECT * INTO V_RECORD FROM EVENT WHERE ROWNUM=1;
    INSERT INTO TMP_EVENT VALUES V_RECORD;
 END;
+
+insert into my_table(col1, col2)
+     values (1, 1);
+
+insert into my_table(col1, col2)
+     values (1, 1),
+            (2, 2);


### PR DESCRIPTION
Updated `values_clause` to support insert statements with multiple rows which are now valid  in Oracle 26ai.

Example :
```plsql
insert into my_table(col1, col2)
     values (1, 1),
            (2, 2);
``` 

https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/INSERT.html#GUID-903F8043-0254-4EE9-ACC1-CB8AC0AF3423__I2122346