### PR TITLE
[clif] Add start rule and targets for CLIF grammar.

### DIFF
--- a/clif/CLIF.g4
+++ b/clif/CLIF.g4
@@ -42,6 +42,8 @@
 
 grammar CLIF;
 
+start: cltext* EOF;
+
 //A.2.3.1 Term sequence
 termseq
     : (term | SEQMARK)*
@@ -125,7 +127,7 @@ commentsent
 
 //A.2.3.10 Module
 module
-    : OPEN 'cl-module' interpretablename (OPEN 'cl-excludes' name* CLOSE)? cltext? CLOSE
+    : OPEN 'cl-module' interpretablename (OPEN 'cl-excludes' name* CLOSE)? cltext* CLOSE
     ;
 
 //A.2.3.11 Phrase

--- a/clif/desc.xml
+++ b/clif/desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <desc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../_scripts/desc.xsd">
-   <targets></targets>
+   <targets>Antlr4ng;CSharp;Cpp;Dart;Go;Java;JavaScript;OphiRust;Python3;TypeScript</targets>
 </desc>
 


### PR DESCRIPTION
Fixes #5004 

While evaluating Trash's complete replacement of Antlr4, I saw that CLIF.g4 did not declare an EOF-terminated start rule. ChatGPT suggested `cltext` from the original, hand-written parser.